### PR TITLE
Fix import issues for integrated data processor launch

### DIFF
--- a/python/data_processor/Data_Processor_r0.py
+++ b/python/data_processor/Data_Processor_r0.py
@@ -43,7 +43,7 @@ except Exception:  # pragma: no cover - optional dependency
     _savgol_filter = None
 
 # Import constants
-from .constants import (
+from constants import (
     DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT, DEFAULT_PADDING, DEFAULT_BUTTON_HEIGHT,
     DEFAULT_TEXT_HEIGHT, DEFAULT_SEARCH_WIDTH, GRID_WEIGHT_MAIN,
     MIN_SIGNAL_DATA_POINTS, MIN_PERIODS_DEFAULT, DEFAULT_MA_WINDOW,

--- a/python/data_processor/folder_tool_tab.py
+++ b/python/data_processor/folder_tool_tab.py
@@ -4,12 +4,12 @@ import tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 
-from .constants import (
+from constants import (
     DEFAULT_PADDING,
     DEFAULT_BUTTON_HEIGHT,
     DEFAULT_TEXT_HEIGHT,
 )
-from .threads import create_processing_thread
+from threads import create_processing_thread
 
 
 class FolderToolTab:

--- a/python/data_processor/launch_integrated.py
+++ b/python/data_processor/launch_integrated.py
@@ -23,8 +23,10 @@ parent_dir = current_dir.parent
 sys.path.insert(0, str(parent_dir))
 sys.path.insert(0, str(current_dir))
 
-# Set the package name for relative imports to work
-os.environ['PYTHONPATH'] = str(parent_dir)
+# Preserve existing PYTHONPATH and prepend project directories for child processes
+existing_pythonpath = os.environ.get('PYTHONPATH')
+prefix = os.pathsep.join([str(parent_dir), str(current_dir)])
+os.environ['PYTHONPATH'] = f"{prefix}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else prefix
 
 try:
     from Data_Processor_Integrated import IntegratedCSVProcessorApp

--- a/python/data_processor/launch_integrated.py
+++ b/python/data_processor/launch_integrated.py
@@ -6,6 +6,7 @@ This script launches the integrated version that includes the compiler converter
 
 import logging
 import sys
+import os
 from pathlib import Path
 
 # Configure logging
@@ -14,8 +15,16 @@ logging.basicConfig(
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
 
-# Add the current directory to the Python path
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+# Get the current script directory and parent directory
+current_dir = Path(__file__).resolve().parent
+parent_dir = current_dir.parent
+
+# Add both directories to the Python path
+sys.path.insert(0, str(parent_dir))
+sys.path.insert(0, str(current_dir))
+
+# Set the package name for relative imports to work
+os.environ['PYTHONPATH'] = str(parent_dir)
 
 try:
     from Data_Processor_Integrated import IntegratedCSVProcessorApp

--- a/python/data_processor/threads.py
+++ b/python/data_processor/threads.py
@@ -5,8 +5,8 @@ import threading
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .converter_tab import ConverterTab
-    from .folder_tool_tab import FolderToolTab
+    from converter_tab import ConverterTab
+    from folder_tool_tab import FolderToolTab
 
 
 class ConversionThread(threading.Thread):


### PR DESCRIPTION
- Convert relative imports to absolute imports in Data_Processor_r0.py
- Fix relative imports in folder_tool_tab.py and threads.py
- Enhance launch_integrated.py Python path setup for better import resolution
- Resolves ImportError when running launch_integrated.py directly

This allows the integrated data processor to launch successfully without package import errors.

## Summary
Explain what changed and why.

## AI Changes
- [ ] If AI-assisted: explain changes line-by-line or attach diff with comments.

## Checklist
- [ ] Reproducible: `matlab/run_all.m` (or Python pipeline) completes
- [ ] Tests pass (MATLAB + Python)
- [ ] Large binaries tracked via LFS
- [ ] Env files updated
- [ ] No secrets added
