### PR TITLE
Fix missing return type hints and docstring in Folders_Tool_r0.py

### DIFF
--- a/python/folder_tool/Folders_Tool_r0.py
+++ b/python/folder_tool/Folders_Tool_r0.py
@@ -2007,7 +2007,7 @@ class FolderProcessorApp:
             close_button.pack(side="right")
 
             # Add copy button for convenience
-            def copy_to_clipboard():
+            def copy_to_clipboard() -> None:
                 """Copy dialog content to clipboard."""
                 try:
                     dialog.clipboard_clear()
@@ -2028,7 +2028,12 @@ class FolderProcessorApp:
             close_button.focus_set()  # Focus on close button for better UX
             
             # Bind escape key to close dialog
-            def on_escape(event):
+            def on_escape(event: tk.Event) -> None:
+                """Close dialog when escape key is pressed.
+                
+                Args:
+                    event: The key event that triggered this function
+                """
                 dialog.destroy()
             
             dialog.bind("<Escape>", on_escape)


### PR DESCRIPTION
## Summary
Explain what changed and why.

## AI Changes
- [ ] If AI-assisted: explain changes line-by-line or attach diff with comments.

## Checklist
- [ ] Reproducible: `matlab/run_all.m` (or Python pipeline) completes
- [ ] Tests pass (MATLAB + Python)
- [ ] Large binaries tracked via LFS
- [ ] Env files updated
- [ ] No secrets added
