### PR TITLE
Fix test imports and mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,16 +8,7 @@ warn_unused_configs = True
 no_implicit_optional = True
 strict_optional = True
 follow_imports = skip
-exclude = (?x)(
-    ^archive/|
-    ^data/|
-    ^matlab/|
-    ^matlab_utilities/|
-    ^javascript/|  # Future-proof: exclude JavaScript/TypeScript directories
-    ^python/folder_tool/|  # Exclude folder_tool under python/
-    ^python/project_packer/|  # Exclude project_packer under python/
-    ^Golf_GUI/Simscape\ Multibody\ Data\ Plotters/Python\ Version/
-)
+exclude = ^(archive/|data/|matlab/|matlab_utilities/|javascript/|python/folder_tool/|python/project_packer/|Golf_GUI/)
 
 [mypy-numpy.*]
 ignore_missing_imports = True

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Pytest configuration for tests.
+
+This file sets up the test environment, including PYTHONPATH configuration
+to ensure imports work correctly in both local and CI environments.
+"""
+
+import sys
+from pathlib import Path
+
+# Add python/src to PYTHONPATH for test imports
+src_path = Path(__file__).parent.parent / "src"
+if str(src_path) not in sys.path:
+    sys.path.insert(0, str(src_path))


### PR DESCRIPTION
Applies consistent test fixes across repositories:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds pytest conftest to fix test imports and simplifies mypy exclude pattern.
> 
> - **Tests**:
>   - Add `python/tests/conftest.py` to prepend `python/src` to `PYTHONPATH` for reliable test imports.
> - **Tooling/Config**:
>   - Simplify `mypy.ini` `exclude` to a concise anchored regex covering excluded directories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdf228a5c15f13f0cfcb3cde56e72ee484e56210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->