### PR TITLE
Fix CI GUI test failure by mocking Tkinter components

### DIFF
--- a/python/project_packer/tests/test_folder_packer_gui.py
+++ b/python/project_packer/tests/test_folder_packer_gui.py
@@ -19,6 +19,12 @@ from folder_packer_gui import (
 class TestFolderPackerGUI:
     """Test cases for folder_packer_gui.py module."""
 
+    @pytest.fixture(autouse=True)
+    def mocked_tk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mock Tkinter to prevent GUI instantiation in headless CI environments."""
+        monkeypatch.setattr("tkinter.Tk", Mock())
+        monkeypatch.setattr("tkinter.Toplevel", Mock())
+
     @pytest.fixture()
     def mock_root(self) -> Mock:
         """Create a mock Tkinter root window."""
@@ -183,12 +189,14 @@ class TestFolderPackerGUI:
         with patch.object(gui_instance, "pack_single_folder") as mock_pack:
             mock_pack.return_value = True
             with patch.object(gui_instance, "update_status") as mock_update:
-                gui_instance.pack_folders()
+                with patch("folder_packer_gui.messagebox.showinfo") as mock_showinfo:
+                    gui_instance.pack_folders()
 
-                mock_pack.assert_called_once_with(str(source_folder))
-                assert (
-                    mock_update.call_count >= 2
-                )  # At least packing and success messages
+                    mock_pack.assert_called_once_with(str(source_folder))
+                    assert (
+                        mock_update.call_count >= 2
+                    )  # At least packing and success messages
+                    mock_showinfo.assert_called_once()
 
     def test_pack_single_folder_success(
         self,


### PR DESCRIPTION
Fixes the CI test failure caused by Tkinter trying to create GUI windows in headless environments.

## Changes
- Add autouse fixture to mock `tkinter.Tk` and `tkinter.Toplevel` globally
- Mock `messagebox.showinfo` in `test_pack_folders_success` test
- Prevents `_tkinter.TclError: no display name and no $DISPLAY environment variable` error in CI

## Testing
- Tests should now run successfully in headless CI environments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Mock Tkinter globally and messagebox in a success test to prevent real GUI creation during tests.
> 
> - **Tests (`python/project_packer/tests/test_folder_packer_gui.py`)**:
>   - Add autouse fixture mocking `tkinter.Tk` and `tkinter.Toplevel`.
>   - Update `test_pack_folders_success` to mock `messagebox.showinfo` and assert it is called.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d2bf28a7c598d9b327a88986276779b1a73486b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->