### PR TITLE
Fix Jules Secret Name

### DIFF
--- a/.github/workflows/Jules-Conflict-Fix.yml
+++ b/.github/workflows/Jules-Conflict-Fix.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
       - run: npm install -g @google/jules
-      - run: jules auth --token ${{ secrets.JULES_API_TOKEN }}
+      - run: jules auth --token ${{ secrets.JULES_API_KEY }}
 
       - name: Scan for Conflicted PRs
         env:

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -43,7 +43,7 @@ jobs:
         if: steps.changes.outputs.files != ''
         run: |
           npm install -g @google/jules
-          jules auth --token ${{ secrets.JULES_API_TOKEN }}
+          jules auth --token ${{ secrets.JULES_API_KEY }}
 
       - name: Create Docs Branch
         if: steps.changes.outputs.files != ''

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
       - run: npm install -g @google/jules
-      - run: jules auth --token ${{ secrets.JULES_API_TOKEN }}
+      - run: jules auth --token ${{ secrets.JULES_API_KEY }}
 
       - name: Create Hotfix Branch
         id: hotfix

--- a/.github/workflows/Jules-Scientific-Auditor.yml
+++ b/.github/workflows/Jules-Scientific-Auditor.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Jules Analysis (Comment Only)
         env:
-          JULES_TOKEN: ${{ secrets.JULES_API_TOKEN }}
+          JULES_TOKEN: ${{ secrets.JULES_API_KEY }}
         run: |
           jules auth --token $JULES_TOKEN
           # FIX: Explicit Read-Only instruction

--- a/.github/workflows/Jules-Tech-Custodian.yml
+++ b/.github/workflows/Jules-Tech-Custodian.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Authenticate Jules
         if: steps.target.outputs.has_issues == 'true'
-        run: jules auth --token ${{ secrets.JULES_API_TOKEN }}
+        run: jules auth --token ${{ secrets.JULES_API_KEY }}
 
       - name: Dispatch Jules
         if: steps.target.outputs.has_issues == 'true'


### PR DESCRIPTION
Updates workflows to use JULES_API_KEY to match repository secrets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace JULES_API_TOKEN with JULES_API_KEY across Jules GitHub Actions authentications.
> 
> - **CI/Workflows**:
>   - Update Jules auth to use `secrets.JULES_API_KEY` instead of `secrets.JULES_API_TOKEN` in:
>     - `.github/workflows/Jules-Conflict-Fix.yml`
>     - `.github/workflows/Jules-Documentation-Scribe.yml`
>     - `.github/workflows/Jules-Hotfix-Creator.yml`
>     - `.github/workflows/Jules-Scientific-Auditor.yml` (via `JULES_TOKEN` env)
>     - `.github/workflows/Jules-Tech-Custodian.yml`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67c4c58a81ee71df3ac696efe0c3e150995eb788. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->