### PR TITLE
chore: Add auto-update-prs workflow

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches: [ "master", "main" ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-prs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a GitHub Action to automatically update PRs with the latest changes from the main branch, ensuring a linear history and reducing merge conflicts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a GitHub Actions workflow to auto-update open PRs on pushes to master/main using autoupdate-action with required permissions.
> 
> - **CI/GitHub Actions**:
>   - **New workflow** `/.github/workflows/auto-update-prs.yml` triggered on pushes to `master`/`main` to auto-update open PRs using `chinthakagodawita/autoupdate-action@v1`.
>   - Grants `contents` and `pull-requests` write permissions; checks out repo before running the action.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fcb1c369df0a36948263af43d78b6b3028c1309. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->