### PR TITLE
chore: ignore jules artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ build/
 
 # Cache
 .cache/
+
+# Jules generated files
+.jules/bolt*
+.jules/palette*
+.jules/pallette*
+.jules/sentinel*


### PR DESCRIPTION
Excludes bolt, palette, and sentinel files generated by .jules from version control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ignore .jules-generated artifacts by adding `.jules/bolt*`, `.jules/palette*`/`.jules/pallette*`, and `.jules/sentinel*` to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 197c25685cd62187c4d178c93604e31d62a1d209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->