### PR TITLE
Fix CI: Disable javascript-tests

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -101,6 +101,7 @@ jobs:
   javascript-tests:
     needs: quality-gate
     runs-on: ubuntu-latest
+    if: false
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Disables the javascript-tests job in .github/workflows/ci-standard.yml because the 'javascript' directory does not exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow adjustment**
> 
> - Added `if: false` to the `javascript-tests` job in `.github/workflows/ci-standard.yml`, effectively disabling the JavaScript test step while leaving other jobs unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 140733bb03090c530ce491f7c84c7314cb0f4773. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->