### PR TITLE
fix(ci): Add fallback for PR creation without labels

### DIFF
--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -66,5 +66,6 @@ jobs:
           if ! git diff --staged --quiet; then
             git commit -m "fix: resolve priority issues"
             git push origin "$BRANCH"
-            gh pr create --title "Issue Resolution - $(date +%Y-%m-%d)" --body "Auto fixes" --label "jules:issue-resolver"
+            gh pr create --title "Issue Resolution - $(date +%Y-%m-%d)" --body "Auto fixes" --label "jules:issue-resolver" || \
+            gh pr create --title "Issue Resolution - $(date +%Y-%m-%d)" --body "Auto fixes"
           fi


### PR DESCRIPTION
## Summary
- Add fallback for PR creation if labels don't exist
- If `gh pr create --label` fails, retry without labels

## Test plan
- [x] Labels have been created in the repo
- [ ] Trigger Issue Resolver workflow to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI workflow robustness**
> 
> - In `/.github/workflows/Jules-Issue-Resolver.yml`, updates the PR creation step to attempt `gh pr create ... --label "jules:issue-resolver"` and, on failure, retry `gh pr create ...` without labels to ensure PRs are created even when label application fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad300310f3950f754aa51a7e9aff6473e9668348. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->