### PR TITLE
fix(ci): Handle existing assessment branch in Assessment Generator

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -57,6 +57,9 @@ jobs:
             exit 0
           fi
 
+          # Delete remote branch if it exists (from previous run today)
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+
           # Create a new branch for the assessment
           git checkout -b "$BRANCH"
 


### PR DESCRIPTION
Deletes remote branch if it exists before creating new one to prevent non-fast-forward errors when workflow runs multiple times per day.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the scheduled assessment workflow can rerun the same day without branch push failures.
> 
> - Adds `git push origin --delete "$BRANCH" || true` before branch creation in `Jules-Assessment-Generator.yml` to remove an existing remote `jules/assessment-<DATE>` branch
> - No other logic changes to generation or PR creation steps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54c007b3116270fe87f4986ab9d54723b4579a52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->