### PR TITLE
fix(workflow): Migrate Assessment Generator to Jules REST API

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -23,26 +23,110 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install
-        run: npm install -g @google/jules
+      - name: Install Dependencies
+        run: sudo apt-get install -y jq
 
-      - name: Archive Old
+      - name: Archive Old Assessments
         run: |
           mkdir -p docs/assessments/archive
-          for f in docs/assessments/Assessment_*.md; do [ -f "$f" ] && mv "$f" docs/assessments/archive/ || true; done
+          DATE=$(date +%Y-%m-%d)
+          for f in docs/assessments/Assessment_*.md; do [ -f "$f" ] && mv "$f" "docs/assessments/archive/$(basename "$f" .md)_archived_$DATE.md" || true; done
+          if [ -f "docs/assessments/Comprehensive_Assessment.md" ]; then
+            mv "docs/assessments/Comprehensive_Assessment.md" "docs/assessments/archive/Comprehensive_Assessment_archived_$DATE.md"
+          fi
 
-      - name: Generate
+      - name: Jules Assessment Generation (REST API)
         env:
-          JULES_TOKEN: ${{ secrets.JULES_API_KEY }}
+          JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          jules auth --token $JULES_TOKEN
+          set -e
+          DATE=$(date +%Y-%m-%d)
+          REPO="${{ github.repository }}"
+          API_BASE="https://jules.googleapis.com/v1alpha"
 
-          jules task fix --prompt "$(cat << 'PROMPT_EOF'
-          Generate graded assessments (0-10) for A-O categories.
-          Save to docs/assessments/. Create comprehensive assessment with weighted grades.
-          For grades < 5: Create GitHub Issue.
+          # Check if API key is configured
+          if [ -z "$JULES_API_KEY" ]; then
+            echo "::warning::JULES_API_KEY not configured. Skipping Jules assessment generation."
+            exit 0
+          fi
+
+          echo "Looking up repository source..."
+          SOURCES=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/sources" || echo '{"sources":[]}')
+          SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.repository.fullName == \"$REPO\") | .name" | head -1)
+
+          if [ -z "$SOURCE_ID" ] || [ "$SOURCE_ID" = "null" ]; then
+            echo "::warning::Repository $REPO not found in Jules sources. Ensure Jules GitHub App is installed."
+            exit 0
+          fi
+
+          echo "Found source: $SOURCE_ID"
+
+          # Create assessment session
+          PROMPT=$(cat << 'PROMPT_EOF'
+          You are the ASSESSMENT GENERATOR agent.
+
+          Generate graded assessments (0-10) for categories A-O:
+          A: Code Structure, B: Documentation, C: Test Coverage, D: Error Handling,
+          E: Performance, F: Security, G: Dependencies, H: CI/CD, I: Code Style,
+          J: API Design, K: Data Handling, L: Logging, M: Configuration, N: Scalability, O: Maintainability
+
+          Output:
+          1. Create docs/assessments/Assessment_X_CATEGORY.md for each category with grade 0-10
+          2. Create docs/assessments/Comprehensive_Assessment.md with weighted grades
+          3. For grades < 5: Create GitHub Issue
+
+          Make safe, non-breaking quick fixes with HIGH confidence.
           PROMPT_EOF
-          )"
+          )
+
+          echo "Creating Jules session..."
+          SESSION_RESPONSE=$(curl -sf -X POST \
+            -H "X-Goog-Api-Key: $JULES_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"source\": \"$SOURCE_ID\", \"prompt\": $(echo "$PROMPT" | jq -Rs .)}" \
+            "$API_BASE/sessions")
+
+          SESSION_ID=$(echo "$SESSION_RESPONSE" | jq -r '.name')
+          if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "null" ]; then
+            echo "::error::Failed to create Jules session"
+            echo "$SESSION_RESPONSE"
+            exit 1
+          fi
+
+          echo "Created session: $SESSION_ID"
+
+          # Poll for session completion (max 30 minutes)
+          MAX_WAIT=1800
+          POLL_INTERVAL=30
+          ELAPSED=0
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            SESSION_STATUS=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/$SESSION_ID")
+            STATE=$(echo "$SESSION_STATUS" | jq -r '.state')
+
+            echo "Session state: $STATE (elapsed: ${ELAPSED}s)"
+
+            case "$STATE" in
+              "COMPLETED"|"SUBMITTED")
+                echo "Session completed successfully!"
+                break
+                ;;
+              "FAILED"|"CANCELLED")
+                echo "::error::Session $STATE"
+                exit 1
+                ;;
+            esac
+
+            sleep $POLL_INTERVAL
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          if [ $ELAPSED -ge $MAX_WAIT ]; then
+            echo "::warning::Session timed out after ${MAX_WAIT}s. Check Jules dashboard for results."
+          fi
+
+          echo "Assessment generation complete. Jules will create a PR with the results."
 
       - name: Create PR with Assessment Results
         env:


### PR DESCRIPTION
Migrate from deprecated CLI to REST API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates the assessment workflow from the deprecated Jules CLI to the REST API with session creation and polling, plus better resilience and archiving.
> 
> - Replaces CLI calls with REST API: resolves source via `/sources`, creates a session, polls for `COMPLETED/SUBMITTED`, handles failures/timeouts, and uses `JULES_API_KEY`
> - Installs `jq` for JSON handling
> - Improves archiving: moves previous `Assessment_*.md` and `Comprehensive_Assessment.md` to `docs/assessments/archive/` with date-suffixed filenames
> - Keeps PR creation step to commit and open a PR with generated assessments if changes are detected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cc55b2af6d7bb2b4557e19712aa93af4edac07f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->