### PR TITLE
fix: correct Jules API source lookup

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -53,10 +53,18 @@ jobs:
 
           echo "Looking up repository source..."
           SOURCES=$(curl -sf -H "X-Goog-Api-Key: $JULES_API_KEY" "$API_BASE/sources" || echo '{"sources":[]}')
-          SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.repository.fullName == \"$REPO\") | .name" | head -1)
+
+          # Parse owner/repo from github.repository (format: "owner/repo")
+          OWNER=$(echo "$REPO" | cut -d'/' -f1)
+          REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+
+          # Jules API uses githubRepo.owner and githubRepo.repo fields
+          SOURCE_ID=$(echo "$SOURCES" | jq -r ".sources[] | select(.githubRepo.owner == \"$OWNER\" and .githubRepo.repo == \"$REPO_NAME\") | .name" | head -1)
 
           if [ -z "$SOURCE_ID" ] || [ "$SOURCE_ID" = "null" ]; then
-            echo "::warning::Repository $REPO not found in Jules sources. Ensure Jules GitHub App is installed."
+            echo "::warning::Repository $REPO not found in Jules sources."
+            echo "Available sources:"
+            echo "$SOURCES" | jq -r '.sources[] | "\(.githubRepo.owner)/\(.githubRepo.repo)"' 2>/dev/null || echo "(none or error parsing)"
             exit 0
           fi
 


### PR DESCRIPTION
Fix incorrect field names in Jules API source lookup (githubRepo.owner/repo instead of repository.fullName)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix Jules source lookup in workflow**
> 
> - Parse `owner` and `repo` from `github.repository` and select sources by `githubRepo.owner`/`githubRepo.repo` instead of `repository.fullName`
> - Improve missing-source handling with clearer warning and a printed list of available sources
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69fe185aaf661b773fcf7b58167ed4c2888d8de1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->