### PR TITLE
fix(workflow): use correct sourceContext format for Jules API

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -89,16 +89,43 @@ jobs:
           )
 
           echo "Creating Jules session..."
-          SESSION_RESPONSE=$(curl -sf -X POST \
+          # Build the request JSON with sourceContext (per Jules API docs)
+          REQUEST_JSON=$(jq -n \
+            --arg prompt "$PROMPT" \
+            --arg source "$SOURCE_ID" \
+            '{
+              prompt: $prompt,
+              sourceContext: {
+                source: $source,
+                githubRepoContext: {
+                  startingBranch: "main"
+                }
+              },
+              automationMode: "AUTO_CREATE_PR"
+            }')
+
+          echo "Request: $REQUEST_JSON"
+
+          # Use -s to suppress progress but capture both stdout and stderr
+          # Use -w to get HTTP status code
+          HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \
             -H "X-Goog-Api-Key: $JULES_API_KEY" \
             -H "Content-Type: application/json" \
-            -d "{\"source\": \"$SOURCE_ID\", \"prompt\": $(echo "$PROMPT" | jq -Rs .)}" \
+            -d "$REQUEST_JSON" \
             "$API_BASE/sessions")
+
+          SESSION_RESPONSE=$(cat /tmp/session_response.json)
+          echo "HTTP Status: $HTTP_CODE"
+          echo "Response: $SESSION_RESPONSE"
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Jules API returned HTTP $HTTP_CODE"
+            exit 1
+          fi
 
           SESSION_ID=$(echo "$SESSION_RESPONSE" | jq -r '.name')
           if [ -z "$SESSION_ID" ] || [ "$SESSION_ID" = "null" ]; then
-            echo "::error::Failed to create Jules session"
-            echo "$SESSION_RESPONSE"
+            echo "::error::Failed to create Jules session - no session ID in response"
             exit 1
           fi
 


### PR DESCRIPTION
Fixes the session creation request body to use the correct sourceContext format per Jules API docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Jules session creation uses the correct request schema and adds better visibility/error checks.
> 
> - Build `REQUEST_JSON` with `sourceContext` (`source`, `githubRepoContext.startingBranch`) and `automationMode: AUTO_CREATE_PR`
> - Post `REQUEST_JSON` to `/sessions`, echo the request, capture HTTP status via `curl -w`, and log the raw response
> - Fail fast on non-`200` responses and when no session ID is returned, with clearer error messages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eda1bc83ddca9b70c4518d6d2cf55c13a3ad076f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->