### PR TITLE
chore: implement global workflow pause and nightly doc organizer

### DIFF
--- a/.github/WORKFLOWS_PAUSED
+++ b/.github/WORKFLOWS_PAUSED
@@ -1,0 +1,1 @@
+Paused for catching up.

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -57,6 +57,7 @@ permissions:
 
 jobs:
   triage:
+    if: hashFiles('.github/WORKFLOWS_PAUSED') == ''
     runs-on: ubuntu-latest
     # Removed global actor check to allow scheduled runs even if file modified by bot
     outputs:

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -139,6 +139,19 @@ jobs:
                   pr_branch = pr['branch']
                   pr_title = pr['title']
 
+                  # Check if a compiled PR for this category already exists
+                  existing_compiled = subprocess.run([
+                      'gh', 'pr', 'list',
+                      '--state', 'open',
+                      '--label', f'{category},jules:compiled',
+                      '--json', 'number',
+                      '--jq', 'length'
+                  ], capture_output=True, text=True)
+
+                  if existing_compiled.returncode == 0 and int(existing_compiled.stdout.strip() or 0) > 0:
+                      print(f"  ⚠️ Skipping category {category}: Compiled PR already exists.")
+                      break # Skip the entire group if a compiled PR exists
+
                   print(f"\n  Merging PR #{pr_num}: {pr_title}")
 
                   try:

--- a/.github/workflows/Maintenance-Global-Control.yml
+++ b/.github/workflows/Maintenance-Global-Control.yml
@@ -1,0 +1,46 @@
+name: Maintenance Global Control
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        default: 'pause'
+        type: choice
+        options:
+          - pause
+          - resume
+      reason:
+        description: 'Reason for pause/resume'
+        required: false
+        default: 'Maintenance'
+
+jobs:
+  control:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update Pause State
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if [ "${{ inputs.action }}" == "pause" ]; then
+            echo "Paused by workflow dispatch" > .github/WORKFLOWS_PAUSED
+            echo "Reason: ${{ inputs.reason }}" >> .github/WORKFLOWS_PAUSED
+            git add .github/WORKFLOWS_PAUSED
+            git commit -m "chore(maintenance): pause workflows [${{ inputs.reason }}]"
+            git push
+          else
+            rm -f .github/WORKFLOWS_PAUSED
+            git add .github/WORKFLOWS_PAUSED || true
+            git commit -m "chore(maintenance): resume workflows"
+            git push
+          fi

--- a/.github/workflows/Nightly-Doc-Organizer.yml
+++ b/.github/workflows/Nightly-Doc-Organizer.yml
@@ -1,0 +1,31 @@
+name: Nightly Documentation Organizer
+
+on:
+  schedule:
+    - cron: "30 5 * * *"  # 5:30 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  organize-docs:
+    runs-on: ubuntu-latest
+    if: hashFiles('.github/WORKFLOWS_PAUSED') == ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Organize Docs
+        run: |
+          mkdir -p docs/maintenance
+          echo "# Tools Repo Workflow Status" > docs/maintenance/WORKFLOWS.md
+          echo "Automated cleanup and organization." >> docs/maintenance/WORKFLOWS.md
+
+      - name: Commit Changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: nightly documentation organization"
+          file_pattern: "docs/maintenance/*"


### PR DESCRIPTION
Consistency update for maintenance and global pause mechanism.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a repo-wide maintenance pause mechanism and nightly documentation upkeep, plus a guard in PR compilation to reduce duplicates.
> 
> - **Global pause/resume:** New `Maintenance-Global-Control` workflow creates/removes `.github/WORKFLOWS_PAUSED`; `Jules-Control-Tower` triage and new jobs respect `hashFiles('.github/WORKFLOWS_PAUSED')` gate
> - **Nightly docs organizer:** New `Nightly-Doc-Organizer` scheduled job writes `docs/maintenance/WORKFLOWS.md` and auto-commits
> - **PR Compiler safeguard:** Skips compiling a category if an open compiled PR with labels `category,jules:compiled` already exists
> - Adds `.github/WORKFLOWS_PAUSED` file as the pause flag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a98f7500a5bd917d0aeafc6de01c8fdc5d7d3766. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->