### PR TITLE
fix(workflow): Remove hashFiles check from Control Tower

### DIFF
--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -57,7 +57,6 @@ permissions:
 
 jobs:
   triage:
-    if: hashFiles('.github/WORKFLOWS_PAUSED') == ''
     runs-on: ubuntu-latest
     # Removed global actor check to allow scheduled runs even if file modified by bot
     outputs:


### PR DESCRIPTION
## Summary
- Removes the hashFiles() check from the triage job's if condition
- hashFiles() at job-level causes GitHub to fail to parse the workflow file

## Test plan
- [x] YAML validation passes
- [ ] Workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the Control Tower workflow by removing a conditional that gated the triage job.
> 
> - Removes `if: hashFiles('.github/WORKFLOWS_PAUSED') == ''` from the `triage` job in `Jules-Control-Tower.yml`, so `triage` runs regardless of the pause file
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 348a53a933c56b01bf6769e901f11e4706a24ddf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->