### PR TITLE
feat: Add shared utility modules (from PR #350)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -62,6 +62,8 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 "replicants/**/*.py" = ["FBT001"]
 # UP038 false positive: isinstance() requires tuple syntax, not union types
 "**/Data_Processor_r0.py" = ["UP038"]
+# Compatibility shims intentionally use version checks for older Python support
+"tools/compatibility.py" = ["UP036", "UP017"]
 
 [lint.isort]
 # Tells Ruff how to group your own code vs. libraries

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,6 @@
+"""Tools package initialization."""
+
+from tools.logger import setup_logging
+
+# Expose setup_logging at package level
+__all__ = ["setup_logging"]

--- a/tools/compatibility.py
+++ b/tools/compatibility.py
@@ -1,0 +1,22 @@
+"""Compatibility shims for supporting older Python versions (3.10+)."""
+
+import sys
+from enum import Enum
+
+# Backport datetime.UTC (Added in Python 3.11)
+if sys.version_info >= (3, 11):
+    from datetime import UTC
+else:
+    from datetime import timezone
+    UTC = timezone.utc
+
+# Backport StrEnum (Added in Python 3.11)
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+
+    class StrEnum(str, Enum):
+        """Enum where members are also (and must be) strings."""
+
+        def __str__(self) -> str:
+            return str(self.value)

--- a/tools/dependency_utils.py
+++ b/tools/dependency_utils.py
@@ -1,0 +1,84 @@
+"""Utilities for managing Python package dependencies."""
+
+import logging
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def check_dependencies(packages: list[str]) -> list[str]:
+    """Check if required packages are installed.
+
+    Args:
+        packages: List of package names to check.
+
+    Returns:
+        List of missing packages.
+    """
+    missing_packages = []
+
+    for package in packages:
+        try:
+            # Basic import check using __import__
+            # Handle special cases where import name != package name if needed
+            import_name = package
+            if package == "PIL":
+                import_name = "PIL"  # Pillow
+            elif package == "customtkinter":
+                import_name = "customtkinter"
+
+            __import__(import_name)
+            logger.debug(f"✓ {package} is available")
+        except ImportError:
+            missing_packages.append(package)
+            logger.warning(f"✗ {package} is missing")
+
+    return missing_packages
+
+
+def install_packages(packages: list[str]) -> bool:
+    """Attempt to install packages using pip.
+
+    Args:
+        packages: List of package names to install.
+
+    Returns:
+        True if all packages installed successfully, False otherwise.
+    """
+    if not packages:
+        return True
+
+    logger.info(f"Attempting to install: {', '.join(packages)}")
+
+    pip_names = {
+        "PIL": "Pillow",
+        "customtkinter": "customtkinter",
+        "pandas": "pandas",
+        "numpy": "numpy",
+        "matplotlib": "matplotlib",
+    }
+
+    try:
+        success = True
+        for package in packages:
+            pip_name = pip_names.get(package, package)
+            logger.info(f"Installing {pip_name}...")
+
+            result = subprocess.run(
+                [sys.executable, "-m", "pip", "install", pip_name],
+                capture_output=True,
+                text=True,
+            )
+
+            if result.returncode == 0:
+                logger.info(f"✓ Successfully installed {pip_name}")
+            else:
+                logger.error(f"✗ Failed to install {pip_name}: {result.stderr}")
+                success = False
+
+        return success
+
+    except (subprocess.SubprocessError, OSError) as e:
+        logger.error(f"Error installing packages: {e}")
+        return False

--- a/tools/logger.py
+++ b/tools/logger.py
@@ -1,0 +1,50 @@
+"""Unified logging configuration for Tools repository."""
+
+import logging
+import sys
+
+
+def setup_logging(
+    name: str,
+    log_file: str | None = None,
+    level: int = logging.INFO,
+    format_string: str = "%(asctime)s - %(levelname)s - %(message)s",
+) -> logging.Logger:
+    """Configure and return a standard logger.
+
+    Args:
+        name: Logger name (usually __name__).
+        log_file: Optional filename to write logs to.
+        level: Logging level (default INFO).
+        format_string: Log message format.
+
+    Returns:
+        Configured Logger instance.
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+
+    # Avoid adding handlers multiple times
+    if logger.hasHandlers():
+        return logger
+
+    formatter = logging.Formatter(format_string)
+
+    # Stream Handler (Console)
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    # File Handler
+    if log_file:
+        try:
+            # You might want to ensure a logs directory exists?
+            # For now, keeping original behavior of local file or specified path
+            file_handler = logging.FileHandler(log_file, encoding="utf-8")
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+        except Exception as e:
+            # Don't crash if file logging fails, just warn to stderr
+            sys.stderr.write(f"Failed to setup file logging to {log_file}: {e}\n")
+
+    return logger

--- a/tools/ui_utils.py
+++ b/tools/ui_utils.py
@@ -1,0 +1,82 @@
+"""Shared UI utilities for Tools applications."""
+
+import logging
+from pathlib import Path
+from typing import Any
+
+try:
+    from tools.launch_utils import get_repo_root
+except ImportError:
+    # Fallback only if absolutely necessary
+    def get_repo_root() -> Path:
+        return Path(__file__).resolve().parent.parent
+
+
+logger = logging.getLogger(__name__)
+
+
+def find_icon(name: str = "tools_icon.ico") -> Path | None:
+    """Find a UI icon by searching standard locations."""
+    repo_root = get_repo_root()
+
+    candidates = [
+        repo_root / name,
+        repo_root / "resources" / name,
+        repo_root / "tools" / "gui" / "resources" / name,
+    ]
+
+    for path in candidates:
+        if path.exists():
+            return path
+
+    return None
+
+
+def set_tk_icon(root: Any, icon_name: str = "tools_icon.ico") -> bool:
+    """Set process icon for a Tkinter root/toplevel window.
+
+    Args:
+        root: Tkinter root or Toplevel instance.
+        icon_name: Name of the icon file.
+
+    Returns:
+        True if icon was set, False otherwise.
+    """
+    icon_path = find_icon(icon_name)
+    if not icon_path:
+        return False
+
+    try:
+        # iconbitmap is Windows specific mostly, but handles .ico well
+        root.iconbitmap(str(icon_path))
+        return True
+    except Exception as e:
+        logger.warning(f"Could not set Tk icon {icon_path}: {e}")
+        return False
+
+
+def set_qt_icon(window: Any, icon_name: str = "tools_icon.ico") -> bool:
+    """Set process icon for a PyQt window.
+
+    Args:
+        window: PyQt QWidget/QMainWindow instance.
+        icon_name: Name of the icon file.
+
+    Returns:
+        True if icon was set, False otherwise.
+    """
+    icon_path = find_icon(icon_name)
+    if not icon_path:
+        return False
+
+    try:
+        from PyQt6.QtGui import QIcon
+
+        window.setWindowIcon(QIcon(str(icon_path)))
+        return True
+    except ImportError:
+        logger.warning("PyQt6 not installed, cannot set Qt icon")
+        return False
+    except Exception as e:
+        logger.warning(f"Could not set Qt icon {icon_path}: {e}")
+        return False


### PR DESCRIPTION
## Summary
- Adds utility modules that were in the closed PR #350 but never merged
- Provides shared functionality for Python 3.10+ compatibility, logging, dependency management, and UI utilities

## Changes
- `tools/__init__.py`: Package initialization exposing `setup_logging`
- `tools/compatibility.py`: Python 3.10+ backports (UTC, StrEnum)
- `tools/dependency_utils.py`: Dependency checking and installation utilities
- `tools/logger.py`: Unified logging configuration for consistent log formatting
- `tools/ui_utils.py`: UI icon utilities for Tk and Qt windows
- `ruff.toml`: Added ignore rules for compatibility.py version checks

## Test plan
- [ ] Verify CI passes (ruff, tests on Python 3.10, 3.11, 3.12)
- [ ] Verify modules can be imported successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces shared Python utilities and lint config updates.
> 
> - Adds `tools/compatibility.py` with Python 3.11 backports (`UTC`, `StrEnum`) guarded by version checks
> - New `tools/logger.py` with `setup_logging`, exposed via `tools/__init__.py`
> - New `tools/dependency_utils.py` for dependency checking and pip installation
> - New `tools/ui_utils.py` to locate icons and set Tk/Qt window icons
> - Updates `ruff.toml` to ignore pyupgrade rules for `tools/compatibility.py` and keep isort config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a330fd5bc9824208ba98dbd5bba16a6c0e93996c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->