### PR TITLE
fix: add automationMode for auto PR creation

### DIFF
--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -140,7 +140,8 @@ jobs:
                 githubRepoContext: {
                   startingBranch: $startBranch
                 }
-              }
+              },
+              automationMode: "AUTO_CREATE_PR"
             }')
 
           HTTP_CODE=$(curl -s -o /tmp/session_response.json -w "%{http_code}" -X POST \


### PR DESCRIPTION
Adds automationMode: AUTO_CREATE_PR so Jules automatically creates PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables automatic PR creation by Jules when an issue mention triggers the workflow.
> 
> - Updates `REQUEST_JSON` in `.github/workflows/Jules-Issue-Mention-Handler.yml` to include `automationMode: "AUTO_CREATE_PR"` in the payload sent to `POST /sessions`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aff7b8f3171fc8b48c1266d71262dd241a66dcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->