### PR TITLE
fix(jules): use BOT_PAT for auto-assign workflow

### DIFF
--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check Issue Labels
         id: check
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
           LABELS: ${{ toJson(github.event.issue.labels) }}
         run: |
           # LABELS is passed via env to prevent shell injection
@@ -40,7 +40,7 @@ jobs:
       - name: Comment @jules
         if: steps.check.outputs.should_assign == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -57,7 +57,7 @@ jobs:
       - name: Add Jules Label
         if: steps.check.outputs.should_assign == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |


### PR DESCRIPTION
## Summary
- Updates Jules Auto-Assign workflow to use BOT_PAT instead of GITHUB_TOKEN
- Enables recursive workflow triggering for Jules integration
- Actions triggered by GITHUB_TOKEN don't trigger subsequent workflows (GitHub security feature)

## Test plan
- [ ] Verify workflow triggers correctly on new issue creation
- [ ] Verify @jules comment triggers the fix workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the `Jules-Auto-Assign-Issues` workflow to use `secrets.BOT_PAT` instead of `GITHUB_TOKEN` for all `gh` operations.
> 
> - Replaces `GH_TOKEN` with `secrets.BOT_PAT` in `Check Issue Labels`, `Comment @jules`, and `Add Jules Label` steps
> - Maintains existing label-skip logic and bot safeguards
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c79454905f0a3e744f70cdac8d27008d06653e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->