### PR TITLE
Restore missing color themes in Folder Packer Pro

### DIFF
--- a/src/python/tests/test_folder_packer_pro.py
+++ b/src/python/tests/test_folder_packer_pro.py
@@ -28,6 +28,11 @@ from unittest.mock import Mock, patch
 # Add python directory to path
 sys.path.append(str(Path(__file__).parent.parent))
 
+# Add tools directory to path
+tools_path = Path(__file__).parents[3] / "src" / "tools" / "folder_tools"
+if tools_path.exists():
+    sys.path.append(str(tools_path))
+
 # Skip entire module if folder_packer_pro is not available
 try:
     from folder_packer_pro.folder_packer_pro import (
@@ -369,3 +374,51 @@ class TestFolderPackerPro:
             app._browse_unpack_dest()
             app.unpack_dest_entry.delete.assert_called()
             app.unpack_dest_entry.insert.assert_called_with(0, str(tmp_path / "dest"))
+
+    def test_theme_switching(
+        self, mock_root: Mock, mock_tk_vars: dict[str, Mock]
+    ) -> None:
+        """Test theme switching functionality."""
+        with (
+            patch("tkinter.Menu"),
+            patch("tkinter.ttk.Notebook"),
+            patch("tkinter.ttk.Frame"),
+            patch("tkinter.ttk.Label"),
+            patch("tkinter.ttk.LabelFrame"),
+            patch("tkinter.ttk.Entry"),
+            patch("tkinter.ttk.Button"),
+            patch("tkinter.scrolledtext.ScrolledText"),
+            patch("tkinter.ttk.Progressbar"),
+            patch("tkinter.ttk.Radiobutton"),
+            patch("tkinter.ttk.Checkbutton"),
+            patch("tkinter.ttk.Treeview"),
+            patch("tkinter.ttk.Scrollbar"),
+            patch("tkinter.Text"),
+            patch("tkinter.ttk.Style"),
+        ):
+            app = FolderPackerPro(mock_root)
+            app._log_message = Mock()  # type: ignore[method-assign]
+
+            # Default theme
+            assert app.current_theme == "dark"
+
+            # Switch to light
+            app._set_theme("light")
+            assert app.current_theme == "light"
+            app._log_message.assert_called_with("Switched to light theme", "info")
+
+            # Switch to legal pad
+            app._set_theme("legal pad")
+            assert app.current_theme == "legal pad"
+
+            # Switch to word
+            app._set_theme("word")
+            assert app.current_theme == "word"
+
+            # Switch to excel
+            app._set_theme("excel")
+            assert app.current_theme == "excel"
+
+            # Try invalid theme (should not change)
+            app._set_theme("invalid_theme")
+            assert app.current_theme == "excel"

--- a/src/tools/folder_tools/folder_packer_pro/folder_packer_pro.py
+++ b/src/tools/folder_tools/folder_packer_pro/folder_packer_pro.py
@@ -190,6 +190,47 @@ LIGHT_THEME = {
     "error": "#dc3545",
 }
 
+LEGAL_PAD_THEME = {
+    "bg": "#ffffcc",
+    "fg": "#000000",
+    "select_bg": "#e6e600",
+    "entry_bg": "#ffffff",
+    "accent": "#0000ff",
+    "success": "#28a745",
+    "warning": "#ffc107",
+    "error": "#dc3545",
+}
+
+WORD_THEME = {
+    "bg": "#f3f2f1",
+    "fg": "#252423",
+    "select_bg": "#c7e0f4",
+    "entry_bg": "#ffffff",
+    "accent": "#2b579a",
+    "success": "#28a745",
+    "warning": "#ffc107",
+    "error": "#dc3545",
+}
+
+EXCEL_THEME = {
+    "bg": "#f3f2f1",
+    "fg": "#252423",
+    "select_bg": "#e6f2e6",
+    "entry_bg": "#ffffff",
+    "accent": "#217346",
+    "success": "#28a745",
+    "warning": "#ffc107",
+    "error": "#dc3545",
+}
+
+THEMES = {
+    "dark": DARK_THEME,
+    "light": LIGHT_THEME,
+    "legal pad": LEGAL_PAD_THEME,
+    "word": WORD_THEME,
+    "excel": EXCEL_THEME,
+}
+
 # Set up professional logging
 log_filename = "folder_packer_pro.log"
 logging.basicConfig(
@@ -370,7 +411,16 @@ class FolderPackerPro:
         # View menu
         view_menu = tk.Menu(menubar, tearoff=0)
         menubar.add_cascade(label="View", menu=view_menu)
-        view_menu.add_command(label="Toggle Theme", command=self._toggle_theme)
+
+        # Themes submenu
+        themes_menu = tk.Menu(view_menu, tearoff=0)
+        view_menu.add_cascade(label="Themes", menu=themes_menu)
+
+        for theme_name in THEMES:
+            themes_menu.add_command(
+                label=theme_name.title(),
+                command=lambda t=theme_name: self._set_theme(t),
+            )
 
         # Tools menu
         tools_menu = tk.Menu(menubar, tearoff=0)
@@ -948,7 +998,7 @@ class FolderPackerPro:
 
     def _apply_theme(self) -> None:
         """Apply color theme to application."""
-        theme = DARK_THEME if self.current_theme == "dark" else LIGHT_THEME
+        theme = THEMES.get(self.current_theme, DARK_THEME)
 
         # Configure ttk styles
         style = ttk.Style()
@@ -963,11 +1013,12 @@ class FolderPackerPro:
             "No operation in progress",
         )
 
-    def _toggle_theme(self) -> None:
-        """Toggle between dark and light themes."""
-        self.current_theme = "light" if self.current_theme == "dark" else "dark"
-        self._apply_theme()
-        self._log_message(f"Switched to {self.current_theme} theme", "info")
+    def _set_theme(self, theme_name: str) -> None:
+        """Set the application theme."""
+        if theme_name in THEMES:
+            self.current_theme = theme_name
+            self._apply_theme()
+            self._log_message(f"Switched to {theme_name} theme", "info")
 
     def _browse_pack_source(self) -> None:
         """Browse for source folder to pack."""


### PR DESCRIPTION
This PR restores the missing "Legal Pad Yellow", "Microsoft Word", and "Microsoft Excel" color themes to the Folder Packer Pro tool. It also refactors the theme management system to be more extensible and includes new unit tests for theme switching.

Changes:
- Modified `src/tools/folder_tools/folder_packer_pro/folder_packer_pro.py`:
    - Added `LEGAL_PAD_THEME`, `WORD_THEME`, and `EXCEL_THEME` dictionaries.
    - Created `THEMES` dictionary.
    - Updated `_create_menu_bar` to use a submenu for themes.
    - Implemented `_set_theme` method.
    - Updated `_apply_theme` to use the `THEMES` dictionary.
- Modified `src/python/tests/test_folder_packer_pro.py`:
    - Added `test_theme_switching` test case.
    - Fixed `sys.path` setup to correctly locate `folder_packer_pro` module.

Verification:
- Ran `pytest src/python/tests/test_folder_packer_pro.py` - All tests passed (11 passed).
- Verified new test case `test_theme_switching` specifically.

---
*PR created automatically by Jules for task [3146210927391215576](https://jules.google.com/task/3146210927391215576) started by @dieterolson*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores additional UI themes and refactors theme handling for extensibility.
> 
> - Adds `LEGAL_PAD_THEME`, `WORD_THEME`, and `EXCEL_THEME` and consolidates all themes in `THEMES`
> - Replaces `Toggle Theme` with a `Themes` submenu listing available themes; implements `_set_theme` and updates `_apply_theme` to use `THEMES`
> - Updates tests to locate the module correctly and adds `test_theme_switching` to verify theme changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e74332eb3b2dc8d5e32095c50c598d3802776082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->