### PR TITLE
docs: Add Completist audit report for 2026-01-28

### DIFF
--- a/docs/assessments/completist/audit_report_2026_01_28.md
+++ b/docs/assessments/completist/audit_report_2026_01_28.md
@@ -1,0 +1,53 @@
+# Completist Audit Report - January 28, 2026
+
+## Executive Summary
+This report presents the findings of the daily audit conducted on the `.jules/completist_data/` directory. The audit analyzed the `todo_markers.txt` artifact against the current codebase state.
+
+**Overall Status**: The "No TODO" policy is largely respected across the repository, with the significant exception of the `media_processing` subsystem, which retains known technical debt and implementation gaps. A new type of false positive (hash collision) was identified in this scan.
+
+## Active Incomplete Work
+
+The following items represent active incomplete work that requires attention:
+
+### 1. Media Processing - Video Processor (Web App)
+**File**: `src/media_processing/video_processor/apps/web/app/page.tsx`
+*   **Backend Integration**: `// TODO: Save to database when backend is ready` (Lines 122, 169) - Pending backend availability.
+*   **Configuration**: `// TODO: Move fps to client-side config or use from video metadata` (Line 36) - Hardcoded value needs parametrization.
+
+**File**: `src/media_processing/video_processor/apps/web/lib/sanitize.ts`
+*   **Security (High Priority)**: `// TODO: Add DOMPurify when ready for production.` (Lines 8, 93) - Critical for XSS prevention in production.
+*   **Validation**: `// TODO: Parse and validate RGB values` (Line 222).
+
+**File**: `src/media_processing/video_processor/apps/web/lib/logger.ts`
+*   **Observability**: `// TODO: Add pino when ready for production.` (Line 9).
+
+### 2. Media Processing - Scientific Modeling (Matlab)
+**File**: `src/media_processing/video_processor/matlab/models/pendulum_model.m`
+*   **Missing Implementation**: `% TODO: Implement pendulum model` (Line 41) - The core triple pendulum simulation logic is completely missing.
+
+### 3. Documentation & Planning
+**File**: `docs/assessments/Assessment_B_Results_2026-01-17_REFRESH.md`
+*   **Technical Debt**: Contains diff blocks with pending tasks (`# TODO: Remove unsafe-inline`, `# TODO: Enable` strict typing).
+
+## False Positives & Tooling Artifacts
+
+The audit identified several non-actionable matches:
+
+1.  **Hash Collision (New)**:
+    *   `media_processing/video_processor/package-lock.json`: A SHA-512 integrity hash contained the substring `XXX` (`...1XXXevb...`), triggering the scanner. This is a pure coincidence.
+
+2.  **Quality Assurance Tools**:
+    *   Regex patterns in `src/tools/code_quality_check.py`, `scripts/quality-check.py`, and `matlab_quality_check.py` are used to enforce the policy, not violate it.
+
+3.  **Policy Documentation**:
+    *   `README.md`, `.cursor/rules/.cursorrules.md`, and `copilot-instructions.md` mention "TODO" as a banned keyword.
+
+## Stale Data Analysis
+
+*   **Resolved**: The marker in `.github/workflows/Jules-Tech-Custodian.yml` regarding "Jules CLI API changed" is no longer present in the file, confirming it has been resolved.
+
+## Recommendations
+
+1.  **Address Security TODOs**: The `DOMPurify` implementation in `sanitize.ts` should be prioritized as it is a security control.
+2.  **Implement Physics Model**: The `pendulum_model.m` file is a shell; implementation is required for the golf swing analysis feature.
+3.  **Refine Scanner**: Update the Completist scanning tool to exclude `.json` files or specifically `package-lock.json` to avoid hash collisions like the one found today.


### PR DESCRIPTION
Created docs/assessments/completist/audit_report_2026_01_28.md based on analysis of .jules/completist_data/todo_markers.txt and current codebase. Identified active TODOs in media_processing and false positives.

---
*PR created automatically by Jules for task [16072900797358008853](https://jules.google.com/task/16072900797358008853) started by @dieterolson*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `docs/assessments/completist/audit_report_2026_01_28.md` summarizing the daily "No TODO" audit.
> 
> - **Active TODOs**: Highlights unresolved items in `media_processing` (web `sanitize.ts` security hardening with DOMPurify, `logger.ts` observability, `page.tsx` backend integration/config), and missing Matlab `pendulum_model.m` implementation.
> - **False positives**: Notes new hash-collision trigger in `package-lock.json` and excludes QA/tooling and policy mentions.
> - **Stale data**: Confirms removal of the `.github/workflows/Jules-Tech-Custodian.yml` marker.
> - **Recommendations**: Prioritize `DOMPurify`, implement `pendulum_model.m`, and refine the scanner to avoid `.json` hash collisions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52a0b165d7c70e6aa3402574e2474d6833ec4472. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->