### PR TITLE
refactor: auto-fix linting issues in pragmatic_programmer_review.py

### DIFF
--- a/scripts/pragmatic_programmer_review.py
+++ b/scripts/pragmatic_programmer_review.py
@@ -115,7 +115,7 @@ def check_dry_violations(files: list[Path]) -> list[dict]:
     issues = []
     chunk_size = 6
     code_blocks = defaultdict(list)
-    magic_numbers = defaultdict(list)
+    defaultdict(list)
 
     for file_path in files:
         try:


### PR DESCRIPTION
## Summary

Automated refactoring of `/home/runner/work/Tools/Tools/scripts/pragmatic_programmer_review.py` which had **4 linting issues**.

### Tools Applied
 autoflake isort ruff-format

### Results
- **Before**: 4 issues
- **After**: 3 issues
- **Fixed**: 1 issues

---
*Generated by Auto-Refactor workflow*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Minor lint-driven refactor in `scripts/pragmatic_programmer_review.py`.
> 
> - In `check_dry_violations`, removed the unused `magic_numbers = defaultdict(list)` assignment (now a standalone `defaultdict(list)` expression)
> - No functional changes elsewhere
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26a93cf8bda41e2623edf8289be138c348473bd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->