### PR TITLE
Implement MakeHuman and SMPL-X mesh generation

### DIFF
--- a/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/mesh_generator.py
@@ -261,28 +261,320 @@ class MakeHumanMeshGenerator(MeshGeneratorInterface):
         output_dir: Path,
         **kwargs: Any,
     ) -> GeneratedMeshResult:
-        """Generate meshes using MakeHuman."""
+        """Generate meshes using MakeHuman.
+
+        Uses MakeHuman's Python API when available, or falls back to
+        loading pre-made MakeHuman exports with vertex group segmentation.
+        """
         if not self.is_available:
             return GeneratedMeshResult(
                 success=False,
                 error_message="MakeHuman not found. Please install MakeHuman or provide path.",
             )
 
-        # TODO: Implement MakeHuman integration
-        # This would involve:
-        # 1. Convert BodyParameters to MakeHuman modifier values
-        # 2. Run MakeHuman in scripted mode to generate mesh
-        # 3. Export mesh and segment by vertex groups
-        # 4. Return paths to generated files
+        output_dir = Path(output_dir)
+        visual_dir = output_dir / "visual"
+        collision_dir = output_dir / "collision"
+        visual_dir.mkdir(parents=True, exist_ok=True)
+        collision_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.warning(
-            "MakeHuman integration not yet implemented. "
-            "Falling back to primitive meshes."
-        )
+        # Convert body parameters to MakeHuman modifiers
+        modifiers = self._convert_params_to_makehuman(params)
 
-        # Fall back to primitive generator
+        # Try to use MakeHuman scripting API
+        try:
+            return self._generate_via_api(
+                params, modifiers, visual_dir, collision_dir, **kwargs
+            )
+        except Exception as e:
+            logger.warning(f"MakeHuman API generation failed: {e}")
+
+        # Fallback: Try to load pre-exported MakeHuman mesh
+        try:
+            return self._generate_from_presets(
+                params, visual_dir, collision_dir, **kwargs
+            )
+        except Exception as e:
+            logger.warning(f"MakeHuman preset loading failed: {e}")
+
+        # Final fallback to primitive generator
+        logger.warning("Falling back to primitive mesh generation")
         primitive_gen = PrimitiveMeshGenerator()
         return primitive_gen.generate(params, output_dir, **kwargs)
+
+    def _generate_via_api(
+        self,
+        params: BodyParameters,
+        modifiers: dict[str, float],
+        visual_dir: Path,
+        collision_dir: Path,
+        **kwargs: Any,
+    ) -> GeneratedMeshResult:
+        """Generate meshes using MakeHuman Python API.
+
+        Requires MakeHuman to be installed and accessible via Python.
+        """
+        import subprocess
+        import tempfile
+        import json
+
+        # Create MakeHuman script
+        script_content = self._create_makehuman_script(modifiers, visual_dir)
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", delete=False
+        ) as script_file:
+            script_file.write(script_content)
+            script_path = script_file.name
+
+        try:
+            # Run MakeHuman in scripted mode
+            mh_executable = self.makehuman_path / "makehuman.py"
+            if not mh_executable.exists():
+                mh_executable = self.makehuman_path / "makehuman"
+
+            result = subprocess.run(
+                ["python", str(mh_executable), "--nogui", "--script", script_path],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+
+            if result.returncode != 0:
+                raise RuntimeError(f"MakeHuman failed: {result.stderr}")
+
+            # Load generated mesh and segment it
+            return self._segment_mesh(visual_dir, collision_dir)
+
+        finally:
+            Path(script_path).unlink(missing_ok=True)
+
+    def _create_makehuman_script(
+        self, modifiers: dict[str, float], output_dir: Path
+    ) -> str:
+        """Create a MakeHuman Python script for mesh generation."""
+        script = """
+import mh
+import human
+import export
+
+def generate_human():
+    # Get human object
+    h = human.human
+
+    # Apply modifiers
+    modifiers = %s
+    for key, value in modifiers.items():
+        try:
+            h.setDetail(key, value)
+        except Exception:
+            pass
+
+    # Export as OBJ with vertex groups
+    export_path = "%s/humanoid.obj"
+    export.exportObj(h, export_path, config={
+        'exportGroups': True,
+        'helper': False,
+        'scale': 1.0,
+    })
+
+generate_human()
+""" % (
+            repr(modifiers),
+            str(output_dir),
+        )
+        return script
+
+    def _generate_from_presets(
+        self,
+        params: BodyParameters,
+        visual_dir: Path,
+        collision_dir: Path,
+        **kwargs: Any,
+    ) -> GeneratedMeshResult:
+        """Load pre-exported MakeHuman mesh based on parameters."""
+        try:
+            import trimesh
+        except ImportError:
+            raise RuntimeError("trimesh required for mesh processing")
+
+        # Look for pre-exported mesh files in MakeHuman data directory
+        presets_dir = self.makehuman_path / "data" / "exports"
+        if not presets_dir.exists():
+            presets_dir = self.makehuman_path / "exports"
+
+        # Select preset based on build type
+        preset_name = params.build_type or "average"
+        gender = "male" if params.get_effective_gender_factor() > 0.5 else "female"
+        preset_file = presets_dir / f"{gender}_{preset_name}.obj"
+
+        if not preset_file.exists():
+            # Try default
+            preset_file = presets_dir / f"{gender}_average.obj"
+
+        if not preset_file.exists():
+            raise FileNotFoundError(f"No MakeHuman preset found: {preset_file}")
+
+        # Load and segment the mesh
+        mesh = trimesh.load(str(preset_file))
+
+        # Scale to target height
+        current_height = mesh.bounds[1][2] - mesh.bounds[0][2]
+        scale_factor = params.height_m / current_height
+        mesh.apply_scale(scale_factor)
+
+        return self._segment_mesh_from_groups(mesh, visual_dir, collision_dir, params)
+
+    def _segment_mesh(
+        self, visual_dir: Path, collision_dir: Path
+    ) -> GeneratedMeshResult:
+        """Segment a generated mesh by vertex groups."""
+        try:
+            import trimesh
+        except ImportError:
+            raise RuntimeError("trimesh required for mesh segmentation")
+
+        obj_file = visual_dir / "humanoid.obj"
+        if not obj_file.exists():
+            raise FileNotFoundError(f"Generated mesh not found: {obj_file}")
+
+        mesh = trimesh.load(str(obj_file))
+
+        # Get vertex groups from OBJ file
+        vertex_groups = self._parse_obj_vertex_groups(obj_file)
+
+        return self._segment_mesh_from_groups(
+            mesh, visual_dir, collision_dir, vertex_groups=vertex_groups
+        )
+
+    def _segment_mesh_from_groups(
+        self,
+        mesh: Any,
+        visual_dir: Path,
+        collision_dir: Path,
+        params: BodyParameters | None = None,
+        vertex_groups: dict[str, list[int]] | None = None,
+    ) -> GeneratedMeshResult:
+        """Segment mesh into body parts using vertex groups or geometry."""
+        import trimesh
+        from humanoid_character_builder.core.segment_definitions import (
+            HUMANOID_SEGMENTS,
+        )
+
+        mesh_paths = {}
+        collision_paths = {}
+
+        # Map MakeHuman vertex groups to our segment names
+        group_mapping = {
+            "head": "head",
+            "neck": "neck",
+            "torso": "torso",
+            "upper_torso": "torso",
+            "lower_torso": "pelvis",
+            "pelvis": "pelvis",
+            "left_upper_arm": "left_upper_arm",
+            "right_upper_arm": "right_upper_arm",
+            "left_forearm": "left_forearm",
+            "right_forearm": "right_forearm",
+            "left_hand": "left_hand",
+            "right_hand": "right_hand",
+            "left_thigh": "left_thigh",
+            "right_thigh": "right_thigh",
+            "left_shin": "left_shin",
+            "right_shin": "right_shin",
+            "left_foot": "left_foot",
+            "right_foot": "right_foot",
+        }
+
+        if vertex_groups:
+            # Use vertex groups for segmentation
+            for group_name, vertex_indices in vertex_groups.items():
+                segment_name = group_mapping.get(group_name.lower())
+                if segment_name and segment_name in HUMANOID_SEGMENTS:
+                    try:
+                        # Extract submesh for this group
+                        face_mask = mesh.faces_sparse.rows[vertex_indices].indices
+                        submesh = mesh.submesh([face_mask], append=True)
+
+                        visual_path = visual_dir / f"{segment_name}.stl"
+                        submesh.export(str(visual_path))
+                        mesh_paths[segment_name] = visual_path
+
+                        collision_mesh = submesh.convex_hull
+                        collision_path = collision_dir / f"{segment_name}.stl"
+                        collision_mesh.export(str(collision_path))
+                        collision_paths[segment_name] = collision_path
+                    except Exception as e:
+                        logger.warning(f"Failed to extract {segment_name}: {e}")
+        else:
+            # Fallback: Use bounding box geometry to segment
+            bounds = mesh.bounds
+            height = bounds[1][2] - bounds[0][2]
+
+            # Define approximate z-ranges for segments (normalized 0-1)
+            segment_z_ranges = {
+                "head": (0.90, 1.0),
+                "neck": (0.85, 0.90),
+                "torso": (0.55, 0.85),
+                "pelvis": (0.45, 0.55),
+                "left_thigh": (0.25, 0.45),
+                "right_thigh": (0.25, 0.45),
+                "left_shin": (0.08, 0.25),
+                "right_shin": (0.08, 0.25),
+                "left_foot": (0.0, 0.08),
+                "right_foot": (0.0, 0.08),
+            }
+
+            for segment_name, (z_low, z_high) in segment_z_ranges.items():
+                if segment_name in HUMANOID_SEGMENTS:
+                    z_min = bounds[0][2] + z_low * height
+                    z_max = bounds[0][2] + z_high * height
+
+                    try:
+                        # Slice mesh at z-bounds
+                        plane_origin = [0, 0, z_min]
+                        plane_normal = [0, 0, 1]
+                        submesh = mesh.slice_plane(plane_origin, plane_normal)
+
+                        if submesh and len(submesh.vertices) > 0:
+                            visual_path = visual_dir / f"{segment_name}.stl"
+                            submesh.export(str(visual_path))
+                            mesh_paths[segment_name] = visual_path
+
+                            collision_path = collision_dir / f"{segment_name}.stl"
+                            submesh.convex_hull.export(str(collision_path))
+                            collision_paths[segment_name] = collision_path
+                    except Exception as e:
+                        logger.warning(f"Failed to slice {segment_name}: {e}")
+
+        return GeneratedMeshResult(
+            success=len(mesh_paths) > 0,
+            mesh_paths=mesh_paths,
+            collision_paths=collision_paths,
+            vertex_groups=vertex_groups or {},
+            metadata={"backend": "makehuman"},
+        )
+
+    def _parse_obj_vertex_groups(self, obj_file: Path) -> dict[str, list[int]]:
+        """Parse vertex groups from OBJ file."""
+        groups: dict[str, list[int]] = {}
+        current_group = "default"
+        vertex_index = 0
+
+        with open(obj_file) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("g "):
+                    current_group = line[2:].strip()
+                    if current_group not in groups:
+                        groups[current_group] = []
+                elif line.startswith("v "):
+                    if current_group not in groups:
+                        groups[current_group] = []
+                    groups[current_group].append(vertex_index)
+                    vertex_index += 1
+
+        return groups
 
     def get_supported_segments(self) -> list[str]:
         # MakeHuman supports all standard humanoid segments
@@ -345,27 +637,377 @@ class SMPLXMeshGenerator(MeshGeneratorInterface):
         except ImportError:
             return False
 
+    def __init__(self, model_path: Path | str | None = None):
+        """Initialize SMPL-X generator.
+
+        Args:
+            model_path: Path to SMPL-X model files (npz format)
+        """
+        self.model_path = Path(model_path) if model_path else None
+        self._model = None
+
     def generate(
         self,
         params: BodyParameters,
         output_dir: Path,
         **kwargs: Any,
     ) -> GeneratedMeshResult:
-        """Generate meshes using SMPL-X."""
+        """Generate meshes using SMPL-X body model.
+
+        SMPL-X provides a differentiable body model with:
+        - 10 body shape parameters (betas)
+        - 55 pose parameters for body joints
+        - Hand and face parameters
+
+        We map our BodyParameters to SMPL-X betas and pose.
+        """
         if not self.is_available:
             return GeneratedMeshResult(
                 success=False,
                 error_message="smplx package not installed. Install with: pip install smplx",
             )
 
-        # TODO: Implement SMPL-X integration
-        logger.warning(
-            "SMPL-X integration not yet implemented. "
-            "Falling back to primitive meshes."
+        try:
+            import numpy as np
+            import smplx
+            import torch
+            import trimesh
+        except ImportError as e:
+            return GeneratedMeshResult(
+                success=False,
+                error_message=f"Missing dependency: {e}",
+            )
+
+        output_dir = Path(output_dir)
+        visual_dir = output_dir / "visual"
+        collision_dir = output_dir / "collision"
+        visual_dir.mkdir(parents=True, exist_ok=True)
+        collision_dir.mkdir(parents=True, exist_ok=True)
+
+        # Find model path
+        model_folder = self._find_model_path()
+        if not model_folder:
+            logger.warning("SMPL-X model not found, falling back to primitives")
+            primitive_gen = PrimitiveMeshGenerator()
+            return primitive_gen.generate(params, output_dir, **kwargs)
+
+        try:
+            # Determine gender
+            gender = "male" if params.get_effective_gender_factor() > 0.5 else "female"
+
+            # Create SMPL-X model
+            model = smplx.create(
+                model_folder,
+                model_type="smplx",
+                gender=gender,
+                use_pca=False,
+                flat_hand_mean=True,
+            )
+
+            # Convert body parameters to SMPL-X betas
+            betas = self._params_to_betas(params)
+            betas_tensor = torch.tensor(betas, dtype=torch.float32).unsqueeze(0)
+
+            # Generate body with neutral pose
+            output = model(betas=betas_tensor)
+
+            # Get vertices and faces
+            vertices = output.vertices.detach().cpu().numpy()[0]
+            faces = model.faces
+
+            # Scale to target height
+            current_height = vertices[:, 1].max() - vertices[:, 1].min()
+            scale_factor = params.height_m / current_height
+            vertices *= scale_factor
+
+            # Create trimesh
+            mesh = trimesh.Trimesh(vertices=vertices, faces=faces)
+
+            # Export full mesh
+            full_mesh_path = visual_dir / "humanoid_full.obj"
+            mesh.export(str(full_mesh_path))
+
+            # Segment mesh using SMPL-X vertex groups
+            return self._segment_smplx_mesh(
+                mesh, model, visual_dir, collision_dir, params
+            )
+
+        except Exception as e:
+            logger.error(f"SMPL-X generation failed: {e}")
+            # Fallback to primitive generator
+            primitive_gen = PrimitiveMeshGenerator()
+            return primitive_gen.generate(params, output_dir, **kwargs)
+
+    def _find_model_path(self) -> Path | None:
+        """Find SMPL-X model files."""
+        if self.model_path and self.model_path.exists():
+            return self.model_path
+
+        # Common locations
+        search_paths = [
+            Path.home() / ".smplx",
+            Path.home() / "smplx",
+            Path("/usr/share/smplx"),
+            Path("./models/smplx"),
+        ]
+
+        for path in search_paths:
+            if path.exists() and (path / "SMPLX_MALE.npz").exists():
+                self.model_path = path
+                return path
+
+        return None
+
+    def _params_to_betas(self, params: BodyParameters) -> list[float]:
+        """Convert BodyParameters to SMPL-X beta shape parameters.
+
+        SMPL-X betas control body shape (10 dimensions):
+        - beta[0]: Overall size/height
+        - beta[1]: Weight/heaviness
+        - beta[2]: Arm/leg length ratio
+        - beta[3]: Shoulder width
+        - beta[4]: Hip width
+        - etc.
+        """
+        import numpy as np
+
+        betas = np.zeros(10)
+
+        # Height deviation from mean (betas[0] affects overall size)
+        # Mean SMPL-X height is ~1.7m
+        height_deviation = (params.height_m - 1.7) / 0.2
+        betas[0] = np.clip(height_deviation, -3, 3)
+
+        # Weight/body composition (beta[1])
+        weight_deviation = (params.mass_kg - 70) / 20
+        betas[1] = np.clip(weight_deviation * 0.5, -2, 2)
+
+        # Muscularity affects shape
+        betas[2] = np.clip(params.muscularity - 0.5, -1, 1)
+
+        # Limb proportions
+        betas[3] = np.clip(params.torso_length_factor - 1.0, -0.5, 0.5) * 2
+        betas[4] = np.clip(params.leg_length_factor - 1.0, -0.5, 0.5) * 2
+
+        # Shoulder width
+        betas[5] = np.clip(params.shoulder_width_factor - 1.0, -0.5, 0.5) * 2
+
+        # Hip width
+        betas[6] = np.clip(params.hip_width_factor - 1.0, -0.5, 0.5) * 2
+
+        return betas.tolist()
+
+    def _segment_smplx_mesh(
+        self,
+        mesh: Any,
+        model: Any,
+        visual_dir: Path,
+        collision_dir: Path,
+        params: BodyParameters,
+    ) -> GeneratedMeshResult:
+        """Segment SMPL-X mesh into body parts using joint positions.
+
+        SMPL-X provides joint positions that we use to segment the mesh.
+        """
+        import numpy as np
+        import trimesh
+        from humanoid_character_builder.core.segment_definitions import (
+            HUMANOID_SEGMENTS,
         )
 
-        primitive_gen = PrimitiveMeshGenerator()
-        return primitive_gen.generate(params, output_dir, **kwargs)
+        mesh_paths = {}
+        collision_paths = {}
+        vertex_groups: dict[str, list[int]] = {}
+
+        # SMPL-X joint names to our segment mapping
+        # SMPL-X has 55 joints, we map to our segments
+        joint_to_segment = {
+            0: "pelvis",  # pelvis
+            1: "left_thigh",  # left_hip
+            2: "right_thigh",  # right_hip
+            3: "torso",  # spine1
+            4: "left_shin",  # left_knee
+            5: "right_shin",  # right_knee
+            6: "torso",  # spine2
+            7: "left_foot",  # left_ankle
+            8: "right_foot",  # right_ankle
+            9: "torso",  # spine3
+            10: "left_foot",  # left_foot
+            11: "right_foot",  # right_foot
+            12: "neck",  # neck
+            13: "left_upper_arm",  # left_collar
+            14: "right_upper_arm",  # right_collar
+            15: "head",  # head
+            16: "left_upper_arm",  # left_shoulder
+            17: "right_upper_arm",  # right_shoulder
+            18: "left_forearm",  # left_elbow
+            19: "right_forearm",  # right_elbow
+            20: "left_hand",  # left_wrist
+            21: "right_hand",  # right_wrist
+        }
+
+        # Get vertex weights from model if available
+        try:
+            # SMPL-X provides blend weights (lbs_weights)
+            weights = model.lbs_weights.cpu().numpy()
+
+            # Assign each vertex to the joint with highest weight
+            vertex_assignments = np.argmax(weights, axis=1)
+
+            # Group vertices by segment
+            for vertex_idx, joint_idx in enumerate(vertex_assignments):
+                segment_name = joint_to_segment.get(joint_idx)
+                if segment_name:
+                    if segment_name not in vertex_groups:
+                        vertex_groups[segment_name] = []
+                    vertex_groups[segment_name].append(vertex_idx)
+
+            # Extract meshes for each segment
+            for segment_name, vertices in vertex_groups.items():
+                if segment_name not in HUMANOID_SEGMENTS or len(vertices) < 10:
+                    continue
+
+                try:
+                    # Find faces that use these vertices
+                    vertex_set = set(vertices)
+                    face_mask = [
+                        i
+                        for i, face in enumerate(mesh.faces)
+                        if any(v in vertex_set for v in face)
+                    ]
+
+                    if not face_mask:
+                        continue
+
+                    # Create submesh
+                    submesh = mesh.submesh([face_mask], append=True)
+
+                    # Export visual mesh
+                    visual_path = visual_dir / f"{segment_name}.stl"
+                    submesh.export(str(visual_path))
+                    mesh_paths[segment_name] = visual_path
+
+                    # Create collision mesh (convex hull)
+                    collision_mesh = submesh.convex_hull
+                    collision_path = collision_dir / f"{segment_name}.stl"
+                    collision_mesh.export(str(collision_path))
+                    collision_paths[segment_name] = collision_path
+
+                except Exception as e:
+                    logger.warning(f"Failed to extract segment {segment_name}: {e}")
+
+        except Exception as e:
+            logger.warning(f"Vertex group extraction failed: {e}")
+            # Fallback to z-slice segmentation
+            return self._fallback_z_segmentation(
+                mesh, visual_dir, collision_dir, params
+            )
+
+        return GeneratedMeshResult(
+            success=len(mesh_paths) > 0,
+            mesh_paths=mesh_paths,
+            collision_paths=collision_paths,
+            vertex_groups=vertex_groups,
+            metadata={
+                "backend": "smplx",
+                "num_segments": len(mesh_paths),
+            },
+        )
+
+    def _fallback_z_segmentation(
+        self,
+        mesh: Any,
+        visual_dir: Path,
+        collision_dir: Path,
+        params: BodyParameters,
+    ) -> GeneratedMeshResult:
+        """Fallback segmentation using z-coordinate slicing."""
+        import trimesh
+        from humanoid_character_builder.core.segment_definitions import (
+            HUMANOID_SEGMENTS,
+        )
+
+        mesh_paths = {}
+        collision_paths = {}
+
+        bounds = mesh.bounds
+        height = bounds[1][1] - bounds[0][1]  # SMPL-X uses Y as up
+
+        # Define segment z-ranges (normalized 0-1 from feet to head)
+        segment_ranges = {
+            "left_foot": (0.0, 0.06),
+            "right_foot": (0.0, 0.06),
+            "left_shin": (0.06, 0.25),
+            "right_shin": (0.06, 0.25),
+            "left_thigh": (0.25, 0.47),
+            "right_thigh": (0.25, 0.47),
+            "pelvis": (0.47, 0.55),
+            "torso": (0.55, 0.80),
+            "neck": (0.80, 0.85),
+            "head": (0.85, 1.0),
+            "left_upper_arm": (0.70, 0.80),
+            "right_upper_arm": (0.70, 0.80),
+            "left_forearm": (0.65, 0.70),
+            "right_forearm": (0.65, 0.70),
+            "left_hand": (0.55, 0.65),
+            "right_hand": (0.55, 0.65),
+        }
+
+        vertices = mesh.vertices
+
+        for segment_name, (y_low, y_high) in segment_ranges.items():
+            if segment_name not in HUMANOID_SEGMENTS:
+                continue
+
+            y_min = bounds[0][1] + y_low * height
+            y_max = bounds[0][1] + y_high * height
+
+            # Find vertices in this range
+            mask = (vertices[:, 1] >= y_min) & (vertices[:, 1] <= y_max)
+
+            # For left/right segments, also filter by x
+            if "left" in segment_name:
+                mask &= vertices[:, 0] > 0
+            elif "right" in segment_name:
+                mask &= vertices[:, 0] < 0
+
+            vertex_indices = list(mask.nonzero()[0])
+
+            if len(vertex_indices) < 10:
+                continue
+
+            try:
+                # Find faces using these vertices
+                vertex_set = set(vertex_indices)
+                face_mask = [
+                    i
+                    for i, face in enumerate(mesh.faces)
+                    if any(v in vertex_set for v in face)
+                ]
+
+                if not face_mask:
+                    continue
+
+                submesh = mesh.submesh([face_mask], append=True)
+
+                visual_path = visual_dir / f"{segment_name}.stl"
+                submesh.export(str(visual_path))
+                mesh_paths[segment_name] = visual_path
+
+                collision_mesh = submesh.convex_hull
+                collision_path = collision_dir / f"{segment_name}.stl"
+                collision_mesh.export(str(collision_path))
+                collision_paths[segment_name] = collision_path
+
+            except Exception as e:
+                logger.warning(f"Failed z-segmentation for {segment_name}: {e}")
+
+        return GeneratedMeshResult(
+            success=len(mesh_paths) > 0,
+            mesh_paths=mesh_paths,
+            collision_paths=collision_paths,
+            metadata={"backend": "smplx", "method": "z_segmentation"},
+        )
 
     def get_supported_segments(self) -> list[str]:
         # SMPL-X provides full body mesh, needs segmentation


### PR DESCRIPTION
## Summary
- Implement full MakeHuman mesh generation integration
- Implement full SMPL-X body model integration
- Add automatic fallbacks and error handling

### MakeHuman Integration
- Python API scripting support
- Preset-based mesh loading
- Vertex group segmentation
- Z-coordinate fallback segmentation

### SMPL-X Integration
- Full body model support via smplx package
- Body parameter to beta shape conversion
- Joint-based vertex group segmentation

## Test plan
- [ ] Test with MakeHuman installed
- [ ] Test with smplx package installed
- [ ] Verify fallback to primitive meshes works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mesh generation paths and adds subprocess execution plus heavy optional dependencies (`smplx`, `torch`, `trimesh`), so failures will be runtime/environment-dependent despite explicit fallbacks.
> 
> **Overview**
> Adds real mesh generation for the `makehuman` and `smplx` backends in `mesh_generator.py`, replacing the previous placeholder behavior.
> 
> For **MakeHuman**, generation now attempts scripted MakeHuman exports via subprocess, then falls back to loading pre-exported OBJ presets; both paths segment the result into per-body-part STL meshes (plus convex-hull collision meshes) using parsed OBJ groups with a geometry-based slicing fallback.
> 
> For **SMPL-X**, introduces model-path discovery, maps `BodyParameters` to SMPL-X `betas`, generates a full-body mesh, and segments it into body-part meshes using blend-weight-driven vertex assignment with a z-slicing fallback; all failures gracefully fall back to `PrimitiveMeshGenerator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddb0e965ff943896d48b680f9f805c64b651bd51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->