### PR TITLE
Add fleet-wide changelog for 2026-01-31

### DIFF
--- a/docs/changelogs/2026-01-31-fleet-updates.md
+++ b/docs/changelogs/2026-01-31-fleet-updates.md
@@ -1,0 +1,45 @@
+# Fleet-Wide Updates - January 31, 2026
+
+## Summary
+
+Major infrastructure and tooling updates across all 9 repositories in the fleet.
+
+## Changes Applied to All Repos
+
+### 1. Workflow Schedule Standardization
+- All automated workflows now run on `0 8 */3 * *` (midnight PST, every 3 days)
+- Reduces CI costs and eliminates daytime automated PR spam
+
+### 2. Claude Skills Added
+Two new Claude skills in `.claude/skills/`:
+- **`/lint`**: Runs ruff, black, mypy and finds/fixes placeholder statements
+- **`/tests`**: Runs full test suite and iterates to fix failures
+
+### 3. CI/CD Verification
+- All repos have `ci-standard.yml` with mypy enabled
+
+## Repository-Specific Changes
+
+### UpstreamDrift
+- Added LOD generation for URDF meshes
+- Added click-to-highlight and side-by-side comparison
+- Renamed package from `golf-suite` to `upstream-drift`
+- Fixed ruff linting issues
+
+### Tools
+- Updated `pyproject.toml` to export all shared packages as `ud-tools`
+- Updated branding/logo to golfer/UD arc design
+
+### Gasification_Model
+- Added Data Processor module with headless API and PyQt6 UI
+
+### Games, MLProjects
+- Fixed ruff linting issues
+
+## Package Structure
+
+```bash
+pip install ud-tools[urdf]     # URDF generation
+pip install ud-tools[signal]   # Signal processing
+pip install ud-tools[all]      # Everything
+```


### PR DESCRIPTION
Documents all infrastructure and tooling updates made today.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a changelog entry; no runtime or CI behavior is modified in this PR.
> 
> **Overview**
> Adds a new changelog document `docs/changelogs/2026-01-31-fleet-updates.md` summarizing fleet-wide workflow schedule standardization, new Claude skills (`/lint`, `/tests`), and CI verification (mypy enabled).
> 
> Also records repo-specific updates (e.g., UpstreamDrift URDF/UX features and rename, Tools packaging/branding, Gasification_Model data processor module, and ruff lint fixes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f123cbf476ac131cd6df6be185d74092d8194eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->