### PR TITLE
fix: Prevent Jules auto-assign from triggering on manual issues

### DIFF
--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -1,11 +1,12 @@
 name: Jules Auto-Assign Issues
 
 # Automatically comments @jules on new issues to trigger the fix workflow
-# This enables fully automated issue resolution
+# IMPORTANT: Only triggers for AUTOMATED issues, NOT manually created ones
+# To manually request Jules help, add the 'jules-triage' label to an issue
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 permissions:
   issues: write
@@ -13,19 +14,24 @@ permissions:
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
-    # Skip if issue was created by a bot to prevent loops
-    if: "!contains(github.event.issue.user.login, '[bot]') && !contains(github.event.issue.user.login, 'github-actions')"
+    # CHANGED: Only trigger for automated issues or explicit jules-triage label
+    # - Issues created by github-actions (from automated assessments)
+    # - Issues with 'jules-triage' or 'auto-generated' labels
+    # This prevents unwanted cascade of PRs when manually creating issues
+    if: |
+      (github.event.action == 'opened' && github.event.issue.user.login == 'github-actions[bot]') ||
+      (github.event.action == 'labeled' && (github.event.label.name == 'jules-triage' || github.event.label.name == 'auto-generated'))
     steps:
       - name: Check Issue Labels
         id: check
         env:
-          GH_TOKEN: ${{ secrets.BOT_PAT }}
+          GH_TOKEN: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
           LABELS: ${{ toJson(github.event.issue.labels) }}
         run: |
           # LABELS is passed via env to prevent shell injection
 
           # Skip if labeled with 'no-jules', 'question', 'documentation', or 'wontfix'
-          SKIP_LABELS="no-jules question documentation wontfix duplicate invalid"
+          SKIP_LABELS="no-jules question documentation wontfix duplicate invalid jules-assigned"
 
           for label in $SKIP_LABELS; do
             if echo "$LABELS" | jq -e ".[] | select(.name == \"$label\")" > /dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Prevent unwanted cascades of PRs when manually creating issues
- Jules Auto-Assign now only triggers for automated issues or explicit opt-in

## Changes
- Issues created by github-actions[bot] (automated assessments) still trigger
- Issues with 'jules-triage' or 'auto-generated' labels trigger
- Manual issues no longer auto-assign Jules

## How to request Jules help manually
Add the `jules-triage` label to any issue you want Jules to analyze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only gating changes; primary risk is misconfigured conditions/labels causing missed or unintended auto-assignments.
> 
> **Overview**
> Prevents the `Jules-Auto-Assign-Issues` workflow from firing on manually created issues by narrowing execution to issues opened by `github-actions[bot]` or issues explicitly labeled `jules-triage`/`auto-generated` (and adding the `labeled` event trigger).
> 
> Improves safety/robustness by allowing `GITHUB_TOKEN` fallback for label checking and by adding `jules-assigned` to the skip list to avoid re-trigger/duplicate assignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d52cec00c14904c24cf5d18e52bf6f7314d610c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->