### PR TITLE
fix: Remove unused type: ignore comments

### DIFF
--- a/src/tools/folder_tools/project_packer/build.py
+++ b/src/tools/folder_tools/project_packer/build.py
@@ -77,7 +77,7 @@ def main() -> None:
             if sys.platform == "win32":
                 response = input("Would you like to run the executable now? (y/n): ")
                 if response.lower() == "y":
-                    os.startfile(exe_path)  # type: ignore[attr-defined]
+                    os.startfile(exe_path)
         else:
             logger.error("❌ Build failed. Check the output above for errors.")
             sys.exit(1)

--- a/src/tools/launch_utils.py
+++ b/src/tools/launch_utils.py
@@ -202,7 +202,7 @@ def launch_batch_tool(
     if sys.platform != "win32":
         raise PlatformError("Batch scripts are only supported on Windows")
 
-    if path.suffix.lower() not in [".bat", ".cmd"]:  # type: ignore
+    if path.suffix.lower() not in [".bat", ".cmd"]:
         raise SecurityError("File must be .bat or .cmd to execute as batch script")
 
     if log_func:


### PR DESCRIPTION
Closes #219

Removes unused type: ignore comments that were flagged by mypy.

## Changes
- Remove unused type: ignore in launch_utils.py line 205
- Remove unused type: ignore in project_packer/build.py line 80

## Result
Mypy now passes with no issues (21 source files checked, 0 errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes two unnecessary `# type: ignore` suppressions without changing runtime behavior; risk is limited to potential mypy/static-analysis differences.
> 
> **Overview**
> Removes two unused mypy suppression comments: one on `os.startfile(exe_path)` in `project_packer/build.py` and one on the `.bat/.cmd` suffix check in `launch_utils.py`.
> 
> No functional behavior changes are intended; this is a typing/cleanup change to keep mypy passing cleanly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e49564ed3fd30dfe352b630451fc1f06c2f659f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->