### PR TITLE
fix: correct workflow schedules to specific days

### DIFF
--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -20,7 +20,7 @@ on:
 
   # Also run on a schedule to catch any missed PRs
   schedule:
-    - cron: "0 8 */3 * *"  # Every 2 hours (reduced from 15 min for cost control)
+    - cron: "0 8 * * 0,4"  # Every 2 hours (reduced from 15 min for cost control)
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/Code-Metrics.yml
+++ b/.github/workflows/Code-Metrics.yml
@@ -10,7 +10,7 @@ on:
     branches: [main]
   schedule:
     # Weekly on Sundays at 4 AM PST (12 UTC)
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 0,4"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/Jules-Assessment-AutoFix.yml
+++ b/.github/workflows/Jules-Assessment-AutoFix.yml
@@ -3,7 +3,7 @@ name: Jules Assessment Auto-Fix
 on:
   schedule:
     # Daily at 5 AM PST (13:00 UTC) - runs after overnight assessments complete
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 0,4"
   workflow_dispatch:
     inputs:
       assessment_type:

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 8 */3 * *"  # Daily at midnight UTC (overnight window)
+  #   - cron: "0 8 * * 0,4"  # Daily at midnight UTC (overnight window)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -38,7 +38,7 @@ on:
         type: boolean
   schedule:
     # Daily at 5 AM PST (13:00 UTC) - runs after overnight assessments complete
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 0,4"
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -11,7 +11,7 @@ on:
         type: string
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 8 */3 * *"  # Daily at 3 AM UTC
+  #   - cron: "0 8 * * 0,4"  # Daily at 3 AM UTC
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Comment-Processor.yml
+++ b/.github/workflows/Jules-Comment-Processor.yml
@@ -17,7 +17,7 @@ on:
           - 'false'
           - 'true'
   schedule:
-    - cron: "0 8 */3 * *"  # Daily at 3 AM UTC
+    - cron: "0 8 * * 0,4"  # Daily at 3 AM UTC
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
   workflow_dispatch:
   schedule:
-    - cron: "0 8 */3 * *"  # Daily at 4 AM UTC
+    - cron: "0 8 * * 0,4"  # Daily at 4 AM UTC
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -2,7 +2,7 @@ name: Jules Comprehensive Assessment
 
 on:
   schedule:
-    - cron: "0 8 */3 * *"  # Every 3 days at 5 AM PST (10 UTC) - cost optimized
+    - cron: "0 8 * * 0,4"  # Every 3 days at 5 AM PST (10 UTC) - cost optimized
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/Jules-Consolidator.yml
+++ b/.github/workflows/Jules-Consolidator.yml
@@ -14,7 +14,7 @@ on:
         default: ''
         type: string
   schedule:
-    - cron: "0 8 */3 * *"  # 5 AM PST Mon-Fri (13 UTC)
+    - cron: "0 8 * * 0,4"  # 5 AM PST Mon-Fri (13 UTC)
 
 concurrency:
   group: jules-consolidator

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -28,7 +28,7 @@ on:
           - create
           - refine
   schedule:
-    - cron: "0 8 */3 * *"  # Daily at 2 AM UTC (overnight schedule)
+    - cron: "0 8 * * 0,4"  # Daily at 2 AM UTC (overnight schedule)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-DRY-Orthogonality.yml
+++ b/.github/workflows/Jules-DRY-Orthogonality.yml
@@ -12,7 +12,7 @@ name: Jules DRY & Orthogonality
 on:
   schedule:
     # Daily at 4 AM PST (12 UTC)
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 0,4"
   workflow_dispatch:
     inputs:
       target_category:

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -11,7 +11,7 @@ on:
         type: string
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 8 */3 * *"  # Daily at 2:30 AM UTC (overnight window)
+  #   - cron: "0 8 * * 0,4"  # Daily at 2:30 AM UTC (overnight window)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -28,7 +28,7 @@ on:
           - create
           - refine
   schedule:
-    - cron: "0 8 */3 * *"  # Daily at 1:30 AM UTC (overnight schedule)
+    - cron: "0 8 * * 0,4"  # Daily at 1:30 AM UTC (overnight schedule)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -5,7 +5,7 @@ name: Jules PR Cleanup
 
 on:
   schedule:
-    - cron: "0 8 */3 * *" # Weekly on Sundays at 5 AM PST (13 UTC)
+    - cron: "0 8 * * 0,4" # Weekly on Sundays at 5 AM PST (13 UTC)
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/Jules-PR-Compiler.yml
+++ b/.github/workflows/Jules-PR-Compiler.yml
@@ -10,7 +10,7 @@ on:
         default: false
         type: boolean
   schedule:
-    - cron: "0 8 */3 * *"  # Daily at 3 AM UTC (overnight schedule)
+    - cron: "0 8 * * 0,4"  # Daily at 3 AM UTC (overnight schedule)
 
 permissions:
   contents: write

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   # Schedule disabled - orchestrated by Jules-Control-Tower.yml
   # schedule:
-  #   - cron: "0 8 */3 * *"  # Weekly on Mondays at 1:30 AM UTC (overnight window)
+  #   - cron: "0 8 * * 0,4"  # Weekly on Mondays at 1:30 AM UTC (overnight window)
 
 permissions:
   contents: write

--- a/.github/workflows/Nightly-Doc-Organizer.yml
+++ b/.github/workflows/Nightly-Doc-Organizer.yml
@@ -2,7 +2,7 @@ name: Nightly Documentation Organizer
 
 on:
   schedule:
-    - cron: "0 8 */3 * *"  # Daily at 3 AM PST (11 UTC)
+    - cron: "0 8 * * 0,4"  # Daily at 3 AM PST (11 UTC)
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/agent-metrics-dashboard.yml
+++ b/.github/workflows/agent-metrics-dashboard.yml
@@ -3,7 +3,7 @@ name: Agent Metrics Dashboard
 on:
   schedule:
     # Every Monday at 10am UTC (after CI failure digest)
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 0,4"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/auto-issue-resolver.yml
+++ b/.github/workflows/auto-issue-resolver.yml
@@ -61,7 +61,7 @@ on:
 
   # Weekly scheduled run
   schedule:
-    - cron: "0 8 */3 * *"  # Monday at 3 AM UTC
+    - cron: "0 8 * * 0,4"  # Monday at 3 AM UTC
 
 concurrency:
   group: auto-issue-resolver

--- a/.github/workflows/ci-failure-digest.yml
+++ b/.github/workflows/ci-failure-digest.yml
@@ -3,7 +3,7 @@ name: Weekly CI Failure Digest
 on:
   schedule:
     # Every Monday at 9am UTC
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 0,4"
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/.github/workflows/jules-assessment-runner.yml
+++ b/.github/workflows/jules-assessment-runner.yml
@@ -15,7 +15,7 @@ on:
   # Scheduled runs - adjust time as needed (UTC)
   schedule:
     # Run at 2 AM UTC daily
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 0,4"
 
   # Manual trigger with assessment selection
   workflow_dispatch:

--- a/.github/workflows/stale-cleanup.yml
+++ b/.github/workflows/stale-cleanup.yml
@@ -3,7 +3,7 @@ name: Stale PR/Issue Cleanup
 on:
   schedule:
     # Run daily at 1 AM PST (9 UTC)
-    - cron: "0 8 */3 * *"
+    - cron: "0 8 * * 0,4"
   workflow_dispatch: # Allow manual trigger
 
 permissions:


### PR DESCRIPTION
## Summary
Fixes workflow schedules to use specific days instead of `*/3` which caused back-to-back runs at month boundaries (e.g., Jan 31 → Feb 1).

## Changes
- **Priority repos**: Thursday & Sunday (`0 8 * * 0,4`)
- **Non-priority repos**: Tuesday (`0 8 * * 2`)

This ensures predictable, evenly-spaced workflow runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes workflow cron schedules; no code, permissions, or execution logic is modified, with risk limited to unintended run frequency/timing.
> 
> **Overview**
> Updates GitHub Actions `schedule` triggers across multiple workflows, replacing the `*/3` day-of-month cadence with a fixed day-of-week schedule (`0 8 * * 0,4`). This avoids month-boundary back-to-back runs and makes automation timing more predictable.
> 
> Also updates the commented-out cron examples in worker workflows to match the new schedule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf675bbfc3bb4ea55cf1bed5c7d2e5f95d221f2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->