### PR TITLE
fix: pin CI tool versions to match pre-commit config

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff black mypy bandit pip-audit types-PyYAML types-requests
+          pip install ruff==0.14.10 black==26.1.0 mypy==1.13.0 bandit==1.7.7 pip-audit types-PyYAML types-requests
 
       - name: Lint (Ruff)
         run: ruff check .


### PR DESCRIPTION
## Summary
- Pin ruff to 0.14.10 in CI workflow
- Pin black to 26.1.0 in CI workflow
- Pin mypy to 1.13.0 in CI workflow
- Pin bandit to 1.7.7 in CI workflow

## Motivation
The CI workflow was using unpinned tool versions, which could lead to inconsistencies between local pre-commit hooks and CI. This pins all tool versions to match the fleet-wide pre-commit configuration.

## Test plan
- [ ] CI workflow should pass with the pinned versions
- [ ] All formatting and linting should remain consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that just pins dependency versions; low blast radius aside from potential CI failures if the pinned versions conflict with existing configs.
> 
> **Overview**
> Pins the CI `quality-gate` tooling to specific versions by installing `ruff==0.14.10`, `black==26.1.0`, `mypy==1.13.0`, and `bandit==1.7.7` in `.github/workflows/ci-standard.yml`, instead of relying on latest.
> 
> This reduces drift between local tooling/pre-commit and CI results by making lint/format/type/security checks deterministic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit babea5befa89ddee4086e8f79493e91afea50615. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->