### PR TITLE
fix(data-processor): convert print statements to logging and fix lint errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,8 @@ repos:
       - id: ruff-format
         name: "ruff format (Python)"
         types: [python]
-        exclude: ^(\.github/|docs/|.*\.md$)
+        # Exclude data_processing from ruff-format (black handles it to avoid conflicts)
+        exclude: ^(\.github/|docs/|.*\.md$|src/data_processing/)
 
   # Black - Python code formatter (backup)
   - repo: https://github.com/psf/black
@@ -206,7 +207,15 @@ repos:
       - id: bandit
         name: "bandit (Python security)"
         stages: [pre-push]
-        args: ["-r", ".", "-ll", "-ii", "-x", "tests/,archive/,legacy/,.github/,node_modules/"]
+        args:
+          [
+            "-r",
+            ".",
+            "-ll",
+            "-ii",
+            "-x",
+            "tests/,archive/,legacy/,.github/,node_modules/",
+          ]
         pass_filenames: false
         types: [python]
 
@@ -220,7 +229,6 @@ repos:
         language: system
         pass_filenames: false
         types: [python]
-
 
   # Semgrep - Free local security + code quality scanning (pre-push)
   - repo: https://github.com/semgrep/semgrep
@@ -286,4 +294,4 @@ ci:
   autofix_prs: true
   autoupdate_branch: "main"
   autoupdate_commit_msg: "chore: update pre-commit hooks"
-  skip: [pytest-unit, bandit, mypy, semgrep, radon]  # Skip slow hooks in CI
+  skip: [pytest-unit, bandit, mypy, semgrep, radon] # Skip slow hooks in CI

--- a/ruff.toml
+++ b/ruff.toml
@@ -68,3 +68,10 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 [lint.isort]
 # Tells Ruff how to group your own code vs. libraries
 known-first-party = ["src", "games", "tools"]
+
+[format]
+# Make ruff-format produce identical output to black
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/src/data_processing/data_processor/python/data_processor/Data_Processor_Integrated.py
+++ b/src/data_processing/data_processor/python/data_processor/Data_Processor_Integrated.py
@@ -43,27 +43,29 @@ except ImportError:
     PYARROW_AVAILABLE = False
 
 # Use shared path utilities
-from utils.path_helpers import ensure_utils_in_path
+from utils.path_helpers import ensure_utils_in_path  # noqa: E402
 
 ensure_utils_in_path()
 
 # Import from centralized utilities
-from utils.file_utils import safe_write_text
+from utils.file_utils import safe_write_text  # noqa: E402
 
 # Import shared file classes
 try:
-    from .file_utils import DataReader, DataWriter, FileFormatDetector
+    from .file_utils import DataReader, DataWriter, FileFormatDetector  # noqa: E402
 except ImportError:
-    from file_utils import DataReader, DataWriter, FileFormatDetector  # type: ignore
+    from file_utils import (  # type: ignore  # noqa: E402
+        DataReader,
+        DataWriter,
+        FileFormatDetector,
+    )
 
-from Data_Processor_r0 import CSVProcessorApp as OriginalCSVProcessorApp
+from Data_Processor_r0 import CSVProcessorApp as OriginalCSVProcessorApp  # noqa: E402
 
-# Import folder tool functionality
-try:
-    FOLDER_TOOL_AVAILABLE = True
-except ImportError:
-    FOLDER_TOOL_AVAILABLE = False
-    print("Warning: Folder tool not available. Folder Tool tab will be disabled.")
+# Folder tool availability flag
+FOLDER_TOOL_AVAILABLE = True
+
+logger = logging.getLogger(__name__)
 
 # =============================================================================
 # COMPILER CONVERTER CLASSES
@@ -676,7 +678,7 @@ class IntegratedCSVProcessorApp(OriginalCSVProcessorApp):
 
                         DataWriter.write_file(df, output_path, output_format)
                         self._log_conversion_message(
-                            f"Converted {Path(file_path).name}" "-> {output_filename}"
+                            f"Converted {Path(file_path).name}-> {{output_filename}}"
                         )
 
                         processed_files += 1
@@ -1443,7 +1445,7 @@ class IntegratedCSVProcessorApp(OriginalCSVProcessorApp):
                         shutil.copy2(source_path, final_dest_path)
                     copied_count += 1
                 except Exception as e:
-                    print(f"Error copying '{Path(source_path).name}': {e}")
+                    logger.error(f"Error copying '{Path(source_path).name}': {e}")
 
                 processed_files += 1
                 if processed_files % 10 == 0:  # Update progress every 10 files
@@ -1528,7 +1530,7 @@ class IntegratedCSVProcessorApp(OriginalCSVProcessorApp):
                         shutil.copy2(source_path, final_dest_path)
                     copied_count += 1
                 except Exception as e:
-                    print(f"Error copying '{file}': {e}")
+                    logger.error(f"Error copying '{file}': {e}")
 
                 processed_files += 1
                 if processed_files % 10 == 0:
@@ -1623,7 +1625,7 @@ class IntegratedCSVProcessorApp(OriginalCSVProcessorApp):
                         shutil.copy2(source_path, dest_path)
                     copied_count += 1
                 except Exception as e:
-                    print(f"Error copying '{file}': {e}")
+                    logger.error(f"Error copying '{file}': {e}")
 
                 processed_files += 1
                 if processed_files % 10 == 0:

--- a/src/data_processing/data_processor/python/data_processor/Data_Processor_r0.py
+++ b/src/data_processing/data_processor/python/data_processor/Data_Processor_r0.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tkinter as tk
 from collections.abc import Callable
@@ -33,6 +34,8 @@ from matplotlib.figure import Figure
 from scipy.interpolate import UnivariateSpline
 from scipy.io import savemat
 from scipy.signal import butter, filtfilt, medfilt, savgol_filter
+
+logger = logging.getLogger(__name__)
 
 
 def safe_read_csv(
@@ -53,6 +56,37 @@ def safe_write_csv(
     if create_parents:
         path.parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(path, **kwargs)
+
+
+def safe_read_json(path: str | Path, default: Any = None, **kwargs: Any) -> Any:
+    """Safely read a JSON file, returning a default value on error."""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f, **kwargs)
+    except Exception:
+        return default
+
+
+def safe_write_json(
+    path: str | Path, data: Any, create_parents: bool = True, **kwargs: Any
+) -> None:
+    """Safely write data to a JSON file, creating parent directories if needed."""
+    path = Path(path)
+    if create_parents:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, **kwargs)
+
+
+def safe_write_text(
+    path: str | Path, content: str, create_parents: bool = True, encoding: str = "utf-8"
+) -> None:
+    """Safely write text to a file, creating parent directories if needed."""
+    path = Path(path)
+    if create_parents:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding=encoding) as f:
+        f.write(content)
 
 
 def _validate_formula_security(formula: str, allowed_names: set[str]) -> None:
@@ -214,7 +248,7 @@ def process_single_csv_file(
         processed_df.reset_index(inplace=True)
         return processed_df
     except Exception as e:
-        print(f"Error processing {file_path}: {e!s}")
+        logger.error(f"Error processing {file_path}: {e!s}")
         return None
 
 
@@ -1780,7 +1814,7 @@ class CSVProcessorApp(ctk.CTk):
                     df[f"cumulative_{signal}"] = cumulative
 
         except Exception as e:
-            print(f"Error in integration: {e}")
+            logger.error(f"Error in integration: {e}")
 
         return df
 
@@ -1869,7 +1903,7 @@ class CSVProcessorApp(ctk.CTk):
                             else:
                                 df[f"{signal}_d{order}"] = np.nan
                         except Exception as e:
-                            print(
+                            logger.debug(
                                 f"Error in spline differentiation for \
                                     {signal}, order {order}: {e}",
                             )
@@ -1897,7 +1931,7 @@ class CSVProcessorApp(ctk.CTk):
                             else:
                                 df[f"{signal}_d{order}"] = np.nan
                         except Exception as e:
-                            print(
+                            logger.debug(
                                 f"Error in polynomial differentiation for \
                                     {signal}, order {order}: {e}",
                             )
@@ -1907,33 +1941,33 @@ class CSVProcessorApp(ctk.CTk):
 
     def select_files(self) -> None:
         """Select input CSV files."""
-        print("DEBUG: select_files() called")
+        logger.debug(" select_files() called")
         file_paths = filedialog.askopenfilenames(
             title="Select CSV Files",
             filetypes=[("CSV files", "*.csv"), ("All files", "*.*")],
         )
-        print(f"DEBUG: File dialog returned: {file_paths}")
+        logger.debug(f" File dialog returned: {file_paths}")
 
         if file_paths:
             self.input_file_paths = list(file_paths)
-            print(f"DEBUG: Set input_file_paths to: {self.input_file_paths}")
+            logger.debug(f" Set input_file_paths to: {self.input_file_paths}")
 
             # Set default output directory to the folder of the first selected file
             if self.input_file_paths:
                 first_file_dir = Path(self.input_file_paths[0]).parent
                 self.output_directory = first_file_dir
-                print(f"DEBUG: Set output directory to: {self.output_directory}")
+                logger.debug(f" Set output directory to: {self.output_directory}")
                 # Update the output label to reflect the new default directory
                 if hasattr(self, "output_label"):
                     self.output_label.configure(text=f"Output: {self.output_directory}")
-                    print("DEBUG: Updated output label")
+                    logger.debug(" Updated output label")
 
-            print("DEBUG: Calling update_file_list()")
+            logger.debug(" Calling update_file_list()")
             self.update_file_list()
-            print("DEBUG: Calling load_signals_from_files()")
+            logger.debug(" Calling load_signals_from_files()")
             self.load_signals_from_files()
         else:
-            print("DEBUG: No files selected (user cancelled)")
+            logger.debug(" No files selected (user cancelled)")
 
     def select_output_folder(self) -> None:
         """Select output directory for processed files."""
@@ -1944,42 +1978,42 @@ class CSVProcessorApp(ctk.CTk):
 
     def update_file_list(self) -> None:
         """Update the file list display."""
-        print("DEBUG: update_file_list() called")
-        print(
+        logger.debug(" update_file_list() called")
+        logger.debug(
             f"DEBUG: input_file_paths = {getattr(self, 'input_file_paths', 'NOT SET')}",
         )
 
         # Clear existing widgets
         for widget in self.file_list_frame.winfo_children():
             widget.destroy()
-        print("DEBUG: Cleared existing widgets")
+        logger.debug(" Cleared existing widgets")
 
         if not self.input_file_paths:
-            print("DEBUG: No input file paths, showing default message")
+            logger.debug(" No input file paths, showing default message")
             label = ctk.CTkLabel(
                 self.file_list_frame,
                 text="Files you select will be listed here.",
             )
             label.pack(padx=5, pady=5)
-            print("DEBUG: Default label created and packed")
+            logger.debug(" Default label created and packed")
             return
 
-        print(f"DEBUG: Creating display for {len(self.input_file_paths)} files")
+        logger.debug(f" Creating display for {len(self.input_file_paths)} files")
         for i, file_path in enumerate(self.input_file_paths):
-            print(f"DEBUG: Creating widget for file {i + 1}: {file_path}")
+            logger.debug(f" Creating widget for file {i + 1}: {file_path}")
             file_frame = ctk.CTkFrame(self.file_list_frame)
             file_frame.pack(fill="x", padx=5, pady=2)
-            print(f"DEBUG: File frame created and packed for file {i + 1}")
+            logger.debug(f" File frame created and packed for file {i + 1}")
 
             filename = Path(file_path).name
-            print(f"DEBUG: Filename: {filename}")
+            logger.debug(f" Filename: {filename}")
             label = ctk.CTkLabel(
                 file_frame,
                 text=f"{i + 1}. {filename}",
                 font=ctk.CTkFont(size=11),
             )
             label.pack(side="left", padx=5, pady=2)
-            print(f"DEBUG: Label created and packed for file {i + 1}")
+            logger.debug(f" Label created and packed for file {i + 1}")
 
             button = ctk.CTkButton(
                 file_frame,
@@ -1988,13 +2022,13 @@ class CSVProcessorApp(ctk.CTk):
                 command=lambda f=file_path: self.remove_file(f),
             )
             button.pack(side="right", padx=5, pady=2)
-            print(f"DEBUG: Remove button created and packed for file {i + 1}")
+            logger.debug(f" Remove button created and packed for file {i + 1}")
 
-        print("DEBUG: update_file_list() completed")
+        logger.debug(" update_file_list() completed")
 
         # Force GUI update
         self.file_list_frame.update_idletasks()
-        print("DEBUG: Forced file_list_frame update_idletasks()")
+        logger.debug(" Forced file_list_frame update_idletasks()")
 
     def remove_file(self, file_path: str) -> None:
         """Remove a file from the list."""
@@ -2005,10 +2039,10 @@ class CSVProcessorApp(ctk.CTk):
 
     def load_signals_from_files(self) -> None:
         """Load signals from all selected files (optimized)."""
-        print("DEBUG: load_signals_from_files() called")
+        logger.debug(" load_signals_from_files() called")
 
         if not self.input_file_paths:
-            print("DEBUG: No input file paths, returning early")
+            logger.debug(" No input file paths, returning early")
             return
 
         # Update status
@@ -2038,9 +2072,9 @@ class CSVProcessorApp(ctk.CTk):
                 all_signals.update(signals)
 
             except Exception as e:
-                print(f"Error reading {file_path}: {e}")
+                logger.error(f"Error reading {file_path}: {e}")
 
-        print(f"DEBUG: All signals collected: {len(all_signals)} unique signals")
+        logger.debug(f" All signals collected: {len(all_signals)} unique signals")
 
         # Update status
         if hasattr(self, "status_label"):
@@ -2074,7 +2108,7 @@ class CSVProcessorApp(ctk.CTk):
                             loaded. Go to Plotting tab to visualize.",
                     )
 
-        print("DEBUG: load_signals_from_files() completed")
+        logger.debug(" load_signals_from_files() completed")
 
     def _auto_select_single_file(self, filename: str) -> None:
         """Auto-select single file - simplified."""
@@ -2084,7 +2118,7 @@ class CSVProcessorApp(ctk.CTk):
                 if current_selection == filename:  # Only proceed if still selected
                     self.on_plot_file_select(filename)
         except Exception as e:
-            print(f"Error in auto-select: {e}")
+            logger.error(f"Error in auto-select: {e}")
 
     def _ensure_data_loaded(self, filename: str) -> None:
         """Ensure data is loaded for the given filename."""
@@ -2112,7 +2146,7 @@ class CSVProcessorApp(ctk.CTk):
                                 pass
                     return True
                 except Exception as e:
-                    print(f"Error loading {filename}: {e}")
+                    logger.error(f"Error loading {filename}: {e}")
                     return False
         return True
 
@@ -2206,25 +2240,25 @@ class CSVProcessorApp(ctk.CTk):
 
     def process_files(self) -> None:
         """Process all selected files with current settings."""
-        print("\n=== STARTING PROCESS_FILES DEBUG ===")
+        logger.debug("=== STARTING PROCESS_FILES DEBUG ===")
         if not self.input_file_paths:
-            print("ERROR: No input file paths selected")
+            logger.error("No input file paths selected")
             messagebox.showerror("Error", "Please select input files first.")
             return
 
-        print(f"Input files: {len(self.input_file_paths)} files")
+        logger.debug(f"Input files: {len(self.input_file_paths)} files")
         for i, path in enumerate(self.input_file_paths):
-            print(f"  {i + 1}: {path}")
+            logger.debug(f"  {i + 1}: {path}")
 
         selected_signals = [
             s for s, data in self.signal_vars.items() if data["var"].get()
         ]
-        print(f"Selected signals: {len(selected_signals)} signals")
+        logger.debug(f"Selected signals: {len(selected_signals)} signals")
         for signal in selected_signals:
-            print(f"  - {signal}")
+            logger.debug(f"  - {signal}")
 
         if not selected_signals:
-            print("ERROR: No signals selected")
+            logger.error(" No signals selected")
             messagebox.showerror(
                 "Error",
                 "Please select at least one signal to process.",
@@ -2263,15 +2297,15 @@ class CSVProcessorApp(ctk.CTk):
             ),
         }
 
-        print("\nProcessing settings:")
+        logger.debug("\nProcessing settings:")
         for key, value in settings.items():
-            print(f"  {key}: {value}")
+            logger.debug(f"  {key}: {value}")
 
         # Check output directory
         if not self.output_directory:
-            print("WARNING: No output directory set, using default")
+            logger.debug("WARNING: No output directory set, using default")
         else:
-            print(f"Output directory: {self.output_directory}")
+            logger.debug(f"Output directory: {self.output_directory}")
 
         # Update status
         self.status_label.configure(text="Processing files...")
@@ -2281,10 +2315,10 @@ class CSVProcessorApp(ctk.CTk):
         processed_files = []
         error_count = 0
 
-        print(f"\nStarting processing of {len(self.input_file_paths)} files...")
+        logger.debug(f"\nStarting processing of {len(self.input_file_paths)} files...")
 
         for i, file_path in enumerate(self.input_file_paths):
-            print(
+            logger.debug(
                 f"\n--- Processing file {i + 1}/{len(self.input_file_paths)}: "
                 f"{Path(file_path).name} ---"
             )
@@ -2297,50 +2331,50 @@ class CSVProcessorApp(ctk.CTk):
 
                 # Check if file exists
                 if not Path(file_path).exists():
-                    print(f"ERROR: File not found: {file_path}")
+                    logger.error(f" File not found: {file_path}")
                     error_count += 1
                     continue
 
-                print(f"File exists, size: {os.path.getsize(file_path)} bytes")
+                logger.debug(f"File exists, size: {os.path.getsize(file_path)} bytes")
 
                 # Process the file
                 processed_df = self._process_single_file(file_path, settings)
 
                 if processed_df is not None and not processed_df.empty:
-                    print(f"SUCCESS: File processed. Shape: {processed_df.shape}")
-                    print(f"Columns: {list(processed_df.columns)}")
+                    logger.info(f" File processed. Shape: {processed_df.shape}")
+                    logger.debug(f"Columns: {list(processed_df.columns)}")
                     processed_files.append((file_path, processed_df))
                     # Store processed data for plotting
                     filename = Path(file_path).name
                     self.processed_files[filename] = processed_df.copy()
-                    print(f"Stored in processed_files cache as: {filename}")
+                    logger.debug(f"Stored in processed_files cache as: {filename}")
                 else:
-                    print("ERROR: File processing returned None or empty DataFrame")
+                    logger.error(" File processing returned None or empty DataFrame")
                     error_count += 1
 
             except Exception as e:
-                print(f"EXCEPTION processing {file_path}: {e}")
+                logger.error(f"EXCEPTION processing {file_path}: {e}")
                 import traceback
 
                 traceback.print_exc()
                 error_count += 1
 
-        print("\nProcessing complete. Results:")
-        print(f"  Processed files: {len(processed_files)}")
-        print(f"  Errors: {error_count}")
+        logger.debug("\nProcessing complete. Results:")
+        logger.debug(f"  Processed files: {len(processed_files)}")
+        logger.debug(f"  Errors: {error_count}")
 
         if not processed_files:
-            print("ERROR: No files were successfully processed")
+            logger.error(" No files were successfully processed")
             messagebox.showerror("Error", "No files were successfully processed.")
             self.status_label.configure(text="Processing failed - no files processed")
             return
 
         # Export processed files
-        print("\nStarting export process...")
-        print(f"Export type: {self.export_type_var.get()}")
+        logger.debug("\nStarting export process...")
+        logger.debug(f"Export type: {self.export_type_var.get()}")
         try:
             self._export_processed_files(processed_files)
-            print("Export completed successfully")
+            logger.debug("Export completed successfully")
 
             # Update status
             success_count = len(processed_files)
@@ -2373,32 +2407,32 @@ class CSVProcessorApp(ctk.CTk):
         self, file_path: str, settings: dict[str, Any]
     ) -> pd.DataFrame | None:
         """Process a single file with all advanced features."""
-        print(f"\n_process_single_file called for: {Path(file_path).name}")
+        logger.debug(f"\n_process_single_file called for: {Path(file_path).name}")
         try:
-            print("  Loading CSV file...")
+            logger.debug("  Loading CSV file...")
             df = safe_read_csv(file_path, low_memory=False)
-            print(f"  Loaded DataFrame shape: {df.shape}")
-            print(f"  Original columns: {list(df.columns)}")
+            logger.debug(f"  Loaded DataFrame shape: {df.shape}")
+            logger.debug(f"  Original columns: {list(df.columns)}")
 
             # Determine which signals to keep for this specific file
             signals_in_this_file = [
                 s for s in settings["selected_signals"] if s in df.columns
             ]
             time_col = df.columns[0]
-            print(f"  Time column: {time_col}")
-            print(f"  Signals found in file: {len(signals_in_this_file)}")
+            logger.debug(f"  Time column: {time_col}")
+            logger.debug(f"  Signals found in file: {len(signals_in_this_file)}")
 
             if time_col not in signals_in_this_file:
                 signals_in_this_file.insert(0, time_col)
-                print("  Added time column to signals")
+                logger.debug("  Added time column to signals")
 
-            print(f"  Final signals to process: {signals_in_this_file}")
+            logger.debug(f"  Final signals to process: {signals_in_this_file}")
 
             processed_df = df[signals_in_this_file].copy()
-            print(f"  Copied DataFrame shape: {processed_df.shape}")
+            logger.debug(f"  Copied DataFrame shape: {processed_df.shape}")
 
             # Data type conversion
-            print("  Converting data types...")
+            logger.debug("  Converting data types...")
             processed_df[time_col] = pd.to_datetime(
                 processed_df[time_col],
                 errors="coerce",
@@ -2406,7 +2440,7 @@ class CSVProcessorApp(ctk.CTk):
             before_drop = len(processed_df)
             processed_df.dropna(subset=[time_col], inplace=True)
             after_drop = len(processed_df)
-            print(f"  Dropped {before_drop - after_drop} rows with invalid time")
+            logger.debug(f"  Dropped {before_drop - after_drop} rows with invalid time")
 
             for col in processed_df.columns:
                 if col != time_col:
@@ -2416,13 +2450,13 @@ class CSVProcessorApp(ctk.CTk):
                         errors="coerce",
                     )
                     after_numeric = processed_df[col].notna().sum()
-                    print(
+                    logger.debug(
                         f"  Column {col}: {before_numeric} -> {after_numeric} \
                             valid values",
                     )
 
             if processed_df.empty:
-                print("  ERROR: DataFrame is empty after data type conversion")
+                logger.debug("  ERROR: DataFrame is empty after data type conversion")
                 return None
 
             # Apply time trimming if specified
@@ -2431,7 +2465,7 @@ class CSVProcessorApp(ctk.CTk):
             trim_end = self.trim_end_entry.get().strip()
 
             if trim_date or trim_start or trim_end:
-                print(
+                logger.debug(
                     f"  Applying time trimming: date={trim_date}, \
                         start={trim_start}, end={trim_end}",
                 )
@@ -2439,14 +2473,14 @@ class CSVProcessorApp(ctk.CTk):
                     # Get the date from the data if not specified
                     if not trim_date:
                         trim_date = processed_df[time_col].iloc[0].strftime("%Y-%m-%d")
-                        print(f"  Using date from data: {trim_date}")
+                        logger.debug(f"  Using date from data: {trim_date}")
 
                     # Create full datetime strings
                     start_time_str = trim_start or "00:00:00"
                     end_time_str = trim_end or "23:59:59"
                     start_full_str = f"{trim_date} {start_time_str}"
                     end_full_str = f"{trim_date} {end_time_str}"
-                    print(f"  Time range: {start_full_str} to {end_full_str}")
+                    logger.debug(f"  Time range: {start_full_str} to {end_full_str}")
 
                     before_trim = len(processed_df)
                     # Filter the data by time range
@@ -2456,28 +2490,28 @@ class CSVProcessorApp(ctk.CTk):
                         .reset_index()
                     )
                     after_trim = len(processed_df)
-                    print(f"  Trimming: {before_trim} -> {after_trim} rows")
+                    logger.debug(f"  Trimming: {before_trim} -> {after_trim} rows")
 
                     if processed_df.empty:
-                        print("  ERROR: Time trimming resulted in empty dataset")
+                        logger.debug("  ERROR: Time trimming resulted in empty dataset")
                         return None
 
                 except Exception as e:
-                    print(f"  ERROR in time trimming: {e}")
+                    logger.debug(f"  ERROR in time trimming: {e}")
 
-            print("  Setting time column as index...")
+            logger.debug("  Setting time column as index...")
             processed_df.set_index(time_col, inplace=True)
-            print(f"  DataFrame shape after indexing: {processed_df.shape}")
+            logger.debug(f"  DataFrame shape after indexing: {processed_df.shape}")
 
             # Apply Filtering
             filter_type = settings.get("filter_type")
-            print(f"  Filter type: {filter_type}")
+            logger.debug(f"  Filter type: {filter_type}")
             if filter_type and filter_type != "None":
-                print("  Applying filtering...")
+                logger.debug("  Applying filtering...")
                 numeric_cols = processed_df.select_dtypes(
                     include=np.number,
                 ).columns.tolist()
-                print(f"  Numeric columns for filtering: {numeric_cols}")
+                logger.debug(f"  Numeric columns for filtering: {numeric_cols}")
                 for col in numeric_cols:
                     signal_data = processed_df[col].dropna()
                     if len(signal_data) < 2:
@@ -2547,7 +2581,7 @@ class CSVProcessorApp(ctk.CTk):
                             )
                             processed_df.loc[outliers, col] = median_filtered[outliers]
                         except Exception as e:
-                            print(f"Error applying Hampel filter: {e}")
+                            logger.error(f"Error applying Hampel filter: {e}")
                             # Fallback to simple median filter
                             processed_df[col] = pd.Series(
                                 medfilt(signal_data, kernel_size=window),
@@ -2589,24 +2623,26 @@ class CSVProcessorApp(ctk.CTk):
             # Apply Resampling
             if settings.get("resample_enabled"):
                 resample_rule = settings.get("resample_rule")
-                print(f"  Applying resampling with rule: {resample_rule}")
+                logger.debug(f"  Applying resampling with rule: {resample_rule}")
                 if resample_rule:
                     before_resample = len(processed_df)
                     processed_df = (
                         processed_df.resample(resample_rule).mean().dropna(how="all")
                     )
                     after_resample = len(processed_df)
-                    print(f"  Resampling: {before_resample} -> {after_resample} rows")
+                    logger.debug(
+                        f"  Resampling: {before_resample} -> {after_resample} rows"
+                    )
             else:
-                print("  Resampling disabled")
+                logger.debug("  Resampling disabled")
 
-            print("  Resetting index...")
+            logger.debug("  Resetting index...")
             processed_df.reset_index(inplace=True)
-            print(f"  DataFrame shape after reset: {processed_df.shape}")
+            logger.debug(f"  DataFrame shape after reset: {processed_df.shape}")
 
-            print("  Applying custom variables...")
+            logger.debug("  Applying custom variables...")
             processed_df = self._apply_custom_variables(processed_df, time_col)
-            print(f"  DataFrame shape after custom vars: {processed_df.shape}")
+            logger.debug(f"  DataFrame shape after custom vars: {processed_df.shape}")
 
             # Apply integration if signals are selected
             signals_to_integrate = [
@@ -2615,7 +2651,7 @@ class CSVProcessorApp(ctk.CTk):
                 if data["var"].get()
             ]
             if signals_to_integrate:
-                print(f"  Applying integration to: {signals_to_integrate}")
+                logger.debug(f"  Applying integration to: {signals_to_integrate}")
                 integration_method = self.integrator_method_var.get()
                 processed_df = self._apply_integration(
                     processed_df,
@@ -2623,14 +2659,18 @@ class CSVProcessorApp(ctk.CTk):
                     signals_to_integrate,
                     integration_method,
                 )
-                print(f"  DataFrame shape after integration: {processed_df.shape}")
+                logger.debug(
+                    f"  DataFrame shape after integration: {processed_df.shape}"
+                )
 
             # Apply differentiation if signals are selected
             signals_to_differentiate = [
                 s for s, data in self.deriv_signal_vars.items() if data["var"].get()
             ]
             if signals_to_differentiate:
-                print(f"  Applying differentiation to: {signals_to_differentiate}")
+                logger.debug(
+                    f"  Applying differentiation to: {signals_to_differentiate}"
+                )
                 differentiation_method = self.deriv_method_var.get()
                 processed_df = self._apply_differentiation(
                     processed_df,
@@ -2638,20 +2678,22 @@ class CSVProcessorApp(ctk.CTk):
                     signals_to_differentiate,
                     differentiation_method,
                 )
-                print(f"  DataFrame shape after differentiation: {processed_df.shape}")
+                logger.debug(
+                    f"  DataFrame shape after differentiation: {processed_df.shape}"
+                )
 
             if processed_df.empty:
-                print("  ERROR: Final DataFrame is empty")
+                logger.debug("  ERROR: Final DataFrame is empty")
                 return None
 
-            print(
+            logger.debug(
                 f"  SUCCESS: Returning processed DataFrame with shape \
                     {processed_df.shape}",
             )
             return processed_df
 
         except Exception as e:
-            print(f"  EXCEPTION in _process_single_file: {e}")
+            logger.debug(f"  EXCEPTION in _process_single_file: {e}")
             import traceback
 
             traceback.print_exc()
@@ -2711,7 +2753,7 @@ class CSVProcessorApp(ctk.CTk):
                 df[name] = result
 
             except Exception as e:
-                print(f"Error applying custom variable '{var['name']}': {e}")
+                logger.error(f"Error applying custom variable '{var['name']}': {e}")
                 df[var["name"]] = np.nan
                 messagebox.showwarning(
                     "Custom Variable Error",
@@ -2765,33 +2807,33 @@ class CSVProcessorApp(ctk.CTk):
 
     def _export_csv_separate(self, processed_files: dict[str, pd.DataFrame]) -> None:
         """Export each file as a separate CSV."""
-        print(f"_export_csv_separate called with {len(processed_files)} files")
+        logger.debug(f"_export_csv_separate called with {len(processed_files)} files")
         exported_count = 0
         for file_path, df in processed_files:
             base_name = Path(file_path).stem
             output_path = Path(self.output_directory) / f"{base_name}_processed.csv"
-            print(f"Exporting to: {output_path}")
+            logger.debug(f"Exporting to: {output_path}")
 
             final_path = self._check_file_overwrite(output_path)
             if final_path is None:
-                print(f"Export cancelled for {base_name}")
+                logger.debug(f"Export cancelled for {base_name}")
                 continue
 
-            print(f"Final export path: {final_path}")
+            logger.debug(f"Final export path: {final_path}")
             df = self._apply_sorting(df)
             safe_write_csv(df, final_path, index=False)
             exported_count += 1
-            print(f"Successfully exported: {final_path}")
+            logger.debug(f"Successfully exported: {final_path}")
 
-        print(f"Export summary: {exported_count} files exported")
+        logger.debug(f"Export summary: {exported_count} files exported")
         if exported_count > 0:
-            print(f"Showing success message for {exported_count} files")
+            logger.debug(f"Showing success message for {exported_count} files")
             messagebox.showinfo(
                 "Export Success",
                 f"Exported {exported_count} files to {self.output_directory}",
             )
         else:
-            print("Showing cancelled message")
+            logger.debug("Showing cancelled message")
             messagebox.showinfo("Export Cancelled", "No files were exported.")
 
     def _export_csv_compiled(self, processed_files: dict[str, pd.DataFrame]) -> None:
@@ -4191,7 +4233,7 @@ class CSVProcessorApp(ctk.CTk):
                 with open(self.layout_config_file) as f:
                     return json.load(f)
         except Exception as e:
-            print(f"Error loading layout config: {e}")
+            logger.error(f"Error loading layout config: {e}")
         return {}
 
     def _save_layout_config(self) -> None:
@@ -4208,7 +4250,7 @@ class CSVProcessorApp(ctk.CTk):
 
             safe_write_json(self.layout_config_file, self.layout_data, indent=2)
         except Exception as e:
-            print(f"Error saving layout config: {e}")
+            logger.error(f"Error saving layout config: {e}")
 
     def _create_splitter(
         self,
@@ -4405,7 +4447,7 @@ class CSVProcessorApp(ctk.CTk):
                 self.update_plot()
 
         except Exception as e:
-            print(f"ERROR in on_plot_file_select: {e}")
+            logger.debug(f"ERROR in on_plot_file_select: {e}")
             import traceback
 
             traceback.print_exc()
@@ -4421,7 +4463,7 @@ class CSVProcessorApp(ctk.CTk):
         """Update the plot with fixed error handling and canvas management."""
         # Check if plot canvas is initialized
         if not hasattr(self, "plot_canvas") or not hasattr(self, "plot_ax"):
-            print("Warning: Plot canvas not initialized")
+            logger.debug("Warning: Plot canvas not initialized")
             return
 
         selected_file = self.plot_file_menu.get()
@@ -4438,7 +4480,7 @@ class CSVProcessorApp(ctk.CTk):
         try:
             df = self.get_data_for_plotting(selected_file)
         except Exception as e:
-            print(f"Error loading data: {e}")
+            logger.error(f"Error loading data: {e}")
             self.plot_ax.text(
                 0.5,
                 0.5,
@@ -4519,18 +4561,18 @@ class CSVProcessorApp(ctk.CTk):
                         x_axis_col,
                     )
                 except Exception as e:
-                    print(f"Warning: Filter failed - {e}")
+                    logger.debug(f"Warning: Filter failed - {e}")
                     # Continue with unfiltered data
 
             # Plot signals
             for i, signal in enumerate(signals_to_plot):
                 if signal not in plot_df.columns:
-                    print(f"Warning: Signal {signal} not found in data")
+                    logger.debug(f"Warning: Signal {signal} not found in data")
                     continue
 
                 signal_data = plot_df[[x_axis_col, signal]].dropna()
                 if len(signal_data) == 0:
-                    print(f"Warning: No valid data for signal {signal}")
+                    logger.debug(f"Warning: No valid data for signal {signal}")
                     continue
 
                 try:
@@ -4609,10 +4651,10 @@ class CSVProcessorApp(ctk.CTk):
                                 linewidth=line_width,
                             )
                         except Exception as e:
-                            print(f"Warning: Filter comparison failed - {e}")
+                            logger.debug(f"Warning: Filter comparison failed - {e}")
 
                 except Exception as e:
-                    print(f"Error plotting signal {signal}: {e}")
+                    logger.error(f"Error plotting signal {signal}: {e}")
                     continue
 
             # Add trendline if configured
@@ -4628,7 +4670,7 @@ class CSVProcessorApp(ctk.CTk):
                         trendline_type,
                     )
             except Exception as e:
-                print(f"Warning: Trendline failed - {e}")
+                logger.debug(f"Warning: Trendline failed - {e}")
 
             # Configure plot appearance
             title = self.plot_title_entry.get() or f"Signals from {selected_file}"
@@ -4673,23 +4715,27 @@ class CSVProcessorApp(ctk.CTk):
                 # Auto-fit to show all data
                 try:
                     self.plot_ax.autoscale_view()
-                    print(f"Auto-zoom applied ({zoom_reason}): fitting to all data")
+                    logger.debug(
+                        f"Auto-zoom applied ({zoom_reason}): fitting to all data"
+                    )
                 except Exception as e:
-                    print(f"Warning: Could not auto-fit plot - {e}")
+                    logger.debug(f"Warning: Could not auto-fit plot - {e}")
             elif zoom_state:
                 # Restore previous zoom state
                 try:
                     self._apply_zoom_state(zoom_state)
-                    print(f"Zoom state restored ({zoom_reason}): preserving user view")
+                    logger.debug(
+                        f"Zoom state restored ({zoom_reason}): preserving user view"
+                    )
                 except Exception as e:
-                    print(f"Warning: Could not apply zoom state - {e}")
+                    logger.debug(f"Warning: Could not apply zoom state - {e}")
 
             # Force canvas update
             self.plot_canvas.draw_idle()  # type: ignore[no-untyped-call]
             self.status_label.configure(text="Plot updated successfully")
 
         except Exception as e:
-            print(f"Error in plotting: {e}")
+            logger.error(f"Error in plotting: {e}")
             import traceback
 
             traceback.print_exc()
@@ -4710,11 +4756,11 @@ class CSVProcessorApp(ctk.CTk):
     def _ensure_plot_canvas_ready(self) -> bool:
         """Ensure plot canvas is properly initialized."""
         if not hasattr(self, "plot_canvas") or self.plot_canvas is None:
-            print("ERROR: Plot canvas not initialized!")
+            logger.error(" Plot canvas not initialized!")
             return False
 
         if not hasattr(self, "plot_ax") or self.plot_ax is None:
-            print("ERROR: Plot axes not initialized!")
+            logger.error(" Plot axes not initialized!")
             return False
 
         # Force a draw to ensure canvas is ready
@@ -4722,7 +4768,7 @@ class CSVProcessorApp(ctk.CTk):
             self.plot_canvas.draw()  # type: ignore[no-untyped-call]
             return True
         except Exception as e:
-            print(f"ERROR: Canvas draw failed - {e}")
+            logger.error(f" Canvas draw failed - {e}")
             return False
 
     def enable_plot_debugging(self) -> None:
@@ -4732,7 +4778,7 @@ class CSVProcessorApp(ctk.CTk):
     def debug_print(self, message: str) -> None:
         """Print debug message if debugging is enabled."""
         if hasattr(self, "plot_debug") and self.plot_debug:
-            print(f"[PLOT DEBUG] {message}")
+            logger.debug(f"[PLOT DEBUG] {message}")
 
     def _apply_plot_filter(
         self, df: pd.DataFrame, signal_cols: list[str], x_axis_col: str
@@ -4816,7 +4862,7 @@ class CSVProcessorApp(ctk.CTk):
                         df[signal].rolling(window=order * 2 + 1, center=True).mean()
                     )
                 except Exception as e:
-                    print(f"Error applying Butterworth filter: {e}")
+                    logger.error(f"Error applying Butterworth filter: {e}")
                     # Fallback to simple smoothing
                     filtered_df[signal] = (
                         df[signal].rolling(window=order * 2 + 1, center=True).mean()
@@ -4862,7 +4908,7 @@ class CSVProcessorApp(ctk.CTk):
                         df[signal].rolling(window=window, center=True).median()
                     )
                 except Exception as e:
-                    print(f"Error applying Hampel filter: {e}")
+                    logger.error(f"Error applying Hampel filter: {e}")
                     # Fallback to simple median filter
                     filtered_df[signal] = (
                         df[signal].rolling(window=window, center=True).median()
@@ -4911,7 +4957,7 @@ class CSVProcessorApp(ctk.CTk):
                         df[signal].rolling(window=window, center=True).mean()
                     )
                 except Exception as e:
-                    print(f"Error applying Savitzky-Golay filter: {e}")
+                    logger.error(f"Error applying Savitzky-Golay filter: {e}")
                     # Fallback to simple smoothing
                     filtered_df[signal] = (
                         df[signal].rolling(window=window, center=True).mean()
@@ -4998,7 +5044,7 @@ class CSVProcessorApp(ctk.CTk):
                                 & (plot_df[x_axis_col] <= self.trendline_selection_end)
                             ]
                     except Exception as e:
-                        print(f"Error applying visual selection: {e}")
+                        logger.error(f"Error applying visual selection: {e}")
 
         # Check if we still have enough data after filtering
         if len(plot_df) < 2:
@@ -5120,7 +5166,7 @@ class CSVProcessorApp(ctk.CTk):
 
         except Exception as e:
             messagebox.showerror("Trendline Error", f"Error adding trendline: {e!s}")
-            print(f"Error adding trendline: {e}")
+            logger.error(f"Error adding trendline: {e}")
             import traceback
 
             traceback.print_exc()
@@ -5161,45 +5207,45 @@ class CSVProcessorApp(ctk.CTk):
 
                 return df
         except Exception as e:
-            print(f"Error loading data for plotting: {e}")
+            logger.error(f"Error loading data for plotting: {e}")
             return None
 
     def _debug_plot_state(self) -> None:
         """Debug helper to print current plotting state."""
-        print("\n=== PLOT DEBUG STATE ===")
-        print(f"plot_file_menu: {getattr(self, 'plot_file_menu', None)}")
+        logger.debug("\n=== PLOT DEBUG STATE ===")
+        logger.debug(f"plot_file_menu: {getattr(self, 'plot_file_menu', None)}")
         if hasattr(self, "plot_file_menu"):
-            print(f"  selected file: {self.plot_file_menu.get()}")
+            logger.debug(f"  selected file: {self.plot_file_menu.get()}")
 
-        print(f"plot_xaxis_menu: {getattr(self, 'plot_xaxis_menu', None)}")
+        logger.debug(f"plot_xaxis_menu: {getattr(self, 'plot_xaxis_menu', None)}")
         if hasattr(self, "plot_xaxis_menu"):
-            print(f"  selected x-axis: {self.plot_xaxis_menu.get()}")
+            logger.debug(f"  selected x-axis: {self.plot_xaxis_menu.get()}")
 
-        print(f"plot_signal_vars: {getattr(self, 'plot_signal_vars', None)}")
+        logger.debug(f"plot_signal_vars: {getattr(self, 'plot_signal_vars', None)}")
         if hasattr(self, "plot_signal_vars"):
-            print(f"  number of signals: {len(self.plot_signal_vars)}")
+            logger.debug(f"  number of signals: {len(self.plot_signal_vars)}")
             selected = [
                 s for s, data in self.plot_signal_vars.items() if data["var"].get()
             ]
-            print(f"  selected signals: {selected}")
+            logger.debug(f"  selected signals: {selected}")
 
-        print(f"plot_canvas: {getattr(self, 'plot_canvas', None)}")
-        print(f"plot_ax: {getattr(self, 'plot_ax', None)}")
+        logger.debug(f"plot_canvas: {getattr(self, 'plot_canvas', None)}")
+        logger.debug(f"plot_ax: {getattr(self, 'plot_ax', None)}")
 
         processed_files_len = (
             len(getattr(self, "processed_files", {}))
             if hasattr(self, "processed_files")
             else "None"
         )
-        print(f"processed_files: {processed_files_len}")
+        logger.debug(f"processed_files: {processed_files_len}")
 
         loaded_data_cache_len = (
             len(getattr(self, "loaded_data_cache", {}))
             if hasattr(self, "loaded_data_cache")
             else "None"
         )
-        print(f"loaded_data_cache: {loaded_data_cache_len}")
-        print("========================\n")
+        logger.debug(f"loaded_data_cache: {loaded_data_cache_len}")
+        logger.debug("========================\n")
 
     def _force_signal_selection(self) -> None:
         """Force select at least one signal for debugging."""
@@ -5215,7 +5261,7 @@ class CSVProcessorApp(ctk.CTk):
                         word in signal.lower() for word in ["time", "date", "timestamp"]
                     ):
                         data["var"].set(True)
-                        print(f"DEBUG: Force-selected signal: {signal}")
+                        logger.debug(f" Force-selected signal: {signal}")
                         break
 
     def _show_setup_help(self) -> None:
@@ -5822,7 +5868,7 @@ COMMON MISTAKES TO AVOID:
                                     ),
                                 )
                     except Exception:
-                        # Skip files that can't be read as JSON or don't have the right structure
+                        # Skip files that can't be read as JSON
                         continue
 
             # Sort by creation date (newest first)
@@ -6131,7 +6177,7 @@ COMMON MISTAKES TO AVOID:
                     text=f"Signal list saved: {signal_list_name} \
                         ({len(selected_signals)} signals)",
                 )
-                print(
+                logger.debug(
                     f"DEBUG: Signal list '{signal_list_name}' saved \
                         successfully with {len(selected_signals)} signals",
                 )
@@ -6141,42 +6187,42 @@ COMMON MISTAKES TO AVOID:
 
     def load_signal_list(self) -> None:
         """Load a saved signal list from file."""
-        print("DEBUG: load_signal_list() called")
+        logger.debug(" load_signal_list() called")
         try:
-            print("DEBUG: Opening file dialog")
+            logger.debug(" Opening file dialog")
             file_path = filedialog.askopenfilename(
                 title="Load Signal List",
                 filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
             )
-            print(f"DEBUG: File dialog returned: {file_path}")
+            logger.debug(f" File dialog returned: {file_path}")
 
             if not file_path:
-                print("DEBUG: No file selected, returning")
+                logger.debug(" No file selected, returning")
                 return  # User cancelled
 
-            print(f"DEBUG: Loading file: {file_path}")
+            logger.debug(f" Loading file: {file_path}")
             signal_list_data = safe_read_json(file_path, default=None)
-            print(f"DEBUG: Successfully loaded JSON data: {signal_list_data}")
-            print(f"DEBUG: Successfully loaded JSON data: {signal_list_data}")
+            logger.debug(f" Successfully loaded JSON data: {signal_list_data}")
+            logger.debug(f" Successfully loaded JSON data: {signal_list_data}")
 
             # Validate the loaded data
-            print("DEBUG: Validating loaded data")
+            logger.debug(" Validating loaded data")
             if (
                 not isinstance(signal_list_data, dict)
                 or "signals" not in signal_list_data
             ):
-                print("DEBUG: Invalid signal list file format")
+                logger.debug(" Invalid signal list file format")
                 messagebox.showerror("Error", "Invalid signal list file format.")
                 return
 
             # Store the loaded signal list
-            print("DEBUG: Storing loaded signal list")
+            logger.debug(" Storing loaded signal list")
             self.saved_signal_list = signal_list_data.get("signals", [])
             self.saved_signal_list_name = signal_list_data.get("name", "Unknown")
-            print(f"DEBUG: Saved signal list: {len(self.saved_signal_list)} signals")
+            logger.debug(f" Saved signal list: {len(self.saved_signal_list)} signals")
 
             # Update status
-            print("DEBUG: Updating status label")
+            logger.debug(" Updating status label")
             self.signal_list_status_label.configure(
                 text=f"Loaded: {self.saved_signal_list_name} \
                     ({len(self.saved_signal_list)} signals)",
@@ -6184,21 +6230,21 @@ COMMON MISTAKES TO AVOID:
             )
 
             # Automatically apply the loaded signals if we have signals available
-            print(f"DEBUG: Checking if signal_vars exist: {bool(self.signal_vars)}")
+            logger.debug(f" Checking if signal_vars exist: {bool(self.signal_vars)}")
             if self.signal_vars:
-                print("DEBUG: Applying loaded signals internally")
+                logger.debug(" Applying loaded signals internally")
                 self._apply_loaded_signals_internal()
 
-            print("DEBUG: Signal list loaded successfully without popup")
+            logger.debug(" Signal list loaded successfully without popup")
             # No popup message - just update status bar for better user experience
             self.status_label.configure(
                 text=f"Signal list loaded: {self.saved_signal_list_name} \
                     ({len(self.saved_signal_list)} signals)",
             )
-            print("DEBUG: load_signal_list() completed successfully")
+            logger.debug(" load_signal_list() completed successfully")
 
         except Exception as e:
-            print(f"DEBUG: Exception in load_signal_list: {e}")
+            logger.debug(f" Exception in load_signal_list: {e}")
             import traceback
 
             traceback.print_exc()
@@ -6206,9 +6252,9 @@ COMMON MISTAKES TO AVOID:
 
     def _apply_loaded_signals_internal(self) -> None:
         """Internal method to apply loaded signals without showing message boxes."""
-        print("DEBUG: _apply_loaded_signals_internal() called")
+        logger.debug(" _apply_loaded_signals_internal() called")
         if not self.saved_signal_list or not self.signal_vars:
-            print(
+            logger.debug(
                 f"DEBUG: Early return - saved_signal_list: "
                 f"{bool(self.saved_signal_list)}, "
                 f"signal_vars: {bool(self.signal_vars)}"
@@ -6217,26 +6263,26 @@ COMMON MISTAKES TO AVOID:
 
         # Get current available signals (use set for O(1) lookup)
         available_signals = set(self.signal_vars.keys())
-        print(f"DEBUG: Available signals: {len(available_signals)}")
+        logger.debug(f" Available signals: {len(available_signals)}")
 
         # Find which saved signals are present
         present_signals = []
         missing_signals = []
 
-        print("DEBUG: Checking saved signals against available signals")
+        logger.debug(" Checking saved signals against available signals")
         for saved_signal in self.saved_signal_list:
             if saved_signal in available_signals:  # O(1) lookup with set
                 present_signals.append(saved_signal)
             else:
                 missing_signals.append(saved_signal)
 
-        print(
+        logger.debug(
             f"DEBUG: Present signals: {len(present_signals)}, "
             f"Missing signals: {len(missing_signals)}"
         )
 
         # Apply the saved signals (select present ones, deselect others)
-        print("DEBUG: Applying signal selections")
+        logger.debug(" Applying signal selections")
         for signal, data in self.signal_vars.items():
             if signal in present_signals:
                 data["var"].set(True)
@@ -6244,13 +6290,13 @@ COMMON MISTAKES TO AVOID:
                 data["var"].set(False)
 
         # Update status
-        print("DEBUG: Updating status label")
+        logger.debug(" Updating status label")
         self.signal_list_status_label.configure(
             text=f"Applied: {self.saved_signal_list_name} \
                 ({len(present_signals)}/{len(self.saved_signal_list)} signals)",
             text_color="blue",
         )
-        print("DEBUG: _apply_loaded_signals_internal() completed")
+        logger.debug(" _apply_loaded_signals_internal() completed")
 
     def apply_saved_signals(self) -> None:
         """Apply the saved signal list to the current file's signals."""
@@ -6640,8 +6686,8 @@ COMMON MISTAKES TO AVOID:
         idx = selection[0]
         plot_config = self.plots_list[idx]
 
-        print(f"DEBUG: Loading plot config: {plot_config.get('name', 'Unknown')}")
-        print(f"DEBUG: File in config: '{plot_config.get('file', '')}'")
+        logger.debug(f" Loading plot config: {plot_config.get('name', 'Unknown')}")
+        logger.debug(f" File in config: '{plot_config.get('file', '')}'")
 
         # Apply the plot configuration using the same method as the main plotting tab
         self._apply_plot_config(plot_config)
@@ -6704,7 +6750,7 @@ COMMON MISTAKES TO AVOID:
             )
             safe_write_json(plots_file, self.plots_list, indent=2)
         except Exception as e:
-            print(f"Error saving plots to file: {e}")
+            logger.error(f"Error saving plots to file: {e}")
 
     def _load_plots_from_file(self) -> None:
         """Load plots list from file."""
@@ -6719,7 +6765,7 @@ COMMON MISTAKES TO AVOID:
                 self._update_plots_listbox()
                 self._update_load_plot_config_menu()
         except Exception as e:
-            print(f"Error loading plots from file: {e}")
+            logger.error(f"Error loading plots from file: {e}")
             self.plots_list = []
 
     def _select_tag_file(self) -> None:
@@ -6844,7 +6890,7 @@ COMMON MISTAKES TO AVOID:
                 safe_write_csv(df, output_path, index=False)
 
             except Exception as e:
-                print(f"Error trimming {file_path}: {e}")
+                logger.error(f"Error trimming {file_path}: {e}")
 
         messagebox.showinfo(
             "Success",
@@ -8280,7 +8326,7 @@ For additional support or feature requests, please refer to the
             signals = plot_config.get("signals", [])
             file_name = plot_config.get("file", "")
 
-            print(
+            logger.debug(
                 f"DEBUG: Preview plot config - File: '{file_name}', Signals: {signals}",
             )
 
@@ -8906,7 +8952,7 @@ For additional support or feature requests, please refer to the
                 self.plot_canvas.draw()  # type: ignore[no-untyped-call]
                 self.status_label.configure(text="Plot auto-fitted to data")
             except Exception as e:
-                print(f"Error auto-fitting plot: {e}")
+                logger.error(f"Error auto-fitting plot: {e}")
 
     def _should_auto_zoom(self, reason: str = "filter_change") -> bool:
         """Determine if auto-zoom should be applied based on the reason."""
@@ -8941,13 +8987,13 @@ For additional support or feature requests, please refer to the
                 self.plot_ax.set_xlim(zoom_state["xlim"])
                 self.plot_ax.set_ylim(zoom_state["ylim"])
             except Exception as e:
-                print(f"Error restoring zoom state: {e}")
+                logger.error(f"Error restoring zoom state: {e}")
 
 
 # =============================================================================
 # MAIN EXECUTION
 # =============================================================================
 if __name__ == "__main__":
-    print("Starting Advanced CSV Processor - Complete Version...")
+    logger.debug("Starting Advanced CSV Processor - Complete Version...")
     app = CSVProcessorApp()
     app.mainloop()

--- a/src/data_processing/data_processor/python/data_processor/core/data_loader.py
+++ b/src/data_processing/data_processor/python/data_processor/core/data_loader.py
@@ -14,17 +14,19 @@ import numpy as np
 import pandas as pd
 
 # Use shared path utilities
-from utils.path_helpers import ensure_utils_in_path
+from utils.path_helpers import ensure_utils_in_path  # noqa: E402
 
 ensure_utils_in_path()
 
 # Import from centralized utilities
-from utils.csv_utils import safe_read_csv, safe_write_csv
-from utils.logging_utils import get_logger
+from utils.csv_utils import safe_read_csv, safe_write_csv  # noqa: E402
+from utils.logging_utils import get_logger  # noqa: E402
 
-from data_processor.constants import TIME_COLUMN_KEYWORDS
-from data_processor.high_performance_loader import HighPerformanceDataLoader
-from data_processor.security_utils import validate_and_check_file
+from data_processor.constants import TIME_COLUMN_KEYWORDS  # noqa: E402
+from data_processor.high_performance_loader import (  # noqa: E402
+    HighPerformanceDataLoader,
+)
+from data_processor.security_utils import validate_and_check_file  # noqa: E402
 
 logger = get_logger(__name__)
 

--- a/src/data_processing/data_processor/python/data_processor/file_utils.py
+++ b/src/data_processing/data_processor/python/data_processor/file_utils.py
@@ -123,7 +123,7 @@ class DataReader:
             file_path: Path to the file
 
         Returns:
-            str | None: Detected format type, or None if file doesn't exist or format is undetectable
+            str | None: Detected format type, or None if undetectable.
         """
         file_path = Path(file_path)
         if not file_path.exists():

--- a/src/data_processing/data_processor/python/data_processor/high_performance_loader.py
+++ b/src/data_processing/data_processor/python/data_processor/high_performance_loader.py
@@ -26,20 +26,23 @@ from typing import Any
 import pandas as pd
 
 # Use shared path utilities
-from utils.path_helpers import ensure_utils_in_path
+from utils.path_helpers import ensure_utils_in_path  # noqa: E402
 
 ensure_utils_in_path()
 
 # Import from centralized utilities
-from utils.csv_utils import safe_read_csv
-from utils.file_utils import safe_read_json
-from utils.logging_utils import get_logger
+from utils.csv_utils import safe_read_csv  # noqa: E402
+from utils.file_utils import safe_read_json  # noqa: E402
+from utils.logging_utils import get_logger  # noqa: E402
 
 # Import security utilities
 try:
-    from .security_utils import FileSizeError, check_file_size
+    from .security_utils import FileSizeError, check_file_size  # noqa: E402
 except ImportError:
-    from security_utils import FileSizeError, check_file_size  # type: ignore
+    from security_utils import (  # type: ignore  # noqa: E402
+        FileSizeError,
+        check_file_size,
+    )
 
 
 # Module logger

--- a/src/data_processing/data_processor/python/tests/test_file_utils.py
+++ b/src/data_processing/data_processor/python/tests/test_file_utils.py
@@ -1,5 +1,7 @@
 """Tests for file utility functions."""
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/src/data_processing/data_processor/python/tests/test_processing_config.py
+++ b/src/data_processing/data_processor/python/tests/test_processing_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from data_processor.models import FilterConfig, PipelineConfig
 


### PR DESCRIPTION
## Summary
- Add logging import and logger instance to Data_Processor_r0.py
- Convert 95+ print statements to logger.debug/error/info calls
- Add logging to Data_Processor_Integrated.py
- Add noqa: E402 comments for legitimate import ordering
- Add missing Path import in test files
- Add safe_read_json, safe_write_json, safe_write_text functions
- Fix line length issues in docstrings
- Configure ruff format to be black-compatible
- Exclude data_processing from ruff-format to avoid formatter conflicts

## Test plan
- [x] pre-commit hooks pass locally
- [ ] CI/CD pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, cross-cutting edits in core GUI processing code are mostly mechanical but could change runtime output/diagnostics and mask errors if logging isn’t configured; a few small string/log message changes may also impact user-visible messages.
> 
> **Overview**
> Switches the data processor GUI code (`Data_Processor_r0.py` and `Data_Processor_Integrated.py`) from pervasive `print()` statements to `logging` (`debug`/`info`/`error`) and adds module-level loggers.
> 
> Adds local safe file helpers in `Data_Processor_r0.py` (`safe_read_json`, `safe_write_json`, `safe_write_text`) and updates a few related call sites; also standardizes some import ordering with `# noqa: E402` in `core/data_loader.py` and `high_performance_loader.py`.
> 
> Tooling/config updates: exclude `src/data_processing/` from `ruff-format` in `.pre-commit-config.yaml`, add Ruff formatter settings to mimic Black in `ruff.toml`, and make minor lint/docstring/test import fixes (e.g., add missing `Path` imports).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86b3045f1aa5727259af8d4217ae39cbacae740c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->