### PR TITLE
feat(theme): integrate shared theme system into all Tools GUI apps

### DIFF
--- a/src/acid_gas_dewpoint/launch_pyqt6.py
+++ b/src/acid_gas_dewpoint/launch_pyqt6.py
@@ -20,6 +20,7 @@ def main() -> int:
         from acid_gas_dewpoint.python.acid_gas_dewpoint.ui.pyqt6.main_window import (
             AcidGasDewpointCalculatorWidget,
         )
+        from shared.python.theme import setup_themed_app
     except ImportError as e:
         print(f"Error: Missing dependencies - {e}")
         print("Please install: pip install PyQt6 matplotlib numpy")
@@ -27,7 +28,6 @@ def main() -> int:
 
     app = QApplication(sys.argv)
     app.setApplicationName("Acid Gas Dewpoint Calculator")
-    app.setStyle("Fusion")
 
     window = QMainWindow()
     window.setWindowTitle("Acid Gas Dewpoint Calculator")
@@ -35,6 +35,7 @@ def main() -> int:
 
     calculator = AcidGasDewpointCalculatorWidget()
     window.setCentralWidget(calculator)
+    setup_themed_app(app, window, settings_app="AcidGasDewpointCalculator")
     window.show()
 
     return app.exec()

--- a/src/baghouse_calculator/launch_pyqt6.py
+++ b/src/baghouse_calculator/launch_pyqt6.py
@@ -22,15 +22,17 @@ def main() -> int:
             print(f"  - {pkg}: pip install {pkg}")
         return 1
 
+    from baghouse_calculator.ui.pyqt6.main_window import BaghouseCalculatorMainWindow
     from PyQt6.QtWidgets import QApplication
 
-    from baghouse_calculator.ui.pyqt6.main_window import BaghouseCalculatorMainWindow
+    from shared.python.theme import setup_themed_app
 
     app = QApplication(sys.argv)
     app.setApplicationName("Baghouse Calculator")
     app.setApplicationVersion("1.0.0")
 
     window = BaghouseCalculatorMainWindow()
+    setup_themed_app(app, window, settings_app="BaghouseCalculator")
     window.show()
 
     return app.exec()

--- a/src/c3d_viewer/launch_pyqt6.py
+++ b/src/c3d_viewer/launch_pyqt6.py
@@ -52,9 +52,11 @@ def main() -> int:
         from PyQt6.QtWidgets import QApplication
 
         from c3d_viewer.ui.pyqt6.main_window import C3DViewerWindow
+        from shared.python.theme import setup_themed_app
 
         app = QApplication(sys.argv)
         window = C3DViewerWindow()
+        setup_themed_app(app, window, settings_app="C3DViewer")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py
@@ -7,31 +7,6 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from data_processor.core.config_manager import ConfigManager
-from data_processor.core.dat_importer import (
-    export_dat_to_csv,
-    read_dat_file,
-)
-from data_processor.core.data_loader import DataLoader
-from data_processor.core.dataset_naming import (
-    generate_dataset_name,
-)
-from data_processor.core.plot_config_manager import PlotConfigManager
-from data_processor.core.signal_list_manager import SignalListManager
-from data_processor.core.signal_processing import (
-    apply_custom_variable,
-    calculate_trendline,
-    differentiate_signals,
-    integrate_signals,
-    resample_data,
-    trim_time_range,
-)
-from data_processor.core.signal_processor import SignalProcessor
-from data_processor.models.processing_config import (
-    DifferentiationConfig,
-    FilterConfig,
-    IntegrationConfig,
-)
 from PyQt6.QtCore import QSettings, Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QAction, QFont, QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
@@ -56,6 +31,32 @@ from PyQt6.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
     QWidget,
+)
+
+from data_processor.core.config_manager import ConfigManager
+from data_processor.core.dat_importer import (
+    export_dat_to_csv,
+    read_dat_file,
+)
+from data_processor.core.data_loader import DataLoader
+from data_processor.core.dataset_naming import (
+    generate_dataset_name,
+)
+from data_processor.core.plot_config_manager import PlotConfigManager
+from data_processor.core.signal_list_manager import SignalListManager
+from data_processor.core.signal_processing import (
+    apply_custom_variable,
+    calculate_trendline,
+    differentiate_signals,
+    integrate_signals,
+    resample_data,
+    trim_time_range,
+)
+from data_processor.core.signal_processor import SignalProcessor
+from data_processor.models.processing_config import (
+    DifferentiationConfig,
+    FilterConfig,
+    IntegrationConfig,
 )
 
 from .widgets import (
@@ -2346,10 +2347,13 @@ def main() -> None:
     """Run the Data Processor application."""
     import sys
 
+    from shared.python.theme import setup_themed_app
+
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
 
     window = DataProcessorMainWindow()
+    setup_themed_app(app, window, settings_app="DataProcessor")
     window.show()
 
     sys.exit(app.exec())

--- a/src/electrode_advisor/launch_pyqt6.py
+++ b/src/electrode_advisor/launch_pyqt6.py
@@ -32,6 +32,7 @@ def main() -> int:
     from PyQt6.QtWidgets import QApplication, QMainWindow
 
     from electrode_advisor.ui.pyqt6.main_window import ElectrodeAdvisorWidget
+    from shared.python.theme import setup_themed_app
 
     app = QApplication(sys.argv)
     app.setApplicationName("Electrode Advisor")
@@ -46,6 +47,7 @@ def main() -> int:
     advisor_widget = ElectrodeAdvisorWidget()
     window.setCentralWidget(advisor_widget)
 
+    setup_themed_app(app, window, settings_app="ElectrodeAdvisor")
     window.show()
     return app.exec()
 

--- a/src/financial_calculator/launch_pyqt6.py
+++ b/src/financial_calculator/launch_pyqt6.py
@@ -29,15 +29,17 @@ def main() -> int:
         return 1
 
     # Import and launch
+    from financial_calculator.ui.pyqt6.main_window import FinancialCalculatorMainWindow
     from PyQt6.QtWidgets import QApplication
 
-    from financial_calculator.ui.pyqt6.main_window import FinancialCalculatorMainWindow
+    from shared.python.theme import setup_themed_app
 
     app = QApplication(sys.argv)
     app.setApplicationName("Financial Calculator")
     app.setApplicationVersion("1.0.0")
 
     window = FinancialCalculatorMainWindow()
+    setup_themed_app(app, window, settings_app="FinancialCalculator")
     window.show()
 
     return app.exec()

--- a/src/flare_calculator/launch_pyqt6.py
+++ b/src/flare_calculator/launch_pyqt6.py
@@ -3,15 +3,17 @@
 
 import sys
 
+from flare_calculator.ui.pyqt6.main_window import FlareCalculatorMainWindow
 from PyQt6.QtWidgets import QApplication
 
-from flare_calculator.ui.pyqt6.main_window import FlareCalculatorMainWindow
+from shared.python.theme import setup_themed_app
 
 
 def main() -> None:
     """Entry point for the Flare Calculator PyQt6 application."""
     app = QApplication(sys.argv)
     window = FlareCalculatorMainWindow()
+    setup_themed_app(app, window, settings_app="FlareCalculator")
     window.show()
     sys.exit(app.exec())
 

--- a/src/flow_rate_converter/python/flow_rate_converter/ui/pyqt6/main_window.py
+++ b/src/flow_rate_converter/python/flow_rate_converter/ui/pyqt6/main_window.py
@@ -534,8 +534,11 @@ class FlowRateConverterWindow(QMainWindow):
 
 def main() -> int:
     """Run the Flow Rate Converter application."""
+    from shared.python.theme import setup_themed_app
+
     app = QApplication(sys.argv)
     window = FlowRateConverterWindow()
+    setup_themed_app(app, window, settings_app="FlowRateConverter")
     window.show()
     return app.exec()
 

--- a/src/function_generator/launch_pyqt6.py
+++ b/src/function_generator/launch_pyqt6.py
@@ -51,6 +51,7 @@ def main() -> int:
     from function_generator.python.function_generator.ui.pyqt6.main_window import (
         FunctionGeneratorWidget,
     )
+    from shared.python.theme import setup_themed_app
 
     app = QApplication(sys.argv)
     app.setApplicationName("Function Generator")
@@ -65,6 +66,7 @@ def main() -> int:
     widget = FunctionGeneratorWidget(window)
     window.setCentralWidget(widget)
 
+    setup_themed_app(app, window, settings_app="FunctionGenerator")
     window.show()
     return app.exec()
 

--- a/src/humanoid_builder_gui/launch_pyqt6.py
+++ b/src/humanoid_builder_gui/launch_pyqt6.py
@@ -43,9 +43,11 @@ def main() -> int:
         from humanoid_builder_gui.ui.pyqt6.main_window import (
             HumanoidBuilderWindow,
         )
+        from shared.python.theme import setup_themed_app
 
         app = QApplication(sys.argv)
         window = HumanoidBuilderWindow()
+        setup_themed_app(app, window, settings_app="HumanoidBuilder")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/inertia_calculator/launch_pyqt6.py
+++ b/src/inertia_calculator/launch_pyqt6.py
@@ -46,9 +46,11 @@ def main() -> int:
         from PyQt6.QtWidgets import QApplication
 
         from inertia_calculator.ui.pyqt6.main_window import InertiaCalculatorWindow
+        from shared.python.theme import setup_themed_app
 
         app = QApplication(sys.argv)
         window = InertiaCalculatorWindow()
+        setup_themed_app(app, window, settings_app="InertiaCalculator")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/multi_param_analysis/launch_pyqt6.py
+++ b/src/multi_param_analysis/launch_pyqt6.py
@@ -48,9 +48,11 @@ def main() -> int:
         from multi_param_analysis.ui.pyqt6.main_window import (
             MultiParamAnalysisWindow,
         )
+        from shared.python.theme import setup_themed_app
 
         app = QApplication(sys.argv)
         window = MultiParamAnalysisWindow()
+        setup_themed_app(app, window, settings_app="MultiParamAnalysis")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/ode_solver/launch_pyqt6.py
+++ b/src/ode_solver/launch_pyqt6.py
@@ -56,9 +56,11 @@ def main() -> int:
         from PyQt6.QtWidgets import QApplication
 
         from ode_solver.ui.pyqt6.main_window import ODESolverWindow
+        from shared.python.theme import setup_themed_app
 
         app = QApplication(sys.argv)
         window = ODESolverWindow()
+        setup_themed_app(app, window, settings_app="ODESolver")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/optimizer_gui/launch_pyqt6.py
+++ b/src/optimizer_gui/launch_pyqt6.py
@@ -46,9 +46,11 @@ def main() -> int:
         from PyQt6.QtWidgets import QApplication
 
         from optimizer_gui.ui.pyqt6.main_window import OptimizerWindow
+        from shared.python.theme import setup_themed_app
 
         app = QApplication(sys.argv)
         window = OptimizerWindow()
+        setup_themed_app(app, window, settings_app="OptimizerGui")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/pressure_drop_calculator/launch_pyqt6.py
+++ b/src/pressure_drop_calculator/launch_pyqt6.py
@@ -38,6 +38,7 @@ def main() -> int:
     from pressure_drop_calculator.python.pressure_drop_calculator.ui.pyqt6.main_window import (
         PressureDropCalculatorWidget,
     )
+    from shared.python.theme import setup_themed_app
 
     app = QApplication(sys.argv)
     app.setApplicationName("Pressure Drop Calculator")
@@ -50,6 +51,7 @@ def main() -> int:
     widget = PressureDropCalculatorWidget(window)
     window.setCentralWidget(widget)
 
+    setup_themed_app(app, window, settings_app="PressureDropCalculator")
     window.show()
     return app.exec()
 

--- a/src/scrubber_calculator/python/scrubber_calculator/ui/pyqt6/main_window.py
+++ b/src/scrubber_calculator/python/scrubber_calculator/ui/pyqt6/main_window.py
@@ -767,10 +767,13 @@ class ScrubberCalculatorWindow(QMainWindow):
 
 def main() -> None:
     """Run the Scrubber Calculator application."""
+    from shared.python.theme import setup_themed_app
+
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
 
     window = ScrubberCalculatorWindow()
+    setup_themed_app(app, window, settings_app="ScrubberCalculator")
     window.show()
 
     sys.exit(app.exec())

--- a/src/shared/python/theme/__init__.py
+++ b/src/shared/python/theme/__init__.py
@@ -49,6 +49,12 @@ from .stylesheets import generate_minimal_stylesheet, generate_stylesheet
 # PyQt6-dependent imports - only available when PyQt6 is installed
 try:
     from .colors import get_qcolor
+    from .integration import (
+        ThemedWindowMixin,
+        apply_theme_to_window,
+        create_theme_menu,
+        setup_themed_app,
+    )
     from .theme_manager import ThemeManager, get_theme_manager
 
     _PYQT6_AVAILABLE = True
@@ -57,11 +63,20 @@ except ImportError:
     ThemeManager = None  # type: ignore[assignment, misc]
     get_theme_manager = None  # type: ignore[assignment]
     get_qcolor = None  # type: ignore[assignment]
+    ThemedWindowMixin = None  # type: ignore[assignment, misc]
+    apply_theme_to_window = None  # type: ignore[assignment]
+    create_theme_menu = None  # type: ignore[assignment]
+    setup_themed_app = None  # type: ignore[assignment]
 
 __all__ = [
     # Theme manager (requires PyQt6)
     "ThemeManager",
     "get_theme_manager",
+    # Integration helpers (requires PyQt6)
+    "ThemedWindowMixin",
+    "apply_theme_to_window",
+    "create_theme_menu",
+    "setup_themed_app",
     # Color utilities
     "BUILTIN_THEMES",
     "CHART_COLORS",

--- a/src/shared/python/theme/integration.py
+++ b/src/shared/python/theme/integration.py
@@ -1,0 +1,282 @@
+"""Theme integration helpers for PyQt6 applications.
+
+This module provides easy-to-use functions and mixins for integrating
+the fleet-wide theme system into PyQt6 applications.
+
+Usage:
+    # Simple function-based approach
+    from shared.python.theme.integration import setup_themed_app
+
+    app = QApplication(sys.argv)
+    window = MyMainWindow()
+    setup_themed_app(app, window)  # Applies theme and adds menu
+    window.show()
+    sys.exit(app.exec())
+
+    # Mixin approach for more control
+    from shared.python.theme.integration import ThemedWindowMixin
+
+    class MyMainWindow(ThemedWindowMixin, QMainWindow):
+        def __init__(self):
+            super().__init__()
+            self.setup_theme_support()  # Adds theme menu and applies theme
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from PyQt6.QtWidgets import QApplication, QMenu, QMenuBar
+
+if TYPE_CHECKING:
+    from PyQt6.QtWidgets import QMainWindow
+
+logger = logging.getLogger(__name__)
+
+
+def get_theme_manager(
+    window: QMainWindow | None = None,
+    settings_org: str = "D-sorganization",
+    settings_app: str = "FleetTheme",
+):
+    """Get or create the singleton ThemeManager.
+
+    Args:
+        window: Optional main window to register with the manager
+        settings_org: QSettings organization name
+        settings_app: QSettings application name
+
+    Returns:
+        ThemeManager instance
+    """
+    from .theme_manager import ThemeManager
+
+    return ThemeManager.instance(
+        main_window=window,
+        settings_org=settings_org,
+        settings_app=settings_app,
+    )
+
+
+def apply_theme_to_window(window: QMainWindow, theme_name: str | None = None) -> None:
+    """Apply theme to a window.
+
+    If theme_name is None, applies the current theme from settings.
+
+    Args:
+        window: Window to apply theme to
+        theme_name: Optional specific theme name, or None for current theme
+    """
+    manager = get_theme_manager(window)
+
+    if theme_name:
+        manager.change_theme(theme_name)
+    else:
+        manager.apply_theme()
+
+
+def create_theme_menu(
+    window: QMainWindow,
+    parent_menu: QMenuBar | QMenu | None = None,
+) -> QMenu:
+    """Create a Theme menu with all available themes.
+
+    Args:
+        window: Main window to apply themes to
+        parent_menu: Parent menubar or menu to add to
+
+    Returns:
+        The created QMenu
+    """
+    from PyQt6.QtGui import QAction, QActionGroup
+
+    manager = get_theme_manager(window)
+
+    # Create the theme menu
+    theme_menu = QMenu("&Theme", window)
+
+    # Create action group for mutually exclusive selection
+    theme_group = QActionGroup(window)
+    theme_group.setExclusive(True)
+
+    # Add all available themes
+    current_theme = manager.get_current_theme_name()
+    for theme_name in manager.get_available_themes():
+        action = QAction(theme_name, window)
+        action.setCheckable(True)
+        action.setChecked(theme_name == current_theme)
+        action.setData(theme_name)
+
+        # Connect to theme change
+        action.triggered.connect(
+            lambda checked, name=theme_name: manager.change_theme(name)
+        )
+
+        theme_group.addAction(action)
+        theme_menu.addAction(action)
+
+    # Connect to theme changed signal to update checkmarks
+    def update_checkmarks(new_theme: str):
+        for action in theme_group.actions():
+            action.setChecked(action.data() == new_theme)
+
+    manager.themeChanged.connect(update_checkmarks)
+
+    # Add to parent if provided
+    if parent_menu is not None:
+        if isinstance(parent_menu, QMenuBar):
+            parent_menu.addMenu(theme_menu)
+        else:
+            parent_menu.addMenu(theme_menu)
+
+    return theme_menu
+
+
+def setup_themed_app(
+    app: QApplication,
+    window: QMainWindow,
+    add_menu: bool = True,
+    settings_org: str = "D-sorganization",
+    settings_app: str | None = None,
+) -> None:
+    """Set up theme support for an application.
+
+    This is the simplest way to add theme support:
+    1. Initializes the ThemeManager
+    2. Applies the saved theme (or default)
+    3. Optionally adds a Theme menu to the menubar
+
+    Args:
+        app: QApplication instance
+        window: Main window to theme
+        add_menu: Whether to add a Theme menu to the menubar
+        settings_org: QSettings organization name
+        settings_app: QSettings application name (defaults to window class name)
+    """
+    # Use window class name as default app name
+    if settings_app is None:
+        settings_app = window.__class__.__name__
+
+    # Initialize theme manager
+    manager = get_theme_manager(window, settings_org, settings_app)
+
+    # Apply the current theme
+    manager.apply_theme()
+
+    # Add theme menu if requested and window has a menubar
+    if add_menu:
+        menubar = window.menuBar()
+        if menubar is not None:
+            create_theme_menu(window, menubar)
+
+    logger.info(
+        "Theme support initialized: theme=%s, app=%s",
+        manager.get_current_theme_name(),
+        settings_app,
+    )
+
+
+class ThemedWindowMixin:
+    """Mixin class for adding theme support to QMainWindow subclasses.
+
+    Usage:
+        class MyMainWindow(ThemedWindowMixin, QMainWindow):
+            def __init__(self):
+                super().__init__()
+                self.setup_theme_support()
+
+    This mixin provides:
+    - Automatic theme application on initialization
+    - Theme menu in the menubar
+    - Theme persistence via QSettings
+    - Theme change notifications
+    """
+
+    _theme_manager = None
+    _settings_org = "D-sorganization"
+    _settings_app = None
+
+    def setup_theme_support(
+        self,
+        add_menu: bool = True,
+        settings_org: str | None = None,
+        settings_app: str | None = None,
+    ) -> None:
+        """Initialize theme support for this window.
+
+        Args:
+            add_menu: Whether to add a Theme menu
+            settings_org: Override default settings organization
+            settings_app: Override default settings application name
+        """
+        if settings_org:
+            self._settings_org = settings_org
+        if settings_app:
+            self._settings_app = settings_app
+        elif self._settings_app is None:
+            self._settings_app = self.__class__.__name__
+
+        # Get theme manager
+        self._theme_manager = get_theme_manager(
+            self,
+            self._settings_org,
+            self._settings_app,
+        )
+
+        # Apply current theme
+        self._theme_manager.apply_theme()
+
+        # Add theme menu
+        if add_menu:
+            menubar = self.menuBar()
+            if menubar is not None:
+                create_theme_menu(self, menubar)
+
+        # Connect to theme changes for custom handling
+        self._theme_manager.themeChanged.connect(self._on_theme_changed)
+
+        logger.info(
+            "Theme support initialized for %s: theme=%s",
+            self.__class__.__name__,
+            self._theme_manager.get_current_theme_name(),
+        )
+
+    def _on_theme_changed(self, theme_name: str) -> None:
+        """Called when the theme changes.
+
+        Override this method to perform custom actions on theme change.
+        The stylesheet is automatically applied before this is called.
+
+        Args:
+            theme_name: Name of the new theme
+        """
+        pass
+
+    def get_theme_manager(self):
+        """Get the theme manager instance."""
+        return self._theme_manager
+
+    def change_theme(self, theme_name: str) -> None:
+        """Change to a specific theme.
+
+        Args:
+            theme_name: Name of the theme to apply
+        """
+        if self._theme_manager:
+            self._theme_manager.change_theme(theme_name)
+
+    def get_current_theme(self) -> str:
+        """Get the current theme name."""
+        if self._theme_manager:
+            return self._theme_manager.get_current_theme_name()
+        return "Light"
+
+
+__all__ = [
+    "ThemedWindowMixin",
+    "apply_theme_to_window",
+    "create_theme_menu",
+    "get_theme_manager",
+    "setup_themed_app",
+]

--- a/src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_gui.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_gui.py
@@ -1013,10 +1013,13 @@ class PSAMainWindow(QMainWindow):
 
 def main() -> None:
     """Main entry point for the GUI application."""
+    from shared.python.theme import setup_themed_app
+
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
 
     window = PSAMainWindow()
+    setup_themed_app(app, window, settings_app="PSAPackage")
     window.show()
 
     sys.exit(app.exec())

--- a/src/steam_engine_calculator/python/steam_engine_calculator/ui/pyqt6/main_window.py
+++ b/src/steam_engine_calculator/python/steam_engine_calculator/ui/pyqt6/main_window.py
@@ -405,12 +405,12 @@ class SteamEngineCalculatorWindow(QMainWindow):
         """Apply Catppuccin Mocha theme styles."""
         self.setStyleSheet(f"""
             QMainWindow, QWidget {{
-                background-color: {COLORS['base']};
-                color: {COLORS['text']};
+                background-color: {COLORS["base"]};
+                color: {COLORS["text"]};
             }}
             QGroupBox {{
-                background-color: {COLORS['mantle']};
-                border: 1px solid {COLORS['surface1']};
+                background-color: {COLORS["mantle"]};
+                border: 1px solid {COLORS["surface1"]};
                 border-radius: 8px;
                 margin-top: 12px;
                 padding-top: 8px;
@@ -419,24 +419,24 @@ class SteamEngineCalculatorWindow(QMainWindow):
                 subcontrol-origin: margin;
                 left: 12px;
                 padding: 0 8px;
-                color: {COLORS['lavender']};
+                color: {COLORS["lavender"]};
             }}
             QLineEdit {{
-                background-color: {COLORS['surface0']};
-                border: 1px solid {COLORS['surface1']};
+                background-color: {COLORS["surface0"]};
+                border: 1px solid {COLORS["surface1"]};
                 border-radius: 4px;
                 padding: 8px;
-                color: {COLORS['text']};
+                color: {COLORS["text"]};
             }}
             QLineEdit:focus {{
-                border-color: {COLORS['blue']};
+                border-color: {COLORS["blue"]};
             }}
             QComboBox {{
-                background-color: {COLORS['surface0']};
-                border: 1px solid {COLORS['surface1']};
+                background-color: {COLORS["surface0"]};
+                border: 1px solid {COLORS["surface1"]};
                 border-radius: 4px;
                 padding: 8px;
-                color: {COLORS['text']};
+                color: {COLORS["text"]};
                 min-width: 80px;
             }}
             QComboBox::drop-down {{
@@ -444,36 +444,36 @@ class SteamEngineCalculatorWindow(QMainWindow):
                 width: 20px;
             }}
             QComboBox QAbstractItemView {{
-                background-color: {COLORS['surface0']};
-                color: {COLORS['text']};
-                selection-background-color: {COLORS['surface1']};
+                background-color: {COLORS["surface0"]};
+                color: {COLORS["text"]};
+                selection-background-color: {COLORS["surface1"]};
             }}
             QPushButton {{
-                background-color: {COLORS['blue']};
-                color: {COLORS['base']};
+                background-color: {COLORS["blue"]};
+                color: {COLORS["base"]};
                 border: none;
                 border-radius: 6px;
                 padding: 10px 20px;
             }}
             QPushButton:hover {{
-                background-color: {COLORS['sapphire']};
+                background-color: {COLORS["sapphire"]};
             }}
             QPushButton:pressed {{
-                background-color: {COLORS['sky']};
+                background-color: {COLORS["sky"]};
             }}
             QFrame {{
-                background-color: {COLORS['surface0']};
+                background-color: {COLORS["surface0"]};
                 border-radius: 6px;
             }}
             QScrollArea {{
                 border: none;
             }}
             QScrollBar:vertical {{
-                background-color: {COLORS['mantle']};
+                background-color: {COLORS["mantle"]};
                 width: 12px;
             }}
             QScrollBar::handle:vertical {{
-                background-color: {COLORS['surface1']};
+                background-color: {COLORS["surface1"]};
                 border-radius: 6px;
                 min-height: 20px;
             }}
@@ -697,8 +697,11 @@ class SteamEngineCalculatorWindow(QMainWindow):
 
 def main() -> None:
     """Main entry point for standalone execution."""
+    from shared.python.theme import setup_themed_app
+
     app = QApplication(sys.argv)
     window = SteamEngineCalculatorWindow()
+    setup_themed_app(app, window, settings_app="SteamEngineCalculator")
     window.show()
     sys.exit(app.exec())
 

--- a/src/syngas_compression/launch_pyqt6.py
+++ b/src/syngas_compression/launch_pyqt6.py
@@ -43,6 +43,7 @@ def main() -> int:
 
     from PyQt6.QtWidgets import QApplication, QMainWindow
 
+    from shared.python.theme import setup_themed_app
     from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
         create_syngas_compression_calculator,
     )
@@ -60,95 +61,7 @@ def main() -> int:
     calculator = create_syngas_compression_calculator(window)
     window.setCentralWidget(calculator)
 
-    # Apply dark theme styling
-    window.setStyleSheet("""
-        QMainWindow {
-            background-color: #1e1e2e;
-        }
-        QWidget {
-            background-color: #1e1e2e;
-            color: #cdd6f4;
-            font-family: 'Segoe UI', Arial, sans-serif;
-        }
-        QGroupBox {
-            border: 1px solid #45475a;
-            border-radius: 4px;
-            margin-top: 8px;
-            padding-top: 8px;
-            background-color: #313244;
-        }
-        QGroupBox::title {
-            color: #cba6f7;
-            subcontrol-origin: margin;
-            left: 10px;
-            padding: 0 5px;
-        }
-        QPushButton {
-            background-color: #89b4fa;
-            color: #1e1e2e;
-            border: none;
-            border-radius: 4px;
-            padding: 8px 16px;
-            font-weight: bold;
-        }
-        QPushButton:hover {
-            background-color: #b4befe;
-        }
-        QPushButton:pressed {
-            background-color: #7287fd;
-        }
-        QSpinBox, QDoubleSpinBox, QComboBox, QLineEdit {
-            background-color: #45475a;
-            border: 1px solid #585b70;
-            border-radius: 4px;
-            padding: 4px 8px;
-            color: #cdd6f4;
-        }
-        QTabWidget::pane {
-            border: 1px solid #45475a;
-            border-radius: 4px;
-            background-color: #313244;
-        }
-        QTabBar::tab {
-            background-color: #45475a;
-            color: #cdd6f4;
-            padding: 8px 16px;
-            border-top-left-radius: 4px;
-            border-top-right-radius: 4px;
-        }
-        QTabBar::tab:selected {
-            background-color: #89b4fa;
-            color: #1e1e2e;
-        }
-        QTableWidget {
-            background-color: #313244;
-            border: 1px solid #45475a;
-            gridline-color: #45475a;
-        }
-        QTableWidget::item {
-            padding: 4px;
-        }
-        QHeaderView::section {
-            background-color: #45475a;
-            color: #cdd6f4;
-            padding: 4px;
-            border: none;
-        }
-        QScrollBar:vertical {
-            background-color: #313244;
-            width: 12px;
-            border-radius: 6px;
-        }
-        QScrollBar::handle:vertical {
-            background-color: #585b70;
-            border-radius: 6px;
-            min-height: 20px;
-        }
-        QScrollBar::handle:vertical:hover {
-            background-color: #6c7086;
-        }
-    """)
-
+    setup_themed_app(app, window, settings_app="SyngasCompressionCalculator")
     window.show()
     return app.exec()
 

--- a/src/syngas_water_calculator/launch_pyqt6.py
+++ b/src/syngas_water_calculator/launch_pyqt6.py
@@ -55,12 +55,14 @@ def main() -> int:
     try:
         from PyQt6.QtWidgets import QApplication
 
+        from shared.python.theme import setup_themed_app
         from syngas_water_calculator.ui.pyqt6.main_window import (
             SyngasWaterCalculatorWindow,
         )
 
         app = QApplication(sys.argv)
         window = SyngasWaterCalculatorWindow()
+        setup_themed_app(app, window, settings_app="SyngasWaterCalculator")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/thermal_profile_predictor/launch_pyqt6.py
+++ b/src/thermal_profile_predictor/launch_pyqt6.py
@@ -50,12 +50,14 @@ def main() -> int:
     try:
         from PyQt6.QtWidgets import QApplication
 
+        from shared.python.theme import setup_themed_app
         from thermal_profile_predictor.ui.pyqt6.main_window import (
             ThermalProfilePredictorWindow,
         )
 
         app = QApplication(sys.argv)
         window = ThermalProfilePredictorWindow()
+        setup_themed_app(app, window, settings_app="ThermalProfilePredictor")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/tools/gui/windows/unified_launcher_window.py
+++ b/src/tools/gui/windows/unified_launcher_window.py
@@ -22,6 +22,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from shared.python.theme import ThemedWindowMixin
 from tools.gui.components.tool_card import ToolCard
 from tools.launch_utils import (
     LaunchError,
@@ -33,7 +34,7 @@ from tools.launch_utils import (
 )
 
 
-class UnifiedLauncher(QMainWindow):
+class UnifiedLauncher(ThemedWindowMixin, QMainWindow):
     """Main launcher window with tabbed interface for all tools."""
 
     def __init__(self) -> None:
@@ -50,6 +51,9 @@ class UnifiedLauncher(QMainWindow):
         self.log_queue: queue.Queue[str] = queue.Queue()
         self.setup_ui()
         self.setup_log_consumer()
+
+        # Initialize theme support with Theme menu
+        self.setup_theme_support(settings_app="UnifiedToolsLauncher")
 
     def setup_ui(self) -> None:
         """Set up the main user interface."""
@@ -77,7 +81,7 @@ class UnifiedLauncher(QMainWindow):
 
         title = QLabel("Unified Tools Launcher")
         title.setFont(QFont("Segoe UI", 24, QFont.Weight.Bold))
-        title.setStyleSheet("color: #2c3e50;")
+        title.setObjectName("titleLabel")  # For theme-specific styling
         header_layout.addWidget(title)
 
         header_layout.addStretch()
@@ -94,40 +98,13 @@ class UnifiedLauncher(QMainWindow):
         log_area.setReadOnly(True)
         log_area.setMaximumHeight(150)
         log_area.setPlaceholderText("Activity log will appear here...")
-        log_area.setStyleSheet("""
-            QTextEdit {
-                background-color: #f5f5f5;
-                border: 1px solid #ddd;
-                border-radius: 4px;
-                font-family: Consolas, monospace;
-                font-size: 10pt;
-                padding: 5px;
-            }
-        """)
+        log_area.setObjectName("activityLog")  # For theme-specific styling
         return log_area
 
     def _create_tool_tabs(self) -> QTabWidget:
         """Create the tabbed interface for tool categories."""
         tabs = QTabWidget()
-        tabs.setStyleSheet("""
-            QTabWidget::pane {
-                border: 1px solid #ddd;
-                background: white;
-                border-radius: 4px;
-            }
-            QTabBar::tab {
-                background: #f0f0f0;
-                padding: 8px 16px;
-                margin-right: 2px;
-                border-top-left-radius: 4px;
-                border-top-right-radius: 4px;
-            }
-            QTabBar::tab:selected {
-                background: white;
-                border-bottom: 2px solid #2196F3;
-                font-weight: bold;
-            }
-        """)
+        tabs.setObjectName("toolTabs")  # For theme-specific styling
 
         from tools.config_loader import CATEGORY_ORDER, load_tools_config
 

--- a/src/trc_vessel_designer/launch_pyqt6.py
+++ b/src/trc_vessel_designer/launch_pyqt6.py
@@ -26,6 +26,7 @@ def main() -> int:
 
     from PyQt6.QtWidgets import QApplication, QMainWindow
 
+    from shared.python.theme import setup_themed_app
     from trc_vessel_designer.ui.pyqt6.main_window import TRCVesselDesignerWidget
 
     app = QApplication(sys.argv)
@@ -39,6 +40,7 @@ def main() -> int:
     designer_widget = TRCVesselDesignerWidget()
     window.setCentralWidget(designer_widget)
 
+    setup_themed_app(app, window, settings_app="TRCVesselDesigner")
     window.show()
     return app.exec()
 

--- a/src/urdf_builder_gui/launch_pyqt6.py
+++ b/src/urdf_builder_gui/launch_pyqt6.py
@@ -40,10 +40,12 @@ def main() -> int:
     try:
         from PyQt6.QtWidgets import QApplication
 
+        from shared.python.theme import setup_themed_app
         from urdf_builder_gui.ui.pyqt6.main_window import URDFBuilderWindow
 
         app = QApplication(sys.argv)
         window = URDFBuilderWindow()
+        setup_themed_app(app, window, settings_app="URDFBuilder")
         window.show()
         return app.exec()
     except ImportError as e:

--- a/src/wgs_reactor/python/wgs_reactor/ui/pyqt6/main_window.py
+++ b/src/wgs_reactor/python/wgs_reactor/ui/pyqt6/main_window.py
@@ -647,10 +647,13 @@ class WGSReactorWindow(QMainWindow):
 
 def main() -> None:
     """Run the WGS Reactor Calculator application."""
+    from shared.python.theme import setup_themed_app
+
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
 
     window = WGSReactorWindow()
+    setup_themed_app(app, window, settings_app="WGSReactorCalculator")
     window.show()
 
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- Adds `setup_themed_app()` to all 23 PyQt6 GUI launchers for consistent theming across the entire Tools suite
- Creates new `integration.py` module with easy-to-use helpers: `setup_themed_app()`, `create_theme_menu()`, `ThemedWindowMixin`
- Removes 90+ lines of hardcoded stylesheet from syngas_compression launcher
- Converts unified_launcher_window to use ThemedWindowMixin

## Changes
### Direct launcher updates (17 files):
- function_generator, syngas_compression, trc_vessel_designer, inertia_calculator
- humanoid_builder_gui, multi_param_analysis, optimizer_gui, ode_solver
- thermal_profile_predictor, syngas_water_calculator, urdf_builder_gui
- c3d_viewer, electrode_advisor, flare_calculator, pressure_drop_calculator
- baghouse_calculator, acid_gas_dewpoint, financial_calculator

### Delegate-pattern main_window.py updates (6 files):
- data_processor, flow_rate_converter, scrubber_calculator
- steam_engine_calculator, wgs_reactor, psa_gui

## Features
All Tools GUI apps now share the fleet-wide theme system with:
- 13 available themes (light and dark variants)
- User preference persistence via QSettings
- Theme menu auto-added to menu bar
- Consistent styling across all applications

## Test plan
- [ ] Verify theme menu appears in each application
- [ ] Verify theme persistence across app restarts
- [ ] Verify all 13 themes apply correctly

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many GUI entrypoints and introduces new theme-integration code that runs at app startup, so regressions could prevent tools from launching or alter UI behavior across the suite.
> 
> **Overview**
> Standardizes theming across the Tools PyQt6 suite by wiring each GUI launcher/main entrypoint to call the shared `setup_themed_app()` helper, enabling a consistent stylesheet and persisted user theme selection.
> 
> Adds a new `shared.python.theme.integration` module (and exports it via `shared.python.theme`) providing `setup_themed_app()`, `create_theme_menu()`, and `ThemedWindowMixin` for easy theme/menu integration, and updates the unified tools launcher to use the mixin and theme-friendly object names.
> 
> Removes bespoke/hardcoded styling in favor of the shared theme system (notably deleting the large custom stylesheet in the `syngas_compression` launcher).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f87fd8fb9745f44d3947d6c0d76e2a5d86f9d99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->