### PR TITLE
fix: repair broken CI workflows

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -11,8 +11,28 @@ jobs:
   update-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Update PRs with strictly linear history
-        uses: chinthakagodawita/autoupdate-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update open PR branches
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const base = context.ref.replace('refs/heads/', '');
+            const pulls = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: base,
+              per_page: 100,
+            });
+            for (const pr of pulls.data) {
+              if (pr.draft) continue;
+              try {
+                await github.rest.pulls.updateBranch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                });
+                core.info(`Updated PR #${pr.number}: ${pr.title}`);
+              } catch (err) {
+                core.warning(`Failed to update PR #${pr.number}: ${err.message}`);
+              }
+            }

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -56,7 +56,7 @@ jobs:
           node-version: "20"
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
@@ -119,7 +119,7 @@ jobs:
           node-version: "20"
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform.target }}
 


### PR DESCRIPTION
## Summary
- Replace dead `chinthakagodawita/autoupdate-action@v1` in `auto-update-prs.yml` with `actions/github-script@v7` using GitHub REST API
- Fix `dtolnay/rust-action@stable` → `dtolnay/rust-toolchain@stable` in `tauri-build.yml`

## Test plan
- [ ] Verify `auto-update-prs.yml` triggers on push to main and updates open PR branches
- [ ] Verify `tauri-build.yml` Rust setup step resolves correctly
- [ ] Manually trigger workflows via `workflow_dispatch` to confirm fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes; main risk is CI behavior changes (PR updates and Rust toolchain installation) potentially failing due to token permissions or API limits.
> 
> **Overview**
> Repairs CI by replacing the removed `chinthakagodawita/autoupdate-action@v1` step with an `actions/github-script@v7` implementation that lists open PRs for the pushed base branch and calls `pulls.updateBranch`, skipping drafts and logging failures.
> 
> Updates the Tauri build workflow to use `dtolnay/rust-toolchain@stable` (instead of `dtolnay/rust-action@stable`) for Rust setup in both `check` and `build` jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 903e717af9d9a7204965a6fb78f2350db9d243c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->