### PR TITLE
Fix pre-commit stage name for push hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -122,7 +122,7 @@ repos:
         name: "rustfmt (Rust format)"
       - id: cargo-check
         name: "cargo check (Rust)"
-        stages: [pre-push]
+        stages: [push]
 
   # ===========================================================================
   # UNIVERSAL FORMATTING (All Languages)
@@ -197,7 +197,7 @@ repos:
     hooks:
       - id: mypy
         name: "mypy (Python type check)"
-        stages: [pre-push]
+        stages: [push]
         additional_dependencies:
           - types-requests
           - types-PyYAML
@@ -224,7 +224,7 @@ repos:
     hooks:
       - id: bandit
         name: "bandit (Python security)"
-        stages: [pre-push]
+        stages: [push]
         args:
           [
             "-r",
@@ -243,7 +243,7 @@ repos:
     hooks:
       - id: pytest-unit
         name: "pytest (Python tests)"
-        stages: [pre-push]
+        stages: [push]
         entry: pytest
         args: ["tests/unit", "-x", "-q", "--tb=short", "-m", "not slow and not integration"]
         language: python
@@ -257,7 +257,7 @@ repos:
     hooks:
       - id: semgrep
         name: "semgrep (security + quality)"
-        stages: [pre-push]
+        stages: [push]
         args: ["--config", "auto", "--error", "--quiet"]
         types: [python]
         exclude: ^(tests/|archive/|legacy/|experimental/|\.github/)
@@ -269,7 +269,7 @@ repos:
     hooks:
       - id: radon
         name: "radon (complexity check)"
-        stages: [pre-push]
+        stages: [push]
         entry: radon
         args: ["cc", "--min", "C", "--show-complexity", "--total-average"]
         language: python


### PR DESCRIPTION
Replaces invalid  with valid  in  so pre-commit can parse and run hooks correctly with current stage schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that just updates hook stage names; risk is limited to hooks running at slightly different times if the previous stage was being relied on.
> 
> **Overview**
> Fixes `pre-commit` stage configuration by replacing the deprecated/invalid `stages: [pre-push]` with `stages: [push]` for the slower hooks (Rust `cargo-check`, `mypy`, `bandit`, `pytest-unit`, `semgrep`, and `radon`).
> 
> This is a config-only change intended to ensure these checks run at push time under the current pre-commit stage schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18cbd829665b3e4bc35376d1103f40c5a8c9c1ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->