### PR TITLE
docs: add Signal Processing Studio to TOOLS_INDEX

### DIFF
--- a/TOOLS_INDEX.md
+++ b/TOOLS_INDEX.md
@@ -72,7 +72,14 @@ This index catalogs every tool and project in the repository to ensure nothing i
 
 ---
 
-## Data Processing & Signal Analysis (4 tools)
+## Data Processing & Signal Analysis (5 tools)
+
+### Signal Processing Studio (NEW - unified launcher)
+
+- **Path**: `src/signal_processing_studio/`
+- **Entry**: `launch_pyqt6.py`
+- **Type**: PyQt6 GUI
+- **Description**: Unified signal processing application combining Function Generator, Signal Toolkit, and Polynomial Generator as tabs with cross-widget signal routing and fleet theme support. Signals generated in Function Generator or Polynomial Generator are automatically routed to Signal Toolkit for analysis.
 
 ### Data Processor
 - **Path**: `src/data_processing/data_processor/`


### PR DESCRIPTION
Add the new Signal Processing Studio entry to the tools index.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating the tools catalog; no runtime or behavior changes.
> 
> **Overview**
> Updates `TOOLS_INDEX.md` to include **Signal Processing Studio** as a new entry under *Data Processing & Signal Analysis*, increasing the section count from 4 to 5.
> 
> Documents it as a unified PyQt6 launcher (`src/signal_processing_studio/`, entry `launch_pyqt6.py`) that combines Function Generator, Signal Toolkit, and Polynomial Generator with cross-widget signal routing and fleet theme support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa7bf3b1ed51b4e918c275442e8d27f0ecbb451a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->