### PR TITLE
fix(polynomial_generator): resample draw line to uniform x spacing

### DIFF
--- a/src/shared/python/signal_toolkit/polynomial_generator.py
+++ b/src/shared/python/signal_toolkit/polynomial_generator.py
@@ -435,14 +435,11 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
     def _on_canvas_release(self, event: matplotlib.backend_bases.MouseEvent) -> None:
         """Handle mouse release events."""
         if self.mode == "draw" and self.drawn_points:
-            # When drawing finishes, convert drawn path to points for fitting
-            # Simplify drawn points to avoid overcrowding
-            if len(self.drawn_points) > 20:
-                indices = np.linspace(0, len(self.drawn_points) - 1, 20, dtype=int)
-                sampled = [self.drawn_points[i] for i in indices]
-                self.current_points.extend(sampled)
-            else:
-                self.current_points.extend(self.drawn_points)
+            # Resample drawn path to evenly-spaced x positions.
+            # Raw mouse events produce unevenly-spaced points (clustered
+            # where the mouse moved slowly), which biases polynomial fits.
+            resampled = self._resample_drawn_points(self.drawn_points, n=30)
+            self.current_points.extend(resampled)
             self.drawn_points = []
             self._update_plot()
 
@@ -491,6 +488,53 @@ class PolynomialGeneratorWidget(QtWidgets.QWidget):
         self.polynomial_coeffs = None
         self.result_text.clear()
         self._update_plot()
+
+    @staticmethod
+    def _resample_drawn_points(
+        points: list[tuple[float, float]],
+        n: int = 30,
+    ) -> list[tuple[float, float]]:
+        """Resample drawn points to evenly-spaced x positions.
+
+        Freehand drawing produces points clustered where the mouse moved
+        slowly and sparse where it moved fast.  This interpolates the
+        drawn path and resamples at *n* uniformly-spaced x values so
+        the polynomial fit is not biased by drawing speed.
+
+        Args:
+            points: Raw (x, y) pairs from mouse events.
+            n: Number of evenly-spaced output points.
+
+        Returns:
+            List of (x, y) tuples with uniform x spacing.
+        """
+        if len(points) < 2:
+            return list(points)
+
+        xs = np.array([p[0] for p in points])
+        ys = np.array([p[1] for p in points])
+
+        # Sort by x so interpolation is well-defined
+        order = np.argsort(xs)
+        xs_sorted = xs[order]
+        ys_sorted = ys[order]
+
+        # Remove duplicate x values (keep mean y)
+        unique_xs, inverse = np.unique(xs_sorted, return_inverse=True)
+        if len(unique_xs) < 2:
+            return list(points)
+        unique_ys = np.zeros_like(unique_xs)
+        counts = np.zeros_like(unique_xs)
+        for i, idx in enumerate(inverse):
+            unique_ys[idx] += ys_sorted[i]
+            counts[idx] += 1
+        unique_ys /= counts
+
+        # Interpolate at evenly-spaced x positions
+        x_uniform = np.linspace(unique_xs[0], unique_xs[-1], n)
+        y_uniform = np.interp(x_uniform, unique_xs, unique_ys)
+
+        return list(zip(x_uniform.tolist(), y_uniform.tolist(), strict=True))
 
     def _calculate_poly_fit(self) -> bool:
         """Calculate the polynomial fit without UI interactions.

--- a/src/signal_processing_studio/tests/test_signal_processing_studio.py
+++ b/src/signal_processing_studio/tests/test_signal_processing_studio.py
@@ -1,0 +1,357 @@
+"""Tests for Signal Processing Studio.
+
+Tests cross-widget signal routing, polynomial resample logic,
+and the unified studio launcher.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+# Path setup (mirrors launch_pyqt6.py) - inner python/ dirs inserted first
+TOOLS_ROOT = Path(__file__).parent.parent.parent.parent
+_PATHS = [
+    TOOLS_ROOT / "src" / "signal_processing_studio" / "python",
+    TOOLS_ROOT / "src" / "function_generator" / "python",
+    TOOLS_ROOT / "src" / "shared" / "python",
+    TOOLS_ROOT / "src",
+]
+for p in reversed(_PATHS):
+    s = str(p)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+
+# Force the inner signal_processing_studio package to take precedence.
+# pytest may have already resolved the outer __init__.py from src/.
+if "signal_processing_studio" in sys.modules:
+    del sys.modules["signal_processing_studio"]
+if "signal_processing_studio.signal_bus" in sys.modules:
+    del sys.modules["signal_processing_studio.signal_bus"]
+if "signal_processing_studio.main_window" in sys.modules:
+    del sys.modules["signal_processing_studio.main_window"]
+
+from signal_toolkit.core import Signal  # noqa: E402
+
+from signal_processing_studio.signal_bus import SignalBus  # noqa: E402
+
+# =============================================================================
+# Resample Drawn Points Tests (polynomial_generator._resample_drawn_points)
+# =============================================================================
+
+
+class TestResampleDrawnPoints:
+    """Tests for PolynomialGeneratorWidget._resample_drawn_points."""
+
+    @pytest.fixture(autouse=True)
+    def _import_resample(self):
+        """Import the static method under test."""
+        from signal_toolkit.polynomial_generator import PolynomialGeneratorWidget
+
+        self.resample = PolynomialGeneratorWidget._resample_drawn_points
+
+    def test_uniform_x_spacing(self) -> None:
+        """Output points should have uniformly spaced x values."""
+        points: list[tuple[float, float]] = [(0.0, 0.0)]
+        for i in range(1, 50):
+            points.append((i * 0.1, float(i)))
+        for i in range(5):
+            points.append((5.0 + i * 2.0, 50.0 + float(i)))
+
+        result = self.resample(points, n=20)
+
+        xs = [p[0] for p in result]
+        assert len(result) == 20
+        diffs = np.diff(xs)
+        assert np.allclose(diffs, diffs[0], rtol=1e-10)
+
+    def test_single_point_passthrough(self) -> None:
+        """A single point should be returned as-is."""
+        result = self.resample([(3.0, 7.0)], n=10)
+        assert result == [(3.0, 7.0)]
+
+    def test_empty_input(self) -> None:
+        """Empty input should return empty list."""
+        result = self.resample([], n=10)
+        assert result == []
+
+    def test_two_points(self) -> None:
+        """Two points should interpolate to n evenly-spaced points."""
+        result = self.resample([(0.0, 0.0), (10.0, 10.0)], n=5)
+
+        assert len(result) == 5
+        assert result[0][0] == pytest.approx(0.0)
+        assert result[-1][0] == pytest.approx(10.0)
+        for x, y in result:
+            assert y == pytest.approx(x, abs=1e-10)
+
+    def test_unsorted_x_values(self) -> None:
+        """Points with unsorted x should be handled correctly."""
+        points = [(5.0, 5.0), (0.0, 0.0), (10.0, 10.0), (2.5, 2.5)]
+        result = self.resample(points, n=5)
+
+        xs = [p[0] for p in result]
+        assert xs == sorted(xs)
+        assert np.allclose(np.diff(xs), np.diff(xs)[0])
+
+    def test_duplicate_x_averaged(self) -> None:
+        """Duplicate x values should have their y values averaged."""
+        points = [(0.0, 0.0), (5.0, 4.0), (5.0, 6.0), (10.0, 10.0)]
+        result = self.resample(points, n=3)
+
+        xs = [p[0] for p in result]
+        ys = [p[1] for p in result]
+        assert xs[1] == pytest.approx(5.0)
+        assert ys[1] == pytest.approx(5.0)
+
+    def test_all_same_x(self) -> None:
+        """All points at the same x should return original points."""
+        points = [(5.0, 1.0), (5.0, 2.0), (5.0, 3.0)]
+        result = self.resample(points, n=10)
+        assert len(result) == 3
+
+    def test_preserves_endpoint_range(self) -> None:
+        """Output x range should match input x range."""
+        points = [(2.0, 10.0), (8.0, 20.0), (5.0, 15.0)]
+        result = self.resample(points, n=15)
+
+        xs = [p[0] for p in result]
+        assert xs[0] == pytest.approx(2.0)
+        assert xs[-1] == pytest.approx(8.0)
+
+    def test_default_n(self) -> None:
+        """Default n=30 should produce 30 points."""
+        points = [(float(i), float(i)) for i in range(100)]
+        result = self.resample(points)
+        assert len(result) == 30
+
+
+# =============================================================================
+# SignalBus Routing Tests
+# =============================================================================
+
+
+def _make_bus(
+    toolkit_signal: Signal | None = None,
+    status_callback=None,
+) -> tuple:
+    """Create a SignalBus with mocked widgets (no Qt event loop needed)."""
+    func_gen = MagicMock()
+    func_gen.signal_generated = MagicMock()
+    func_gen.signal_generated.connect = MagicMock()
+
+    toolkit = MagicMock()
+    toolkit.current_signal = toolkit_signal
+
+    poly_gen = MagicMock()
+    poly_gen.polynomial_generated = MagicMock()
+    poly_gen.polynomial_generated.connect = MagicMock()
+
+    bus = SignalBus.__new__(SignalBus)
+    bus.signal_routed = MagicMock()
+    bus.func_gen = func_gen
+    bus.toolkit = toolkit
+    bus.poly_gen = poly_gen
+    bus._status_callback = status_callback
+
+    return bus, func_gen, toolkit, poly_gen
+
+
+class TestSignalBus:
+    """Tests for SignalBus cross-widget routing."""
+
+    def test_func_gen_signal_routed_to_toolkit(self) -> None:
+        """Function Generator signal should be routed to toolkit."""
+        bus, func_gen, toolkit, _ = _make_bus()
+
+        mock_signal = MagicMock()
+        mock_signal.name = "test_sine"
+        mock_signal.n_samples = 1000
+        mock_signal.fs = 100.0
+
+        bus._on_func_gen_signal(mock_signal)
+
+        toolkit.load_external_signal.assert_called_once_with(mock_signal)
+        bus.signal_routed.emit.assert_called_once()
+
+    def test_poly_coefficients_reversed(self) -> None:
+        """Polynomial coefficients should be reversed before creating Signal."""
+        t = np.linspace(0, 10, 100)
+        toolkit_signal = Signal(t, np.zeros(100))
+        bus, _, toolkit, _ = _make_bus(toolkit_signal=toolkit_signal)
+
+        # np.polyfit returns [highest, ..., lowest]
+        # y = 3*x^2 + 2*x + 1 -> polyfit returns [3, 2, 1]
+        bus._on_poly_generated("knee", [3.0, 2.0, 1.0])
+
+        toolkit.load_external_signal.assert_called_once()
+        routed_signal = toolkit.load_external_signal.call_args[0][0]
+        assert routed_signal.name == "Polynomial (knee)"
+
+        # Reversed coeffs: 1 + 2t + 3t^2
+        assert routed_signal.values[0] == pytest.approx(1.0, abs=0.01)
+        assert routed_signal.values[-1] == pytest.approx(321.0, abs=1.0)
+
+    def test_poly_default_time_range(self) -> None:
+        """When toolkit has no signal, default time range should be used."""
+        bus, _, toolkit, _ = _make_bus(toolkit_signal=None)
+
+        bus._on_poly_generated("hip", [1.0, 0.0])
+
+        routed_signal = toolkit.load_external_signal.call_args[0][0]
+        assert len(routed_signal.time) == 1000
+        assert routed_signal.time[0] == pytest.approx(0.0)
+        assert routed_signal.time[-1] == pytest.approx(10.0)
+
+    def test_send_current_to_toolkit_none(self) -> None:
+        """send_current_to_toolkit should do nothing when no current signal."""
+        bus, func_gen, toolkit, _ = _make_bus()
+        func_gen.current_signal = None
+
+        bus.send_current_to_toolkit()
+        toolkit.load_external_signal.assert_not_called()
+
+    def test_send_current_to_toolkit(self) -> None:
+        """send_current_to_toolkit should route the func_gen current signal."""
+        bus, func_gen, toolkit, _ = _make_bus()
+
+        mock_signal = MagicMock()
+        mock_signal.name = "test"
+        mock_signal.n_samples = 500
+        mock_signal.fs = 50.0
+        func_gen.current_signal = mock_signal
+
+        bus.send_current_to_toolkit()
+        toolkit.load_external_signal.assert_called_once_with(mock_signal)
+
+    def test_status_callback(self) -> None:
+        """Status callback should be called when provided."""
+        messages: list[str] = []
+        bus, _, toolkit, _ = _make_bus(status_callback=messages.append)
+
+        mock_signal = MagicMock()
+        mock_signal.name = "wave"
+        mock_signal.n_samples = 100
+        mock_signal.fs = 10.0
+        bus._on_func_gen_signal(mock_signal)
+
+        assert len(messages) == 1
+        assert "wave" in messages[0]
+
+    def test_status_no_callback(self) -> None:
+        """Status with no callback should not raise."""
+        bus, _, _, _ = _make_bus(status_callback=None)
+
+        mock_signal = MagicMock()
+        mock_signal.name = "safe"
+        mock_signal.n_samples = 10
+        mock_signal.fs = 1.0
+        bus._on_func_gen_signal(mock_signal)
+
+
+# =============================================================================
+# load_external_signal Tests
+# =============================================================================
+
+
+class TestLoadExternalSignal:
+    """Tests for SignalToolkitWidget.load_external_signal."""
+
+    def test_load_external_signal_sets_current(self) -> None:
+        """load_external_signal should set current_signal and original_signal."""
+        with patch("signal_toolkit.widget.QWidget.__init__"):
+            from signal_toolkit.widget import SignalToolkitWidget
+
+            widget = SignalToolkitWidget.__new__(SignalToolkitWidget)
+            widget.current_signal = None
+            widget.original_signal = None
+            widget._update_plot = MagicMock()
+            widget._log = MagicMock()
+            widget.signal_updated = MagicMock()
+
+            t = np.linspace(0, 5, 500)
+            signal = Signal(t, np.sin(t), name="ext_sine")
+
+            widget.load_external_signal(signal)
+
+            assert widget.current_signal is signal
+            assert widget.original_signal is not None
+            assert widget.original_signal is not signal
+            widget._update_plot.assert_called_once()
+            widget.signal_updated.emit.assert_called_once_with(signal)
+            widget._log.assert_called_once()
+
+
+# =============================================================================
+# use_builtin_theme Tests
+# =============================================================================
+
+
+class TestBuiltinTheme:
+    """Tests for use_builtin_theme parameter on widgets."""
+
+    def test_polynomial_generator_theme_flag_exists(self) -> None:
+        """PolynomialGeneratorWidget.__init__ should accept use_builtin_theme."""
+        import inspect
+
+        from signal_toolkit.polynomial_generator import PolynomialGeneratorWidget
+
+        sig = inspect.signature(PolynomialGeneratorWidget.__init__)
+        assert "use_builtin_theme" in sig.parameters
+        assert sig.parameters["use_builtin_theme"].default is True
+
+    def test_signal_toolkit_theme_flag_exists(self) -> None:
+        """SignalToolkitWidget.__init__ should accept use_builtin_theme."""
+        import inspect
+
+        from signal_toolkit.widget import SignalToolkitWidget
+
+        sig = inspect.signature(SignalToolkitWidget.__init__)
+        assert "use_builtin_theme" in sig.parameters
+        assert sig.parameters["use_builtin_theme"].default is True
+
+
+# =============================================================================
+# Launcher / Registration Tests
+# =============================================================================
+
+
+class TestLauncher:
+    """Tests for Signal Processing Studio launcher."""
+
+    def test_launcher_dependency_check(self) -> None:
+        """Launcher should detect required dependencies."""
+        import importlib
+
+        launcher_dir = str(TOOLS_ROOT / "src" / "signal_processing_studio")
+        if launcher_dir not in sys.path:
+            sys.path.insert(0, launcher_dir)
+
+        # Import by file path to avoid polluting sys.modules["launch_pyqt6"]
+        # (which would shadow the Function Generator's launch_pyqt6 in other tests)
+        spec = importlib.util.spec_from_file_location(
+            "studio_launch_pyqt6",
+            TOOLS_ROOT / "src" / "signal_processing_studio" / "launch_pyqt6.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        ok, missing = mod.check_dependencies()
+        assert isinstance(ok, bool)
+        assert isinstance(missing, list)
+
+    def test_signal_bus_class(self) -> None:
+        """SignalBus should have expected methods."""
+        assert hasattr(SignalBus, "_on_func_gen_signal")
+        assert hasattr(SignalBus, "_on_poly_generated")
+        assert hasattr(SignalBus, "send_current_to_toolkit")
+
+    def test_main_window_class(self) -> None:
+        """SignalProcessingStudio should be importable."""
+        from signal_processing_studio.main_window import SignalProcessingStudio
+
+        assert SignalProcessingStudio is not None


### PR DESCRIPTION
## Summary
- **Draw line fix**: Freehand drawing now resamples points to 30 evenly-spaced x positions via `_resample_drawn_points()`, preventing polynomial fit bias from uneven mouse-speed clustering
- **Studio tests**: Added 22 tests covering SignalBus routing, coefficient reversal, resample edge cases, `load_external_signal`, `use_builtin_theme` flags, and launcher imports

## Test plan
- [x] 9 resample tests (uniform spacing, edge cases, duplicate x averaging, endpoint preservation)
- [x] 7 SignalBus routing tests (func_gen→toolkit, poly→toolkit with reversed coefficients, status callbacks)
- [x] 1 `load_external_signal` test (sets current/original signal, emits update)
- [x] 2 `use_builtin_theme` parameter signature tests
- [x] 3 launcher/import tests (dependency check, class availability)
- [x] All 34 tests pass when run alongside function generator tests (no sys.modules collisions)
- [x] ruff + black pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to point processing for polynomial fitting plus new unit tests; minimal impact beyond improving fit behavior for freehand drawing.
> 
> **Overview**
> Freehand draw input in `PolynomialGeneratorWidget` is now resampled to *uniformly spaced x values* (via new `_resample_drawn_points`) before adding points for polynomial fitting, avoiding bias from mouse-event clustering and handling unsorted/duplicate x coordinates.
> 
> Adds a new `signal_processing_studio` test suite covering the resampling helper, `SignalBus` routing behavior (including polynomial coefficient reversal and default time range), `SignalToolkitWidget.load_external_signal`, widget `use_builtin_theme` signature flags, and launcher dependency/import checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fafaaa2e901eb1e3333329c9d99d352411b823e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->