### PR TITLE
docs(assessment): add model explorer & URDF tooling review

### DIFF
--- a/docs/assessments/Assessment_Model_Explorer_Review.md
+++ b/docs/assessments/Assessment_Model_Explorer_Review.md
@@ -1,0 +1,291 @@
+# Assessment: Model Explorer & URDF Tooling Review
+
+**Date**: 2026-02-08
+**Assessor**: AI Assessment Agent
+**Scope**: `model_generation`, `humanoid_character_builder`, `humanoid_builder_gui`, `web_applications/urdf_viewer`
+
+---
+
+## Executive Summary
+
+The "model explorer" ecosystem spans four interconnected components: a comprehensive `model_generation` Python package, a standalone `humanoid_character_builder` library, a PyQt6 character builder GUI, and a web-based URDF viewer. The system is architecturally ambitious with well-designed APIs, but is **non-functional at runtime** due to a circular import that prevents the core `model_generation` package from loading. The Frankenstein component editor contains substantial, well-structured code that cannot execute. No pose estimation capability exists. URDF visualization works only through the standalone web viewer.
+
+**Overall Verdict**: Extensive code investment with a critical blocker preventing all core functionality.
+
+---
+
+## 1. Video Game-Like Character Builder
+
+### What Exists
+
+**Backend (`humanoid_character_builder/interfaces/api.py`)**:
+- `CharacterBuilder` class with parametric body generation from height, mass, build type
+- `BodyParameters` dataclass with muscularity, body fat, gender factor, and per-segment overrides
+- Presets system (athletic, average, heavy, lean) via `create_from_preset()`
+- Mesh generation with visual and collision LODs (`MeshGenerator` with pluggable backends)
+- De Leva (1996) anthropometry data for anatomically accurate segment proportions
+- URDF export with package structure (meshes, config, URDF file)
+- Inertia calculation via primitives or mesh-based (trimesh) methods
+
+**GUI (`humanoid_builder_gui/.../main_window.py`)**:
+- PyQt6 interface with Catppuccin Mocha theme
+- 4 tabs: Body Parameters, Proportions, Results, Export
+- Sliders for: height, mass, build type, gender model, muscularity, body fat
+- 9 proportion sliders: shoulder width, hip width, arm/leg length, torso length, head/hand/foot scale, neck length
+- Real-time BMI calculation with color-coded categories
+- Segment breakdown table (17 body segments with mass, length, width, depth)
+
+### Functionality Status
+
+| Component | Status | Detail |
+|-----------|--------|--------|
+| Backend `CharacterBuilder` API | **Broken** | Cannot import due to shared dependency on `model_generation.core` circular import |
+| GUI parameter adjustment | **Works** | Segment calculations and table population function correctly in isolation |
+| GUI export | **Stub** | Displays placeholder text: `"(File dialog would appear in full implementation)"` |
+| Preset loading | **Broken** | Depends on `model_generation` import chain |
+| Mesh generation | **Untested** | Code exists but cannot be reached due to import failure |
+
+### Assessment
+
+The character builder concept is well-executed at the design level. The anthropometric data, proportion system, and parametric API are thoughtfully designed. However:
+
+- **CRITICAL**: The GUI export (`main_window.py:794-810`) is a dead-end stub
+- **CRITICAL**: The backend cannot be imported (circular dependency in `model_generation.core`)
+- The GUI duplicates anthropometry constants rather than using the shared `humanoid_character_builder.core.anthropometry` module
+- No integration between the PyQt6 GUI and the `CharacterBuilder` backend API
+
+**Score: 3/10** -- Significant code exists but nothing produces usable output.
+
+---
+
+## 2. Pose Estimation and Import
+
+### What Exists
+
+**Nothing.** There is no pose estimation or pose import functionality anywhere in the model explorer tooling.
+
+### Searched Locations
+
+| Search Term | Files Found | Relevant? |
+|-------------|-------------|-----------|
+| `pose estimat` | 3 files | No -- all in unrelated golf video processing docs |
+| `pose import` | 0 files | -- |
+| `joint configuration` / `joint state` | 0 files (in model_generation) | -- |
+| `keypoint` / `skeleton detection` | 0 files | -- |
+| `mediapipe` / `openpose` | 0 files | -- |
+
+### What Would Be Needed
+
+To add pose estimation/import, the system would require:
+
+1. **Pose definition format** -- A way to store/load named joint angle configurations (e.g., YAML/JSON mapping joint names to radian values)
+2. **Import from motion capture** -- C3D reader exists at `upstream_drift_tools/lab/bio/c3d_reader.py` but is not connected to the URDF tools
+3. **Visual pose estimation** -- Integration with a library like MediaPipe or OpenPose for camera-based pose estimation
+4. **Pose application** -- Logic to map estimated/imported poses to URDF joint values and update the 3D viewer
+
+**Score: 0/10** -- Feature does not exist in any form.
+
+---
+
+## 3. Implementation Functionality (Is It Actually Functional?)
+
+### Critical Blocker: Circular Import
+
+The entire `model_generation` package fails to import:
+
+```
+model_generation/__init__.py
+  -> model_generation.builders.base_builder
+    -> model_generation.core.contracts
+      -> model_generation.core.validation
+        -> model_generation.core.contracts  [CIRCULAR]
+```
+
+**Error**: `ImportError: cannot import name 'postcondition' from partially initialized module 'model_generation.core.contracts'`
+
+This blocks **all** of the following from loading:
+- `FrankensteinEditor`
+- `URDFTextEditor`
+- `ParametricBuilder` / `ManualBuilder`
+- `URDFParser` / `MJCFConverter`
+- `ModelLibrary`
+- CLI (`model-gen` command)
+- REST API
+
+### Component-by-Component Status
+
+| Component | Can Import? | Can Execute? | Tests Pass? |
+|-----------|-------------|--------------|-------------|
+| `model_generation` package | No (circular import) | No | No |
+| `humanoid_character_builder` | Not tested (likely broken, shares core types) | No | No |
+| `humanoid_builder_gui` PyQt6 | Partial (UI works, backend broken) | UI only | No tests |
+| `urdf_viewer` web app (FastAPI) | Yes (independent) | Yes (standalone) | No tests |
+| `urdf_viewer` frontend (React/Three.js) | Yes (CDN-loaded) | Fragile (runtime Babel) | No tests |
+
+### REST API Gaps
+
+The `model_generation` REST API (`api/rest_api.py:908-909`) has an explicit stub:
+
+```python
+# For now, return not implemented
+return APIResponse.error("Remove not implemented", 501)
+```
+
+### Documentation Self-Assessment
+
+The project's own `docs/user_manual/12_implementation_gaps.md` acknowledges:
+- URDF Web Viewer: "Basic viewer with TODO markers"
+- Humanoid Builder GUI: "Advanced mesh generation, physics simulation" missing
+- 85 TODO/FIXME/NotImplementedError markers across 30 files
+
+**Score: 2/10** -- A circular import prevents the core package from loading. Only the standalone URDF web viewer can function.
+
+---
+
+## 4. Frankenstein Component Switching
+
+### What Exists
+
+`FrankensteinEditor` (`model_generation/editor/frankenstein_editor.py`) is a 1400-line class with:
+
+**Core Operations**:
+- `load_model()` / `create_model()` / `duplicate_model()` / `unload_model()` -- Multi-model workspace
+- `copy_link()` / `copy_subtree()` / `copy_material()` -- Clipboard-based component selection
+- `paste()` / `paste_subtree()` -- Paste with automatic name conflict resolution (prefix/suffix/counter)
+- `delete_link()` / `delete_subtree()` -- With optional child reparenting
+- `rename_link()` / `rename_joint()` -- Updates all references across joints
+- `modify_joint()` -- Change joint type, origin, axis, limits, dynamics
+- `attach_link()` / `detach_link()` -- Create/remove joints between existing links
+- `mirror_subtree()` -- Mirror limbs with automatic left/right name substitution
+- `apply_prefix()` -- Batch rename all links, joints, materials
+- `compare_models()` -- Diff two models by link/joint sets
+- `export_model()` -- Write composed model to URDF
+
+**Infrastructure**:
+- Full undo/redo with deep-copy state snapshots (50-level history)
+- Read-only model protection
+- Rename event callbacks
+- Model statistics (mass totals, joint type counts)
+- CLI integration via `model-gen compose` command
+- REST API endpoint (partially implemented)
+
+**Tests** (`tests/test_editor.py`):
+- 16 test methods covering: creation, load from string, duplication, copy link, copy subtree, paste, delete, rename (link + joint references), undo/redo, export, compare, statistics
+- Two URDF test fixtures (simple 2-link robot, two-arm robot)
+
+### Functionality Status
+
+| Operation | Code Quality | Can Execute? |
+|-----------|-------------|--------------|
+| Load model from URDF string | Good | No (circular import) |
+| Copy/paste subtrees between models | Good, handles name conflicts | No |
+| Delete subtree with reparenting | Good | No |
+| Mirror limbs (left->right) | Good, auto name substitution | No |
+| Undo/redo | Good, deep-copy state snapshots | No |
+| Export to URDF | Good | No |
+| CLI compose workflow | Good | No |
+| REST API compose | Partial (delete returns 501) | No |
+
+### Assessment
+
+The Frankenstein editor is the most complete and well-designed component in the model explorer ecosystem. The API is clean, the operations are comprehensive, and the test coverage is good. The concept of loading multiple URDF models, copying subtrees between them, and composing new robots is genuinely useful.
+
+**However, none of it can run.** The circular import in `model_generation.core` prevents any code path from executing.
+
+**Score: 2/10** -- Excellent design and code quality, completely non-functional.
+
+---
+
+## 5. Visualization of URDFs
+
+### What Exists
+
+**Web-based URDF Viewer** (`src/web_applications/urdf_viewer/`):
+
+**Backend** (`app.py`):
+- FastAPI server with CORS support
+- File upload endpoint (`POST /api/upload`) with path traversal protection
+- Model listing (`GET /api/models`) and serving (`GET /api/models/{filename}`)
+- Static file serving for the frontend
+
+**Frontend** (`static/viewer.js`, `static/index.html`):
+- React application using Three.js and `urdf-loader`
+- 3D viewport with grid, axes, ambient + directional lighting
+- OrbitControls for camera manipulation
+- Automatic camera framing based on model bounding box
+- Interactive joint angle sliders (range inputs) for non-fixed joints
+- Collision geometry toggle (show/hide collision meshes)
+- File upload with drag-and-drop model selection from sidebar
+- Responsive viewport resizing
+
+### Functionality Status
+
+| Feature | Status | Detail |
+|---------|--------|--------|
+| URDF file upload | **Works** | FastAPI backend with proper path sanitization |
+| 3D rendering | **Works** | Three.js + urdf-loader, with grid/axes/lighting |
+| Joint manipulation | **Works** | Sliders for revolute/continuous joints with min/max limits |
+| Collision toggle | **Works** | Toggles `isURDFCollision` mesh visibility |
+| Camera controls | **Works** | OrbitControls with auto-framing |
+| Multi-robot support | **Missing** | Only one robot visible at a time |
+| Animation playback | **Missing** | No trajectory/sequence playback |
+| Mesh file loading | **Fragile** | URDF meshes must be co-located or URL-accessible |
+| Frontend build | **Fragile** | Runtime Babel transpilation from CDN, no build step |
+
+### Architecture Concerns
+
+1. **No build pipeline**: The React JSX is transpiled at runtime via `@babel/standalone` loaded from unpkg CDN. This is fragile, slow, and inappropriate for production.
+2. **CDN dependencies**: Three.js, React, and urdf-loader are loaded from `esm.sh` at runtime. Offline use is impossible.
+3. **No mesh serving**: The backend serves URDF files but has no logic for serving referenced mesh files (STL/DAE/OBJ). Models with external meshes will fail to render.
+4. **No integration with `model_generation`**: The viewer is completely standalone. It cannot use `FrankensteinEditor`, `CharacterBuilder`, or any other backend tool.
+
+### Assessment
+
+The URDF viewer is the **only functional component** in the model explorer ecosystem. It provides a usable (if basic) 3D visualization of URDF models with joint manipulation. The FastAPI backend has proper security (path traversal protection, CORS).
+
+**Score: 5/10** -- Basic functionality works, but fragile architecture and missing features (mesh serving, build pipeline, backend integration).
+
+---
+
+## Summary Scorecard
+
+| Feature | Score | Status |
+|---------|-------|--------|
+| Video game-like character builder | 3/10 | Code exists, GUI partially works, export is stub, backend broken |
+| Pose estimation / import | 0/10 | Does not exist |
+| Overall implementation functionality | 2/10 | Circular import prevents core package from loading |
+| Frankenstein component switching | 2/10 | Excellent code, completely non-functional |
+| URDF visualization | 5/10 | Only working component, basic but functional |
+| **Overall** | **2.4/10** | |
+
+---
+
+## Critical Fix Required
+
+The single highest-priority fix is resolving the circular import:
+
+```
+model_generation.core.contracts <-> model_generation.core.validation
+```
+
+**Root cause**: `contracts.py` imports `ValidationResult` from `validation.py`, while `validation.py` imports `precondition` and `postcondition` from `contracts.py`.
+
+**Suggested fix**: Break the cycle by either:
+1. Moving `ValidationResult` into `contracts.py` (or a shared `_base.py` module)
+2. Using lazy imports (import inside function bodies) for one direction
+3. Merging the two modules since they are tightly coupled
+
+Until this is fixed, approximately 90% of the model explorer code is dead code.
+
+---
+
+## Recommendations (Priority Order)
+
+1. **Fix circular import** in `model_generation.core` -- Unblocks everything
+2. **Wire GUI export** to `CharacterBuilder` backend -- Currently a dead-end stub
+3. **Add a frontend build step** for URDF viewer -- Replace runtime Babel with Vite/esbuild
+4. **Add mesh file serving** to URDF viewer backend -- Support models with STL/DAE meshes
+5. **Integrate URDF viewer with `FrankensteinEditor`** -- Enable compose-and-view workflow
+6. **Add pose definition/loading** -- YAML/JSON joint angle configurations
+7. **Connect C3D reader to URDF tools** -- Enable motion capture data import
+8. **Add end-to-end integration tests** -- Verify the full pipeline from parameters to URDF file


### PR DESCRIPTION
Comprehensive assessment of the model explorer ecosystem covering:
- Character builder (game-like parametric body generation)
- Frankenstein component switching editor
- URDF web viewer visualization
- Pose estimation (not implemented)
- Critical circular import blocker in model_generation.core

https://claude.ai/code/session_01W5ahSGreUV9U4UsqhLdMCw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime behavior or deployed code paths.
> 
> **Overview**
> Adds a new assessment doc (`docs/assessments/Assessment_Model_Explorer_Review.md`) that evaluates the model explorer ecosystem (character builder API + GUI, Frankenstein editor, and the standalone URDF web viewer), and documents current gaps like missing pose estimation and stubbed exports/API endpoints.
> 
> Calls out a **critical circular import** in `model_generation.core` as a runtime blocker and provides prioritized remediation recommendations (break the import cycle, connect GUI export to backend, and harden the URDF viewer build/asset serving).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30347b39d2427e6885228a13f7cefb77b6137763. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->