### PR TITLE
refactor(waves-2-3): clean up utils namespaces and standardize imports

### DIFF
--- a/src/acid_gas_dewpoint/gui_registration.py
+++ b/src/acid_gas_dewpoint/gui_registration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 try:
-    from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+    from gui_launcher import GUIType, LaunchConfig, register_gui
 
     MODULE_DIR = Path(__file__).parent
 

--- a/src/acid_gas_dewpoint/python/acid_gas_dewpoint/ui/pyqt6/main_window.py
+++ b/src/acid_gas_dewpoint/python/acid_gas_dewpoint/ui/pyqt6/main_window.py
@@ -218,7 +218,7 @@ class AcidGasDewpointCalculatorWidget(QWidget):
     def _calculate(self) -> None:
         """Perform the dewpoint calculation."""
         try:
-            from shared.python.upstream_drift_tools.process_calculators.acid_gas_dewpoint_calculator import (
+            from upstream_drift_tools.process_calculators.acid_gas_dewpoint_calculator import (
                 AcidGasComposition,
                 AcidGasDewpointCalculator,
             )

--- a/src/data_processing/data_processor/gui_registration.py
+++ b/src/data_processing/data_processor/gui_registration.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 # Try to import from shared gui_launcher
 try:
-    from shared.python.gui_launcher import (
+    from gui_launcher import (
         GUIType,
         LaunchConfig,
         register_gui,

--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/analysis_widgets.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/analysis_widgets.py
@@ -1049,7 +1049,7 @@ if PYQT6_AVAILABLE:
             self._setup_ui()
 
         def _setup_ui(self) -> None:
-            from shared.python.plot_engine.pyqt6_widget import PlotWidget
+            from plot_engine.pyqt6_widget import PlotWidget
 
             layout = QVBoxLayout(self)
 
@@ -1117,8 +1117,8 @@ if PYQT6_AVAILABLE:
             layout.addWidget(self._plot_widget, stretch=1)
 
         def _generate_plot(self) -> None:
-            from shared.python.plot_engine.contour import scatter_to_grid
-            from shared.python.plot_engine.specs import AxisSpec, ContourPlotSpec
+            from plot_engine.contour import scatter_to_grid
+            from plot_engine.specs import AxisSpec, ContourPlotSpec
 
             x_col = self._x_combo.currentText()
             y_col = self._y_combo.currentText()
@@ -1170,7 +1170,7 @@ if PYQT6_AVAILABLE:
             self._setup_ui()
 
         def _setup_ui(self) -> None:
-            from shared.python.plot_engine.pyqt6_widget import PlotWidget
+            from plot_engine.pyqt6_widget import PlotWidget
 
             layout = QVBoxLayout(self)
 
@@ -1208,8 +1208,8 @@ if PYQT6_AVAILABLE:
             layout.addWidget(self._plot_widget, stretch=1)
 
         def _generate_plot(self) -> None:
-            from shared.python.plot_engine.contour import correlation_matrix
-            from shared.python.plot_engine.specs import HeatmapSpec
+            from plot_engine.contour import correlation_matrix
+            from plot_engine.specs import HeatmapSpec
 
             try:
                 numeric_df = self.df.select_dtypes(include=[np.number])
@@ -1266,7 +1266,7 @@ if PYQT6_AVAILABLE:
             self._generate_plot()
 
         def _setup_ui(self) -> None:
-            from shared.python.plot_engine.pyqt6_widget import PlotWidget
+            from plot_engine.pyqt6_widget import PlotWidget
 
             layout = QVBoxLayout(self)
 
@@ -1282,7 +1282,7 @@ if PYQT6_AVAILABLE:
             layout.addWidget(self._plot_widget, stretch=1)
 
         def _generate_plot(self) -> None:
-            from shared.python.plot_engine.specs import (
+            from plot_engine.specs import (
                 AxisSpec,
                 FilterComparisonSpec,
                 SeriesData,
@@ -1487,7 +1487,7 @@ if PYQT6_AVAILABLE:
 
         def get_series_style(self):
             """Build a SeriesStyle from current widget state."""
-            from shared.python.plot_engine.specs import SeriesStyle
+            from plot_engine.specs import SeriesStyle
 
             return SeriesStyle(
                 color=self._selected_color,
@@ -1501,7 +1501,7 @@ if PYQT6_AVAILABLE:
 
         def get_trendline_spec(self):
             """Build a TrendlineSpec or None."""
-            from shared.python.plot_engine.specs import TrendlineSpec
+            from plot_engine.specs import TrendlineSpec
 
             trend_type = self._trend_type_combo.currentText()
             if trend_type == "None":
@@ -1515,7 +1515,7 @@ if PYQT6_AVAILABLE:
 
         def get_axis_specs(self):
             """Build X and Y AxisSpec from current widget state."""
-            from shared.python.plot_engine.specs import AxisSpec
+            from plot_engine.specs import AxisSpec
 
             x_axis = AxisSpec(
                 label=self._x_label_edit.currentText(),
@@ -1531,7 +1531,7 @@ if PYQT6_AVAILABLE:
 
         def get_legend_spec(self):
             """Build a LegendSpec from current widget state."""
-            from shared.python.plot_engine.specs import LegendSpec
+            from plot_engine.specs import LegendSpec
 
             return LegendSpec(
                 visible=self._legend_visible_check.isChecked(),

--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py
@@ -2713,7 +2713,7 @@ def main() -> None:
     """Run the Data Processor application."""
     import sys
 
-    from shared.python.plot_theme import setup_plot_theme_for_app
+    from plot_theme import setup_plot_theme_for_app
     from shared.python.theme import setup_themed_app
 
     app = QApplication(sys.argv)

--- a/src/electrode_advisor/gui_registration.py
+++ b/src/electrode_advisor/gui_registration.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+from gui_launcher import GUIType, LaunchConfig, register_gui
 
 # Get the current directory for relative paths
 CURRENT_DIR = Path(__file__).parent

--- a/src/electrode_advisor/python/electrode_advisor/__init__.py
+++ b/src/electrode_advisor/python/electrode_advisor/__init__.py
@@ -7,7 +7,7 @@ Uses the shared electrical model engine from upstream_drift_tools.
 from __future__ import annotations
 
 # Re-export the shared engine components
-from shared.python.upstream_drift_tools.calculators.electrical import (
+from upstream_drift_tools.calculators.electrical import (
     ElectrodeConfig,
     GlassPropertiesInterface,
     ThreePhaseElectricalModelEnhanced,

--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window.py
@@ -87,8 +87,7 @@ from PyQt6.QtWidgets import (  # noqa: E402
     QVBoxLayout,
     QWidget,
 )
-
-from shared.python.upstream_drift_tools.calculators.electrical import (  # noqa: E402
+from upstream_drift_tools.calculators.electrical import (  # noqa: E402
     ElectrodeConfig,
     GlassPropertiesInterface,
     ThreePhaseElectricalModelEnhanced,

--- a/src/electrode_advisor/tests/test_electrode_advisor_gui.py
+++ b/src/electrode_advisor/tests/test_electrode_advisor_gui.py
@@ -36,7 +36,7 @@ class TestElectrodeAdvisorGUI:
     def test_imports(self):
         """Test that all imports work correctly."""
         # Test shared engine imports
-        from shared.python.upstream_drift_tools.calculators.electrical import (
+        from upstream_drift_tools.calculators.electrical import (
             ElectrodeConfig,
             GlassPropertiesInterface,
             ThreePhaseElectricalModelEnhanced,
@@ -48,7 +48,7 @@ class TestElectrodeAdvisorGUI:
 
     def test_config_creation(self):
         """Test that ElectrodeConfig can be created with defaults."""
-        from shared.python.upstream_drift_tools.calculators.electrical import (
+        from upstream_drift_tools.calculators.electrical import (
             ElectrodeConfig,
         )
 
@@ -59,7 +59,7 @@ class TestElectrodeAdvisorGUI:
 
     def test_electrical_model_creation(self):
         """Test that the electrical model can be instantiated."""
-        from shared.python.upstream_drift_tools.calculators.electrical import (
+        from upstream_drift_tools.calculators.electrical import (
             ElectrodeConfig,
             GlassPropertiesInterface,
             ThreePhaseElectricalModelEnhanced,
@@ -75,8 +75,7 @@ class TestElectrodeAdvisorGUI:
     def test_electrical_model_calculation(self):
         """Test that the electrical model produces results."""
         import numpy as np
-
-        from shared.python.upstream_drift_tools.calculators.electrical import (
+        from upstream_drift_tools.calculators.electrical import (
             ElectrodeConfig,
             GlassPropertiesInterface,
             ThreePhaseElectricalModelEnhanced,
@@ -148,7 +147,7 @@ class TestGUIRegistration:
     def test_registration_imports(self):
         """Test that registration module can be imported."""
         try:
-            from shared.python.gui_launcher import (
+            from gui_launcher import (
                 GUIType,
                 LaunchConfig,
                 register_gui,

--- a/src/flare_calculator/gui_registration.py
+++ b/src/flare_calculator/gui_registration.py
@@ -1,6 +1,6 @@
 """GUI registration for Flare Calculator."""
 
-from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+from gui_launcher import GUIType, LaunchConfig, register_gui
 
 
 def register_flare_calculator_guis() -> None:

--- a/src/function_generator/__init__.py
+++ b/src/function_generator/__init__.py
@@ -4,7 +4,7 @@ Provides standalone GUI interfaces for signal/waveform generation.
 Uses the shared SignalGenerator engine from signal_toolkit.
 """
 
-from shared.python.signal_toolkit import Signal, SignalGenerator
+from signal_toolkit import Signal, SignalGenerator
 
 __all__ = [
     "Signal",

--- a/src/function_generator/gui_registration.py
+++ b/src/function_generator/gui_registration.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 
 try:
-    from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+    from gui_launcher import GUIType, LaunchConfig, register_gui
 
     MODULE_DIR = Path(__file__).parent
 

--- a/src/function_generator/python/function_generator/__init__.py
+++ b/src/function_generator/python/function_generator/__init__.py
@@ -3,7 +3,7 @@
 Provides PyQt6 GUI for waveform generation and visualization.
 """
 
-from shared.python.signal_toolkit import Signal, SignalGenerator
+from signal_toolkit import Signal, SignalGenerator
 
 __all__ = [
     "Signal",

--- a/src/function_generator/python/function_generator/ui/pyqt6/main_window.py
+++ b/src/function_generator/python/function_generator/ui/pyqt6/main_window.py
@@ -34,8 +34,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-
-from shared.python.signal_toolkit import Signal, SignalGenerator
+from signal_toolkit import Signal, SignalGenerator
 
 
 class FunctionGeneratorWidget(QWidget):

--- a/src/function_generator/tests/test_function_generator_gui.py
+++ b/src/function_generator/tests/test_function_generator_gui.py
@@ -29,14 +29,14 @@ class TestSignalGeneratorEngine:
 
     def test_engine_imports(self) -> None:
         """Test that all engine imports work correctly."""
-        from shared.python.signal_toolkit import Signal, SignalGenerator
+        from signal_toolkit import Signal, SignalGenerator
 
         assert Signal is not None
         assert SignalGenerator is not None
 
     def test_sinusoid_generation(self) -> None:
         """Test sinusoid signal generation."""
-        from shared.python.signal_toolkit import SignalGenerator
+        from signal_toolkit import SignalGenerator
 
         t = np.linspace(0, 1, 1000)
         signal = SignalGenerator.sinusoid(t, amplitude=2.0, frequency=5.0)
@@ -48,7 +48,7 @@ class TestSignalGeneratorEngine:
 
     def test_square_wave_generation(self) -> None:
         """Test square wave generation."""
-        from shared.python.signal_toolkit import SignalGenerator
+        from signal_toolkit import SignalGenerator
 
         t = np.linspace(0, 1, 1000)
         signal = SignalGenerator.square(t, frequency=5.0, amplitude=1.0, duty_cycle=0.5)
@@ -58,7 +58,7 @@ class TestSignalGeneratorEngine:
 
     def test_triangle_wave_generation(self) -> None:
         """Test triangle wave generation."""
-        from shared.python.signal_toolkit import SignalGenerator
+        from signal_toolkit import SignalGenerator
 
         t = np.linspace(0, 1, 1000)
         signal = SignalGenerator.triangle(t, frequency=5.0, amplitude=1.0)
@@ -68,7 +68,7 @@ class TestSignalGeneratorEngine:
 
     def test_exponential_generation(self) -> None:
         """Test exponential signal generation."""
-        from shared.python.signal_toolkit import SignalGenerator
+        from signal_toolkit import SignalGenerator
 
         t = np.linspace(0, 1, 1000)
         signal = SignalGenerator.exponential(t, amplitude=1.0, decay_rate=2.0)
@@ -78,7 +78,7 @@ class TestSignalGeneratorEngine:
 
     def test_chirp_generation(self) -> None:
         """Test chirp signal generation."""
-        from shared.python.signal_toolkit import SignalGenerator
+        from signal_toolkit import SignalGenerator
 
         t = np.linspace(0, 1, 1000)
         signal = SignalGenerator.chirp(t, f0=1.0, f1=10.0)
@@ -88,7 +88,7 @@ class TestSignalGeneratorEngine:
 
     def test_polynomial_generation(self) -> None:
         """Test polynomial signal generation."""
-        from shared.python.signal_toolkit import SignalGenerator
+        from signal_toolkit import SignalGenerator
 
         t = np.linspace(0, 1, 100)
         coeffs = [1, 2, 3]  # 1 + 2t + 3t^2
@@ -100,7 +100,7 @@ class TestSignalGeneratorEngine:
 
     def test_superposition(self) -> None:
         """Test signal superposition."""
-        from shared.python.signal_toolkit import SignalGenerator
+        from signal_toolkit import SignalGenerator
 
         t = np.linspace(0, 1, 1000)
         s1 = SignalGenerator.sinusoid(t, amplitude=1.0, frequency=5.0)
@@ -173,7 +173,7 @@ class TestGUIRegistration:
     def test_registration_imports(self) -> None:
         """Test that registration module can be imported."""
         try:
-            from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+            from gui_launcher import GUIType, LaunchConfig, register_gui
 
             assert GUIType is not None
             assert LaunchConfig is not None

--- a/src/glass_bath_fea/interfaces/electrode_adapter.py
+++ b/src/glass_bath_fea/interfaces/electrode_adapter.py
@@ -46,7 +46,7 @@ class ElectrodeAdapter:
             ElectrodeConfig instance from electrode adviser.
         """
         if self._electrode_config is None:
-            from shared.python.upstream_drift_tools.calculators.electrical.config import (
+            from upstream_drift_tools.calculators.electrical.config import (
                 ElectrodeConfig,
             )
 
@@ -65,7 +65,7 @@ class ElectrodeAdapter:
             GlassPropertiesInterface instance.
         """
         if self._glass_interface is None:
-            from shared.python.upstream_drift_tools.calculators.electrical.glass_interface import (
+            from upstream_drift_tools.calculators.electrical.glass_interface import (
                 GlassPropertiesInterface,
             )
 
@@ -81,7 +81,7 @@ class ElectrodeAdapter:
             ThreePhaseElectricalModelEnhanced instance.
         """
         if self._electrical_model is None:
-            from shared.python.upstream_drift_tools.calculators.electrical.electrical_model import (
+            from upstream_drift_tools.calculators.electrical.electrical_model import (
                 ThreePhaseElectricalModelEnhanced,
             )
 

--- a/src/pressure_drop_calculator/__init__.py
+++ b/src/pressure_drop_calculator/__init__.py
@@ -4,7 +4,7 @@ Provides standalone GUI interfaces for pipe pressure drop analysis.
 Uses the shared engine from upstream_drift_tools.
 """
 
-from shared.python.upstream_drift_tools.process_calculators.pressure_drop_calculator import (
+from upstream_drift_tools.process_calculators.pressure_drop_calculator import (
     PressureDropCalculationEngine,
     PressureDropInputs,
     PressureDropResults,

--- a/src/pressure_drop_calculator/gui_registration.py
+++ b/src/pressure_drop_calculator/gui_registration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 try:
-    from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+    from gui_launcher import GUIType, LaunchConfig, register_gui
 
     MODULE_DIR = Path(__file__).parent
 

--- a/src/pressure_drop_calculator/python/pressure_drop_calculator/__init__.py
+++ b/src/pressure_drop_calculator/python/pressure_drop_calculator/__init__.py
@@ -1,6 +1,6 @@
 """Pressure Drop Calculator Python Package."""
 
-from shared.python.upstream_drift_tools.process_calculators.pressure_drop_calculator import (
+from upstream_drift_tools.process_calculators.pressure_drop_calculator import (
     PressureDropCalculationEngine,
     PressureDropInputs,
     PressureDropResults,

--- a/src/pressure_drop_calculator/python/pressure_drop_calculator/ui/pyqt6/main_window.py
+++ b/src/pressure_drop_calculator/python/pressure_drop_calculator/ui/pyqt6/main_window.py
@@ -272,7 +272,7 @@ class PressureDropCalculatorWidget(QWidget):
     def _calculate(self) -> None:
         """Perform the pressure drop calculation."""
         try:
-            from shared.python.upstream_drift_tools.process_calculators.pressure_drop_calculator import (
+            from upstream_drift_tools.process_calculators.pressure_drop_calculator import (
                 calculate_pressure_drop,
             )
 

--- a/src/pressure_drop_calculator/tests/test_pressure_drop_calculator_gui.py
+++ b/src/pressure_drop_calculator/tests/test_pressure_drop_calculator_gui.py
@@ -25,7 +25,7 @@ class TestPressureDropEngine:
 
     def test_engine_imports(self) -> None:
         """Test that all engine imports work correctly."""
-        from shared.python.upstream_drift_tools.process_calculators.pressure_drop_calculator import (
+        from upstream_drift_tools.process_calculators.pressure_drop_calculator import (
             PressureDropCalculationEngine,
         )
 
@@ -33,7 +33,7 @@ class TestPressureDropEngine:
 
     def test_interface_imports(self) -> None:
         """Test that interface imports work correctly."""
-        from shared.python.upstream_drift_tools.process_calculators.pressure_drop_calculator import (
+        from upstream_drift_tools.process_calculators.pressure_drop_calculator import (
             calculate_pressure_drop,
         )
 
@@ -41,7 +41,7 @@ class TestPressureDropEngine:
 
     def test_basic_calculation(self) -> None:
         """Test a basic pressure drop calculation."""
-        from shared.python.upstream_drift_tools.process_calculators.pressure_drop_calculator import (
+        from upstream_drift_tools.process_calculators.pressure_drop_calculator import (
             calculate_pressure_drop,
         )
 
@@ -124,7 +124,7 @@ class TestGUIRegistration:
     def test_registration_imports(self) -> None:
         """Test that registration module can be imported."""
         try:
-            from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+            from gui_launcher import GUIType, LaunchConfig, register_gui
 
             assert GUIType is not None
             assert LaunchConfig is not None

--- a/src/python/src/utils/__init__.py
+++ b/src/python/src/utils/__init__.py
@@ -1,5 +1,4 @@
-"""
-Utils package providing common utilities across the repository.
+"""Utils package providing common utilities across the repository.
 
 This package contains:
 - logging_utils: Logging configuration and utilities
@@ -7,142 +6,31 @@ This package contains:
 - test_utils: Testing utilities, fixtures, and assertions
 - debug_utils: Debugging, profiling, and diagnostic tools
 - integration_test_helpers: Integration test base classes and helpers
+- path_setup: Repository root detection and Python path configuration
+- file_utils: Safe file read/write operations
+- validation: Input validation helpers
+- csv_utils: CSV reading/writing utilities
+- config_loader: Configuration loading from YAML/JSON
+- env_utils: Environment variable helpers
+- os_utils: OS-level helpers
+- subprocess_utils: Safe subprocess execution
+
+Import directly from submodules for explicit, lightweight imports::
+
+    from utils.logging_utils import get_logger, setup_logging
+    from utils.error_handling import safe_execute, exit_on_error
+    from utils.path_setup import get_repo_root, setup_python_path
 """
 
-from utils.debug_utils import (
-    MemoryStats,
-    PerformanceWatchdog,
-    ProfileResult,
-    StackFrame,
-    SystemDiagnostics,
-    TimingStats,
-    debug_exception,
-    debug_log,
-    debug_only,
-    debug_vars,
-    deprecated,
-    get_call_stack,
-    get_caller_info,
-    get_memory_usage,
-    get_system_diagnostics,
-    get_watchdog,
-    is_debug_mode,
-    memory_profile,
-    memory_tracker,
-    profile,
-    profile_block,
-    set_debug_mode,
-    timed,
-    timer,
-    trace_calls,
-)
-from utils.error_handling import (
-    exit_on_error,
-    handle_file_errors,
-    handle_import_error,
-    log_and_continue,
-    safe_execute,
-)
-from utils.logging_utils import (
-    DEFAULT_FORMAT,
-    DEFAULT_SEED,
-    SIMPLE_FORMAT,
-    JsonFormatter,
-    get_logger,
-    init_default_logging,
-    set_seeds,
-    setup_logging,
-)
-from utils.test_utils import (
-    AssertionHelpers,
-    BaseTestCase,
-    DataGeneratorConfig,
-    IntegrationTestCase,
-    MockFactory,
-    PytestMarkers,
-    TestDataConfig,
-    TestMarkers,
-    TimingResult,
-    assert_helpers,
-    assert_performance,
-    captured_logs,
-    captured_output,
-    environment_variables,
-    generate_edge_case_data,
-    generate_sample_data,
-    markers,
-    mock_datetime,
-    retry_on_failure,
-    skip_if_no_module,
-    temporary_directory,
-    temporary_file,
-    time_function,
-)
-
-__all__ = [
-    # logging_utils
-    "DEFAULT_FORMAT",
-    "DEFAULT_SEED",
-    "SIMPLE_FORMAT",
-    "JsonFormatter",
-    "get_logger",
-    "init_default_logging",
-    "set_seeds",
-    "setup_logging",
-    # error_handling
-    "exit_on_error",
-    "handle_file_errors",
-    "handle_import_error",
-    "log_and_continue",
-    "safe_execute",
-    # test_utils
-    "AssertionHelpers",
-    "BaseTestCase",
-    "DataGeneratorConfig",
-    "IntegrationTestCase",
-    "MockFactory",
-    "PytestMarkers",
-    "TestDataConfig",  # Alias for DataGeneratorConfig
-    "TestMarkers",  # Alias for PytestMarkers
-    "TimingResult",
-    "assert_helpers",
-    "assert_performance",
-    "captured_logs",
-    "captured_output",
-    "environment_variables",
-    "generate_edge_case_data",
-    "generate_sample_data",
-    "markers",
-    "mock_datetime",
-    "retry_on_failure",
-    "skip_if_no_module",
-    "temporary_directory",
-    "temporary_file",
-    "time_function",
-    # debug_utils
-    "MemoryStats",
-    "PerformanceWatchdog",
-    "ProfileResult",
-    "StackFrame",
-    "SystemDiagnostics",
-    "TimingStats",
-    "debug_exception",
-    "debug_log",
-    "debug_only",
-    "debug_vars",
-    "deprecated",
-    "get_call_stack",
-    "get_caller_info",
-    "get_memory_usage",
-    "get_system_diagnostics",
-    "get_watchdog",
-    "is_debug_mode",
-    "memory_profile",
-    "memory_tracker",
-    "profile",
-    "profile_block",
-    "set_debug_mode",
-    "timed",
-    "timer",
-    "trace_calls",
-]
+# Intentionally empty: submodules should be imported directly
+# to avoid loading unnecessary dependencies at package init time.
+#
+# Before (eager, loaded everything on `import utils`):
+#     from utils.debug_utils import MemoryStats, ...
+#     from utils.error_handling import exit_on_error, ...
+#     from utils.logging_utils import get_logger, ...
+#     from utils.test_utils import BaseTestCase, ...
+#
+# After (lazy, import what you need):
+#     from utils.logging_utils import get_logger
+#     from utils.file_utils import safe_read_text

--- a/src/scrubber_calculator/gui_registration.py
+++ b/src/scrubber_calculator/gui_registration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 try:
-    from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+    from gui_launcher import GUIType, LaunchConfig, register_gui
 
     MODULE_DIR = Path(__file__).parent
 

--- a/src/scrubber_calculator/python/scrubber_calculator/ui/pyqt6/main_window.py
+++ b/src/scrubber_calculator/python/scrubber_calculator/ui/pyqt6/main_window.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 # Import the scrubber calculator engine
 try:
-    from shared.python.upstream_drift_tools.process_calculators.scrubber_calculator import (
+    from upstream_drift_tools.process_calculators.scrubber_calculator import (
         PACKING_DATABASE,
         calculate_caustic_requirement,
         calculate_column_diameter,

--- a/src/shared/python/__init__.py
+++ b/src/shared/python/__init__.py
@@ -10,12 +10,15 @@ Available packages:
     - humanoid_character_builder: URDF humanoid model generation
     - model_generation: URDF/MJCF model building and conversion
 
-Usage:
-    from shared.python.theme import ThemeManager, get_theme_manager
+Preferred imports (direct from package, since src/shared/python is on sys.path):
+    from shared.python.theme import ThemeManager, get_theme_manager  # theme: keep prefix
     from humanoid_character_builder import CharacterBuilder, BodyParameters
     from model_generation import quick_urdf, ManualBuilder, FrankensteinEditor
     from signal_toolkit import Signal, SignalGenerator, FunctionFitter
     from upstream_drift_tools.process_calculators import FlareCalculator
+    from gui_launcher import GUIType, LaunchConfig, register_gui
+    from plot_engine.specs import PlotSpec, SeriesData
+    from plot_theme import apply_plot_theme
 """
 
 __all__ = [

--- a/src/shared/python/chat/__init__.py
+++ b/src/shared/python/chat/__init__.py
@@ -6,7 +6,7 @@ for the chat protocol.
 
 Usage::
 
-    from shared.python.chat import ChatDockWidget
+    from chat import ChatDockWidget
 
     dock = ChatDockWidget(
         app_context="gasification",

--- a/src/shared/python/chat/chat_dock_widget.py
+++ b/src/shared/python/chat/chat_dock_widget.py
@@ -9,7 +9,7 @@ with no application-specific imports.
 
 Usage::
 
-    from shared.python.chat import ChatDockWidget
+    from chat import ChatDockWidget
 
     dock = ChatDockWidget(
         app_context="gasification",

--- a/src/shared/python/gui_launcher/__init__.py
+++ b/src/shared/python/gui_launcher/__init__.py
@@ -9,7 +9,7 @@ The launcher handles dependency checking, environment setup, and provides
 consistent launch mechanisms across different GUI frameworks.
 
 Example:
-    from shared.python.gui_launcher import GUILauncher, GUIType
+    from gui_launcher import GUILauncher, GUIType
 
     # Launch PyQt6 app
     launcher = GUILauncher(tool_name="data_processor", gui_type=GUIType.PYQT6)

--- a/src/shared/python/plot_engine/__init__.py
+++ b/src/shared/python/plot_engine/__init__.py
@@ -4,9 +4,9 @@ This module provides a DRY plotting system that renders the same PlotSpec
 contracts to both matplotlib (PyQt6) and Plotly.js JSON (React/Tauri).
 
 Usage:
-    from shared.python.plot_engine.specs import PlotSpec, SeriesData
-    from shared.python.plot_engine.matplotlib_renderer import MatplotlibRenderer
-    from shared.python.plot_engine.plotly_converter import PlotlyConverter
+    from plot_engine.specs import PlotSpec, SeriesData
+    from plot_engine.matplotlib_renderer import MatplotlibRenderer
+    from plot_engine.plotly_converter import PlotlyConverter
 
     spec = PlotSpec(title="My Plot", series=[...])
 

--- a/src/shared/python/plot_engine/matplotlib_renderer.py
+++ b/src/shared/python/plot_engine/matplotlib_renderer.py
@@ -28,8 +28,7 @@ from .trendline import compute_trendline
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
-
-    from shared.python.plot_theme.manager import PlotThemeManager
+    from plot_theme.manager import PlotThemeManager
 
 logger = logging.getLogger(__name__)
 

--- a/src/shared/python/plot_engine/pyqt6_widget.py
+++ b/src/shared/python/plot_engine/pyqt6_widget.py
@@ -26,7 +26,7 @@ from .matplotlib_renderer import MatplotlibRenderer
 from .specs import PlotSpec
 
 if TYPE_CHECKING:
-    from shared.python.plot_theme.manager import PlotThemeManager
+    from plot_theme.manager import PlotThemeManager
 
 logger = logging.getLogger(__name__)
 

--- a/src/shared/python/plot_engine/tests/test_matplotlib_renderer.py
+++ b/src/shared/python/plot_engine/tests/test_matplotlib_renderer.py
@@ -14,9 +14,8 @@ matplotlib.use("Agg")  # Non-interactive backend for testing
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-
-from shared.python.plot_engine.matplotlib_renderer import MatplotlibRenderer
-from shared.python.plot_engine.specs import (
+from plot_engine.matplotlib_renderer import MatplotlibRenderer
+from plot_engine.specs import (
     AxisSpec,
     ContourPlotSpec,
     FilterComparisonSpec,

--- a/src/shared/python/plot_engine/tests/test_plotly_converter.py
+++ b/src/shared/python/plot_engine/tests/test_plotly_converter.py
@@ -7,9 +7,8 @@ with correct type fields, data arrays, and layout settings.
 from __future__ import annotations
 
 import pytest
-
-from shared.python.plot_engine.plotly_converter import PlotlyConverter
-from shared.python.plot_engine.specs import (
+from plot_engine.plotly_converter import PlotlyConverter
+from plot_engine.specs import (
     AxisSpec,
     ContourPlotSpec,
     FilterComparisonSpec,

--- a/src/shared/python/plot_engine/tests/test_specs.py
+++ b/src/shared/python/plot_engine/tests/test_specs.py
@@ -9,9 +9,7 @@ from __future__ import annotations
 import json
 
 import pytest
-from pydantic import ValidationError
-
-from shared.python.plot_engine.specs import (
+from plot_engine.specs import (
     AxisSpec,
     ContourPlotSpec,
     FilterComparisonSpec,
@@ -24,6 +22,7 @@ from shared.python.plot_engine.specs import (
     SurfacePlotSpec,
     TrendlineSpec,
 )
+from pydantic import ValidationError
 
 # ── SeriesStyle ──────────────────────────────────────────────────────────────
 

--- a/src/shared/python/plot_engine/tests/test_trendline.py
+++ b/src/shared/python/plot_engine/tests/test_trendline.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-
-from shared.python.plot_engine.trendline import TrendlineResult, compute_trendline
+from plot_engine.trendline import TrendlineResult, compute_trendline
 
 # ── Linear trendline ─────────────────────────────────────────────────────────
 

--- a/src/shared/python/plot_theme/__init__.py
+++ b/src/shared/python/plot_theme/__init__.py
@@ -4,7 +4,7 @@ This module provides a consistent color theme system for plots across all
 D-sorganization applications, similar to the app theme system for PyQt6.
 
 Usage:
-    from shared.python.plot_theme import PlotThemeManager, apply_plot_theme
+    from plot_theme import PlotThemeManager, apply_plot_theme
 
     # Apply a theme to matplotlib
     manager = PlotThemeManager()

--- a/src/shared/python/plot_theme/integration.py
+++ b/src/shared/python/plot_theme/integration.py
@@ -27,7 +27,7 @@ def apply_plot_theme(
 
     This is the simplest way to use the plot theme system:
 
-        from shared.python.plot_theme import apply_plot_theme
+        from plot_theme import apply_plot_theme
 
         apply_plot_theme("scientific_violet")
 

--- a/src/shared/python/upstream_drift_tools/utils/__init__.py
+++ b/src/shared/python/upstream_drift_tools/utils/__init__.py
@@ -1,1 +1,27 @@
-# Utilities
+"""Upstream Drift Tools - Utility subpackage.
+
+Submodules:
+- paths: Canonical get_repo_root() for repository root discovery
+- logging: Logger factory with file+console support
+- state_manager: Save/load calculation states and sessions
+- unit_constants: NIST-standard conversion factors and physical constants
+
+Overlap with utils (src/python/src/utils):
+----------------------------------------------
+The following functions have duplicates across packages.  The *canonical*
+location is listed first; the other copy is kept for backward compat.
+
++-------------------+---------------------------------------+-----------------------------+
+| Function          | Canonical                             | Duplicate (compat)          |
++-------------------+---------------------------------------+-----------------------------+
+| get_repo_root()   | upstream_drift_tools.utils.paths      | utils.path_setup            |
+| get_logger()      | utils.logging_utils                   | upstream_drift_tools.utils  |
+|                   |                                       |   .logging (wraps canonical)|
+| safe_read_json()  | utils.file_utils                      | upstream_drift_tools.utils  |
+|                   |                                       |   .state_manager (private)  |
+| safe_write_json() | utils.file_utils                      | upstream_drift_tools.utils  |
+|                   |                                       |   .state_manager (private)  |
++-------------------+---------------------------------------+-----------------------------+
+
+New code should always import from the canonical location.
+"""

--- a/src/signal_processing_studio/gui_registration.py
+++ b/src/signal_processing_studio/gui_registration.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 
 try:
-    from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+    from gui_launcher import GUIType, LaunchConfig, register_gui
 
     MODULE_DIR = Path(__file__).parent
 

--- a/src/signal_processing_studio/python/signal_processing_studio/main_window.py
+++ b/src/signal_processing_studio/python/signal_processing_studio/main_window.py
@@ -16,9 +16,8 @@ from PyQt6.QtWidgets import (
     QMessageBox,
     QTabWidget,
 )
-
-from shared.python.signal_toolkit.polynomial_generator import PolynomialGeneratorWidget
-from shared.python.signal_toolkit.widget import SignalToolkitWidget
+from signal_toolkit.polynomial_generator import PolynomialGeneratorWidget
+from signal_toolkit.widget import SignalToolkitWidget
 
 from .signal_bus import SignalBus
 
@@ -138,8 +137,7 @@ class SignalProcessingStudio(*_get_base_classes()):
     def _on_poly_fallback(self, joint_name: str, coeffs: list) -> None:
         """Fallback when Function Generator is unavailable."""
         import numpy as np
-
-        from shared.python.signal_toolkit.core import SignalGenerator
+        from signal_toolkit.core import SignalGenerator
 
         if self.toolkit.current_signal is not None:
             t = self.toolkit.current_signal.time

--- a/src/signal_processing_studio/python/signal_processing_studio/signal_bus.py
+++ b/src/signal_processing_studio/python/signal_processing_studio/signal_bus.py
@@ -6,8 +6,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from PyQt6.QtCore import QObject, pyqtSignal
-
-from shared.python.signal_toolkit.core import Signal, SignalGenerator
+from signal_toolkit.core import Signal, SignalGenerator
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/src/syngas_compression/__init__.py
+++ b/src/syngas_compression/__init__.py
@@ -4,7 +4,7 @@ Provides standalone GUI interfaces for syngas compression analysis.
 Uses the shared engine from upstream_drift_tools.
 """
 
-from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
     CompressionStage,
     SyngasCompressionEngine,
 )

--- a/src/syngas_compression/gui_registration.py
+++ b/src/syngas_compression/gui_registration.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 
 try:
-    from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+    from gui_launcher import GUIType, LaunchConfig, register_gui
 
     # Register Syngas Compression Calculator
     MODULE_DIR = Path(__file__).parent

--- a/src/syngas_compression/launch_pyqt6.py
+++ b/src/syngas_compression/launch_pyqt6.py
@@ -44,11 +44,11 @@ def main() -> int:
         return 1
 
     from PyQt6.QtWidgets import QApplication, QMainWindow
-
-    from shared.python.theme import setup_themed_app
-    from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+    from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
         create_syngas_compression_calculator,
     )
+
+    from shared.python.theme import setup_themed_app
 
     app = QApplication(sys.argv)
     app.setApplicationName("Syngas Compression Calculator")

--- a/src/syngas_compression/python/syngas_compression/__init__.py
+++ b/src/syngas_compression/python/syngas_compression/__init__.py
@@ -3,7 +3,7 @@
 Provides PyQt6 GUI for syngas compression analysis.
 """
 
-from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
     CompressionStage,
     SyngasCompressionEngine,
     create_syngas_compression_calculator,

--- a/src/syngas_compression/python/syngas_compression/ui/pyqt6/__init__.py
+++ b/src/syngas_compression/python/syngas_compression/ui/pyqt6/__init__.py
@@ -1,6 +1,6 @@
 """PyQt6 UI components for Syngas Compression Calculator."""
 
-from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
     SyngasCompressionCalculatorWidget,
     create_syngas_compression_calculator,
 )

--- a/src/syngas_compression/tests/test_syngas_compression_gui.py
+++ b/src/syngas_compression/tests/test_syngas_compression_gui.py
@@ -29,7 +29,7 @@ class TestSyngasCompressionEngine:
 
     def test_engine_imports(self) -> None:
         """Test that all engine imports work correctly."""
-        from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+        from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
             CompressionStage,
             SyngasCompressionEngine,
         )
@@ -39,7 +39,7 @@ class TestSyngasCompressionEngine:
 
     def test_compression_stage_creation(self) -> None:
         """Test that CompressionStage can be created."""
-        from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+        from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
             CompressionStage,
         )
 
@@ -58,7 +58,7 @@ class TestSyngasCompressionEngine:
 
     def test_engine_calculation(self) -> None:
         """Test that the engine produces valid results."""
-        from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+        from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
             SyngasCompressionEngine,
         )
 
@@ -84,7 +84,7 @@ class TestSyngasCompressionEngine:
 
     def test_compression_work_calculation(self) -> None:
         """Test compression work calculation."""
-        from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+        from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
             CompressionStage,
             SyngasCompressionEngine,
         )
@@ -158,7 +158,7 @@ class TestSyngasCompressionGUI:
     def test_factory_function_exists(self, mock_qt_app) -> None:
         """Test that the factory function exists and is callable."""
         try:
-            from shared.python.upstream_drift_tools.process_calculators.syngas_compression_calculator import (
+            from upstream_drift_tools.process_calculators.syngas_compression_calculator import (
                 create_syngas_compression_calculator,
             )
 
@@ -173,7 +173,7 @@ class TestGUIRegistration:
     def test_registration_imports(self) -> None:
         """Test that registration module can be imported."""
         try:
-            from shared.python.gui_launcher import (
+            from gui_launcher import (
                 GUIType,
                 LaunchConfig,
                 register_gui,

--- a/src/trc_vessel_designer/gui_registration.py
+++ b/src/trc_vessel_designer/gui_registration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+from gui_launcher import GUIType, LaunchConfig, register_gui
 
 CURRENT_DIR = Path(__file__).parent
 

--- a/src/trc_vessel_designer/python/trc_vessel_designer/__init__.py
+++ b/src/trc_vessel_designer/python/trc_vessel_designer/__init__.py
@@ -7,7 +7,7 @@ Uses the shared TRC geometry engine from upstream_drift_tools.
 from __future__ import annotations
 
 # Re-export the shared engine components
-from shared.python.upstream_drift_tools.calculators.mechanical.trc_geometry import (
+from upstream_drift_tools.calculators.mechanical.trc_geometry import (
     LayerConfig,
     LayerResult,
     TRCGeometryEngine,

--- a/src/trc_vessel_designer/python/trc_vessel_designer/ui/pyqt6/main_window.py
+++ b/src/trc_vessel_designer/python/trc_vessel_designer/ui/pyqt6/main_window.py
@@ -26,7 +26,7 @@ from PyQt6.QtWidgets import (
 )
 
 # Import the shared engine from Tools
-from shared.python.upstream_drift_tools.calculators.mechanical.trc_geometry import (
+from upstream_drift_tools.calculators.mechanical.trc_geometry import (
     LayerConfig,
     TRCGeometryEngine,
     VesselDimensions,

--- a/src/trc_vessel_designer/tests/test_trc_vessel_designer_gui.py
+++ b/src/trc_vessel_designer/tests/test_trc_vessel_designer_gui.py
@@ -29,7 +29,7 @@ class TestTRCVesselDesignerEngine:
 
     def test_engine_imports(self):
         """Test that all engine imports work correctly."""
-        from shared.python.upstream_drift_tools.calculators.mechanical.trc_geometry import (
+        from upstream_drift_tools.calculators.mechanical.trc_geometry import (
             LayerConfig,
             LayerResult,
             TRCGeometryEngine,
@@ -45,7 +45,7 @@ class TestTRCVesselDesignerEngine:
 
     def test_engine_calculation(self):
         """Test that the engine produces valid results."""
-        from shared.python.upstream_drift_tools.calculators.mechanical.trc_geometry import (
+        from upstream_drift_tools.calculators.mechanical.trc_geometry import (
             LayerConfig,
             TRCGeometryEngine,
             VesselDimensions,
@@ -85,7 +85,7 @@ class TestTRCVesselDesignerEngine:
 
     def test_layer_config_creation(self):
         """Test that LayerConfig can be created with defaults."""
-        from shared.python.upstream_drift_tools.calculators.mechanical.trc_geometry import (
+        from upstream_drift_tools.calculators.mechanical.trc_geometry import (
             LayerConfig,
         )
 
@@ -103,7 +103,7 @@ class TestTRCVesselDesignerEngine:
 
     def test_vessel_dimensions_creation(self):
         """Test that VesselDimensions can be created."""
-        from shared.python.upstream_drift_tools.calculators.mechanical.trc_geometry import (
+        from upstream_drift_tools.calculators.mechanical.trc_geometry import (
             VesselDimensions,
         )
 
@@ -175,7 +175,7 @@ class TestGUIRegistration:
     def test_registration_imports(self):
         """Test that registration module can be imported."""
         try:
-            from shared.python.gui_launcher import (
+            from gui_launcher import (
                 GUIType,
                 LaunchConfig,
                 register_gui,

--- a/src/wgs_reactor/gui_registration.py
+++ b/src/wgs_reactor/gui_registration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 try:
-    from shared.python.gui_launcher import GUIType, LaunchConfig, register_gui
+    from gui_launcher import GUIType, LaunchConfig, register_gui
 
     MODULE_DIR = Path(__file__).parent
 

--- a/tests/shared/python/chat/test_chat_dock_widget.py
+++ b/tests/shared/python/chat/test_chat_dock_widget.py
@@ -13,7 +13,7 @@ import pytest
 # requires libEGL.so.1 on Linux. Skip the entire file when unavailable.
 pytest.importorskip("PyQt6.QtWidgets", reason="PyQt6.QtWidgets requires display server")
 
-from shared.python.chat.chat_dock_widget import (  # noqa: E402
+from chat.chat_dock_widget import (  # noqa: E402
     _read_shared_session_id,
     _session_file_path,
     _write_shared_session_id,
@@ -53,7 +53,7 @@ class TestChatMessageBubble:
     """Tests for ChatMessageBubble widget."""
 
     def test_user_bubble(self, qtbot):
-        from shared.python.chat.chat_dock_widget import ChatMessageBubble
+        from chat.chat_dock_widget import ChatMessageBubble
 
         bubble = ChatMessageBubble("user", "Hello")
         qtbot.addWidget(bubble)
@@ -61,14 +61,14 @@ class TestChatMessageBubble:
         assert bubble._content == "Hello"
 
     def test_assistant_bubble(self, qtbot):
-        from shared.python.chat.chat_dock_widget import ChatMessageBubble
+        from chat.chat_dock_widget import ChatMessageBubble
 
         bubble = ChatMessageBubble("assistant", "Hi there")
         qtbot.addWidget(bubble)
         assert bubble._role == "assistant"
 
     def test_append_content(self, qtbot):
-        from shared.python.chat.chat_dock_widget import ChatMessageBubble
+        from chat.chat_dock_widget import ChatMessageBubble
 
         bubble = ChatMessageBubble("assistant", "")
         qtbot.addWidget(bubble)
@@ -77,7 +77,7 @@ class TestChatMessageBubble:
         assert bubble._content == "Hello world"
 
     def test_set_content(self, qtbot):
-        from shared.python.chat.chat_dock_widget import ChatMessageBubble
+        from chat.chat_dock_widget import ChatMessageBubble
 
         bubble = ChatMessageBubble("user", "old")
         qtbot.addWidget(bubble)
@@ -85,7 +85,7 @@ class TestChatMessageBubble:
         assert bubble._content == "new"
 
     def test_custom_accent_color(self, qtbot):
-        from shared.python.chat.chat_dock_widget import ChatMessageBubble
+        from chat.chat_dock_widget import ChatMessageBubble
 
         bubble = ChatMessageBubble("user", "test", accent_color="#3498db")
         qtbot.addWidget(bubble)
@@ -96,7 +96,7 @@ class TestChatDockWidget:
     """Tests for ChatDockWidget construction."""
 
     def test_construction_defaults(self, qtbot):
-        from shared.python.chat.chat_dock_widget import ChatDockWidget
+        from chat.chat_dock_widget import ChatDockWidget
 
         ChatDockWidget._shared_session_id = None
         widget = ChatDockWidget(app_name="test_app")
@@ -107,7 +107,7 @@ class TestChatDockWidget:
         widget.close()
 
     def test_custom_parameters(self, qtbot):
-        from shared.python.chat.chat_dock_widget import ChatDockWidget
+        from chat.chat_dock_widget import ChatDockWidget
 
         ChatDockWidget._shared_session_id = None
         widget = ChatDockWidget(
@@ -123,7 +123,7 @@ class TestChatDockWidget:
         widget.close()
 
     def test_explicit_session_id(self, qtbot):
-        from shared.python.chat.chat_dock_widget import ChatDockWidget
+        from chat.chat_dock_widget import ChatDockWidget
 
         ChatDockWidget._shared_session_id = None
         widget = ChatDockWidget(app_name="test_app", session_id="explicit-123")

--- a/tests/shared/python/chat/test_models.py
+++ b/tests/shared/python/chat/test_models.py
@@ -6,7 +6,7 @@ import pytest
 
 pydantic = pytest.importorskip("pydantic")
 
-from shared.python.chat.models import (  # noqa: E402
+from chat.models import (  # noqa: E402
     ChatChunkResponse,
     ChatHistoryResponse,
     ChatMessageRequest,

--- a/tests/shared/python/plot_theme/test_integration.py
+++ b/tests/shared/python/plot_theme/test_integration.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from shared.python.plot_theme.integration import (
+from plot_theme.integration import (
     PlotThemeMixin,
     apply_plot_theme,
     get_theme_colors,
 )
-from shared.python.plot_theme.manager import PlotThemeManager
+from plot_theme.manager import PlotThemeManager
 
 
 class TestApplyPlotTheme:
@@ -20,7 +19,7 @@ class TestApplyPlotTheme:
     def test_returns_manager(self) -> None:
         """Test that apply_plot_theme returns a PlotThemeManager."""
         with patch(
-            "shared.python.plot_theme.integration.get_plot_theme_manager"
+            "plot_theme.integration.get_plot_theme_manager"
         ) as mock_get:
             mock_manager = MagicMock(spec=PlotThemeManager)
             mock_get.return_value = mock_manager
@@ -34,7 +33,7 @@ class TestApplyPlotTheme:
     def test_without_theme_name(self) -> None:
         """Test apply_plot_theme without theme name."""
         with patch(
-            "shared.python.plot_theme.integration.get_plot_theme_manager"
+            "plot_theme.integration.get_plot_theme_manager"
         ) as mock_get:
             mock_manager = MagicMock(spec=PlotThemeManager)
             mock_get.return_value = mock_manager
@@ -138,7 +137,7 @@ class TestCreateThemedFigure:
     )
     def test_creates_figure_and_axes(self) -> None:
         """Test that create_themed_figure returns figure and axes."""
-        from shared.python.plot_theme.integration import create_themed_figure
+        from plot_theme.integration import create_themed_figure
 
         fig, ax = create_themed_figure(figsize=(8, 6))
 
@@ -156,8 +155,7 @@ class TestStyleAxis:
     def test_styles_axis(self) -> None:
         """Test that style_axis applies theme to axes."""
         import matplotlib.pyplot as plt
-
-        from shared.python.plot_theme.integration import style_axis
+        from plot_theme.integration import style_axis
 
         fig, ax = plt.subplots()
         style_axis(ax, "scientific_violet")

--- a/tests/shared/python/plot_theme/test_manager.py
+++ b/tests/shared/python/plot_theme/test_manager.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from shared.python.plot_theme.manager import PlotThemeManager, get_plot_theme_manager
-from shared.python.plot_theme.themes import DEFAULT_THEME, PLOT_THEMES
+from plot_theme.manager import PlotThemeManager, get_plot_theme_manager
+from plot_theme.themes import DEFAULT_THEME, PLOT_THEMES
 
 
 class TestPlotThemeManager:

--- a/tests/shared/python/plot_theme/test_themes.py
+++ b/tests/shared/python/plot_theme/test_themes.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import pytest
-
-from shared.python.plot_theme.themes import (
+from plot_theme.themes import (
     DEFAULT_THEME,
     PLOT_THEMES,
     PlotTheme,

--- a/tests/test_waves_2_3_imports.py
+++ b/tests/test_waves_2_3_imports.py
@@ -1,0 +1,205 @@
+"""Tests for Waves 2-3: utils namespace cleanup and import standardization.
+
+Wave 2 verifies:
+- utils/__init__.py no longer eagerly imports all submodule symbols
+- Direct submodule imports still work (from utils.logging_utils import ...)
+- upstream_drift_tools.utils has documented overlap table
+
+Wave 3 verifies:
+- Direct package imports work (from upstream_drift_tools.X import ...)
+- Direct package imports work (from signal_toolkit import ...)
+- Direct package imports work (from gui_launcher import ...)
+- Direct package imports work (from plot_engine.specs import ...)
+- Direct package imports work (from plot_theme import ...)
+- Backward compat: shared.python.X still importable for transition
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+# ── Wave 2: utils namespace is thin ─────────────────────────────────────────
+
+
+class TestUtilsNamespaceThin:
+    """utils/__init__.py should NOT eagerly import submodule symbols."""
+
+    def test_no_eager_get_logger(self) -> None:
+        """get_logger should not be importable from bare 'utils'."""
+        # Reload to ensure clean state
+        if "utils" in sys.modules:
+            importlib.reload(sys.modules["utils"])
+        import utils
+
+        assert not hasattr(utils, "get_logger"), (
+            "utils.__init__.py should not eagerly import get_logger; "
+            "import from utils.logging_utils instead"
+        )
+
+    def test_no_eager_safe_execute(self) -> None:
+        import utils
+
+        assert not hasattr(utils, "safe_execute")
+
+    def test_no_eager_BaseTestCase(self) -> None:
+        import utils
+
+        assert not hasattr(utils, "BaseTestCase")
+
+    def test_no_eager_debug_log(self) -> None:
+        import utils
+
+        assert not hasattr(utils, "debug_log")
+
+    def test_submodule_import_still_works(self) -> None:
+        """Direct submodule imports must continue to work."""
+        from utils.logging_utils import get_logger
+
+        assert callable(get_logger)
+
+    def test_error_handling_submodule(self) -> None:
+        from utils.error_handling import safe_execute
+
+        assert callable(safe_execute)
+
+    def test_path_setup_submodule(self) -> None:
+        from utils.path_setup import get_repo_root
+
+        root = get_repo_root()
+        assert root.exists()
+
+
+class TestUpstreamDriftToolsUtilsDocumented:
+    """upstream_drift_tools.utils docstring documents overlaps."""
+
+    def test_docstring_mentions_overlap(self) -> None:
+        import upstream_drift_tools.utils
+
+        doc = upstream_drift_tools.utils.__doc__ or ""
+        assert "Overlap" in doc or "overlap" in doc
+        assert "get_repo_root" in doc
+        assert "get_logger" in doc
+
+
+# ── Wave 3: direct package imports ──────────────────────────────────────────
+
+
+class TestDirectUpstreamDriftToolsImport:
+    """from upstream_drift_tools.X should work without shared.python prefix."""
+
+    def test_utils_paths(self) -> None:
+        from upstream_drift_tools.utils.paths import get_repo_root
+
+        root = get_repo_root()
+        assert root.exists()
+
+    def test_utils_state_manager(self) -> None:
+        from upstream_drift_tools.utils.state_manager import StateManager
+
+        assert StateManager is not None
+
+    def test_utils_unit_constants(self) -> None:
+        from upstream_drift_tools.utils.unit_constants import R_UNIVERSAL
+
+        assert abs(R_UNIVERSAL - 8.314462618) < 1e-6
+
+    def test_bootstrap(self) -> None:
+        from upstream_drift_tools.bootstrap import ensure_paths
+
+        assert callable(ensure_paths)
+
+
+class TestDirectSignalToolkitImport:
+    """from signal_toolkit should work without shared.python prefix."""
+
+    def test_signal_generator(self) -> None:
+        try:
+            from signal_toolkit import SignalGenerator
+
+            assert SignalGenerator is not None
+        except ImportError:
+            pytest.skip("signal_toolkit not available (optional dep)")
+
+
+class TestDirectGuiLauncherImport:
+    """from gui_launcher should work without shared.python prefix."""
+
+    def test_gui_type(self) -> None:
+        try:
+            from gui_launcher import GUIType
+
+            assert GUIType is not None
+        except ImportError:
+            pytest.skip("gui_launcher not available")
+
+
+class TestDirectPlotEngineImport:
+    """from plot_engine.specs should work without shared.python prefix."""
+
+    def test_plot_spec(self) -> None:
+        try:
+            from plot_engine.specs import PlotSpec
+
+            assert PlotSpec is not None
+        except ImportError:
+            pytest.skip("plot_engine not available (needs pydantic)")
+
+
+class TestDirectPlotThemeImport:
+    """from plot_theme should work without shared.python prefix."""
+
+    def test_plot_theme_manager(self) -> None:
+        try:
+            from plot_theme import PlotThemeManager
+
+            assert PlotThemeManager is not None
+        except ImportError:
+            pytest.skip("plot_theme not available")
+
+
+class TestDirectChatImport:
+    """from chat should work without shared.python prefix."""
+
+    def test_chat_models(self) -> None:
+        try:
+            from chat.models import ChatMessageRequest
+
+            assert ChatMessageRequest is not None
+        except ImportError:
+            pytest.skip("chat models not available (needs pydantic)")
+
+
+# ── Backward compatibility: shared.python.X still works ─────────────────────
+
+
+class TestBackwardCompatSharedPython:
+    """The old shared.python.X import style should still resolve."""
+
+    def test_shared_python_theme_still_works(self) -> None:
+        """Theme imports use shared.python prefix intentionally."""
+        try:
+            from shared.python.theme import ThemeManager  # noqa: F401
+
+            assert ThemeManager is not None
+        except ImportError:
+            pytest.skip("theme not available (needs PyQt6)")
+
+    def test_shared_python_upstream_drift_tools_still_resolves(self) -> None:
+        """Even though we prefer direct, the old path still works."""
+        from shared.python.upstream_drift_tools.utils.paths import (
+            get_repo_root,
+        )
+
+        root = get_repo_root()
+        assert root.exists()
+
+    def test_shared_python_signal_toolkit_still_resolves(self) -> None:
+        try:
+            from shared.python.signal_toolkit import SignalGenerator  # noqa: F401
+
+            assert SignalGenerator is not None
+        except ImportError:
+            pytest.skip("signal_toolkit not available")


### PR DESCRIPTION
## Summary
- **Wave 2**: Thin out `utils/__init__.py` to eliminate eager imports of 70+ symbols from debug_utils, error_handling, logging_utils, and test_utils. No consumer relied on these re-exports. Document overlapping functions between `utils` and `upstream_drift_tools.utils` with a canonical-location table.
- **Wave 3**: Replace ~75 occurrences of `from shared.python.X` with direct package imports across 57 files (upstream_drift_tools, signal_toolkit, gui_launcher, plot_engine, plot_theme, chat). Theme imports intentionally kept as `shared.python.theme` for future unification.
- Fix mock patch paths in plot_theme tests that broke due to module path change.
- Add 20 new backward-compatibility and direct-import tests (all 628 tests pass, ruff clean).

## Changes by category
| Category | Files | Description |
|----------|-------|-------------|
| Utils cleanup | 2 | `utils/__init__.py` thinned, `upstream_drift_tools/utils/__init__.py` documented |
| upstream_drift_tools imports | 18 | `from shared.python.upstream_drift_tools.X` -> `from upstream_drift_tools.X` |
| gui_launcher imports | 12 | `from shared.python.gui_launcher` -> `from gui_launcher` |
| signal_toolkit imports | 5 | `from shared.python.signal_toolkit` -> `from signal_toolkit` |
| plot_engine imports | 8 | `from shared.python.plot_engine.X` -> `from plot_engine.X` |
| plot_theme imports | 5 | `from shared.python.plot_theme` -> `from plot_theme` |
| chat imports | 4 | `from shared.python.chat` -> `from chat` |
| Tests | 1 new + 3 fixed | `test_waves_2_3_imports.py` (20 tests), plot_theme test patch paths |

## Test plan
- [x] All 628 existing tests pass (0 failures)
- [x] 20 new import tests verify both direct and backward-compat paths
- [x] `ruff check` clean (17 auto-fixed I001 import-sorting issues)
- [x] Wave 1 tests still pass (12/12)
- [ ] CI pipeline passes

Closes #632, Closes #633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad, cross-cutting import-path refactor across many tools and tests; primary risk is runtime import resolution/packaging differences despite no behavioral logic changes.
> 
> **Overview**
> Standardizes imports across the repo by replacing `shared.python.*` references with direct package imports (e.g., `upstream_drift_tools`, `signal_toolkit`, `gui_launcher`, `plot_engine`, `plot_theme`, `chat`) throughout multiple tool GUIs and their tests, while keeping `shared.python.theme` intentionally.
> 
> Thins `utils/__init__.py` to stop re-exporting dozens of symbols (forcing explicit submodule imports) and documents canonical-vs-compat utility function locations in `upstream_drift_tools.utils`. Adds/updates tests to validate the new direct-import style and preserve backward-compatible `shared.python.*` imports, including fixing `plot_theme` test patch paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84bb2258060477d9f7bf817f67534befd92ff66e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->