### PR TITLE
refactor(dry): consolidate duplicated patterns across tools

### DIFF
--- a/src/acid_gas_dewpoint/gui_registration.py
+++ b/src/acid_gas_dewpoint/gui_registration.py
@@ -15,6 +15,10 @@ GUI_INFO = {
         "settings_app": "AcidGasDewpointCalculator",
         "min_size": [1000, 700],
     },
+    "web": {
+        "port": 5176,
+        "auto_open_browser": True,
+    },
 }
 
 

--- a/src/acid_gas_dewpoint/launch_web.py
+++ b/src/acid_gas_dewpoint/launch_web.py
@@ -1,59 +1,21 @@
 #!/usr/bin/env python3
-"""Launch script for Acid Gas Dewpoint Calculator React Web GUI."""
+"""Launch the Acid Gas Dewpoint Calculator React web application."""
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
-import webbrowser
 from pathlib import Path
-from time import sleep
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def main() -> int:
-    """Launch the Acid Gas Dewpoint Calculator React application."""
-    web_dir = Path(__file__).parent / "web"
+ensure_paths(_REPO_ROOT)
 
-    if not web_dir.exists():
-        print(f"Error: Web directory not found at {web_dir}")
-        return 1
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-    # Check for node_modules
-    if not (web_dir / "node_modules").exists():
-        print("Installing dependencies...")
-        result = subprocess.run(
-            ["npm", "install"],
-            cwd=web_dir,
-            shell=False,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            print(f"Error installing dependencies: {result.stderr}")
-            return 1
-
-    # Set port
-    port = int(os.environ.get("PORT", "5176"))
-
-    # Open browser after delay
-    def open_browser() -> None:
-        sleep(2)
-        webbrowser.open(f"http://localhost:{port}")
-
-    import threading
-
-    threading.Thread(target=open_browser, daemon=True).start()
-
-    # Start dev server
-    print(f"Starting Acid Gas Dewpoint Calculator on http://localhost:{port}")
-    dev_result = subprocess.run(
-        ["npm", "run", "dev", "--", "--port", str(port)],
-        cwd=web_dir,
-        shell=False,
-    )
-    return dev_result.returncode
-
+from acid_gas_dewpoint.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/baghouse_calculator/gui_registration.py
+++ b/src/baghouse_calculator/gui_registration.py
@@ -18,6 +18,10 @@ GUI_INFO = {
         "module": "upstream_drift_tools.process_calculators.baghouse_calculator",
         "class": "BaghouseCalculator",
     },
+    "web": {
+        "port": 5173,
+        "auto_open_browser": False,
+    },
 }
 
 

--- a/src/baghouse_calculator/launch_web.py
+++ b/src/baghouse_calculator/launch_web.py
@@ -1,38 +1,21 @@
 #!/usr/bin/env python3
-"""Standalone launcher for Baghouse Calculator React web application."""
+"""Launch the Baghouse Calculator React web application."""
 
 from __future__ import annotations
 
-import subprocess
 import sys
 from pathlib import Path
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def main() -> int:
-    """Main entry point for the Baghouse Calculator web launcher."""
-    web_dir = Path(__file__).parent / "web"
+ensure_paths(_REPO_ROOT)
 
-    if not web_dir.exists():
-        print(f"Error: Web directory not found at {web_dir}")
-        return 1
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-    node_modules = web_dir / "node_modules"
-    if not node_modules.exists():
-        print("Installing dependencies...")
-        result = subprocess.run(["npm", "install"], cwd=web_dir, shell=False)
-        if result.returncode != 0:
-            return 1
-
-    print("Starting Baghouse Calculator web application...")
-    print("Open http://localhost:5173 in your browser")
-
-    try:
-        subprocess.run(["npm", "run", "dev"], cwd=web_dir, shell=False)
-    except KeyboardInterrupt:
-        print("\nShutting down...")
-
-    return 0
-
+from baghouse_calculator.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/data_processing/data_processor/gui_registration.py
+++ b/src/data_processing/data_processor/gui_registration.py
@@ -14,6 +14,10 @@ GUI_INFO = {
         "dependencies": ["PyQt6", "pandas", "numpy"],
         "settings_app": "DataProcessor",
     },
+    "web": {
+        "port": 3000,
+        "auto_open_browser": True,
+    },
 }
 
 

--- a/src/data_processing/data_processor/launch_web.py
+++ b/src/data_processing/data_processor/launch_web.py
@@ -1,110 +1,21 @@
 #!/usr/bin/env python3
-"""Launch the Data Processor React Web GUI.
-
-This script starts the Vite development server for the React-based
-Data Processor web application.
-"""
+"""Launch the Data Processor React web application."""
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
-import time
-import webbrowser
 from pathlib import Path
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def check_node() -> bool:
-    """Check if Node.js is installed."""
-    try:
-        result = subprocess.run(
-            ["npm", "--version"],
-            capture_output=True,
-            text=True,
-            shell=False,
-        )
-        return result.returncode == 0
-    except FileNotFoundError:
-        return False
+ensure_paths(_REPO_ROOT)
 
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-def check_dependencies(web_path: Path) -> bool:
-    """Check if npm dependencies are installed."""
-    return (web_path / "node_modules").exists()
-
-
-def install_dependencies(web_path: Path) -> bool:
-    """Install npm dependencies."""
-    print("Installing dependencies...")
-    result = subprocess.run(
-        ["npm", "install"],
-        cwd=web_path,
-        shell=False,
-    )
-    return result.returncode == 0
-
-
-def main() -> int:
-    """Main entry point."""
-    print("=" * 60)
-    print("Data Processor - React Web GUI Launcher")
-    print("=" * 60)
-
-    # Check Node.js
-    if not check_node():
-        print("\nNode.js is not installed or not in PATH.")
-        print("Please install Node.js from https://nodejs.org/")
-        return 1
-
-    # Get web project path
-    web_path = Path(__file__).parent / "web"
-    if not web_path.exists():
-        print(f"\nWeb project not found at: {web_path}")
-        return 1
-
-    # Check package.json
-    if not (web_path / "package.json").exists():
-        print(f"\npackage.json not found in: {web_path}")
-        return 1
-
-    # Install dependencies if needed
-    if not check_dependencies(web_path):
-        print("\nNode modules not found. Installing dependencies...")
-        if not install_dependencies(web_path):
-            print("Failed to install dependencies.")
-            return 1
-        print("Dependencies installed successfully.\n")
-
-    # Start dev server
-    port = 3000
-    print(f"\nStarting development server on port {port}...")
-    print(f"Web UI will be available at: http://localhost:{port}")
-    print("\nPress Ctrl+C to stop the server.\n")
-
-    # Set environment
-    env = os.environ.copy()
-    env["PORT"] = str(port)
-
-    # Start the dev server
-    process = subprocess.Popen(
-        ["npm", "run", "dev"],
-        cwd=web_path,
-        shell=False,
-        env=env,
-    )
-
-    # Wait a moment then open browser
-    time.sleep(3)
-    webbrowser.open(f"http://localhost:{port}")
-
-    try:
-        return process.wait()
-    except KeyboardInterrupt:
-        print("\nShutting down server...")
-        process.terminate()
-        return 0
-
+from data_processing.data_processor.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/electrode_advisor/gui_registration.py
+++ b/src/electrode_advisor/gui_registration.py
@@ -15,6 +15,10 @@ GUI_INFO = {
         "settings_app": "ElectrodeAdvisor",
         "min_size": [1200, 800],
     },
+    "web": {
+        "port": 3001,
+        "auto_open_browser": True,
+    },
 }
 
 

--- a/src/electrode_advisor/launch_web.py
+++ b/src/electrode_advisor/launch_web.py
@@ -1,106 +1,21 @@
 #!/usr/bin/env python3
-"""Standalone launcher for Electrode Advisor Web GUI.
-
-This launcher checks dependencies and starts the React development server.
-"""
+"""Launch the Electrode Advisor React web application."""
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
-import webbrowser
 from pathlib import Path
-from time import sleep
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def check_node() -> bool:
-    """Check if Node.js is available."""
-    try:
-        subprocess.run(
-            ["node", "--version"],
-            capture_output=True,
-            check=True,
-        )
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
+ensure_paths(_REPO_ROOT)
 
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-def check_npm() -> bool:
-    """Check if npm is available."""
-    try:
-        subprocess.run(
-            ["npm", "--version"],
-            capture_output=True,
-            check=True,
-        )
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
-
-
-def install_dependencies(web_path: Path) -> bool:
-    """Install npm dependencies if needed."""
-    node_modules = web_path / "node_modules"
-    if not node_modules.exists():
-        print("Installing dependencies...")
-        result = subprocess.run(
-            ["npm", "install"],
-            cwd=web_path,
-            shell=False,
-        )
-        return result.returncode == 0
-    return True
-
-
-def main() -> int:
-    """Main entry point for the Electrode Advisor Web GUI."""
-    # Check dependencies
-    if not check_node():
-        print("Error: Node.js is not installed or not in PATH")
-        print("Install Node.js from https://nodejs.org/")
-        return 1
-
-    if not check_npm():
-        print("Error: npm is not installed or not in PATH")
-        return 1
-
-    # Get web directory
-    web_path = Path(__file__).parent / "web"
-    if not web_path.exists():
-        print(f"Error: Web directory not found at {web_path}")
-        return 1
-
-    # Install dependencies if needed
-    if not install_dependencies(web_path):
-        print("Error: Failed to install dependencies")
-        return 1
-
-    # Start dev server
-    port = 3001
-    print(f"Starting Electrode Advisor Web GUI on port {port}...")
-
-    env = os.environ.copy()
-    env["PORT"] = str(port)
-
-    process = subprocess.Popen(
-        ["npm", "run", "dev"],
-        cwd=web_path,
-        env=env,
-        shell=False,
-    )
-
-    # Open browser after delay
-    sleep(2)
-    webbrowser.open(f"http://localhost:{port}")
-
-    try:
-        return process.wait()
-    except KeyboardInterrupt:
-        process.terminate()
-        return 0
-
+from electrode_advisor.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/financial_calculator/gui_registration.py
+++ b/src/financial_calculator/gui_registration.py
@@ -18,6 +18,10 @@ GUI_INFO = {
         "module": "upstream_drift_tools.process_calculators.financial_calculator",
         "class": "FinancialModelCalculator",
     },
+    "web": {
+        "port": 5173,
+        "auto_open_browser": False,
+    },
 }
 
 

--- a/src/financial_calculator/launch_web.py
+++ b/src/financial_calculator/launch_web.py
@@ -1,52 +1,21 @@
 #!/usr/bin/env python3
-"""Standalone launcher for Financial Calculator React web application.
-
-This launcher starts a development server for the React application.
-"""
+"""Launch the Financial Calculator React web application."""
 
 from __future__ import annotations
 
-import subprocess
 import sys
 from pathlib import Path
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def main() -> int:
-    """Main entry point for the Financial Calculator web launcher."""
-    web_dir = Path(__file__).parent / "web"
+ensure_paths(_REPO_ROOT)
 
-    if not web_dir.exists():
-        print(f"Error: Web directory not found at {web_dir}")
-        return 1
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-    # Check if node_modules exists
-    node_modules = web_dir / "node_modules"
-    if not node_modules.exists():
-        print("Installing dependencies...")
-        result = subprocess.run(
-            ["npm", "install"],
-            cwd=web_dir,
-            shell=False,
-        )
-        if result.returncode != 0:
-            print("Failed to install dependencies")
-            return 1
-
-    # Start dev server
-    print("Starting Financial Calculator web application...")
-    print("Open http://localhost:5173 in your browser")
-
-    try:
-        subprocess.run(
-            ["npm", "run", "dev"],
-            cwd=web_dir,
-            shell=False,
-        )
-    except KeyboardInterrupt:
-        print("\nShutting down...")
-
-    return 0
-
+from financial_calculator.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/flare_calculator/gui_registration.py
+++ b/src/flare_calculator/gui_registration.py
@@ -14,6 +14,10 @@ GUI_INFO = {
         "dependencies": ["PyQt6"],
         "settings_app": "FlareCalculator",
     },
+    "web": {
+        "port": 5179,
+        "auto_open_browser": True,
+    },
 }
 
 

--- a/src/flare_calculator/launch_web.py
+++ b/src/flare_calculator/launch_web.py
@@ -1,34 +1,21 @@
 #!/usr/bin/env python3
 """Launch the Flare Calculator React web application."""
 
-import subprocess
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def main() -> None:
-    """Entry point for the Flare Calculator web application."""
-    web_dir = Path(__file__).parent / "web"
+ensure_paths(_REPO_ROOT)
 
-    if not web_dir.exists():
-        print(f"Error: Web directory not found at {web_dir}")
-        sys.exit(1)
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-    # Check if node_modules exists
-    node_modules = web_dir / "node_modules"
-    if not node_modules.exists():
-        print("Installing dependencies...")
-        subprocess.run(["npm", "install"], cwd=web_dir, check=True, shell=False)
-
-    # Start the development server
-    print("Starting Flare Calculator web application on http://localhost:5179")
-    subprocess.run(
-        ["npm", "run", "dev", "--", "--port", "5179"],
-        cwd=web_dir,
-        check=True,
-        shell=False,
-    )
-
+from flare_calculator.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    main()
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/function_generator/gui_registration.py
+++ b/src/function_generator/gui_registration.py
@@ -15,6 +15,10 @@ GUI_INFO = {
         "settings_app": "FunctionGenerator",
         "min_size": [1200, 700],
     },
+    "web": {
+        "port": 5174,
+        "auto_open_browser": True,
+    },
 }
 
 

--- a/src/function_generator/launch_web.py
+++ b/src/function_generator/launch_web.py
@@ -1,99 +1,21 @@
 #!/usr/bin/env python3
-"""Standalone React web launcher for Function Generator.
-
-This launcher starts a development server for the React-based
-function generator web application.
-"""
+"""Launch the Function Generator React web application."""
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
-import webbrowser
 from pathlib import Path
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def check_dependencies() -> list[str]:
-    """Check for required dependencies."""
-    missing = []
+ensure_paths(_REPO_ROOT)
 
-    try:
-        subprocess.run(
-            ["node", "--version"],
-            capture_output=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        missing.append("node")
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-    try:
-        subprocess.run(
-            ["npm", "--version"],
-            capture_output=True,
-            check=True,
-            shell=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        missing.append("npm")
-
-    return missing
-
-
-def install_dependencies(web_dir: Path) -> bool:
-    """Install npm dependencies if needed."""
-    node_modules = web_dir / "node_modules"
-    if not node_modules.exists():
-        print("Installing npm dependencies...")
-        result = subprocess.run(
-            ["npm", "install"],
-            cwd=str(web_dir),
-            shell=True,
-        )
-        return result.returncode == 0
-    return True
-
-
-def main() -> int:
-    """Launch the Function Generator React application."""
-    missing = check_dependencies()
-    if missing:
-        print(f"Missing dependencies: {', '.join(missing)}")
-        print("Please install Node.js from https://nodejs.org/")
-        return 1
-
-    web_dir = Path(__file__).parent / "web"
-    if not web_dir.exists():
-        print(f"Web directory not found: {web_dir}")
-        return 1
-
-    if not install_dependencies(web_dir):
-        print("Failed to install npm dependencies")
-        return 1
-
-    print("Starting Function Generator web application...")
-    print("Opening http://localhost:5174 in your browser...")
-
-    def open_browser() -> None:
-        import time
-
-        time.sleep(2)
-        webbrowser.open("http://localhost:5174")
-
-    import threading
-
-    threading.Thread(target=open_browser, daemon=True).start()
-
-    env = os.environ.copy()
-    result = subprocess.run(
-        ["npm", "run", "dev"],
-        cwd=str(web_dir),
-        shell=True,
-        env=env,
-    )
-
-    return result.returncode
-
+from function_generator.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/pressure_drop_calculator/gui_registration.py
+++ b/src/pressure_drop_calculator/gui_registration.py
@@ -15,6 +15,10 @@ GUI_INFO = {
         "settings_app": "PressureDropCalculator",
         "min_size": [1100, 700],
     },
+    "web": {
+        "port": 5175,
+        "auto_open_browser": True,
+    },
 }
 
 

--- a/src/pressure_drop_calculator/launch_web.py
+++ b/src/pressure_drop_calculator/launch_web.py
@@ -1,72 +1,21 @@
 #!/usr/bin/env python3
-"""Standalone React web launcher for Pressure Drop Calculator."""
+"""Launch the Pressure Drop Calculator React web application."""
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
-import webbrowser
 from pathlib import Path
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def check_dependencies() -> list[str]:
-    """Check for required dependencies."""
-    missing = []
-    try:
-        subprocess.run(["node", "--version"], capture_output=True, check=True)
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        missing.append("node")
-    try:
-        subprocess.run(
-            ["npm", "--version"], capture_output=True, check=True, shell=False
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        missing.append("npm")
-    return missing
+ensure_paths(_REPO_ROOT)
 
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-def install_dependencies(web_dir: Path) -> bool:
-    """Install npm dependencies if needed."""
-    if not (web_dir / "node_modules").exists():
-        print("Installing npm dependencies...")
-        result = subprocess.run(["npm", "install"], cwd=str(web_dir), shell=False)
-        return result.returncode == 0
-    return True
-
-
-def main() -> int:
-    """Launch the Pressure Drop Calculator React application."""
-    missing = check_dependencies()
-    if missing:
-        print(f"Missing dependencies: {', '.join(missing)}")
-        return 1
-
-    web_dir = Path(__file__).parent / "web"
-    if not web_dir.exists():
-        print(f"Web directory not found: {web_dir}")
-        return 1
-
-    if not install_dependencies(web_dir):
-        return 1
-
-    print("Starting Pressure Drop Calculator web application...")
-
-    def open_browser() -> None:
-        import time
-
-        time.sleep(2)
-        webbrowser.open("http://localhost:5175")
-
-    import threading
-
-    threading.Thread(target=open_browser, daemon=True).start()
-
-    result = subprocess.run(
-        ["npm", "run", "dev"], cwd=str(web_dir), shell=False, env=os.environ.copy()
-    )
-    return result.returncode
-
+from pressure_drop_calculator.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/python/src/utils/path_setup.py
+++ b/src/python/src/utils/path_setup.py
@@ -38,12 +38,12 @@ def get_repo_root(start_path: Path | str | None = None) -> Path:
     except (ImportError, FileNotFoundError):
         pass
 
-    # Backward-compatible fallback with wider marker search
+    # Minimal fallback -- kept thin to avoid duplicating the canonical impl
     current = Path(start_path).resolve()
-    for _ in range(20):
+    for _ in range(10):
         if any(
             (current / m).exists()
-            for m in (".git", "pyproject.toml", "requirements.txt", "tools.json")
+            for m in (".git", "pyproject.toml", "tools.json")
         ):
             return current
         parent = current.parent

--- a/src/scrubber_calculator/gui_registration.py
+++ b/src/scrubber_calculator/gui_registration.py
@@ -14,6 +14,10 @@ GUI_INFO = {
         "dependencies": ["PyQt6", "matplotlib"],
         "settings_app": "ScrubberCalculator",
     },
+    "web": {
+        "port": 5177,
+        "auto_open_browser": False,
+    },
 }
 
 

--- a/src/scrubber_calculator/launch_web.py
+++ b/src/scrubber_calculator/launch_web.py
@@ -1,45 +1,21 @@
 #!/usr/bin/env python3
-"""Launch script for Scrubber Calculator React web application."""
+"""Launch the Scrubber Calculator React web application."""
 
 from __future__ import annotations
 
-import subprocess
 import sys
 from pathlib import Path
 
-MODULE_DIR = Path(__file__).parent
-WEB_DIR = MODULE_DIR / "web"
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
+ensure_paths(_REPO_ROOT)
 
-def main() -> int:
-    """Launch the Scrubber Calculator React web application."""
-    if not WEB_DIR.exists():
-        print(f"Error: Web directory not found: {WEB_DIR}")
-        return 1
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-    # Check if node_modules exists
-    node_modules = WEB_DIR / "node_modules"
-    if not node_modules.exists():
-        print("Installing dependencies...")
-        install_result = subprocess.run(
-            ["npm", "install"],
-            cwd=WEB_DIR,
-            shell=False,
-        )
-        if install_result.returncode != 0:
-            print("Error: Failed to install dependencies")
-            return 1
-
-    # Run the dev server
-    print("Starting Scrubber Calculator web application...")
-    print("Open http://localhost:5177 in your browser")
-    dev_result = subprocess.run(
-        ["npm", "run", "dev"],
-        cwd=WEB_DIR,
-        shell=False,
-    )
-    return dev_result.returncode
-
+from scrubber_calculator.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/shared/python/gui_launcher/__init__.py
+++ b/src/shared/python/gui_launcher/__init__.py
@@ -27,6 +27,8 @@ from .launcher import (
     launch_from_gui_info,
     launch_pyqt6_app,
     launch_tool_by_name,
+    launch_web_app,
+    launch_web_from_gui_info,
 )
 from .registry import GUIRegistry, auto_discover_guis, get_registry, register_gui
 
@@ -39,6 +41,8 @@ __all__ = [
     "launch_from_gui_info",
     "launch_pyqt6_app",
     "launch_tool_by_name",
+    "launch_web_app",
+    "launch_web_from_gui_info",
     "register_gui",
     "get_registry",
 ]

--- a/src/shared/python/gui_launcher/launcher.py
+++ b/src/shared/python/gui_launcher/launcher.py
@@ -449,6 +449,129 @@ def launch_from_gui_info(gui_info: dict[str, Any]) -> int:
     return launch_pyqt6_app(config)
 
 
+def launch_web_app(
+    tool_name: str,
+    web_dir: Path,
+    port: int = 5173,
+    auto_open_browser: bool = True,
+    npm_args: list[str] | None = None,
+) -> int:
+    """Launch a React/Vite web application dev server.
+
+    This is the consolidated web launcher that eliminates boilerplate from
+    individual launch_web.py scripts. It handles:
+    - Node.js and npm availability checks
+    - npm dependency installation
+    - Dev server startup
+    - Optional browser opening
+
+    Args:
+        tool_name: Human-readable name for log messages.
+        web_dir: Path to the web project directory (containing package.json).
+        port: Port number for the dev server.
+        auto_open_browser: Whether to open the browser automatically.
+        npm_args: Additional arguments to pass to ``npm run dev``.
+
+    Returns:
+        Process exit code (0 for success, 1 for error).
+    """
+    # Check Node.js / npm
+    for cmd_name in ("node", "npm"):
+        try:
+            subprocess.run(
+                [cmd_name, "--version"],
+                capture_output=True,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            print(f"Error: {cmd_name} is not installed or not in PATH")
+            if cmd_name == "node":
+                print("Install Node.js from https://nodejs.org/")
+            return 1
+
+    if not web_dir.exists():
+        print(f"Error: Web directory not found at {web_dir}")
+        return 1
+
+    # Install dependencies if needed
+    if not (web_dir / "node_modules").exists():
+        print("Installing dependencies...")
+        install_result = subprocess.run(
+            ["npm", "install"],
+            cwd=str(web_dir),
+            shell=False,
+        )
+        if install_result.returncode != 0:
+            print("Error: Failed to install npm dependencies")
+            return 1
+
+    # Build dev server command
+    dev_cmd: list[str] = ["npm", "run", "dev"]
+    if npm_args:
+        dev_cmd.extend(npm_args)
+
+    env = os.environ.copy()
+    env["PORT"] = str(port)
+
+    print(f"Starting {tool_name} web application on http://localhost:{port}")
+
+    process = subprocess.Popen(
+        dev_cmd,
+        cwd=str(web_dir),
+        env=env,
+        shell=False,
+    )
+
+    if auto_open_browser:
+        import threading
+        import time
+
+        def _open_browser() -> None:
+            time.sleep(2)
+            webbrowser.open(f"http://localhost:{port}")
+
+        threading.Thread(target=_open_browser, daemon=True).start()
+
+    try:
+        return process.wait()
+    except KeyboardInterrupt:
+        print("\nShutting down...")
+        process.terminate()
+        return 0
+
+
+def launch_web_from_gui_info(gui_info: dict[str, Any], caller_file: str) -> int:
+    """Launch a React web app from a GUI_INFO dict.
+
+    Each launch_web.py script can be reduced to::
+
+        from my_tool.gui_registration import GUI_INFO
+        from gui_launcher import launch_web_from_gui_info
+        sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))
+
+    Args:
+        gui_info: The GUI_INFO dictionary from gui_registration.py.
+        caller_file: ``__file__`` of the calling launch_web.py script,
+            used to locate the ``web/`` directory relative to the caller.
+
+    Returns:
+        Application exit code.
+    """
+    web_cfg = gui_info.get("web", {})
+    tool_name = gui_info.get("name", gui_info.get("tool_name", "Unknown"))
+
+    web_dir = Path(caller_file).parent / "web"
+    port = web_cfg.get("port", 5173)
+    auto_open = web_cfg.get("auto_open_browser", True)
+
+    return launch_web_app(
+        tool_name=tool_name,
+        web_dir=web_dir,
+        port=port,
+        auto_open_browser=auto_open,
+    )
+
+
 def launch_tool_by_name(tool_name: str) -> int:
     """Launch a tool by its registered name.
 

--- a/src/syngas_compression/gui_registration.py
+++ b/src/syngas_compression/gui_registration.py
@@ -15,6 +15,10 @@ GUI_INFO = {
         "settings_app": "SyngasCompressionCalculator",
         "min_size": [1200, 800],
     },
+    "web": {
+        "port": 5173,
+        "auto_open_browser": True,
+    },
 }
 
 

--- a/src/syngas_compression/launch_web.py
+++ b/src/syngas_compression/launch_web.py
@@ -1,104 +1,21 @@
 #!/usr/bin/env python3
-"""Standalone React web launcher for Syngas Compression Calculator.
-
-This launcher starts a development server for the React-based
-syngas compression calculator web application.
-"""
+"""Launch the Syngas Compression Calculator React web application."""
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
-import webbrowser
 from pathlib import Path
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def check_dependencies() -> list[str]:
-    """Check for required dependencies."""
-    missing = []
+ensure_paths(_REPO_ROOT)
 
-    # Check for Node.js
-    try:
-        subprocess.run(
-            ["node", "--version"],
-            capture_output=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        missing.append("node")
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-    # Check for npm
-    try:
-        subprocess.run(
-            ["npm", "--version"],
-            capture_output=True,
-            check=True,
-            shell=False,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        missing.append("npm")
-
-    return missing
-
-
-def install_dependencies(web_dir: Path) -> bool:
-    """Install npm dependencies if needed."""
-    node_modules = web_dir / "node_modules"
-    if not node_modules.exists():
-        print("Installing npm dependencies...")
-        result = subprocess.run(
-            ["npm", "install"],
-            cwd=str(web_dir),
-            shell=False,
-        )
-        return result.returncode == 0
-    return True
-
-
-def main() -> int:
-    """Launch the Syngas Compression Calculator React application."""
-    missing = check_dependencies()
-    if missing:
-        print(f"Missing dependencies: {', '.join(missing)}")
-        print("Please install Node.js from https://nodejs.org/")
-        return 1
-
-    web_dir = Path(__file__).parent / "web"
-    if not web_dir.exists():
-        print(f"Web directory not found: {web_dir}")
-        return 1
-
-    # Install dependencies if needed
-    if not install_dependencies(web_dir):
-        print("Failed to install npm dependencies")
-        return 1
-
-    print("Starting Syngas Compression Calculator web application...")
-    print("Opening http://localhost:5173 in your browser...")
-
-    # Open browser after a short delay
-    def open_browser() -> None:
-        import time
-
-        time.sleep(2)
-        webbrowser.open("http://localhost:5173")
-
-    import threading
-
-    threading.Thread(target=open_browser, daemon=True).start()
-
-    # Start development server
-    env = os.environ.copy()
-    result = subprocess.run(
-        ["npm", "run", "dev"],
-        cwd=str(web_dir),
-        shell=False,
-        env=env,
-    )
-
-    return result.returncode
-
+from syngas_compression.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/tools/launch_utils.py
+++ b/src/tools/launch_utils.py
@@ -19,12 +19,18 @@ def get_repo_root() -> Path:
 
         return _get_repo_root()
     except ImportError:
-        # Fallback for when package is not installed
+        # Minimal fallback -- uses same markers as canonical implementation
         current = Path(__file__).resolve().parent
-        for _ in range(5):
-            if (current / "tools.json").exists() or (current / ".git").exists():
+        for _ in range(10):
+            if any(
+                (current / m).exists()
+                for m in (".git", "pyproject.toml", "tools.json")
+            ):
                 return current
-            current = current.parent
+            parent = current.parent
+            if parent == current:
+                break
+            current = parent
         return Path.cwd()
 
 

--- a/src/tools/ui_utils.py
+++ b/src/tools/ui_utils.py
@@ -5,11 +5,14 @@ from pathlib import Path
 from typing import Any
 
 try:
-    from tools.launch_utils import get_repo_root
+    from upstream_drift_tools.utils.paths import get_repo_root
 except ImportError:
-    # Fallback only if absolutely necessary
-    def get_repo_root() -> Path:
-        return Path(__file__).resolve().parent.parent
+    try:
+        from tools.launch_utils import get_repo_root
+    except ImportError:
+
+        def get_repo_root() -> Path:  # type: ignore[misc]
+            return Path(__file__).resolve().parent.parent
 
 
 logger = logging.getLogger(__name__)

--- a/src/trc_vessel_designer/gui_registration.py
+++ b/src/trc_vessel_designer/gui_registration.py
@@ -15,6 +15,10 @@ GUI_INFO = {
         "settings_app": "TRCVesselDesigner",
         "min_size": [1200, 800],
     },
+    "web": {
+        "port": 3002,
+        "auto_open_browser": True,
+    },
 }
 
 

--- a/src/trc_vessel_designer/launch_web.py
+++ b/src/trc_vessel_designer/launch_web.py
@@ -1,80 +1,21 @@
 #!/usr/bin/env python3
-"""Standalone launcher for TRC Vessel Designer Web GUI."""
+"""Launch the TRC Vessel Designer React web application."""
 
 from __future__ import annotations
 
-import os
-import subprocess
 import sys
-import webbrowser
 from pathlib import Path
-from time import sleep
 
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-def check_node() -> bool:
-    """Check if Node.js is available."""
-    try:
-        subprocess.run(["node", "--version"], capture_output=True, check=True)
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
+ensure_paths(_REPO_ROOT)
 
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-def check_npm() -> bool:
-    """Check if npm is available."""
-    try:
-        subprocess.run(["npm", "--version"], capture_output=True, check=True)
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
-
-
-def install_dependencies(web_path: Path) -> bool:
-    """Install npm dependencies if needed."""
-    node_modules = web_path / "node_modules"
-    if not node_modules.exists():
-        print("Installing dependencies...")
-        result = subprocess.run(["npm", "install"], cwd=web_path, shell=True)
-        return result.returncode == 0
-    return True
-
-
-def main() -> int:
-    """Main entry point for the TRC Vessel Designer Web GUI."""
-    if not check_node():
-        print("Error: Node.js is not installed or not in PATH")
-        return 1
-
-    if not check_npm():
-        print("Error: npm is not installed or not in PATH")
-        return 1
-
-    web_path = Path(__file__).parent / "web"
-    if not web_path.exists():
-        print(f"Error: Web directory not found at {web_path}")
-        return 1
-
-    if not install_dependencies(web_path):
-        print("Error: Failed to install dependencies")
-        return 1
-
-    port = 3002
-    print(f"Starting TRC Vessel Designer Web GUI on port {port}...")
-
-    env = os.environ.copy()
-    env["PORT"] = str(port)
-
-    process = subprocess.Popen(["npm", "run", "dev"], cwd=web_path, env=env, shell=True)
-
-    sleep(2)
-    webbrowser.open(f"http://localhost:{port}")
-
-    try:
-        return process.wait()
-    except KeyboardInterrupt:
-        process.terminate()
-        return 0
-
+from trc_vessel_designer.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/src/wgs_reactor/gui_registration.py
+++ b/src/wgs_reactor/gui_registration.py
@@ -14,6 +14,10 @@ GUI_INFO = {
         "dependencies": ["PyQt6"],
         "settings_app": "WGSReactor",
     },
+    "web": {
+        "port": 5178,
+        "auto_open_browser": False,
+    },
 }
 
 

--- a/src/wgs_reactor/launch_web.py
+++ b/src/wgs_reactor/launch_web.py
@@ -1,45 +1,21 @@
 #!/usr/bin/env python3
-"""Launch script for WGS Reactor Calculator React web application."""
+"""Launch the WGS Reactor Calculator React web application."""
 
 from __future__ import annotations
 
-import subprocess
 import sys
 from pathlib import Path
 
-MODULE_DIR = Path(__file__).parent
-WEB_DIR = MODULE_DIR / "web"
+# Bootstrap imports for development mode (before pip install -e .)
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
+from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
+ensure_paths(_REPO_ROOT)
 
-def main() -> int:
-    """Launch the WGS Reactor Calculator React web application."""
-    if not WEB_DIR.exists():
-        print(f"Error: Web directory not found: {WEB_DIR}")
-        return 1
+from gui_launcher import launch_web_from_gui_info  # noqa: E402
 
-    # Check if node_modules exists
-    node_modules = WEB_DIR / "node_modules"
-    if not node_modules.exists():
-        print("Installing dependencies...")
-        install_result = subprocess.run(
-            ["npm", "install"],
-            cwd=WEB_DIR,
-            shell=False,
-        )
-        if install_result.returncode != 0:
-            print("Error: Failed to install dependencies")
-            return 1
-
-    # Run the dev server
-    print("Starting WGS Reactor Calculator web application...")
-    print("Open http://localhost:5178 in your browser")
-    dev_result = subprocess.run(
-        ["npm", "run", "dev"],
-        cwd=WEB_DIR,
-        shell=False,
-    )
-    return dev_result.returncode
-
+from wgs_reactor.gui_registration import GUI_INFO  # noqa: E402
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(launch_web_from_gui_info(GUI_INFO, __file__))

--- a/tests/test_dry_compliance.py
+++ b/tests/test_dry_compliance.py
@@ -1,0 +1,283 @@
+"""Tests for DRY compliance: shared modules, launcher deduplication, and path utilities.
+
+Verifies:
+- All launch_web.py files use the shared launch_web_from_gui_info pattern
+- All gui_registration.py files with a sibling launch_web.py define a "web" config
+- launch_web_app and launch_web_from_gui_info are importable and well-formed
+- get_repo_root implementations agree across modules
+- launch_pyqt6.py files follow the thin-wrapper pattern
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ── Path constants ────────────────────────────────────────────────────────
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "src"
+
+# PSA package uses Streamlit, not the React/npm pattern
+_NON_REACT_WEB_LAUNCHERS = {"psa_package"}
+
+
+# ── Helper ────────────────────────────────────────────────────────────────
+
+
+def _load_module_from_path(name: str, path: Path):  # noqa: ANN201
+    """Dynamically load a Python module from a file path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec and spec.loader:
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    return None
+
+
+def _collect_launch_web_files() -> list[Path]:
+    """Find all launch_web.py files under src/."""
+    return sorted(SRC_DIR.rglob("launch_web.py"))
+
+
+def _collect_launch_pyqt6_files() -> list[Path]:
+    """Find all launch_pyqt6.py files under src/."""
+    return sorted(SRC_DIR.rglob("launch_pyqt6.py"))
+
+
+def _collect_gui_registrations() -> list[Path]:
+    """Find all gui_registration.py files under src/."""
+    return sorted(SRC_DIR.rglob("gui_registration.py"))
+
+
+# ── Web launcher DRY tests ───────────────────────────────────────────────
+
+
+class TestWebLauncherDRY:
+    """All React launch_web.py files should use the shared pattern."""
+
+    def test_launch_web_files_use_shared_function(self) -> None:
+        """Every React launch_web.py should import launch_web_from_gui_info."""
+        files = _collect_launch_web_files()
+        assert len(files) > 0, "No launch_web.py files found"
+
+        problems = []
+        for path in files:
+            # Skip non-React launchers (e.g. Streamlit)
+            tool_dir = path.parent.name
+            if tool_dir in _NON_REACT_WEB_LAUNCHERS:
+                continue
+
+            content = path.read_text(encoding="utf-8")
+            if "launch_web_from_gui_info" not in content:
+                rel = str(path.relative_to(REPO_ROOT))
+                problems.append(rel)
+
+        assert problems == [], (
+            "launch_web.py files not using shared launch_web_from_gui_info:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+    def test_launch_web_files_import_gui_info(self) -> None:
+        """Every React launch_web.py should import GUI_INFO from gui_registration."""
+        files = _collect_launch_web_files()
+
+        problems = []
+        for path in files:
+            tool_dir = path.parent.name
+            if tool_dir in _NON_REACT_WEB_LAUNCHERS:
+                continue
+
+            content = path.read_text(encoding="utf-8")
+            if "GUI_INFO" not in content:
+                rel = str(path.relative_to(REPO_ROOT))
+                problems.append(rel)
+
+        assert problems == [], (
+            "launch_web.py files not importing GUI_INFO:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+
+class TestGUIInfoWebConfig:
+    """gui_registration.py files with launch_web.py siblings should have web config."""
+
+    def test_web_config_exists_when_launch_web_exists(self) -> None:
+        """If a tool has launch_web.py, its GUI_INFO should have a 'web' key."""
+        launch_web_files = _collect_launch_web_files()
+        gui_reg_files = _collect_gui_registrations()
+
+        # Build set of directories that have launch_web.py
+        web_dirs = {f.parent for f in launch_web_files}
+
+        # Build map of directories that have gui_registration.py
+        reg_by_dir = {f.parent: f for f in gui_reg_files}
+
+        problems = []
+        for web_dir in web_dirs:
+            tool_dir = web_dir.name
+            if tool_dir in _NON_REACT_WEB_LAUNCHERS:
+                continue
+
+            reg_file = reg_by_dir.get(web_dir)
+            if reg_file is None:
+                continue  # No gui_registration.py at all -- different issue
+
+            try:
+                module = _load_module_from_path(f"gui_reg_{tool_dir}", reg_file)
+            except Exception:
+                continue
+
+            if module is None:
+                continue
+
+            gui_info = getattr(module, "GUI_INFO", None)
+            if gui_info is None:
+                continue
+
+            if "web" not in gui_info:
+                rel = str(reg_file.relative_to(REPO_ROOT))
+                problems.append(f"{rel}: missing 'web' config")
+
+        assert problems == [], (
+            "gui_registration.py files with sibling launch_web.py but no web config:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+    def test_web_config_has_port(self) -> None:
+        """Every web config should specify a port."""
+        gui_reg_files = _collect_gui_registrations()
+
+        problems = []
+        for path in gui_reg_files:
+            try:
+                module = _load_module_from_path(f"gui_reg_{path.stem}", path)
+            except Exception:
+                continue
+
+            if module is None:
+                continue
+
+            gui_info = getattr(module, "GUI_INFO", None)
+            if gui_info is None or "web" not in gui_info:
+                continue
+
+            web = gui_info["web"]
+            if "port" not in web:
+                rel = str(path.relative_to(REPO_ROOT))
+                problems.append(f"{rel}: web config missing 'port'")
+
+        assert problems == [], (
+            "web config problems:\n" + "\n".join(f"  - {p}" for p in problems)
+        )
+
+
+# ── Shared launcher function tests ──────────────────────────────────────
+
+
+class TestLaunchWebApp:
+    """launch_web_app should be importable and well-formed."""
+
+    def test_importable(self) -> None:
+        from gui_launcher import launch_web_app
+
+        assert callable(launch_web_app)
+
+    def test_launch_web_from_gui_info_importable(self) -> None:
+        from gui_launcher import launch_web_from_gui_info
+
+        assert callable(launch_web_from_gui_info)
+
+    def test_returns_error_for_missing_web_dir(self, tmp_path: Path) -> None:
+        from gui_launcher.launcher import launch_web_app
+
+        result = launch_web_app(
+            tool_name="test",
+            web_dir=tmp_path / "nonexistent",
+            port=9999,
+            auto_open_browser=False,
+        )
+        assert result == 1
+
+    @patch("gui_launcher.launcher.subprocess.run")
+    def test_returns_error_when_node_missing(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        from gui_launcher.launcher import launch_web_app
+
+        mock_run.side_effect = FileNotFoundError("node not found")
+        result = launch_web_app(
+            tool_name="test",
+            web_dir=tmp_path,
+            port=9999,
+            auto_open_browser=False,
+        )
+        assert result == 1
+
+    def test_launch_web_from_gui_info_returns_error_without_web_config(
+        self,
+    ) -> None:
+        """If GUI_INFO has no web config, should still run with defaults."""
+        import tempfile
+
+        from gui_launcher.launcher import launch_web_from_gui_info
+
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            caller_file = f.name
+
+        # No web dir exists, so it should error
+        gui_info = {"name": "Test", "tool_name": "test"}
+        result = launch_web_from_gui_info(gui_info, caller_file)
+        assert result == 1
+
+
+# ── PyQt6 launcher DRY tests ────────────────────────────────────────────
+
+
+class TestPyQt6LauncherDRY:
+    """All launch_pyqt6.py files should follow the thin-wrapper pattern."""
+
+    def test_launch_pyqt6_files_use_bootstrap(self) -> None:
+        """Every launch_pyqt6.py should import ensure_paths from bootstrap."""
+        files = _collect_launch_pyqt6_files()
+        assert len(files) > 0, "No launch_pyqt6.py files found"
+
+        problems = []
+        for path in files:
+            content = path.read_text(encoding="utf-8")
+            if "ensure_paths" not in content:
+                rel = str(path.relative_to(REPO_ROOT))
+                problems.append(rel)
+
+        assert problems == [], (
+            "launch_pyqt6.py files not using ensure_paths:\n"
+            + "\n".join(f"  - {p}" for p in problems)
+        )
+
+
+# ── get_repo_root consistency ────────────────────────────────────────────
+
+
+class TestGetRepoRootConsistency:
+    """All get_repo_root implementations should agree."""
+
+    def test_canonical_implementation_exists(self) -> None:
+        from upstream_drift_tools.utils.paths import get_repo_root
+
+        result = get_repo_root()
+        assert result.is_absolute()
+        assert (result / ".git").exists() or (result / "pyproject.toml").exists()
+
+    def test_launch_utils_delegates_to_canonical(self) -> None:
+        from upstream_drift_tools.utils.paths import get_repo_root as canonical
+
+        from tools.launch_utils import get_repo_root as launch_get_root
+
+        assert launch_get_root() == canonical()
+
+    def test_path_setup_delegates_to_canonical(self) -> None:
+        from upstream_drift_tools.utils.paths import get_repo_root as canonical
+        from utils.path_setup import get_repo_root as setup_get_root
+
+        assert setup_get_root() == canonical()


### PR DESCRIPTION
## Summary
- **Web launcher deduplication**: Added `launch_web_app()` and `launch_web_from_gui_info()` to the shared `gui_launcher` module, replacing ~700 lines of duplicated React launcher boilerplate across 12 `launch_web.py` files with thin 20-line wrappers that delegate to the shared implementation
- **GUI_INFO web config**: Extended the `GUI_INFO` dict pattern (from Wave 4) with a `"web"` section specifying `port` and `auto_open_browser` for all 12 React-enabled tools
- **get_repo_root consolidation**: Simplified `ui_utils.py`, `launch_utils.py`, and `path_setup.py` to delegate to the canonical `upstream_drift_tools.utils.paths.get_repo_root()` with consistent fallback markers (`.git`, `pyproject.toml`, `tools.json`)
- **DRY compliance tests**: Added 13 new tests verifying launcher patterns, web config consistency, and `get_repo_root` agreement across modules

**Net change**: -408 lines (587 added, 712 removed), 658 tests passing, ruff clean.

Closes #635

## Test plan
- [x] All 658 existing tests pass
- [x] 13 new DRY compliance tests pass
- [x] Ruff check passes with zero errors
- [x] Wave 4 launcher tests still pass (17/17)
- [x] Path setup tests still pass (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes all React dev-server launching into shared code; any subtle behavior differences (ports/env vars, npm invocation, browser auto-open, path bootstrapping) could impact multiple tools at once, but changes are mostly refactoring with added regression tests.
> 
> **Overview**
> Refactors all React-enabled tools’ `launch_web.py` scripts into thin wrappers that bootstrap paths and delegate to a new shared `gui_launcher.launch_web_from_gui_info()`, removing duplicated Node/npm install + dev-server startup logic.
> 
> Extends each affected tool’s `GUI_INFO` with a `web` section (`port`, `auto_open_browser`) and adds `launch_web_app()`/`launch_web_from_gui_info()` exports in `gui_launcher` to drive the shared behavior.
> 
> Unifies `get_repo_root` usage by delegating to `upstream_drift_tools.utils.paths.get_repo_root()` with a slimmer, consistent fallback in `tools/launch_utils.py`, `tools/ui_utils.py`, and `utils/path_setup.py`, and adds `tests/test_dry_compliance.py` to enforce the new launcher patterns and path/root consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c23c4d109166bef024516239584f4e8b61181dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->