### PR TITLE
feat: 4 React tool conversions, data analytics suite, and FEA mesh export (#579, #607, #608)

### DIFF
--- a/src/data_processing/data_processor/web/src/App.tsx
+++ b/src/data_processing/data_processor/web/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { Database, Settings, BarChart3, Table, Calculator, Clock, Scissors, LineChart, HelpCircle } from 'lucide-react';
+import { Database, Settings, BarChart3, Table, Calculator, Clock, Scissors, LineChart, HelpCircle, FlaskConical } from 'lucide-react';
 import {
   FileUpload,
   SignalList,
@@ -12,6 +12,7 @@ import {
   TimeRangePanel,
   TrendlinePanel,
   HelpPanel,
+  AnalyticsSuite,
 } from './components';
 import { useDataProcessor } from './hooks';
 import type {
@@ -27,7 +28,7 @@ import type {
 
 type TabType = 'chart' | 'table';
 type LeftPanelTab = 'signals' | 'advanced' | 'resample' | 'timerange';
-type RightPanelTab = 'stats' | 'trendline' | 'export' | 'help';
+type RightPanelTab = 'stats' | 'analytics' | 'trendline' | 'export' | 'help';
 
 function App() {
   const [activeTab, setActiveTab] = useState<TabType>('chart');
@@ -305,6 +306,13 @@ function App() {
                 Stats
               </button>
               <button
+                onClick={() => setRightPanelTab('analytics')}
+                className={`px-3 py-2 ${rightPanelTab === 'analytics' ? 'border-b-2 border-blue-500 text-blue-400' : 'text-dark-400'}`}
+              >
+                <FlaskConical className="w-3 h-3 inline mr-1" />
+                Analytics
+              </button>
+              <button
                 onClick={() => setRightPanelTab('trendline')}
                 className={`px-3 py-2 ${rightPanelTab === 'trendline' ? 'border-b-2 border-blue-500 text-blue-400' : 'text-dark-400'}`}
               >
@@ -330,6 +338,14 @@ function App() {
             {rightPanelTab === 'stats' && (
               <StatisticsPanel
                 statistics={statistics}
+                selectedSignals={selectedSignals}
+              />
+            )}
+
+            {rightPanelTab === 'analytics' && (
+              <AnalyticsSuite
+                data={filteredData}
+                signals={signals}
                 selectedSignals={selectedSignals}
               />
             )}

--- a/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
+++ b/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
@@ -1,0 +1,665 @@
+/**
+ * Advanced Analytics Suite for the Data Processor.
+ *
+ * Provides:
+ *  - Correlation matrix with heatmap visualization
+ *  - PCA (Principal Component Analysis) with scree plot
+ *  - Regression analysis with residual diagnostics
+ *
+ * See issue #607.
+ */
+import React, { useState, useMemo, useCallback } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ScatterChart,
+  Scatter,
+  Cell,
+  LineChart,
+  Line,
+  Legend,
+} from 'recharts';
+import type {
+  DataRow,
+  CorrelationMatrix,
+  PCAResult,
+  RegressionResult,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface AnalyticsSuiteProps {
+  data: DataRow[];
+  signals: string[];
+  selectedSignals: string[];
+}
+
+type AnalyticsTab = 'correlation' | 'pca' | 'regression';
+
+// ---------------------------------------------------------------------------
+// Math helpers
+// ---------------------------------------------------------------------------
+
+function pearsonCorrelation(x: number[], y: number[]): number {
+  const n = x.length;
+  if (n < 2) return NaN;
+  const meanX = x.reduce((a, b) => a + b, 0) / n;
+  const meanY = y.reduce((a, b) => a + b, 0) / n;
+  let num = 0;
+  let denX = 0;
+  let denY = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = x[i] - meanX;
+    const dy = y[i] - meanY;
+    num += dx * dy;
+    denX += dx * dx;
+    denY += dy * dy;
+  }
+  const den = Math.sqrt(denX * denY);
+  return den === 0 ? 0 : num / den;
+}
+
+function computeCorrelation(data: DataRow[], signals: string[]): CorrelationMatrix {
+  const n = signals.length;
+  const matrix: number[][] = Array.from({ length: n }, () => Array(n).fill(0));
+
+  const columns = signals.map((sig) =>
+    data.map((row) => (typeof row[sig] === 'number' ? (row[sig] as number) : NaN)),
+  );
+
+  for (let i = 0; i < n; i++) {
+    for (let j = i; j < n; j++) {
+      const valid = columns[i]
+        .map((v, k) => ({ x: v, y: columns[j][k] }))
+        .filter(({ x, y }) => !isNaN(x) && !isNaN(y));
+      const r = pearsonCorrelation(
+        valid.map((d) => d.x),
+        valid.map((d) => d.y),
+      );
+      matrix[i][j] = r;
+      matrix[j][i] = r;
+    }
+  }
+
+  return { signals, matrix };
+}
+
+/**
+ * Simple PCA via covariance eigen-decomposition (power iteration for the
+ * top-k eigenvalues).  Good enough for interactive analytics on moderate
+ * datasets.
+ */
+function computePCA(data: DataRow[], signals: string[], numComponents?: number): PCAResult {
+  const n = data.length;
+  const p = signals.length;
+  const nc = Math.min(numComponents ?? p, p);
+
+  // Build centered/scaled column matrix
+  const cols = signals.map((sig) =>
+    data.map((row) => (typeof row[sig] === 'number' ? (row[sig] as number) : 0)),
+  );
+
+  const means = cols.map((c) => c.reduce((a, b) => a + b, 0) / n);
+  const stds = cols.map((c, ci) => {
+    const s = Math.sqrt(c.reduce((a, v) => a + (v - means[ci]) ** 2, 0) / n);
+    return s === 0 ? 1 : s;
+  });
+
+  // Standardized matrix (n x p)
+  const Z: number[][] = Array.from({ length: n }, (_, i) =>
+    cols.map((c, j) => (c[i] - means[j]) / stds[j]),
+  );
+
+  // Covariance matrix (p x p)
+  const cov: number[][] = Array.from({ length: p }, () => Array(p).fill(0));
+  for (let i = 0; i < p; i++) {
+    for (let j = i; j < p; j++) {
+      let s = 0;
+      for (let k = 0; k < n; k++) s += Z[k][i] * Z[k][j];
+      s /= n - 1 || 1;
+      cov[i][j] = s;
+      cov[j][i] = s;
+    }
+  }
+
+  // Power-iteration for top eigenvalues (simple Jacobi-like)
+  const eigenvalues: number[] = [];
+  const eigenvectors: number[][] = [];
+  const A = cov.map((row) => [...row]);
+
+  for (let comp = 0; comp < nc; comp++) {
+    let v = Array.from({ length: p }, () => Math.random());
+    let norm = Math.sqrt(v.reduce((a, b) => a + b * b, 0));
+    v = v.map((x) => x / norm);
+
+    for (let iter = 0; iter < 300; iter++) {
+      const Av = A.map((row) => row.reduce((s, aij, j) => s + aij * v[j], 0));
+      norm = Math.sqrt(Av.reduce((a, b) => a + b * b, 0));
+      if (norm === 0) break;
+      v = Av.map((x) => x / norm);
+    }
+
+    eigenvalues.push(norm);
+    eigenvectors.push(v);
+
+    // Deflate
+    for (let i = 0; i < p; i++) {
+      for (let j = 0; j < p; j++) {
+        A[i][j] -= norm * v[i] * v[j];
+      }
+    }
+  }
+
+  const totalVar = eigenvalues.reduce((a, b) => a + b, 0) || 1;
+  const explained = eigenvalues.map((e) => e / totalVar);
+  const cumulative: number[] = [];
+  explained.reduce((acc, e, i) => {
+    cumulative[i] = acc + e;
+    return cumulative[i];
+  }, 0);
+
+  // Scores (n x nc)
+  const scores = Z.map((row) =>
+    eigenvectors.map((ev) => row.reduce((s, z, j) => s + z * ev[j], 0)),
+  );
+
+  // Loadings (p x nc)
+  const loadings = eigenvectors.map((ev) => [...ev]);
+
+  return {
+    explainedVariance: explained,
+    cumulativeVariance: cumulative,
+    numComponents: nc,
+    scores,
+    loadings: loadings[0].map((_, ci) => eigenvectors.map((ev) => ev[ci])),
+    signals,
+  };
+}
+
+function computeRegression(
+  data: DataRow[],
+  xSignal: string,
+  ySignal: string,
+  degree: number,
+): RegressionResult {
+  const pairs = data
+    .map((row) => ({
+      x: typeof row[xSignal] === 'number' ? (row[xSignal] as number) : NaN,
+      y: typeof row[ySignal] === 'number' ? (row[ySignal] as number) : NaN,
+    }))
+    .filter(({ x, y }) => !isNaN(x) && !isNaN(y));
+
+  const xs = pairs.map((d) => d.x);
+  const ys = pairs.map((d) => d.y);
+  const n = xs.length;
+
+  let coefficients: number[];
+  let predictions: number[];
+
+  if (degree === 1) {
+    // Simple linear regression
+    const meanX = xs.reduce((a, b) => a + b, 0) / n;
+    const meanY = ys.reduce((a, b) => a + b, 0) / n;
+    let num = 0;
+    let den = 0;
+    for (let i = 0; i < n; i++) {
+      num += (xs[i] - meanX) * (ys[i] - meanY);
+      den += (xs[i] - meanX) ** 2;
+    }
+    const slope = den === 0 ? 0 : num / den;
+    const intercept = meanY - slope * meanX;
+    coefficients = [intercept, slope];
+    predictions = xs.map((x) => intercept + slope * x);
+  } else {
+    // Polynomial regression via normal equations
+    // Build Vandermonde matrix
+    const X: number[][] = xs.map((x) =>
+      Array.from({ length: degree + 1 }, (_, d) => x ** d),
+    );
+    // X^T X
+    const XtX: number[][] = Array.from({ length: degree + 1 }, (_, i) =>
+      Array.from({ length: degree + 1 }, (__, j) =>
+        X.reduce((s, row) => s + row[i] * row[j], 0),
+      ),
+    );
+    // X^T y
+    const XtY: number[] = Array.from({ length: degree + 1 }, (_, i) =>
+      X.reduce((s, row, k) => s + row[i] * ys[k], 0),
+    );
+
+    // Solve via Gaussian elimination
+    coefficients = solveLinearSystem(XtX, XtY);
+    predictions = xs.map((x) =>
+      coefficients.reduce((s, c, d) => s + c * x ** d, 0),
+    );
+  }
+
+  const residuals = ys.map((y, i) => y - predictions[i]);
+  const meanY = ys.reduce((a, b) => a + b, 0) / n;
+  const ssTotal = ys.reduce((s, y) => s + (y - meanY) ** 2, 0);
+  const ssResidual = residuals.reduce((s, r) => s + r * r, 0);
+  const rSquared = ssTotal === 0 ? 1 : 1 - ssResidual / ssTotal;
+  const p = coefficients.length;
+  const adjustedRSquared = n <= p ? rSquared : 1 - ((1 - rSquared) * (n - 1)) / (n - p);
+
+  // Build equation string
+  let equation: string;
+  if (degree === 1) {
+    equation = `y = ${coefficients[1].toFixed(4)}x + ${coefficients[0].toFixed(4)}`;
+  } else {
+    const terms = coefficients
+      .map((c, d) => {
+        if (d === 0) return c.toFixed(4);
+        const sign = c >= 0 ? ' + ' : ' - ';
+        const coef = Math.abs(c).toFixed(4);
+        const xPart = d === 1 ? 'x' : `x^${d}`;
+        return `${sign}${coef}${xPart}`;
+      })
+      .join('');
+    equation = `y = ${terms}`;
+  }
+
+  return {
+    type: degree === 1 ? 'linear' : 'polynomial',
+    equation,
+    rSquared,
+    adjustedRSquared,
+    coefficients,
+    residuals,
+    predictions,
+    xSignal,
+    ySignal,
+  };
+}
+
+function solveLinearSystem(A: number[][], b: number[]): number[] {
+  const n = A.length;
+  const aug = A.map((row, i) => [...row, b[i]]);
+
+  // Forward elimination
+  for (let i = 0; i < n; i++) {
+    let maxRow = i;
+    for (let k = i + 1; k < n; k++) {
+      if (Math.abs(aug[k][i]) > Math.abs(aug[maxRow][i])) maxRow = k;
+    }
+    [aug[i], aug[maxRow]] = [aug[maxRow], aug[i]];
+
+    if (Math.abs(aug[i][i]) < 1e-12) continue;
+
+    for (let k = i + 1; k < n; k++) {
+      const factor = aug[k][i] / aug[i][i];
+      for (let j = i; j <= n; j++) {
+        aug[k][j] -= factor * aug[i][j];
+      }
+    }
+  }
+
+  // Back substitution
+  const x = Array(n).fill(0);
+  for (let i = n - 1; i >= 0; i--) {
+    let s = aug[i][n];
+    for (let j = i + 1; j < n; j++) s -= aug[i][j] * x[j];
+    x[i] = Math.abs(aug[i][i]) < 1e-12 ? 0 : s / aug[i][i];
+  }
+  return x;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+const COLORS_POSITIVE = ['#0d47a1', '#1565c0', '#1976d2', '#42a5f5', '#90caf9'];
+const COLORS_NEGATIVE = ['#b71c1c', '#c62828', '#d32f2f', '#ef5350', '#ef9a9a'];
+
+function correlationColor(r: number): string {
+  if (isNaN(r)) return '#4a4a4a';
+  const idx = Math.min(4, Math.floor(Math.abs(r) * 5));
+  return r >= 0 ? COLORS_POSITIVE[4 - idx] : COLORS_NEGATIVE[4 - idx];
+}
+
+export function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuiteProps) {
+  const [tab, setTab] = useState<AnalyticsTab>('correlation');
+  const [regXSignal, setRegXSignal] = useState<string>(selectedSignals[0] ?? '');
+  const [regYSignal, setRegYSignal] = useState<string>(selectedSignals[1] ?? selectedSignals[0] ?? '');
+  const [regDegree, setRegDegree] = useState<number>(1);
+
+  const activeSignals = selectedSignals.length > 0 ? selectedSignals : signals.slice(0, 5);
+
+  // Correlation
+  const correlation = useMemo<CorrelationMatrix | null>(() => {
+    if (data.length === 0 || activeSignals.length < 2) return null;
+    return computeCorrelation(data, activeSignals);
+  }, [data, activeSignals]);
+
+  // PCA
+  const pca = useMemo<PCAResult | null>(() => {
+    if (data.length === 0 || activeSignals.length < 2) return null;
+    return computePCA(data, activeSignals);
+  }, [data, activeSignals]);
+
+  // Regression (on demand)
+  const [regression, setRegression] = useState<RegressionResult | null>(null);
+
+  const runRegression = useCallback(() => {
+    if (!regXSignal || !regYSignal || data.length === 0) return;
+    const result = computeRegression(data, regXSignal, regYSignal, regDegree);
+    setRegression(result);
+  }, [data, regXSignal, regYSignal, regDegree]);
+
+  if (data.length === 0 || activeSignals.length < 2) {
+    return (
+      <div className="card">
+        <div className="card-header">Analytics Suite</div>
+        <div className="card-body text-dark-400 text-center py-8">
+          Load data and select at least 2 signals to use analytics.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Tab Selector */}
+      <div className="flex border-b border-dark-700 text-sm">
+        {(['correlation', 'pca', 'regression'] as const).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={`px-4 py-2 capitalize ${
+              tab === t
+                ? 'border-b-2 border-blue-500 text-blue-400'
+                : 'text-dark-400 hover:text-dark-300'
+            }`}
+          >
+            {t === 'pca' ? 'PCA' : t}
+          </button>
+        ))}
+      </div>
+
+      {/* --- Correlation Matrix --- */}
+      {tab === 'correlation' && correlation && (
+        <div className="card">
+          <div className="card-header">Correlation Matrix</div>
+          <div className="card-body overflow-x-auto">
+            <table className="text-xs w-full">
+              <thead>
+                <tr>
+                  <th className="py-1 px-2 text-left text-dark-400"></th>
+                  {correlation.signals.map((s) => (
+                    <th key={s} className="py-1 px-2 text-dark-400 text-center truncate max-w-[6rem]">
+                      {s}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {correlation.signals.map((rowSig, ri) => (
+                  <tr key={rowSig}>
+                    <td className="py-1 px-2 text-dark-400 font-medium truncate max-w-[6rem]">
+                      {rowSig}
+                    </td>
+                    {correlation.matrix[ri].map((r, ci) => (
+                      <td
+                        key={ci}
+                        className="py-1 px-2 text-center font-mono"
+                        style={{
+                          backgroundColor: correlationColor(r),
+                          color: Math.abs(r) > 0.5 ? '#fff' : '#ccc',
+                        }}
+                      >
+                        {isNaN(r) ? '-' : r.toFixed(2)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* --- PCA --- */}
+      {tab === 'pca' && pca && (
+        <div className="space-y-4">
+          {/* Scree Plot */}
+          <div className="card">
+            <div className="card-header">Scree Plot (Variance Explained)</div>
+            <div className="card-body h-56">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={pca.explainedVariance.map((ev, i) => ({
+                    name: `PC${i + 1}`,
+                    variance: +(ev * 100).toFixed(1),
+                    cumulative: +(pca.cumulativeVariance[i] * 100).toFixed(1),
+                  }))}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                  <XAxis dataKey="name" stroke="#94a3b8" />
+                  <YAxis stroke="#94a3b8" label={{ value: '%', angle: -90, position: 'insideLeft', fill: '#94a3b8' }} />
+                  <Tooltip contentStyle={{ backgroundColor: '#1e293b', border: 'none' }} />
+                  <Legend />
+                  <Bar dataKey="variance" name="Individual %" fill="#3b82f6" />
+                  <Bar dataKey="cumulative" name="Cumulative %" fill="#22c55e" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+
+          {/* PCA Biplot (PC1 vs PC2) */}
+          {pca.numComponents >= 2 && (
+            <div className="card">
+              <div className="card-header">
+                PCA Score Plot (PC1 vs PC2)
+              </div>
+              <div className="card-body h-64">
+                <ResponsiveContainer width="100%" height="100%">
+                  <ScatterChart>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                    <XAxis
+                      type="number"
+                      dataKey="x"
+                      name="PC1"
+                      stroke="#94a3b8"
+                      label={{ value: `PC1 (${(pca.explainedVariance[0] * 100).toFixed(1)}%)`, position: 'bottom', fill: '#94a3b8' }}
+                    />
+                    <YAxis
+                      type="number"
+                      dataKey="y"
+                      name="PC2"
+                      stroke="#94a3b8"
+                      label={{ value: `PC2 (${(pca.explainedVariance[1] * 100).toFixed(1)}%)`, angle: -90, position: 'insideLeft', fill: '#94a3b8' }}
+                    />
+                    <Tooltip contentStyle={{ backgroundColor: '#1e293b', border: 'none' }} />
+                    <Scatter
+                      data={pca.scores.map((s) => ({ x: s[0], y: s[1] }))}
+                      fill="#3b82f6"
+                    >
+                      {pca.scores.map((_, i) => (
+                        <Cell key={i} fill="#3b82f6" opacity={0.6} />
+                      ))}
+                    </Scatter>
+                  </ScatterChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          )}
+
+          {/* Loadings table */}
+          <div className="card">
+            <div className="card-header">Component Loadings</div>
+            <div className="card-body overflow-x-auto">
+              <table className="w-full text-xs">
+                <thead>
+                  <tr className="text-dark-400 border-b border-dark-700">
+                    <th className="text-left py-1 px-2">Signal</th>
+                    {pca.explainedVariance.map((_, i) => (
+                      <th key={i} className="text-right py-1 px-2">PC{i + 1}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {pca.signals.map((sig, si) => (
+                    <tr key={sig} className="border-b border-dark-800">
+                      <td className="py-1 px-2 text-dark-300">{sig}</td>
+                      {pca.loadings[si]?.map((l, ci) => (
+                        <td key={ci} className="text-right py-1 px-2 font-mono text-dark-300">
+                          {l.toFixed(3)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* --- Regression --- */}
+      {tab === 'regression' && (
+        <div className="space-y-4">
+          {/* Controls */}
+          <div className="card">
+            <div className="card-header">Regression Setup</div>
+            <div className="card-body space-y-3">
+              <div className="grid grid-cols-3 gap-3">
+                <div>
+                  <label className="block text-xs text-dark-400 mb-1">X Signal</label>
+                  <select
+                    value={regXSignal}
+                    onChange={(e) => setRegXSignal(e.target.value)}
+                    className="w-full bg-dark-700 text-dark-100 rounded px-2 py-1 text-sm border border-dark-600"
+                  >
+                    {signals.map((s) => (
+                      <option key={s} value={s}>{s}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs text-dark-400 mb-1">Y Signal</label>
+                  <select
+                    value={regYSignal}
+                    onChange={(e) => setRegYSignal(e.target.value)}
+                    className="w-full bg-dark-700 text-dark-100 rounded px-2 py-1 text-sm border border-dark-600"
+                  >
+                    {signals.map((s) => (
+                      <option key={s} value={s}>{s}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs text-dark-400 mb-1">Degree</label>
+                  <select
+                    value={regDegree}
+                    onChange={(e) => setRegDegree(Number(e.target.value))}
+                    className="w-full bg-dark-700 text-dark-100 rounded px-2 py-1 text-sm border border-dark-600"
+                  >
+                    {[1, 2, 3, 4, 5].map((d) => (
+                      <option key={d} value={d}>{d === 1 ? 'Linear' : `Polynomial (${d})`}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <button
+                onClick={runRegression}
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-semibold py-2 rounded transition-colors"
+              >
+                Run Regression
+              </button>
+            </div>
+          </div>
+
+          {/* Results */}
+          {regression && (
+            <>
+              {/* Summary */}
+              <div className="card">
+                <div className="card-header">Regression Results</div>
+                <div className="card-body space-y-2 text-sm">
+                  <div className="grid grid-cols-2 gap-2">
+                    <div>
+                      <span className="text-dark-400">Equation:</span>{' '}
+                      <span className="text-dark-100 font-mono text-xs">{regression.equation}</span>
+                    </div>
+                    <div>
+                      <span className="text-dark-400">R-squared:</span>{' '}
+                      <span className="text-green-400 font-mono">{regression.rSquared.toFixed(4)}</span>
+                    </div>
+                    <div>
+                      <span className="text-dark-400">Adj. R-squared:</span>{' '}
+                      <span className="text-green-400 font-mono">{regression.adjustedRSquared.toFixed(4)}</span>
+                    </div>
+                    <div>
+                      <span className="text-dark-400">Type:</span>{' '}
+                      <span className="text-dark-100 capitalize">{regression.type}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Scatter + Fit */}
+              <div className="card">
+                <div className="card-header">Fit Plot</div>
+                <div className="card-body h-64">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <ScatterChart>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                      <XAxis type="number" dataKey="x" name={regression.xSignal} stroke="#94a3b8" />
+                      <YAxis type="number" dataKey="y" name={regression.ySignal} stroke="#94a3b8" />
+                      <Tooltip contentStyle={{ backgroundColor: '#1e293b', border: 'none' }} />
+                      <Scatter
+                        name="Data"
+                        data={data
+                          .map((row) => ({
+                            x: typeof row[regression.xSignal] === 'number' ? row[regression.xSignal] : undefined,
+                            y: typeof row[regression.ySignal] === 'number' ? row[regression.ySignal] : undefined,
+                          }))
+                          .filter((d) => d.x !== undefined && d.y !== undefined)
+                        }
+                        fill="#3b82f6"
+                        opacity={0.5}
+                      />
+                    </ScatterChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+
+              {/* Residual Plot */}
+              <div className="card">
+                <div className="card-header">Residual Plot</div>
+                <div className="card-body h-48">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart
+                      data={regression.residuals.map((r, i) => ({ index: i, residual: r }))}
+                    >
+                      <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
+                      <XAxis dataKey="index" stroke="#94a3b8" />
+                      <YAxis stroke="#94a3b8" />
+                      <Tooltip contentStyle={{ backgroundColor: '#1e293b', border: 'none' }} />
+                      <Line
+                        type="monotone"
+                        dataKey="residual"
+                        stroke="#f59e0b"
+                        dot={false}
+                        strokeWidth={1}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default AnalyticsSuite;

--- a/src/data_processing/data_processor/web/src/components/index.ts
+++ b/src/data_processing/data_processor/web/src/components/index.ts
@@ -10,3 +10,4 @@ export { ResamplePanel } from './ResamplePanel';
 export { TimeRangePanel } from './TimeRangePanel';
 export { TrendlinePanel } from './TrendlinePanel';
 export { HelpPanel } from './HelpPanel';
+export { AnalyticsSuite } from './AnalyticsSuite';

--- a/src/data_processing/data_processor/web/src/types/index.ts
+++ b/src/data_processing/data_processor/web/src/types/index.ts
@@ -151,3 +151,42 @@ export interface AppConfig {
   integrationMethod?: IntegrationMethod;
   differentiationMethod?: DifferentiationMethod;
 }
+
+// ---------------------------------------------------------------------------
+// Advanced analytics types -- See issue #607
+// ---------------------------------------------------------------------------
+
+/** Correlation matrix between selected signals. */
+export interface CorrelationMatrix {
+  signals: string[];
+  matrix: number[][];
+}
+
+/** Result of a PCA (Principal Component Analysis). */
+export interface PCAResult {
+  /** Proportion of variance explained by each component. */
+  explainedVariance: number[];
+  /** Cumulative variance explained. */
+  cumulativeVariance: number[];
+  /** Number of components retained. */
+  numComponents: number;
+  /** PCA scores for each data row (rows x numComponents). */
+  scores: number[][];
+  /** Loading vectors (signals x numComponents). */
+  loadings: number[][];
+  /** Signal names in the same order as loadings rows. */
+  signals: string[];
+}
+
+/** Result of a regression analysis. */
+export interface RegressionResult {
+  type: 'linear' | 'polynomial';
+  equation: string;
+  rSquared: number;
+  adjustedRSquared: number;
+  coefficients: number[];
+  residuals: number[];
+  predictions: number[];
+  xSignal: string;
+  ySignal: string;
+}

--- a/src/flow_rate_converter/web/src/App.tsx
+++ b/src/flow_rate_converter/web/src/App.tsx
@@ -1,0 +1,21 @@
+import { FlowRateConverter } from './components/FlowRateConverter'
+
+function App() {
+  return (
+    <div className="min-h-screen bg-slate-900">
+      <header className="bg-slate-800 shadow-lg">
+        <div className="max-w-7xl mx-auto px-4 py-4">
+          <h1 className="text-2xl font-bold text-white">Flow Rate Converter</h1>
+          <p className="text-slate-400 text-sm mt-1">
+            Convert between mass, molar, and volumetric flow rate units
+          </p>
+        </div>
+      </header>
+      <main className="max-w-7xl mx-auto px-4 py-6">
+        <FlowRateConverter />
+      </main>
+    </div>
+  )
+}
+
+export default App

--- a/src/flow_rate_converter/web/src/components/FlowRateConverter.tsx
+++ b/src/flow_rate_converter/web/src/components/FlowRateConverter.tsx
@@ -1,0 +1,229 @@
+import { useState, useCallback } from 'react';
+
+// API base URL -- defaults to shared calc backend.
+// Override via VITE_CALC_API_URL environment variable.
+// See issue #608.
+const CALC_API_BASE = import.meta.env.VITE_CALC_API_URL ?? 'http://localhost:8010';
+
+// Supported units per category
+const UNITS: Record<string, string[]> = {
+  mass: ['kg/s', 'kg/h', 'kg/min', 'g/s', 'g/h', 'lb/s', 'lb/h', 'lb/min', 'ton/h'],
+  molar: ['mol/s', 'mol/h', 'mol/min', 'kmol/s', 'kmol/h', 'kmol/min', 'lbmol/s', 'lbmol/h', 'lbmol/min'],
+  volumetric: ['m3/s', 'm3/h', 'm3/min', 'L/s', 'L/min', 'L/h', 'ft3/s', 'ft3/min', 'ft3/h', 'CFM', 'GPM'],
+};
+
+// Client-side conversion factors (SI base: kg/s, mol/s, m3/s)
+// See issue #608 for context on why the Python backend is preferred.
+const MASS_TO_KG_S: Record<string, number> = {
+  'kg/s': 1, 'kg/h': 1 / 3600, 'kg/min': 1 / 60, 'g/s': 1e-3, 'g/h': 1e-3 / 3600,
+  'lb/s': 0.45359237, 'lb/h': 0.45359237 / 3600, 'lb/min': 0.45359237 / 60, 'ton/h': 1000 / 3600,
+};
+
+const MOLAR_TO_MOL_S: Record<string, number> = {
+  'mol/s': 1, 'mol/h': 1 / 3600, 'mol/min': 1 / 60, 'kmol/s': 1e3, 'kmol/h': 1e3 / 3600,
+  'kmol/min': 1e3 / 60, 'lbmol/s': 453.59237, 'lbmol/h': 453.59237 / 3600, 'lbmol/min': 453.59237 / 60,
+};
+
+const VOLUMETRIC_TO_M3_S: Record<string, number> = {
+  'm3/s': 1, 'm3/h': 1 / 3600, 'm3/min': 1 / 60, 'L/s': 1e-3, 'L/min': 1e-3 / 60,
+  'L/h': 1e-3 / 3600, 'ft3/s': 0.028316846592, 'ft3/min': 0.028316846592 / 60,
+  'ft3/h': 0.028316846592 / 3600, 'CFM': 0.028316846592 / 60, 'GPM': 6.30902e-5,
+};
+
+const TABLES: Record<string, Record<string, number>> = {
+  mass: MASS_TO_KG_S,
+  molar: MOLAR_TO_MOL_S,
+  volumetric: VOLUMETRIC_TO_M3_S,
+};
+
+interface ConversionResult {
+  result: number;
+  fromUnit: string;
+  toUnit: string;
+  category: string;
+  engine: string;
+}
+
+function convertFallback(value: number, fromUnit: string, toUnit: string, category: string): ConversionResult {
+  const table = TABLES[category];
+  if (!table || !table[fromUnit] || !table[toUnit]) {
+    throw new Error(`Unknown unit or category: ${fromUnit} -> ${toUnit} (${category})`);
+  }
+  const base = value * table[fromUnit];
+  const result = base / table[toUnit];
+  return { result, fromUnit, toUnit, category, engine: 'client-fallback' };
+}
+
+async function fetchFromBackend(
+  value: number, fromUnit: string, toUnit: string, category: string,
+): Promise<ConversionResult> {
+  const response = await fetch(`${CALC_API_BASE}/api/calc/flow-rate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value, from_unit: fromUnit, to_unit: toUnit, category }),
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({ detail: response.statusText }));
+    throw new Error(body.detail ?? `API error ${response.status}`);
+  }
+
+  const data = await response.json();
+  return {
+    result: data.result,
+    fromUnit: data.from_unit,
+    toUnit: data.to_unit,
+    category: data.category,
+    engine: 'python-backend',
+  };
+}
+
+export function FlowRateConverter() {
+  const [category, setCategory] = useState<string>('mass');
+  const [value, setValue] = useState<number>(1000);
+  const [fromUnit, setFromUnit] = useState<string>('kg/h');
+  const [toUnit, setToUnit] = useState<string>('lb/h');
+  const [result, setResult] = useState<ConversionResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCategoryChange = useCallback((newCategory: string) => {
+    setCategory(newCategory);
+    const units = UNITS[newCategory];
+    setFromUnit(units[0]);
+    setToUnit(units[1]);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  const swapUnits = useCallback(() => {
+    setFromUnit(toUnit);
+    setToUnit(fromUnit);
+    setResult(null);
+  }, [fromUnit, toUnit]);
+
+  const convert = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      let res: ConversionResult;
+      try {
+        res = await fetchFromBackend(value, fromUnit, toUnit, category);
+      } catch {
+        res = convertFallback(value, fromUnit, toUnit, category);
+      }
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Conversion failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [value, fromUnit, toUnit, category]);
+
+  const currentUnits = UNITS[category] || [];
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {/* Category Selector */}
+      <div className="flex border-b border-slate-700">
+        {Object.keys(UNITS).map((cat) => (
+          <button
+            key={cat}
+            onClick={() => handleCategoryChange(cat)}
+            className={`px-6 py-3 font-medium capitalize transition-colors ${
+              category === cat
+                ? 'text-blue-400 border-b-2 border-blue-400'
+                : 'text-slate-400 hover:text-slate-300'
+            }`}
+          >
+            {cat} Flow
+          </button>
+        ))}
+      </div>
+
+      {/* Conversion Panel */}
+      <div className="bg-slate-800 rounded-lg p-6 space-y-5">
+        {/* Input Value */}
+        <div>
+          <label className="block text-sm text-slate-300 mb-2">Value</label>
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => setValue(Number(e.target.value))}
+            className="w-full bg-slate-700 text-white text-lg rounded px-4 py-3 border border-slate-600 focus:border-blue-500 focus:outline-none"
+          />
+        </div>
+
+        {/* From / Swap / To */}
+        <div className="grid grid-cols-[1fr_auto_1fr] gap-3 items-end">
+          <div>
+            <label className="block text-sm text-slate-300 mb-2">From</label>
+            <select
+              value={fromUnit}
+              onChange={(e) => setFromUnit(e.target.value)}
+              className="w-full bg-slate-700 text-white rounded px-3 py-3 border border-slate-600 focus:border-blue-500 focus:outline-none"
+            >
+              {currentUnits.map((u) => (
+                <option key={u} value={u}>{u}</option>
+              ))}
+            </select>
+          </div>
+
+          <button
+            onClick={swapUnits}
+            className="px-3 py-3 text-slate-400 hover:text-white transition-colors"
+            title="Swap units"
+          >
+            &#8646;
+          </button>
+
+          <div>
+            <label className="block text-sm text-slate-300 mb-2">To</label>
+            <select
+              value={toUnit}
+              onChange={(e) => setToUnit(e.target.value)}
+              className="w-full bg-slate-700 text-white rounded px-3 py-3 border border-slate-600 focus:border-blue-500 focus:outline-none"
+            >
+              {currentUnits.map((u) => (
+                <option key={u} value={u}>{u}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* Convert Button */}
+        <button
+          onClick={convert}
+          disabled={loading}
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-4 rounded-lg transition-colors disabled:opacity-50"
+        >
+          {loading ? 'Converting...' : 'Convert'}
+        </button>
+      </div>
+
+      {/* Result */}
+      {result && (
+        <div className="bg-green-900/30 border border-green-700 rounded-lg p-6 text-center">
+          <p className="text-slate-400 text-sm mb-2">Result</p>
+          <p className="text-3xl font-bold text-green-400">
+            {result.result.toLocaleString(undefined, { maximumSignificantDigits: 8 })} {result.toUnit}
+          </p>
+          <p className="text-slate-500 text-sm mt-3">
+            {value.toLocaleString()} {result.fromUnit} = {result.result.toLocaleString(undefined, { maximumSignificantDigits: 8 })} {result.toUnit}
+          </p>
+          {/* Engine indicator -- See issue #608 */}
+          <p className="text-xs text-slate-600 mt-2">Engine: {result.engine}</p>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="bg-red-900/30 border border-red-700 rounded-lg p-4">
+          <p className="text-red-400">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FlowRateConverter;

--- a/src/flow_rate_converter/web/src/index.css
+++ b/src/flow_rate_converter/web/src/index.css
@@ -1,0 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/src/flow_rate_converter/web/src/main.tsx
+++ b/src/flow_rate_converter/web/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/src/glass_bath_fea/exporters/__init__.py
+++ b/src/glass_bath_fea/exporters/__init__.py
@@ -5,6 +5,7 @@ from .mat_exporter import (
     export_mesh_to_mat,
     validate_mesh_data,
 )
+from .mesh_export_pipeline import MeshExportPipeline, MeshExportResult
 from .msh_exporter import export_mesh_to_msh, read_msh_file
 
 __all__ = [
@@ -13,4 +14,6 @@ __all__ = [
     "export_fea_data_package",
     "validate_mesh_data",
     "read_msh_file",
+    "MeshExportPipeline",
+    "MeshExportResult",
 ]

--- a/src/glass_bath_fea/exporters/mesh_export_pipeline.py
+++ b/src/glass_bath_fea/exporters/mesh_export_pipeline.py
@@ -1,0 +1,267 @@
+"""Mesh export pipeline for Glass Bath FEA.
+
+Orchestrates the full workflow from electrode configuration through mesh
+generation to multi-format file export (.msh, .mat).  Builds on the
+geometry sync from Phase 3 (issue #575).
+
+See issue #579.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from glass_bath_fea.core.config import GlassBathFEAConfig
+from glass_bath_fea.core.mesh_generator import MeshGenerator
+from glass_bath_fea.exporters.mat_exporter import export_mesh_to_mat, validate_mesh_data
+from glass_bath_fea.exporters.msh_exporter import export_mesh_to_msh
+from glass_bath_fea.interfaces.geometry_sync import GeometrySynchronizer
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Export result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MeshExportResult:
+    """Result of the mesh export pipeline."""
+
+    success: bool
+    mesh_stats: dict[str, Any]
+    exported_files: list[str]
+    errors: list[str]
+    warnings: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+class MeshExportPipeline:
+    """End-to-end pipeline: electrode config -> mesh -> export files.
+
+    Usage::
+
+        pipeline = MeshExportPipeline()
+        result = pipeline.run(output_dir="./export", formats=["msh", "mat"])
+
+    Attributes:
+        config: The resolved ``GlassBathFEAConfig`` (available after run).
+        mesh_data: The generated mesh dict (available after run).
+    """
+
+    def __init__(
+        self,
+        electrode_config: Any | None = None,
+        fea_config: GlassBathFEAConfig | None = None,
+    ) -> None:
+        """Initialise the pipeline.
+
+        Provide *either* an ``electrode_config`` (from the Electrode Advisor)
+        which will be synced via ``GeometrySynchronizer``, *or* a direct
+        ``GlassBathFEAConfig``.  If both are *None*, the synchroniser will
+        use its own defaults.
+
+        Args:
+            electrode_config: Optional electrode advisor config.
+            fea_config: Optional direct FEA config (skips geometry sync).
+        """
+        self._electrode_config = electrode_config
+        self._fea_config = fea_config
+        self.config: GlassBathFEAConfig | None = None
+        self.mesh_data: dict | None = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        output_dir: str | Path,
+        formats: list[str] | None = None,
+        coarse: bool = True,
+        physical_names: dict[int, str] | None = None,
+    ) -> MeshExportResult:
+        """Execute the full pipeline.
+
+        Args:
+            output_dir: Directory where exported files will be written.
+            formats: List of export formats.  Supported: ``"msh"``,
+                ``"mat"``, ``"json"``.  Defaults to all three.
+            coarse: Whether to use a coarse mesh (faster, for development).
+            physical_names: Optional mapping of material IDs to region
+                names for the MSH exporter.
+
+        Returns:
+            A ``MeshExportResult`` summarising what was exported.
+        """
+        if formats is None:
+            formats = ["msh", "mat", "json"]
+
+        errors: list[str] = []
+        warnings: list[str] = []
+        exported_files: list[str] = []
+        output_path = Path(output_dir)
+
+        # Step 1: Resolve configuration
+        try:
+            self.config = self._resolve_config(warnings)
+        except Exception as exc:
+            return MeshExportResult(
+                success=False,
+                mesh_stats={},
+                exported_files=[],
+                errors=[f"Configuration error: {exc}"],
+                warnings=warnings,
+            )
+
+        # Step 2: Generate mesh
+        try:
+            self.mesh_data = self._generate_mesh(coarse)
+        except ImportError:
+            logger.info("pygmsh not available, using mock mesh")
+            warnings.append("pygmsh not available -- using mock mesh for export")
+            mesh_gen = MeshGenerator(self.config)
+            self.mesh_data = mesh_gen.create_mock_mesh()
+        except Exception as exc:
+            return MeshExportResult(
+                success=False,
+                mesh_stats={},
+                exported_files=[],
+                errors=[f"Mesh generation error: {exc}"],
+                warnings=warnings,
+            )
+
+        # Step 3: Validate mesh
+        if not validate_mesh_data(self.mesh_data):
+            errors.append("Mesh validation failed -- nodes or elements invalid")
+            return MeshExportResult(
+                success=False,
+                mesh_stats=self._mesh_statistics(),
+                exported_files=[],
+                errors=errors,
+                warnings=warnings,
+            )
+
+        # Step 4: Quality check
+        mesh_gen = MeshGenerator(self.config)
+        quality = mesh_gen.check_mesh_quality(self.mesh_data)
+        if quality.get("mean_quality", 0) < 0.1:
+            warnings.append(
+                f"Low average mesh quality ({quality.get('mean_quality', 0):.3f})"
+            )
+
+        # Step 5: Export to requested formats
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        if "msh" in formats:
+            try:
+                msh_path = output_path / "mesh.msh"
+                export_mesh_to_msh(
+                    self.mesh_data, msh_path, physical_names=physical_names
+                )
+                exported_files.append(str(msh_path))
+                logger.info("Exported MSH to %s", msh_path)
+            except Exception as exc:
+                errors.append(f"MSH export error: {exc}")
+
+        if "mat" in formats:
+            try:
+                mat_path = output_path / "mesh.mat"
+                export_mesh_to_mat(self.mesh_data, mat_path)
+                exported_files.append(str(mat_path))
+                logger.info("Exported MAT to %s", mat_path)
+            except Exception as exc:
+                errors.append(f"MAT export error: {exc}")
+
+        if "json" in formats:
+            try:
+                json_path = output_path / "mesh_metadata.json"
+                self._export_json_metadata(json_path, quality)
+                exported_files.append(str(json_path))
+                logger.info("Exported JSON metadata to %s", json_path)
+            except Exception as exc:
+                errors.append(f"JSON metadata export error: {exc}")
+
+        return MeshExportResult(
+            success=len(errors) == 0,
+            mesh_stats=self._mesh_statistics(),
+            exported_files=exported_files,
+            errors=errors,
+            warnings=warnings,
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_config(self, warnings: list[str]) -> GlassBathFEAConfig:
+        """Resolve FEA configuration from electrode config or direct config."""
+        if self._fea_config is not None:
+            return self._fea_config
+
+        sync = GeometrySynchronizer(self._electrode_config)
+        validation = sync.validate()
+        for w in validation.warnings:
+            warnings.append(w)
+        return sync.sync()
+
+    def _generate_mesh(self, coarse: bool) -> dict:
+        """Generate mesh using MeshGenerator."""
+        assert self.config is not None
+        mesh_gen = MeshGenerator(self.config)
+        return mesh_gen.generate_mesh(coarse=coarse)
+
+    def _mesh_statistics(self) -> dict[str, Any]:
+        """Calculate statistics for the current mesh."""
+        if self.mesh_data is None or self.config is None:
+            return {}
+        mesh_gen = MeshGenerator(self.config)
+        return mesh_gen.get_mesh_statistics(self.mesh_data)
+
+    def _export_json_metadata(self, path: Path, quality: dict) -> None:
+        """Export mesh metadata as JSON."""
+        assert self.config is not None and self.mesh_data is not None
+
+        stats = self._mesh_statistics()
+        metadata = {
+            "mesh_statistics": stats,
+            "mesh_quality": quality,
+            "config": {
+                "bath_diameter_in": self.config.bath_diameter,
+                "glass_depth_in": self.config.glass_depth,
+                "metal_layer_thickness_in": self.config.metal_layer_thickness,
+                "num_electrodes": self.config.num_electrodes,
+                "electrode_diameter_in": self.config.electrode_diameter,
+                "electrode_insertion_depth_in": self.config.electrode_insertion_depth,
+                "operating_temperature_c": self.config.operating_temperature,
+            },
+            "dimensions_meters": self.config.get_dimensions_meters(),
+            "export_formats": ["msh", "mat", "json"],
+        }
+
+        path.write_text(
+            json.dumps(metadata, indent=2, default=_json_default),
+            encoding="utf-8",
+        )
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON serialiser fallback for numpy types."""
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")

--- a/src/pressure_drop_calculator/web/src/components/PressureDropCalculator.tsx
+++ b/src/pressure_drop_calculator/web/src/components/PressureDropCalculator.tsx
@@ -1,6 +1,11 @@
 import { useState, useCallback, useMemo } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar } from 'recharts';
 
+// API base URL -- defaults to shared calc backend.
+// Override via VITE_CALC_API_URL environment variable.
+// See issue #608.
+const CALC_API_BASE = import.meta.env.VITE_CALC_API_URL ?? 'http://localhost:8010';
+
 const PIPE_SIZES = ['0.5', '0.75', '1', '1.25', '1.5', '2', '2.5', '3', '4', '6', '8', '10', '12', '14', '16', '18', '20', '24'];
 const PIPE_SCHEDULES = ['5', '10', '20', '30', '40', '60', '80', '100', '120', '140', '160', 'STD', 'XS', 'XXS'];
 const FLOW_UNITS = ['kg/h', 'kg/s', 'lb/hr', 'm³/h', 'SCFM', 'Nm³/h'];
@@ -36,6 +41,51 @@ interface Results {
   erosionalVelocity: number;
   erosionRatio: number;
   warnings: string[];
+  engine: string;
+}
+
+// ---------------------------------------------------------------------------
+// Backend integration -- See issue #608
+// ---------------------------------------------------------------------------
+
+async function fetchFromBackend(
+  diameter: number,
+  pipeLength: number,
+  roughness: number,
+  massFlowKgS: number,
+  temperature: number,
+  pressurePa: number,
+  mw: number,
+): Promise<{ pressureDropPa: number; reynolds: number; frictionFactor: number; velocity: number; flowRegime: string; density: number; viscosity: number }> {
+  const response = await fetch(`${CALC_API_BASE}/api/calc/pressure-drop`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      pipe_diameter_m: diameter,
+      pipe_length_m: pipeLength,
+      roughness_m: roughness,
+      flow_rate_kg_s: massFlowKgS,
+      temperature_k: temperature,
+      pressure_pa: pressurePa,
+      molecular_weight_kg_mol: mw / 1000,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({ detail: response.statusText }));
+    throw new Error(body.detail ?? `API error ${response.status}`);
+  }
+
+  const data = await response.json();
+  return {
+    pressureDropPa: data.pressure_drop_pa,
+    reynolds: data.reynolds_number,
+    frictionFactor: data.friction_factor,
+    velocity: data.velocity_m_s,
+    flowRegime: data.flow_regime,
+    density: data.density_kg_m3,
+    viscosity: data.viscosity_pa_s,
+  };
 }
 
 // Physical constants and helper functions
@@ -90,7 +140,7 @@ export function PressureDropCalculator() {
     setGasComp(prev => ({ ...prev, [key]: val }));
   }, []);
 
-  const calculate = useCallback(() => {
+  const calculate = useCallback(async () => {
     // Normalize composition
     const total = Object.values(gasComp).reduce((a, b) => a + b, 0);
     if (Math.abs(total - 100) > 1) {
@@ -114,17 +164,38 @@ export function PressureDropCalculator() {
       massFlowKgS = flowRate * rho / 3600;
     }
 
-    // Calculate properties
+    // Calculate properties (client-side, used as fallback and for derived metrics)
     const mw = calcMixtureMW(normComp);
     const P_Pa = pressure * 1e5;
-    const rho = calcDensity(P_Pa, temperature, mw);
-    const mu = calcViscosity(temperature);
-    const velocity = massFlowKgS / (rho * area);
-    const Re = rho * velocity * diameter / mu;
-    const f = colebrookFrictionFactor(Re, roughness, diameter);
 
-    // Friction pressure drop (Darcy-Weisbach)
-    const dP_friction = f * (pipeLength / diameter) * 0.5 * rho * velocity * velocity;
+    // Try the validated Python backend first; fall back to client-side.
+    // See issue #608.
+    let engine = 'client-fallback';
+    let rho: number;
+    let velocity: number;
+    let Re: number;
+    let f: number;
+    let dP_friction: number;
+
+    try {
+      const backend = await fetchFromBackend(
+        diameter, pipeLength, roughness, massFlowKgS, temperature, P_Pa, mw,
+      );
+      rho = backend.density;
+      velocity = backend.velocity;
+      Re = backend.reynolds;
+      f = backend.frictionFactor;
+      dP_friction = backend.pressureDropPa;
+      engine = 'python-backend';
+    } catch {
+      // Fallback: local Darcy-Weisbach
+      rho = calcDensity(P_Pa, temperature, mw);
+      const mu = calcViscosity(temperature);
+      velocity = massFlowKgS / (rho * area);
+      Re = rho * velocity * diameter / mu;
+      f = colebrookFrictionFactor(Re, roughness, diameter);
+      dP_friction = f * (pipeLength / diameter) * 0.5 * rho * velocity * velocity;
+    }
 
     // Elevation pressure drop
     const dP_elevation = rho * 9.81 * elevation;
@@ -161,6 +232,7 @@ export function PressureDropCalculator() {
       erosionalVelocity: erosionalVel,
       erosionRatio: velocity / erosionalVel,
       warnings,
+      engine,
     });
     setActiveTab('results');
   }, [pipeSize, pipeLength, material, elevation, flowRate, flowUnit, pressure, temperature, gasComp, frictionMethod]);
@@ -341,9 +413,14 @@ export function PressureDropCalculator() {
                   ))}
                 </ul>
               ) : (
-                <p className="text-green-400 text-sm">✓ No warnings. All parameters within acceptable ranges.</p>
+                <p className="text-green-400 text-sm">No warnings. All parameters within acceptable ranges.</p>
               )}
             </div>
+          </div>
+
+          {/* Engine indicator -- See issue #608 */}
+          <div className="text-right">
+            <span className="text-xs text-slate-500">Engine: {results.engine}</span>
           </div>
         </div>
       )}

--- a/src/shared/python/calc_backend/app.py
+++ b/src/shared/python/calc_backend/app.py
@@ -21,6 +21,7 @@ from .routers import (
     baghouse,
     financial,
     flare,
+    flow_rate,
     pressure_drop,
     scrubber,
     wgs_reactor,
@@ -61,6 +62,7 @@ app.include_router(scrubber.router)
 app.include_router(financial.router)
 app.include_router(acid_gas_dewpoint.router)
 app.include_router(pressure_drop.router)
+app.include_router(flow_rate.router)
 
 
 # ---------------------------------------------------------------------------
@@ -86,5 +88,6 @@ def list_endpoints() -> dict[str, list[str]]:
             "POST /api/calc/financial",
             "POST /api/calc/acid-gas-dewpoint",
             "POST /api/calc/pressure-drop",
+            "POST /api/calc/flow-rate",
         ],
     }

--- a/src/shared/python/calc_backend/contracts/__init__.py
+++ b/src/shared/python/calc_backend/contracts/__init__.py
@@ -8,6 +8,7 @@ from .acid_gas_dewpoint import AcidGasDewpointRequest, AcidGasDewpointResponse
 from .baghouse import BaghouseRequest, BaghouseResponse
 from .financial import FinancialRequest, FinancialResponse
 from .flare import FlareRequest, FlareResponse
+from .flow_rate import FlowRateConvertRequest, FlowRateConvertResponse
 from .pressure_drop import PressureDropRequest, PressureDropResponse
 from .scrubber import ScrubberRequest, ScrubberResponse
 from .wgs_reactor import WGSReactorRequest, WGSReactorResponse
@@ -27,4 +28,6 @@ __all__ = [
     "AcidGasDewpointResponse",
     "PressureDropRequest",
     "PressureDropResponse",
+    "FlowRateConvertRequest",
+    "FlowRateConvertResponse",
 ]

--- a/src/shared/python/calc_backend/contracts/flow_rate.py
+++ b/src/shared/python/calc_backend/contracts/flow_rate.py
@@ -1,0 +1,26 @@
+"""Pydantic contracts for flow rate converter endpoints.  See issue #608."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class FlowRateConvertRequest(BaseModel):
+    """Request model for flow rate unit conversion."""
+
+    value: float = Field(..., description="Numeric value to convert")
+    from_unit: str = Field(..., description="Source unit (e.g. 'kg/s', 'lb/h')")
+    to_unit: str = Field(..., description="Target unit")
+    category: str = Field(
+        default="mass",
+        description="Flow category: 'mass', 'molar', or 'volumetric'",
+    )
+
+
+class FlowRateConvertResponse(BaseModel):
+    """Response model for flow rate conversion."""
+
+    result: float = Field(description="Converted value")
+    from_unit: str
+    to_unit: str
+    category: str

--- a/src/shared/python/calc_backend/routers/flow_rate.py
+++ b/src/shared/python/calc_backend/routers/flow_rate.py
@@ -1,0 +1,93 @@
+"""Flow rate converter router.  See issue #608."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from ..contracts.flow_rate import FlowRateConvertRequest, FlowRateConvertResponse
+
+router = APIRouter(prefix="/api/calc/flow-rate", tags=["flow-rate"])
+
+# ---------------------------------------------------------------------------
+# Conversion factors -- all relative to SI base (kg/s, mol/s, m3/s)
+# ---------------------------------------------------------------------------
+
+MASS_TO_KG_S: dict[str, float] = {
+    "kg/s": 1.0,
+    "kg/h": 1.0 / 3600.0,
+    "kg/min": 1.0 / 60.0,
+    "g/s": 1e-3,
+    "g/h": 1e-3 / 3600.0,
+    "lb/s": 0.45359237,
+    "lb/h": 0.45359237 / 3600.0,
+    "lb/min": 0.45359237 / 60.0,
+    "ton/h": 1000.0 / 3600.0,
+}
+
+MOLAR_TO_MOL_S: dict[str, float] = {
+    "mol/s": 1.0,
+    "mol/h": 1.0 / 3600.0,
+    "mol/min": 1.0 / 60.0,
+    "kmol/s": 1e3,
+    "kmol/h": 1e3 / 3600.0,
+    "kmol/min": 1e3 / 60.0,
+    "lbmol/s": 453.59237,
+    "lbmol/h": 453.59237 / 3600.0,
+    "lbmol/min": 453.59237 / 60.0,
+}
+
+VOLUMETRIC_TO_M3_S: dict[str, float] = {
+    "m3/s": 1.0,
+    "m3/h": 1.0 / 3600.0,
+    "m3/min": 1.0 / 60.0,
+    "L/s": 1e-3,
+    "L/min": 1e-3 / 60.0,
+    "L/h": 1e-3 / 3600.0,
+    "ft3/s": 0.028316846592,
+    "ft3/min": 0.028316846592 / 60.0,
+    "ft3/h": 0.028316846592 / 3600.0,
+    "CFM": 0.028316846592 / 60.0,
+    "GPM": 6.30902e-5,
+}
+
+_TABLES = {
+    "mass": MASS_TO_KG_S,
+    "molar": MOLAR_TO_MOL_S,
+    "volumetric": VOLUMETRIC_TO_M3_S,
+}
+
+
+@router.post("", response_model=FlowRateConvertResponse)
+def convert_flow_rate(request: FlowRateConvertRequest) -> FlowRateConvertResponse:
+    """Convert a flow rate value between compatible units."""
+    table = _TABLES.get(request.category)
+    if table is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown category '{request.category}'. "
+            f"Must be one of: {', '.join(_TABLES)}",
+        )
+
+    if request.from_unit not in table:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown from_unit '{request.from_unit}' for category "
+            f"'{request.category}'. Valid units: {', '.join(table)}",
+        )
+    if request.to_unit not in table:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown to_unit '{request.to_unit}' for category "
+            f"'{request.category}'. Valid units: {', '.join(table)}",
+        )
+
+    # Convert: source -> base SI -> target
+    base = request.value * table[request.from_unit]
+    result = base / table[request.to_unit]
+
+    return FlowRateConvertResponse(
+        result=result,
+        from_unit=request.from_unit,
+        to_unit=request.to_unit,
+        category=request.category,
+    )

--- a/tests/calc_backend/test_calc_backend_api.py
+++ b/tests/calc_backend/test_calc_backend_api.py
@@ -338,3 +338,104 @@ class TestWGSReactorEndpoint:
         self._skip_if_unavailable(resp)
         assert resp.status_code == 200
         assert resp.json()["sizing"] is None
+
+
+# ---------------------------------------------------------------------------
+# Flow Rate Converter -- See issue #608
+# ---------------------------------------------------------------------------
+
+
+class TestFlowRateEndpoint:
+    """POST /api/calc/flow-rate"""
+
+    def test_mass_kg_h_to_lb_h(self) -> None:
+        """Convert 1000 kg/h to lb/h."""
+        resp = client.post(
+            "/api/calc/flow-rate",
+            json={
+                "value": 1000.0,
+                "from_unit": "kg/h",
+                "to_unit": "lb/h",
+                "category": "mass",
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["from_unit"] == "kg/h"
+        assert data["to_unit"] == "lb/h"
+        # 1 kg = 2.20462 lb
+        assert abs(data["result"] - 2204.62) < 1.0
+
+    def test_mass_identity(self) -> None:
+        """Same unit should return the same value."""
+        resp = client.post(
+            "/api/calc/flow-rate",
+            json={
+                "value": 42.0,
+                "from_unit": "kg/s",
+                "to_unit": "kg/s",
+                "category": "mass",
+            },
+        )
+        assert resp.status_code == 200
+        assert abs(resp.json()["result"] - 42.0) < 1e-9
+
+    def test_molar_kmol_h_to_mol_s(self) -> None:
+        """Convert 100 kmol/h to mol/s."""
+        resp = client.post(
+            "/api/calc/flow-rate",
+            json={
+                "value": 100.0,
+                "from_unit": "kmol/h",
+                "to_unit": "mol/s",
+                "category": "molar",
+            },
+        )
+        assert resp.status_code == 200
+        # 100 * 1000 / 3600 = 27.778 mol/s
+        assert abs(resp.json()["result"] - 27.778) < 0.01
+
+    def test_volumetric_m3_h_to_cfm(self) -> None:
+        """Convert 1000 m3/h to CFM."""
+        resp = client.post(
+            "/api/calc/flow-rate",
+            json={
+                "value": 1000.0,
+                "from_unit": "m3/h",
+                "to_unit": "CFM",
+                "category": "volumetric",
+            },
+        )
+        assert resp.status_code == 200
+        # 1 m3/h = 0.5886 CFM, so 1000 m3/h = 588.6 CFM
+        assert abs(resp.json()["result"] - 588.58) < 1.0
+
+    def test_invalid_category(self) -> None:
+        resp = client.post(
+            "/api/calc/flow-rate",
+            json={
+                "value": 1.0,
+                "from_unit": "kg/s",
+                "to_unit": "lb/h",
+                "category": "invalid",
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_unit(self) -> None:
+        resp = client.post(
+            "/api/calc/flow-rate",
+            json={
+                "value": 1.0,
+                "from_unit": "bananas/s",
+                "to_unit": "lb/h",
+                "category": "mass",
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_endpoints_list_includes_flow_rate(self) -> None:
+        resp = client.get("/api/calc/endpoints")
+        assert resp.status_code == 200
+        endpoints = resp.json()["calculators"]
+        assert any("flow-rate" in ep for ep in endpoints)

--- a/tests/glass_bath_fea/test_mesh_export_pipeline.py
+++ b/tests/glass_bath_fea/test_mesh_export_pipeline.py
@@ -1,0 +1,244 @@
+"""Tests for the Glass Bath FEA mesh export pipeline.
+
+Verifies the end-to-end export workflow: config resolution, mesh generation,
+validation, and multi-format export (.msh, .mat, .json).
+
+See issue #579.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from glass_bath_fea.core.config import GlassBathFEAConfig
+from glass_bath_fea.exporters.mat_exporter import validate_mesh_data
+from glass_bath_fea.exporters.mesh_export_pipeline import (
+    MeshExportPipeline,
+)
+from glass_bath_fea.exporters.msh_exporter import read_msh_file
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_stub_electrode_config(**overrides: float) -> MagicMock:
+    """Create a stub that looks like ``ElectrodeConfig``."""
+    defaults = {
+        "bath_diameter": 120.0,
+        "glass_depth": 15.0,
+        "metal_depth": 2.0,
+        "tip_diameter": 6.0,
+        "electrode_spacing_degrees": 120.0,
+        "bath_temperature": 1350.0,
+        "metal_conductivity": 10000.0,
+        "electrode_depths": np.array([10.0, 10.0, 10.0]),
+        "phase_voltages": np.array([100.0, 100.0, 100.0]),
+    }
+    defaults.update(overrides)
+    cfg = MagicMock(**defaults)
+    for k, v in defaults.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Tests: direct FEA config (skips geometry sync)
+# ---------------------------------------------------------------------------
+
+
+class TestMeshExportPipelineDirectConfig:
+    """Pipeline with a direct GlassBathFEAConfig (no electrode sync)."""
+
+    def test_export_all_formats(self) -> None:
+        """Export to all three formats and verify files exist."""
+        config = GlassBathFEAConfig()
+        pipeline = MeshExportPipeline(fea_config=config)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = pipeline.run(output_dir=tmp, formats=["msh", "mat", "json"])
+
+        assert result.success, f"Pipeline failed: {result.errors}"
+        assert len(result.exported_files) == 3
+        assert result.mesh_stats.get("num_nodes", 0) > 0
+        assert result.mesh_stats.get("num_elements", 0) > 0
+
+    def test_export_msh_only(self) -> None:
+        """Export only MSH and verify the file is valid."""
+        config = GlassBathFEAConfig()
+        pipeline = MeshExportPipeline(fea_config=config)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = pipeline.run(output_dir=tmp, formats=["msh"])
+            assert result.success
+
+            msh_path = Path(tmp) / "mesh.msh"
+            assert msh_path.exists()
+
+            # Read it back and verify structure
+            mesh_back = read_msh_file(msh_path)
+            assert mesh_back["nodes"].shape[0] == 3
+            assert mesh_back["nodes"].shape[1] > 0
+
+    def test_export_mat_only(self) -> None:
+        """Export only MAT."""
+        config = GlassBathFEAConfig()
+        pipeline = MeshExportPipeline(fea_config=config)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = pipeline.run(output_dir=tmp, formats=["mat"])
+            assert result.success
+
+            mat_path = Path(tmp) / "mesh.mat"
+            assert mat_path.exists()
+            assert mat_path.stat().st_size > 0
+
+    def test_export_json_metadata(self) -> None:
+        """Export JSON metadata and verify contents."""
+        config = GlassBathFEAConfig()
+        pipeline = MeshExportPipeline(fea_config=config)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = pipeline.run(output_dir=tmp, formats=["json"])
+            assert result.success
+
+            json_path = Path(tmp) / "mesh_metadata.json"
+            assert json_path.exists()
+
+            metadata = json.loads(json_path.read_text(encoding="utf-8"))
+            assert "mesh_statistics" in metadata
+            assert "config" in metadata
+            assert "dimensions_meters" in metadata
+            assert metadata["config"]["bath_diameter_in"] == config.bath_diameter
+
+    def test_mesh_statistics_populated(self) -> None:
+        """Verify mesh statistics are returned."""
+        config = GlassBathFEAConfig()
+        pipeline = MeshExportPipeline(fea_config=config)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = pipeline.run(output_dir=tmp, formats=["json"])
+
+        assert result.mesh_stats["num_nodes"] > 0
+        assert result.mesh_stats["num_elements"] > 0
+
+    def test_custom_physical_names(self) -> None:
+        """Custom physical names propagate to MSH export."""
+        config = GlassBathFEAConfig()
+        pipeline = MeshExportPipeline(fea_config=config)
+        names = {1: "Molten_Glass", 2: "Metal_Bottom", 3: "Electrode_Zone"}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = pipeline.run(output_dir=tmp, formats=["msh"], physical_names=names)
+            assert result.success
+
+            # Read MSH and verify physical names appear
+            msh_text = (Path(tmp) / "mesh.msh").read_text(encoding="utf-8")
+            assert "$PhysicalNames" in msh_text
+
+
+# ---------------------------------------------------------------------------
+# Tests: electrode sync path
+# ---------------------------------------------------------------------------
+
+
+class TestMeshExportPipelineWithSync:
+    """Pipeline using GeometrySynchronizer from electrode config."""
+
+    def test_sync_and_export(self) -> None:
+        """Full pipeline with electrode config sync."""
+        ec = _make_stub_electrode_config()
+        pipeline = MeshExportPipeline(electrode_config=ec)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = pipeline.run(output_dir=tmp, formats=["msh", "json"])
+
+        assert result.success, f"Pipeline failed: {result.errors}"
+        assert len(result.exported_files) == 2
+
+    def test_invalid_electrode_config_returns_error(self) -> None:
+        """Pipeline returns error for geometrically invalid electrode config."""
+        ec = _make_stub_electrode_config(
+            bath_diameter=10.0,
+            electrode_depths=np.array([100.0, 100.0, 100.0]),
+        )
+        pipeline = MeshExportPipeline(electrode_config=ec)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            result = pipeline.run(output_dir=tmp)
+
+        assert not result.success
+        assert len(result.errors) > 0
+        assert "Configuration error" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests: mesh validation edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestMeshValidation:
+    """Edge-case validation within the pipeline."""
+
+    def test_validate_mesh_data_valid(self) -> None:
+        """A proper mesh passes validation."""
+        mesh_data = {
+            "nodes": np.array([[0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]]),
+            "elements": np.array([[1], [2], [3], [4]]),
+            "material_ids": np.array([1]),
+        }
+        assert validate_mesh_data(mesh_data) is True
+
+    def test_validate_mesh_data_empty_nodes(self) -> None:
+        """Empty nodes fails validation."""
+        mesh_data = {
+            "nodes": np.array([]).reshape(3, 0),
+            "elements": np.array([]).reshape(4, 0),
+        }
+        assert validate_mesh_data(mesh_data) is False
+
+    def test_validate_mesh_data_bad_index(self) -> None:
+        """Element referencing non-existent node fails."""
+        mesh_data = {
+            "nodes": np.array([[0, 1], [0, 0], [0, 0]]),
+            "elements": np.array([[1], [2], [3], [99]]),  # node 99 doesn't exist
+        }
+        assert validate_mesh_data(mesh_data) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: round-trip MSH
+# ---------------------------------------------------------------------------
+
+
+class TestMshRoundTrip:
+    """Verify MSH export -> read round-trip preserves mesh data."""
+
+    def test_round_trip(self) -> None:
+        """Export a simple mesh to MSH and read it back."""
+        nodes = np.array([[0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]], dtype=float)
+        elements = np.array([[1, 1], [2, 2], [3, 3], [4, 4]])
+        material_ids = np.array([1, 2])
+
+        mesh_data = {
+            "nodes": nodes,
+            "elements": elements,
+            "material_ids": material_ids,
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "test.msh"
+            from glass_bath_fea.exporters.msh_exporter import export_mesh_to_msh
+
+            export_mesh_to_msh(mesh_data, out)
+
+            mesh_back = read_msh_file(out)
+
+        assert mesh_back["nodes"].shape == nodes.shape
+        np.testing.assert_allclose(mesh_back["nodes"], nodes, atol=1e-10)
+        assert mesh_back["elements"].shape == elements.shape


### PR DESCRIPTION
## Summary
- **Flow Rate Converter** (#608): New `POST /api/calc/flow-rate` calc_backend endpoint with mass/molar/volumetric conversion tables + React component with category tabs, swap-units UX, and backend-first/client-fallback pattern
- **Pressure Drop Calculator** (#608): Integrated with calc_backend `/api/calc/pressure-drop` using backend-first/fallback pattern, added engine indicator
- **Acid Gas Dewpoint & Baghouse** (#608): Already had backend integration from Phase 3 (confirmed working)
- **Data Processor Analytics Suite** (#607): New `AnalyticsSuite` component with correlation matrix heatmap, PCA (scree plot + biplot + loadings table), and polynomial regression with residual diagnostics
- **Glass Bath FEA Mesh Export Pipeline** (#579): `MeshExportPipeline` orchestrates electrode config sync -> mesh generation -> multi-format export (.msh, .mat, .json metadata) with quality checks and validation

## Test plan
- [x] 7 new flow-rate endpoint tests (unit conversion accuracy, identity, invalid categories/units)
- [x] 12 new mesh export pipeline tests (direct config, sync path, round-trip MSH, validation edge cases)
- [x] All 57 existing calc_backend + glass_bath_fea tests still pass (3 WGS skipped -- pre-existing)
- [x] Ruff check + format clean

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple domains (React UIs plus shared FastAPI backend) and adds nontrivial analytics/mesh-export logic; main risk is runtime correctness/performance and API compatibility rather than security-sensitive behavior.
> 
> **Overview**
> **Adds three new capabilities across web + Python.** The Data Processor UI gains a new right-sidebar `AnalyticsSuite` tab providing correlation, PCA, and regression views (with new analytics types exported in `types`).
> 
> Introduces a new Flow Rate Converter React app that calls a new calc backend `POST /api/calc/flow-rate` endpoint (with Pydantic contracts), using a backend-first/client-fallback conversion strategy; the backend’s endpoint list is updated accordingly and new API tests are added.
> 
> Updates the Pressure Drop Calculator UI to prefer the existing backend `POST /api/calc/pressure-drop` (fallback to local calculation) and display which engine was used.
> 
> Adds a `MeshExportPipeline` to Glass Bath FEA to orchestrate config resolution (optional geometry sync), mesh generation/validation/quality checks, and exporting `.msh`/`.mat` plus JSON metadata; exporters are re-exported and comprehensive pipeline/round-trip tests are added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bebcf768cf3b94e48e49588deb271fa4f15311a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->