### PR TITLE
fix: make mypy blocking in CI and pin requirements-lock.txt (#650, #653)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -3,19 +3,19 @@ on:
   push:
     branches: ["**"]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.github/**'
+      - "docs/**"
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+      - ".github/**"
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.github/**'
+      - "docs/**"
+      - "**.md"
+      - "LICENSE"
+      - ".gitignore"
+      - ".github/**"
   workflow_dispatch:
 
 concurrency:
@@ -49,7 +49,6 @@ jobs:
         run: black --check .
 
       - name: Type Check (Mypy)
-        continue-on-error: true  # Non-blocking - address type issues incrementally
         run: mypy . --ignore-missing-imports --install-types --non-interactive --exclude "tests/"
 
       # CodeQL is explicitly disabled via codeql-analysis.yml to reduce costs.

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -1,39 +1,35 @@
-# Locked dependency versions for reproducibility
-# Generated from requirements.txt - pin exact versions to ensure consistent builds
-# To update: pip install -r requirements.txt && pip freeze | grep -E "(numpy|pandas|scipy|matplotlib|sympy|pytest|ruff|mypy|PyQt6|pygame|PyOpenGL|flask|cryptography|pyyaml|playwright|pytest-cov|types-PyYAML|types-requests)" > requirements-lock.txt
+# Locked dependency versions for reproducible builds
+# Generated: 2026-02-10
+# To regenerate: pip install -r requirements.txt && pip freeze > requirements-lock.txt
 
 # Core Scientific Computing
-numpy==2.2.6
-pandas>=2.2.2  # Note: Exact version depends on environment
-scipy==1.15.3
-matplotlib==3.5.1
-sympy==1.9
+numpy==2.4.1
+pandas==2.2.3
+scipy==1.16.0
+matplotlib==3.10.3
+sympy==1.14.0
 
 # Testing & Quality Assurance
-pytest==9.0.2
-pytest-cov  # Version depends on pytest version
-ruff==0.5.0
-mypy==1.19.1
-types-PyYAML  # Version depends on PyYAML version
-types-requests  # Version depends on requests version
+pytest==8.4.1
+pytest-cov==7.0.0
+ruff==0.14.10
+black==26.1.0
+mypy==1.13.0
+bandit==1.9.3
+types-PyYAML==6.0.12.20250915
+types-requests==2.32.4.20250913
 
 # GUI & Desktop Applications
-PyQt6>=6.7.0  # Note: Exact version depends on environment
-pygame>=2.0.0  # Note: Exact version depends on environment
-PyOpenGL>=3.1.5  # Note: Exact version depends on environment
-PyOpenGL_accelerate>=3.1.5  # Note: Exact version depends on environment
+PyQt6==6.9.1
+pygame==2.6.1
+PyOpenGL==3.1.9
 
 # Web Applications
-flask>=3.0.0  # Note: Exact version depends on environment
+flask==3.1.1
 
-# Security & Encryption
-cryptography==3.4.8
-
-# Data Formats & Configuration
-pyyaml>=6.0.1  # Note: Exact version depends on environment
-
-# Web Automation & Testing
-playwright>=1.40.0  # Note: Exact version depends on environment
-
-# Note: Some packages show >= because they weren't installed in the current environment.
-# For full reproducibility, run: pip install -r requirements.txt && pip freeze > requirements-lock.txt
+# Security & Utilities
+cryptography==45.0.5
+defusedxml==0.7.1
+PyYAML==6.0.2
+pillow==11.2.1
+trimesh==4.11.1


### PR DESCRIPTION
Phase 4: Made mypy blocking (removed continue-on-error). Pinned all deps with exact versions. Closes #650, #653

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI will now fail on mypy type errors, which can block merges for existing typing issues. Large dependency version changes may also introduce compatibility or build/test regressions across Python versions.
> 
> **Overview**
> Makes the `mypy` type-check step in `ci-standard.yml` *blocking* by removing `continue-on-error`, so type errors now fail the quality gate.
> 
> Refreshes `requirements-lock.txt` from a partial/annotated list to a fully pinned lockfile (with updated versions and additional pinned tooling/security deps), improving build reproducibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45e08b2308aabe4e27da17ed768070a7d7000537. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->