### PR TITLE
feat: add tool_surface_contract.json generation for cross-repo parity

### DIFF
--- a/.github/workflows/check-tools-manifest.yml
+++ b/.github/workflows/check-tools-manifest.yml
@@ -1,34 +1,61 @@
 name: Check Tools Manifest
 
 on:
-    push:
-        paths:
-            - "src/**/gui_registration.py"
-            - "scripts/generate_tools_json.py"
-            - "tools.json"
-    pull_request:
-        paths:
-            - "src/**/gui_registration.py"
-            - "scripts/generate_tools_json.py"
-            - "tools.json"
+  push:
+    paths:
+      - "src/**/gui_registration.py"
+      - "scripts/generate_tools_json.py"
+      - "tools.json"
+      - "tool_surface_contract.json"
+  pull_request:
+    paths:
+      - "src/**/gui_registration.py"
+      - "scripts/generate_tools_json.py"
+      - "tools.json"
+      - "tool_surface_contract.json"
 
 jobs:
-    check-manifest:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
+  check-manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: "3.11"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
 
-            - name: Generate tools.json
-              run: python scripts/generate_tools_json.py
+      - name: Generate tools.json and tool_surface_contract.json
+        run: python scripts/generate_tools_json.py
 
-            - name: Check for changes
-              run: |
-                  git diff --exit-code tools.json || {
-                    echo "tools.json is out of sync with gui_registration.py files."
-                    echo "Please run python scripts/generate_tools_json.py and commit the result."
-                    exit 1
-                  }
+      - name: Check tools.json for changes
+        run: |
+          git diff --exit-code tools.json || {
+            echo "::error::tools.json is out of sync with gui_registration.py files."
+            echo "Run: python scripts/generate_tools_json.py"
+            exit 1
+          }
+
+      - name: Check tool_surface_contract.json for changes
+        run: |
+          git diff --exit-code tool_surface_contract.json || {
+            echo "::error::tool_surface_contract.json is out of sync with gui_registration.py files."
+            echo "Run: python scripts/generate_tools_json.py"
+            exit 1
+          }
+
+      - name: Publish contract summary
+        if: always()
+        run: |
+          echo "## Tool Surface Contract" >> "$GITHUB_STEP_SUMMARY"
+          python -c "
+          import json
+          c = json.load(open('tool_surface_contract.json'))
+          tools = c['tools']
+          dual = sum(1 for t in tools if t['surfaces']['pyqt6'] and t['surfaces']['web'])
+          pyqt_only = sum(1 for t in tools if t['surfaces']['pyqt6'] and not t['surfaces']['web'])
+          web_only = sum(1 for t in tools if not t['surfaces']['pyqt6'] and t['surfaces']['web'])
+          print(f'- **Total tools**: {len(tools)}')
+          print(f'- **Dual surface** (PyQt6 + Web): {dual}')
+          print(f'- **PyQt6 only**: {pyqt_only}')
+          print(f'- **Web only**: {web_only}')
+          " >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/generate_tools_json.py
+++ b/scripts/generate_tools_json.py
@@ -1,100 +1,250 @@
 #!/usr/bin/env python3
-"""Generate tools.json from gui_registration.py files."""
+"""Generate tools.json and tool_surface_contract.json from gui_registration.py files.
+
+This script scans all gui_registration.py files under src/ and produces:
+1. tools.json — Unified Launcher manifest (categorized, surface-expanded entries)
+2. tool_surface_contract.json — Cross-repo parity contract (one entry per logical tool)
+"""
 
 import importlib.util
 import json
-import sys
+import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
-def load_gui_info(path: Path) -> Optional[Dict[str, Any]]:
-    """Load GUI_INFO from a python file."""
+logger = logging.getLogger(__name__)
+
+CONTRACT_VERSION = "1.0.0"
+
+
+@dataclass(frozen=True)
+class ToolRegistration:
+    """Internal representation of a discovered tool registration.
+
+    Invariants (Design by Contract):
+    - id is always a non-empty snake_case string
+    - name is always a non-empty string
+    - category is always a non-empty string
+    - At least one surface (has_pyqt6 or has_web) is True
+    """
+
+    id: str
+    name: str
+    description: str
+    category: str
+    has_pyqt6: bool
+    has_web: bool
+
+
+def load_gui_info(path: Path) -> dict[str, Any] | None:
+    """Load GUI_INFO from a python file.
+
+    Pre-condition: path is a valid file path.
+    Post-condition: Returns the GUI_INFO dict or None if not loadable.
+    """
     try:
-
-        spec = importlib.util.spec_from_file_location(f"gui_reg_{path.stem}", path)
+        spec = importlib.util.spec_from_file_location(
+            f"gui_reg_{path.parent.name}", path
+        )
         if spec is None or spec.loader is None:
             return None
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         return getattr(module, "GUI_INFO", None)
-    except Exception as e:
-        print(f"Warning: Failed to load {path}: {e}", file=sys.stderr)
+    except Exception as exc:
+        logger.warning("Failed to load %s: %s", path, exc)
         return None
 
-def generate_manifest_data(repo_root: Path) -> Dict[str, List[Dict[str, Any]]]:
-    """Generate manifest data from gui_registration.py files."""
-    src_dir = repo_root / "src"
-    manifest: Dict[str, List[Dict[str, Any]]] = {}
 
-    # Find all gui_registration.py files
-    for reg_file in src_dir.glob("**/gui_registration.py"):
+def _discover_registrations(repo_root: Path) -> list[ToolRegistration]:
+    """Discover all gui_registration.py files and extract ToolRegistration entries.
+
+    Pre-condition: repo_root / 'src' exists.
+    Post-condition: Returns a sorted (by id) list of unique ToolRegistrations.
+    """
+    src_dir = repo_root / "src"
+    seen_ids: dict[str, ToolRegistration] = {}
+
+    for reg_file in sorted(src_dir.glob("**/gui_registration.py")):
         info = load_gui_info(reg_file)
         if not info:
             continue
-            
-        category = info.get("category", "Uncategorized")
-        if category not in manifest:
-            manifest[category] = []
-            
-        base_name = info.get("name", "Unknown Tool")
+
         tool_dir = reg_file.parent
-        
-        # Check for PyQt6 surface
-        if "pyqt6" in info:
-            # Check if launch script exists
-            launch_script = tool_dir / "launch_pyqt6.py"
-            if launch_script.exists():
-                # Determine name: if web also exists, append (PyQt6)
-                name = base_name
-                if "web" in info:
-                    name = f"{base_name} (PyQt6)"
-                    
-                entry = {
-                    "name": name,
-                    "path": str(launch_script.relative_to(repo_root)).replace("\\", "/"),
-                    "type": "python",
-                    "desc": info.get("description", "")
-                }
-                manifest[category].append(entry)
 
-        # Check for Web surface
-        if "web" in info:
-            launch_script = tool_dir / "launch_web.py"
-            if launch_script.exists():
-                name = base_name
-                if "pyqt6" in info:
-                    name = f"{base_name} (Web)"
-                else:
-                    name = f"{base_name} (Web)" # Web usually implies distinct runtime, so explicit suffix is good
+        # Determine tool ID: prefer explicit 'tool_name', fall back to directory name
+        tool_id = info.get("tool_name") or tool_dir.name
 
-                entry = {
-                    "name": name,
-                    "path": str(launch_script.relative_to(repo_root)).replace("\\", "/"),
-                    "type": "python",
-                    "desc": info.get("description", "")
-                }
-                manifest[category].append(entry)
+        # Determine surface availability
+        has_pyqt6 = "pyqt6" in info and (tool_dir / "launch_pyqt6.py").exists()
+        has_web = "web" in info and (tool_dir / "launch_web.py").exists()
+
+        # Skip tools with no available surface
+        if not has_pyqt6 and not has_web:
+            continue
+
+        registration = ToolRegistration(
+            id=tool_id,
+            name=info.get("name", "Unknown Tool"),
+            description=info.get("description", ""),
+            category=info.get("category", "Uncategorized"),
+            has_pyqt6=has_pyqt6,
+            has_web=has_web,
+        )
+
+        if tool_id in seen_ids:
+            logger.warning(
+                "Duplicate tool_name '%s' found, skipping %s", tool_id, reg_file
+            )
+        else:
+            seen_ids[tool_id] = registration
+
+    return sorted(seen_ids.values(), key=lambda r: r.id)
+
+
+def generate_manifest_data(repo_root: Path) -> dict[str, list[dict[str, Any]]]:
+    """Generate manifest data (tools.json format) from gui_registration.py files.
+
+    Pre-condition: repo_root is a valid repo root with src/ directory.
+    Post-condition: Returns a dict keyed by category with sorted tool entries.
+    """
+    registrations = _discover_registrations(repo_root)
+    manifest: dict[str, list[dict[str, Any]]] = {}
+
+    for reg in registrations:
+        if reg.category not in manifest:
+            manifest[reg.category] = []
+
+        if reg.has_pyqt6:
+            name = f"{reg.name} (PyQt6)" if reg.has_web else reg.name
+            src_dir = repo_root / "src"
+            # We need to find the actual registration file to get the right path
+            tool_dir = _find_tool_dir(src_dir, reg.id)
+            if tool_dir:
+                launch_script = tool_dir / "launch_pyqt6.py"
+                manifest[reg.category].append(
+                    {
+                        "name": name,
+                        "path": str(launch_script.relative_to(repo_root)).replace(
+                            "\\", "/"
+                        ),
+                        "type": "python",
+                        "desc": reg.description,
+                    }
+                )
+
+        if reg.has_web:
+            name = f"{reg.name} (Web)" if reg.has_pyqt6 else f"{reg.name} (Web)"
+            src_dir = repo_root / "src"
+            tool_dir = _find_tool_dir(src_dir, reg.id)
+            if tool_dir:
+                launch_script = tool_dir / "launch_web.py"
+                manifest[reg.category].append(
+                    {
+                        "name": name,
+                        "path": str(launch_script.relative_to(repo_root)).replace(
+                            "\\", "/"
+                        ),
+                        "type": "python",
+                        "desc": reg.description,
+                    }
+                )
 
     # Sort categories and tools for determinism
-    sorted_manifest = {}
+    sorted_manifest: dict[str, list[dict[str, Any]]] = {}
     for cat in sorted(manifest.keys()):
         tools = manifest[cat]
-        # Sort tools by name
         tools.sort(key=lambda x: x["name"])
         sorted_manifest[cat] = tools
-        
+
     return sorted_manifest
 
-def main():
+
+def _find_tool_dir(src_dir: Path, tool_id: str) -> Path | None:
+    """Find the directory containing a tool's gui_registration.py by its ID.
+
+    Searches gui_registration.py files for a matching tool_name or directory name.
+    """
+    for reg_file in sorted(src_dir.glob("**/gui_registration.py")):
+        info = load_gui_info(reg_file)
+        if not info:
+            continue
+        candidate_id = info.get("tool_name") or reg_file.parent.name
+        if candidate_id == tool_id:
+            return reg_file.parent
+    return None
+
+
+def generate_contract_data(repo_root: Path) -> dict[str, Any]:
+    """Generate tool surface contract data for cross-repo parity checking.
+
+    Pre-condition: repo_root is a valid repo root with src/ directory.
+    Post-condition: Returns a dict conforming to tool_surface_contract.schema.json:
+      - "version": semver string
+      - "tools": list of tool entries sorted by id, each with:
+        - "id": snake_case tool identifier
+        - "name": human-readable display name
+        - "description": tool description
+        - "category": tool category
+        - "surfaces": {"pyqt6": bool, "web": bool}
+    """
+    registrations = _discover_registrations(repo_root)
+
+    tools: list[dict[str, Any]] = []
+    for reg in registrations:
+        tools.append(
+            {
+                "id": reg.id,
+                "name": reg.name,
+                "description": reg.description,
+                "category": reg.category,
+                "surfaces": {
+                    "pyqt6": reg.has_pyqt6,
+                    "web": reg.has_web,
+                },
+            }
+        )
+
+    return {
+        "version": CONTRACT_VERSION,
+        "tools": tools,
+    }
+
+
+def main() -> int:
+    """Generate tools.json and optionally tool_surface_contract.json."""
     repo_root = Path(__file__).resolve().parents[1]
+
+    # Generate manifest
     manifest = generate_manifest_data(repo_root)
-    
     tools_json_path = repo_root / "tools.json"
     with open(tools_json_path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=4)
-        f.write("\n") # POSIX newline
-    
-    print(f"Generated tools.json with {sum(len(v) for v in manifest.values())} tools.")
+        f.write("\n")  # POSIX newline
+
+    tool_count = sum(len(v) for v in manifest.values())
+    logger.info("Generated tools.json with %d tools.", tool_count)
+
+    # Generate contract
+    contract = generate_contract_data(repo_root)
+    contract_path = repo_root / "tool_surface_contract.json"
+    with open(contract_path, "w", encoding="utf-8") as f:
+        json.dump(contract, f, indent=2)
+        f.write("\n")
+
+    logger.info(
+        "Generated tool_surface_contract.json with %d tools.",
+        len(contract["tools"]),
+    )
+
+    # Print summary to stdout for CI visibility
+    print(f"Generated tools.json with {tool_count} tools.")
+    print(f"Generated tool_surface_contract.json with {len(contract['tools'])} tools.")
+
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    raise SystemExit(main())

--- a/tests/scripts/test_generate_tools_json.py
+++ b/tests/scripts/test_generate_tools_json.py
@@ -1,11 +1,12 @@
-"""Tests for tools.json generation from gui_registration.py sources."""
+"""Tests for tools.json and tool_surface_contract.json generation from gui_registration.py sources."""
 
-import json
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
 import pytest
+
 
 def load_script_module():
     """Load the generate_tools_json script module."""
@@ -13,8 +14,10 @@ def load_script_module():
     # tests/scripts/test_generate_tools_json.py -> tests/scripts -> tests -> repo_root
     repo_root = Path(__file__).resolve().parents[2]
     script_path = repo_root / "scripts" / "generate_tools_json.py"
-    
-    spec = importlib.util.spec_from_file_location("generate_tools_json_module", script_path)
+
+    spec = importlib.util.spec_from_file_location(
+        "generate_tools_json_module", script_path
+    )
     if spec is None or spec.loader is None:
         raise ImportError(f"Could not load script {script_path}")
     module = importlib.util.module_from_spec(spec)
@@ -22,9 +25,11 @@ def load_script_module():
     spec.loader.exec_module(module)
     return module
 
+
 @pytest.fixture
 def manifest_gen_module():
     return load_script_module()
+
 
 @pytest.fixture
 def mock_repo_root(tmp_path):
@@ -36,7 +41,7 @@ def mock_repo_root(tmp_path):
     t1 = src / "electrode_advisor"
     t1.mkdir()
     (t1 / "gui_registration.py").write_text(
-        'GUI_INFO = {\n'
+        "GUI_INFO = {\n"
         '    "name": "Electrode Advisor",\n'
         '    "tool_name": "electrode_advisor",\n'
         '    "description": "AC Electrode Analysis",\n'
@@ -44,11 +49,11 @@ def mock_repo_root(tmp_path):
         '    "pyqt6": {\n'
         '        "module": "electrode.ui",\n'
         '        "class": "Widget"\n'
-        '    },\n'
+        "    },\n"
         '    "web": {"port": 3000}\n'
-        '}\n'
-        'def get_gui_info(): return GUI_INFO\n',
-        encoding="utf-8"
+        "}\n"
+        "def get_gui_info(): return GUI_INFO\n",
+        encoding="utf-8",
     )
     # create dummy launch scripts relative to what generate_tools_json expects
     # The generator usually looks relative to repo root, e.g. src/electrode_advisor/launch_pyqt6.py
@@ -59,7 +64,7 @@ def mock_repo_root(tmp_path):
     t2 = src / "pressure_drop"
     t2.mkdir()
     (t2 / "gui_registration.py").write_text(
-        'GUI_INFO = {\n'
+        "GUI_INFO = {\n"
         '    "name": "Pressure Drop",\n'
         '    "tool_name": "pressure_drop",\n'
         '    "description": "Pipe Analysis",\n'
@@ -67,49 +72,245 @@ def mock_repo_root(tmp_path):
         '    "pyqt6": {\n'
         '        "module": "pressure.ui",\n'
         '        "class": "Widget"\n'
-        '    }\n'
-        '}\n'
-        'def get_gui_info(): return GUI_INFO\n',
-        encoding="utf-8"
+        "    }\n"
+        "}\n"
+        "def get_gui_info(): return GUI_INFO\n",
+        encoding="utf-8",
     )
     (t2 / "launch_pyqt6.py").touch()
-    
+
     return tmp_path
 
-def test_generate_manifest_structure(manifest_gen_module, mock_repo_root):
-    """Test standard manifest generation."""
-    manifest = manifest_gen_module.generate_manifest_data(mock_repo_root)
-    
-    # Assert top-level categories exist
-    assert "Process Simulation" in manifest
-    assert "Engineering Tools" in manifest
-    
-    # Check Engineering Tools (Pressure Drop - PyQt only)
-    eng_tools = manifest["Engineering Tools"]
-    assert len(eng_tools) == 1
-    tool = eng_tools[0]
-    assert tool["name"] == "Pressure Drop" # Single surface name, usually just the name
-    assert tool["type"] == "python"
-    assert "src/pressure_drop/launch_pyqt6.py" in tool["path"].replace("\\", "/")
 
-def test_dual_surface_expansion(manifest_gen_module, mock_repo_root):
-    """Test that dual-surface tools expand into two entries (PyQt and Web)."""
-    manifest = manifest_gen_module.generate_manifest_data(mock_repo_root)
-    
-    sim_tools = manifest["Process Simulation"]
-    # Electrode Advisor has both pyqt6 and web keys -> expecting 2 entries
-    assert len(sim_tools) == 2
-    
-    names = {t["name"] for t in sim_tools}
-    assert "Electrode Advisor (PyQt6)" in names
-    assert "Electrode Advisor (Web)" in names
-    
-    web_tool = next(t for t in sim_tools if t["name"] == "Electrode Advisor (Web)")
-    assert "launch_web.py" in web_tool["path"]
+@pytest.fixture
+def mock_repo_with_web_only(tmp_path):
+    """Create a mock repo with a tool that only has web surface (no pyqt6)."""
+    src = tmp_path / "src"
+    src.mkdir()
 
-def test_idempotency(manifest_gen_module, mock_repo_root):
-    """Test that generation is deterministic (sorted keys/lists)."""
-    run1 = manifest_gen_module.generate_manifest_data(mock_repo_root)
-    run2 = manifest_gen_module.generate_manifest_data(mock_repo_root)
-    
-    assert json.dumps(run1, sort_keys=True) == json.dumps(run2, sort_keys=True)
+    t1 = src / "web_only_tool"
+    t1.mkdir()
+    (t1 / "gui_registration.py").write_text(
+        "GUI_INFO = {\n"
+        '    "name": "Web Only Tool",\n'
+        '    "tool_name": "web_only_tool",\n'
+        '    "description": "A web-only tool",\n'
+        '    "category": "Testing",\n'
+        '    "web": {"port": 5000}\n'
+        "}\n"
+        "def get_gui_info(): return GUI_INFO\n",
+        encoding="utf-8",
+    )
+    (t1 / "launch_web.py").touch()
+
+    return tmp_path
+
+
+@pytest.fixture
+def mock_repo_no_tool_name(tmp_path):
+    """Create a mock repo with a tool that has no tool_name (tests fallback)."""
+    src = tmp_path / "src"
+    src.mkdir()
+
+    t1 = src / "legacy_tool"
+    t1.mkdir()
+    (t1 / "gui_registration.py").write_text(
+        "GUI_INFO = {\n"
+        '    "name": "Legacy Tool",\n'
+        '    "description": "Tool without tool_name field",\n'
+        '    "category": "Legacy",\n'
+        '    "pyqt6": {\n'
+        '        "module": "legacy.ui",\n'
+        '        "class": "Widget"\n'
+        "    }\n"
+        "}\n"
+        "def get_gui_info(): return GUI_INFO\n",
+        encoding="utf-8",
+    )
+    (t1 / "launch_pyqt6.py").touch()
+
+    return tmp_path
+
+
+# ============================================================================
+# Phase 1 Tests: Manifest Generation (existing)
+# ============================================================================
+
+
+class TestManifestGeneration:
+    """Tests for tools.json manifest generation."""
+
+    def test_generate_manifest_structure(self, manifest_gen_module, mock_repo_root):
+        """Test standard manifest generation."""
+        manifest = manifest_gen_module.generate_manifest_data(mock_repo_root)
+
+        # Assert top-level categories exist
+        assert "Process Simulation" in manifest
+        assert "Engineering Tools" in manifest
+
+        # Check Engineering Tools (Pressure Drop - PyQt only)
+        eng_tools = manifest["Engineering Tools"]
+        assert len(eng_tools) == 1
+        tool = eng_tools[0]
+        assert (
+            tool["name"] == "Pressure Drop"
+        )  # Single surface name, usually just the name
+        assert tool["type"] == "python"
+        assert "src/pressure_drop/launch_pyqt6.py" in tool["path"].replace("\\", "/")
+
+    def test_dual_surface_expansion(self, manifest_gen_module, mock_repo_root):
+        """Test that dual-surface tools expand into two entries (PyQt and Web)."""
+        manifest = manifest_gen_module.generate_manifest_data(mock_repo_root)
+
+        sim_tools = manifest["Process Simulation"]
+        # Electrode Advisor has both pyqt6 and web keys -> expecting 2 entries
+        assert len(sim_tools) == 2
+
+        names = {t["name"] for t in sim_tools}
+        assert "Electrode Advisor (PyQt6)" in names
+        assert "Electrode Advisor (Web)" in names
+
+        web_tool = next(t for t in sim_tools if t["name"] == "Electrode Advisor (Web)")
+        assert "launch_web.py" in web_tool["path"]
+
+    def test_idempotency(self, manifest_gen_module, mock_repo_root):
+        """Test that generation is deterministic (sorted keys/lists)."""
+        run1 = manifest_gen_module.generate_manifest_data(mock_repo_root)
+        run2 = manifest_gen_module.generate_manifest_data(mock_repo_root)
+
+        assert json.dumps(run1, sort_keys=True) == json.dumps(run2, sort_keys=True)
+
+
+# ============================================================================
+# Phase 1, Task 1.4 Tests: Contract Generation
+# ============================================================================
+
+
+class TestContractGeneration:
+    """Tests for tool_surface_contract.json generation."""
+
+    def test_contract_has_version(self, manifest_gen_module, mock_repo_root):
+        """Contract must contain a semver version string."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+        assert "version" in contract
+        assert isinstance(contract["version"], str)
+        # Semver format
+        parts = contract["version"].split(".")
+        assert len(parts) == 3
+        for part in parts:
+            assert part.isdigit()
+
+    def test_contract_has_tools_list(self, manifest_gen_module, mock_repo_root):
+        """Contract must contain a 'tools' list."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+        assert "tools" in contract
+        assert isinstance(contract["tools"], list)
+        assert len(contract["tools"]) > 0
+
+    def test_contract_tool_entry_structure(self, manifest_gen_module, mock_repo_root):
+        """Each contract tool entry must have id, name, description, category, and surfaces."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+
+        for tool in contract["tools"]:
+            assert "id" in tool, f"Missing 'id' in tool entry: {tool}"
+            assert "name" in tool, f"Missing 'name' in tool entry: {tool}"
+            assert "description" in tool, f"Missing 'description' in tool entry: {tool}"
+            assert "category" in tool, f"Missing 'category' in tool entry: {tool}"
+            assert "surfaces" in tool, f"Missing 'surfaces' in tool entry: {tool}"
+
+    def test_contract_tool_id_format(self, manifest_gen_module, mock_repo_root):
+        """Tool IDs must be snake_case."""
+        import re
+
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+        pattern = re.compile(r"^[a-z0-9_]+$")
+
+        for tool in contract["tools"]:
+            assert pattern.match(
+                tool["id"]
+            ), f"Tool ID '{tool['id']}' is not snake_case"
+
+    def test_contract_surfaces_structure(self, manifest_gen_module, mock_repo_root):
+        """Each tool's surfaces dict must have exactly pyqt6 and web booleans."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+
+        for tool in contract["tools"]:
+            surfaces = tool["surfaces"]
+            assert "pyqt6" in surfaces, f"Missing 'pyqt6' in surfaces for {tool['id']}"
+            assert "web" in surfaces, f"Missing 'web' in surfaces for {tool['id']}"
+            assert isinstance(surfaces["pyqt6"], bool)
+            assert isinstance(surfaces["web"], bool)
+
+    def test_contract_dual_surface_tool(self, manifest_gen_module, mock_repo_root):
+        """Electrode advisor with both surfaces should show pyqt6=True, web=True."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+        electrode = next(t for t in contract["tools"] if t["id"] == "electrode_advisor")
+
+        assert electrode["surfaces"]["pyqt6"] is True
+        assert electrode["surfaces"]["web"] is True
+        assert electrode["name"] == "Electrode Advisor"
+        assert electrode["description"] == "AC Electrode Analysis"
+        assert electrode["category"] == "Process Simulation"
+
+    def test_contract_pyqt_only_tool(self, manifest_gen_module, mock_repo_root):
+        """Pressure drop (pyqt only) should show pyqt6=True, web=False."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+        pd = next(t for t in contract["tools"] if t["id"] == "pressure_drop")
+
+        assert pd["surfaces"]["pyqt6"] is True
+        assert pd["surfaces"]["web"] is False
+
+    def test_contract_web_only_tool(self, manifest_gen_module, mock_repo_with_web_only):
+        """Web-only tool should show pyqt6=False, web=True."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_with_web_only)
+        web_tool = next(t for t in contract["tools"] if t["id"] == "web_only_tool")
+
+        assert web_tool["surfaces"]["pyqt6"] is False
+        assert web_tool["surfaces"]["web"] is True
+
+    def test_contract_tool_name_fallback(
+        self, manifest_gen_module, mock_repo_no_tool_name
+    ):
+        """Tools without tool_name should use directory name as ID."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_no_tool_name)
+
+        assert len(contract["tools"]) == 1
+        tool = contract["tools"][0]
+        # Should fall back to using directory name
+        assert tool["id"] == "legacy_tool"
+
+    def test_contract_is_sorted_by_id(self, manifest_gen_module, mock_repo_root):
+        """Contract tools must be sorted by ID for deterministic output."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+        ids = [t["id"] for t in contract["tools"]]
+        assert ids == sorted(ids)
+
+    def test_contract_idempotency(self, manifest_gen_module, mock_repo_root):
+        """Contract generation must be deterministic."""
+        run1 = manifest_gen_module.generate_contract_data(mock_repo_root)
+        run2 = manifest_gen_module.generate_contract_data(mock_repo_root)
+
+        assert json.dumps(run1, sort_keys=True) == json.dumps(run2, sort_keys=True)
+
+    def test_contract_no_duplicate_ids(self, manifest_gen_module, mock_repo_root):
+        """Contract must not contain duplicate tool IDs."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+        ids = [t["id"] for t in contract["tools"]]
+        assert len(ids) == len(set(ids)), f"Duplicate IDs found: {ids}"
+
+    def test_contract_schema_compliance(self, manifest_gen_module, mock_repo_root):
+        """Contract must match the expected schema structure."""
+        contract = manifest_gen_module.generate_contract_data(mock_repo_root)
+
+        # Top-level keys
+        assert set(contract.keys()) == {"version", "tools"}
+
+        # Each tool entry
+        expected_tool_keys = {"id", "name", "description", "category", "surfaces"}
+        expected_surface_keys = {"pyqt6", "web"}
+
+        for tool in contract["tools"]:
+            assert (
+                set(tool.keys()) == expected_tool_keys
+            ), f"Unexpected keys in tool entry: {set(tool.keys()) - expected_tool_keys}"
+            assert set(tool["surfaces"].keys()) == expected_surface_keys

--- a/tool_surface_contract.json
+++ b/tool_surface_contract.json
@@ -1,0 +1,285 @@
+{
+  "version": "1.0.0",
+  "tools": [
+    {
+      "id": "acid_gas_dewpoint",
+      "name": "Acid Gas Dewpoint Calculator",
+      "description": "HF, HCl, H2S dewpoint analysis for syngas applications",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "baghouse_calculator",
+      "name": "Baghouse Calculator",
+      "description": "Baghouse filter performance and drum sizing calculator",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "c3d_viewer",
+      "name": "C3D Motion Capture Viewer",
+      "description": "View and analyze C3D motion capture files",
+      "category": "Biomechanics",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "data_processor",
+      "name": "Data Processor",
+      "description": "Signal processing and time-series data analysis tool",
+      "category": "Data Processing",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "electrode_advisor",
+      "name": "Electrode Advisor",
+      "description": "AC Electrode Advancement Module for electrode system analysis",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "financial_calculator",
+      "name": "Financial Calculator",
+      "description": "Comprehensive financial modeling for plant operations",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "flare_calculator",
+      "name": "Flare Calculator",
+      "description": "Flare sizing and safety zone calculator",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "flow_rate_converter",
+      "name": "Flow Rate Converter",
+      "description": "Convert between mass, molar, and volumetric flow rate units",
+      "category": "Utilities",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "folder_packer_pro",
+      "name": "Folder Packer Pro",
+      "description": "Professional Project Archiving and Distribution Tool",
+      "category": "Development Tools",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "folder_tool",
+      "name": "Folder Tool (Utility)",
+      "description": "Directory Management Utility",
+      "category": "Development Tools",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "function_generator",
+      "name": "Function Generator",
+      "description": "Generate and visualize various waveforms (sine, square, triangle, etc.)",
+      "category": "Signal Processing",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "humanoid_builder_gui",
+      "name": "Humanoid Character Builder",
+      "description": "Build parametric humanoid characters with anthropometric calculations",
+      "category": "Robotics",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "inertia_calculator",
+      "name": "Inertia Calculator",
+      "description": "Calculate and validate inertia tensors for rigid bodies",
+      "category": "Robotics",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "multi_param_analysis",
+      "name": "Multi-Parameter Analysis",
+      "description": "Run multi-parameter sensitivity analysis with grid evaluation",
+      "category": "Analysis",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "ode_solver",
+      "name": "ODE Solver",
+      "description": "Solve systems of ordinary differential equations symbolically",
+      "category": "Mathematics",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "optimizer_gui",
+      "name": "Adam Optimizer",
+      "description": "Configure and run Adam-based optimization",
+      "category": "Optimization",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "pdf_renamer",
+      "name": "PDF Renamer",
+      "description": "Intelligent PDF File Renaming Tool",
+      "category": "Development Tools",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "pressure_drop_calculator",
+      "name": "Pressure Drop Calculator",
+      "description": "Pipe flow pressure drop analysis with multiple friction methods",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "psa_package",
+      "name": "PSA System Analysis",
+      "description": "Two-stage Pressure Swing Adsorption system analysis",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "scrubber_calculator",
+      "name": "Scrubber Calculator",
+      "description": "Packed bed scrubber design with NTU/HTU mass transfer",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "signal_processing_studio",
+      "name": "Signal Processing Studio",
+      "description": "Unified signal processing: waveform generation, analysis, filtering, curve fitting",
+      "category": "Signal Processing",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "steam_engine_calculator",
+      "name": "Steam Engine Calculator",
+      "description": "Calculate thermodynamic properties of steam/water",
+      "category": "Thermodynamics",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "syngas_compression",
+      "name": "Syngas Compression Calculator",
+      "description": "Multi-stage compression analysis with water dropout calculations",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "syngas_water_calculator",
+      "name": "Syngas Water Calculator",
+      "description": "Calculate water content and dew point in syngas systems",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "thermal_profile_predictor",
+      "name": "Thermal Profile Predictor",
+      "description": "Predict temperature profiles for heated vessels",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "trc_vessel_designer",
+      "name": "TRC Vessel Designer",
+      "description": "Thermal Reaction Chamber vessel design tool",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    },
+    {
+      "id": "urdf_builder_gui",
+      "name": "Parametric URDF Builder",
+      "description": "Generate parametric URDF models for robotics applications",
+      "category": "Robotics",
+      "surfaces": {
+        "pyqt6": true,
+        "web": false
+      }
+    },
+    {
+      "id": "wgs_reactor",
+      "name": "WGS Reactor Calculator",
+      "description": "Water-Gas Shift reactor equilibrium and sizing calculations",
+      "category": "Process Simulation",
+      "surfaces": {
+        "pyqt6": true,
+        "web": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Phase 1, Task 1.4: Enhance  to emit  alongside . This contract is the authoritative artifact consumed by  for Dual GUI Parity enforcement.

## Changes

- **Refactored** generator to use shared  function (DRY)
- **Added**  dataclass for internal representation (Orthogonality)
- **New**  function with Design by Contract documentation
- **Extended** CI workflow () to validate contract sync
- **New**  artifact (28 tools, deterministic output)
- **13 new TDD tests** covering contract schema, surfaces, determinism, and edge cases

## Testing

- 16/16 tests pass (3 existing manifest + 13 new contract)
-  remains unchanged (backward compatible)
- CI validates both manifest and contract are in sync

## Epic

- Ref: D-sorganization/Gasification_Model#1245 (Dual GUI Parity)
- Unblocks: D-sorganization/Gasification_Model#1246 (Phase 2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the source-of-truth generation path for `tools.json` and adds a new required artifact enforced by CI, so mismatches or discovery/path lookup issues could break the launcher manifest or PR checks.
> 
> **Overview**
> The tools manifest generator now emits a new deterministic `tool_surface_contract.json` (one entry per logical tool with `id`, metadata, and `pyqt6`/`web` surface booleans) alongside the existing `tools.json`, using a shared discovery step and improved logging/deduping behavior.
> 
> CI is extended to treat `tool_surface_contract.json` as a required synced artifact (diff check) and to publish a run summary of surface coverage, and the test suite is expanded to cover contract schema/determinism plus web-only and missing-`tool_name` edge cases. A generated `tool_surface_contract.json` file is added to the repo.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f8ea5712b37adfa6e9682aebfcb8362299811ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->