### PR TITLE
fix: Video processor DOMPurify, logging, and security (#663)

### DIFF
--- a/src/media_processing/video_processor/apps/web/app/page.tsx
+++ b/src/media_processing/video_processor/apps/web/app/page.tsx
@@ -119,8 +119,14 @@ export default function HomePage() {
 
       toast.success('Audio commentary recorded successfully');
 
-      // TODO: Save to database when backend is ready
-      // await saveAudioTrack({ url: audioUrl, startTime, duration: audioBlob.size });
+      // TODO(#663): Save to database when backend API is available.
+      // Expected endpoint: POST /api/audio-tracks
+      // Expected payload: { videoId: string, url: string, startTime: number, duration: number }
+      // await fetch('/api/audio-tracks', {
+      //   method: 'POST',
+      //   headers: { 'Content-Type': 'application/json' },
+      //   body: JSON.stringify({ videoId: videoFile?.name, url: audioUrl, startTime, duration: audioBlob.size }),
+      // });
     } catch (error) {
       logger.error('Failed to process audio recording', { error, audioBlob, startTime });
       toast.error(getUserMessage(error));
@@ -166,7 +172,9 @@ export default function HomePage() {
         currentFrame,
       });
 
-      // TODO: Save pose data to state or database when ready
+      // TODO(#663): Save pose data to database when backend API is available.
+      // Expected endpoint: POST /api/pose-data
+      // Expected payload: { videoId: string, frame: number, timestamp: number, landmarks: unknown }
       // For now, just log for debugging
     } catch (error) {
       logger.error('Failed to process pose detection', { error, landmarks });

--- a/src/media_processing/video_processor/apps/web/lib/__tests__/logger.test.ts
+++ b/src/media_processing/video_processor/apps/web/lib/__tests__/logger.test.ts
@@ -1,210 +1,115 @@
 /**
- * Tests for Logger utility
+ * Tests for Logger utility (pino-based)
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockDebug = vi.fn();
+const mockInfo = vi.fn();
+const mockWarn = vi.fn();
+const mockError = vi.fn();
+const mockChild = vi.fn();
+
+vi.mock('pino', () => {
+  const pinoFn = () => ({
+    debug: mockDebug,
+    info: mockInfo,
+    warn: mockWarn,
+    error: mockError,
+    child: mockChild.mockReturnValue({
+      debug: mockDebug,
+      info: mockInfo,
+      warn: mockWarn,
+      error: mockError,
+      child: mockChild,
+    }),
+  });
+
+  pinoFn.stdTimeFunctions = {
+    isoTime: () => `,"time":"${new Date().toISOString()}"`,
+  };
+
+  return { default: pinoFn };
+});
+
+// Import after mock setup
 import { logger } from '../logger';
 
 describe('Logger', () => {
-  let consoleDebugSpy: ReturnType<typeof vi.spyOn>;
-  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
-  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
-  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
-
   beforeEach(() => {
-    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
-    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('Basic Logging', () => {
-    it('should log debug messages', () => {
+    it('should log debug messages via pino', () => {
       logger.debug('Test debug message');
-
-      expect(consoleDebugSpy).toHaveBeenCalled();
-      const loggedMessage = consoleDebugSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('DEBUG');
-      expect(loggedMessage).toContain('Test debug message');
+      expect(mockDebug).toHaveBeenCalledWith('Test debug message');
     });
 
-    it('should log info messages', () => {
+    it('should log info messages via pino', () => {
       logger.info('Test info message');
-
-      expect(consoleInfoSpy).toHaveBeenCalled();
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('INFO');
-      expect(loggedMessage).toContain('Test info message');
+      expect(mockInfo).toHaveBeenCalledWith('Test info message');
     });
 
-    it('should log warn messages', () => {
+    it('should log warn messages via pino', () => {
       logger.warn('Test warn message');
-
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      const loggedMessage = consoleWarnSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('WARN');
-      expect(loggedMessage).toContain('Test warn message');
+      expect(mockWarn).toHaveBeenCalledWith('Test warn message');
     });
 
-    it('should log error messages', () => {
+    it('should log error messages via pino', () => {
       logger.error('Test error message');
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      const loggedMessage = consoleErrorSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('ERROR');
-      expect(loggedMessage).toContain('Test error message');
-    });
-  });
-
-  describe('Message Formatting', () => {
-    it('should include ISO timestamp in log message', () => {
-      logger.info('Test message');
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      // Check for ISO timestamp pattern
-      expect(loggedMessage).toMatch(/\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]/);
-    });
-
-    it('should format message with level in uppercase', () => {
-      logger.info('Test message');
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('INFO:');
-    });
-
-    it('should include message content', () => {
-      logger.info('This is my test message');
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('This is my test message');
-    });
-
-    it('should format timestamp, level, and message in correct order', () => {
-      logger.info('Test');
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      // Should match pattern: [timestamp] LEVEL: message
-      expect(loggedMessage).toMatch(/\[.+\] INFO: Test/);
+      expect(mockError).toHaveBeenCalledWith('Test error message');
     });
   });
 
   describe('Metadata Handling', () => {
-    it('should log metadata as JSON', () => {
+    it('should log metadata as first arg and message as second (pino convention)', () => {
       const metadata = { userId: 123, action: 'login' };
       logger.info('User logged in', metadata);
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"userId": 123');
-      expect(loggedMessage).toContain('"action": "login"');
-    });
-
-    it('should format metadata with indentation', () => {
-      const metadata = { key: 'value' };
-      logger.info('Test', metadata);
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      // JSON.stringify with 2 spaces should create indented output
-      expect(loggedMessage).toContain('{\n');
+      expect(mockInfo).toHaveBeenCalledWith(metadata, 'User logged in');
     });
 
     it('should handle nested metadata objects', () => {
       const metadata = {
-        user: {
-          id: 123,
-          name: 'John',
-        },
-        request: {
-          method: 'GET',
-          path: '/api/users',
-        },
+        user: { id: 123, name: 'John' },
+        request: { method: 'GET', path: '/api/users' },
       };
-
       logger.info('API request', metadata);
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"user"');
-      expect(loggedMessage).toContain('"id": 123');
-      expect(loggedMessage).toContain('"name": "John"');
-      expect(loggedMessage).toContain('"method": "GET"');
+      expect(mockInfo).toHaveBeenCalledWith(metadata, 'API request');
     });
 
     it('should handle metadata with arrays', () => {
-      const metadata = {
-        tags: ['video', 'golf', 'analysis'],
-      };
-
+      const metadata = { tags: ['video', 'golf', 'analysis'] };
       logger.info('Tagged content', metadata);
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"tags"');
-      expect(loggedMessage).toContain('video');
-      expect(loggedMessage).toContain('golf');
-      expect(loggedMessage).toContain('analysis');
+      expect(mockInfo).toHaveBeenCalledWith(metadata, 'Tagged content');
     });
 
     it('should handle empty metadata object', () => {
       logger.info('Test', {});
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Test');
-      expect(loggedMessage).toContain('{}');
+      expect(mockInfo).toHaveBeenCalledWith({}, 'Test');
     });
 
     it('should not include metadata when not provided', () => {
       logger.info('Test without metadata');
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Test without metadata');
-      expect(loggedMessage).not.toContain('{');
+      expect(mockInfo).toHaveBeenCalledWith('Test without metadata');
     });
 
     it('should handle metadata with null values', () => {
       const metadata = { value: null };
       logger.info('Test', metadata);
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"value": null');
-    });
-
-    it('should handle metadata with undefined values', () => {
-      const metadata = { value: undefined };
-      logger.info('Test', metadata);
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      // undefined is not serialized in JSON
-      expect(loggedMessage).toContain('Test');
+      expect(mockInfo).toHaveBeenCalledWith(metadata, 'Test');
     });
 
     it('should handle metadata with numbers', () => {
-      const metadata = {
-        count: 42,
-        price: 19.99,
-        negative: -5,
-      };
-
+      const metadata = { count: 42, price: 19.99, negative: -5 };
       logger.info('Numbers', metadata);
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"count": 42');
-      expect(loggedMessage).toContain('"price": 19.99');
-      expect(loggedMessage).toContain('"negative": -5');
+      expect(mockInfo).toHaveBeenCalledWith(metadata, 'Numbers');
     });
 
     it('should handle metadata with booleans', () => {
-      const metadata = {
-        isActive: true,
-        isDeleted: false,
-      };
-
+      const metadata = { isActive: true, isDeleted: false };
       logger.info('Booleans', metadata);
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"isActive": true');
-      expect(loggedMessage).toContain('"isDeleted": false');
+      expect(mockInfo).toHaveBeenCalledWith(metadata, 'Booleans');
     });
   });
 
@@ -213,252 +118,195 @@ describe('Logger', () => {
       const error = new Error('Test error');
       logger.error('An error occurred', { error });
 
-      const loggedMessage = consoleErrorSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Test error');
-      expect(loggedMessage).toContain('"name": "Error"');
-      expect(loggedMessage).toContain('"message": "Test error"');
-    });
-
-    it('should include stack trace from Error object', () => {
-      const error = new Error('Test error');
-      logger.error('An error occurred', { error });
-
-      const loggedMessage = consoleErrorSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"stack"');
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            name: 'Error',
+            message: 'Test error',
+            stack: expect.any(String),
+          }),
+        }),
+        'An error occurred'
+      );
     });
 
     it('should handle TypeError', () => {
       const error = new TypeError('Type mismatch');
       logger.error('Type error occurred', { error });
 
-      const loggedMessage = consoleErrorSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"name": "TypeError"');
-      expect(loggedMessage).toContain('Type mismatch');
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            name: 'TypeError',
+            message: 'Type mismatch',
+          }),
+        }),
+        'Type error occurred'
+      );
     });
 
     it('should handle RangeError', () => {
       const error = new RangeError('Out of range');
       logger.error('Range error occurred', { error });
 
-      const loggedMessage = consoleErrorSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"name": "RangeError"');
-      expect(loggedMessage).toContain('Out of range');
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            name: 'RangeError',
+            message: 'Out of range',
+          }),
+        }),
+        'Range error occurred'
+      );
     });
 
     it('should handle error with additional metadata', () => {
       const error = new Error('Test error');
       logger.error('Error with context', { error, userId: 123, action: 'upload' });
 
-      const loggedMessage = consoleErrorSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Test error');
-      expect(loggedMessage).toContain('"userId": 123');
-      expect(loggedMessage).toContain('"action": "upload"');
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 123,
+          action: 'upload',
+        }),
+        'Error with context'
+      );
     });
   });
 
   describe('Argument Order Flexibility', () => {
     it('should support message first, metadata second', () => {
       logger.info('Message', { key: 'value' });
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Message');
-      expect(loggedMessage).toContain('"key": "value"');
+      expect(mockInfo).toHaveBeenCalledWith({ key: 'value' }, 'Message');
     });
 
     it('should support metadata first, message second', () => {
       logger.info({ key: 'value' }, 'Message');
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Message');
-      expect(loggedMessage).toContain('"key": "value"');
+      expect(mockInfo).toHaveBeenCalledWith({ key: 'value' }, 'Message');
     });
 
     it('should work with debug level in both orders', () => {
       logger.debug('Debug message', { debug: true });
       logger.debug({ debug: false }, 'Another debug message');
-
-      expect(consoleDebugSpy).toHaveBeenCalledTimes(2);
+      expect(mockDebug).toHaveBeenCalledTimes(2);
     });
 
     it('should work with warn level in both orders', () => {
       logger.warn('Warning', { severity: 'high' });
       logger.warn({ severity: 'low' }, 'Another warning');
-
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+      expect(mockWarn).toHaveBeenCalledTimes(2);
     });
 
     it('should work with error level in both orders', () => {
       logger.error('Error occurred', { code: 500 });
       logger.error({ code: 404 }, 'Not found');
-
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+      expect(mockError).toHaveBeenCalledTimes(2);
     });
   });
 
   describe('Child Logger', () => {
-    it('should create child logger with default metadata', () => {
+    it('should create child logger via pino.child()', () => {
       const childLogger = logger.child({ module: 'video', component: 'uploader' });
-      childLogger.info('Test message');
+      expect(mockChild).toHaveBeenCalledWith({ module: 'video', component: 'uploader' });
 
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"module": "video"');
-      expect(loggedMessage).toContain('"component": "uploader"');
-      expect(loggedMessage).toContain('Test message');
+      childLogger.info('Test message');
+      expect(mockInfo).toHaveBeenCalledWith('Test message');
     });
 
-    it('should merge child metadata with call metadata', () => {
+    it('should pass metadata to child logger calls', () => {
       const childLogger = logger.child({ module: 'video' });
       childLogger.info('Upload started', { fileName: 'test.mp4' });
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"module": "video"');
-      expect(loggedMessage).toContain('"fileName": "test.mp4"');
-    });
-
-    it('should override child metadata with call metadata', () => {
-      const childLogger = logger.child({ priority: 'low' });
-      childLogger.info('Important message', { priority: 'high' });
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('"priority": "high"');
+      expect(mockInfo).toHaveBeenCalledWith({ fileName: 'test.mp4' }, 'Upload started');
     });
 
     it('should support multiple child loggers independently', () => {
-      const videoLogger = logger.child({ module: 'video' });
-      const authLogger = logger.child({ module: 'auth' });
-
-      videoLogger.info('Video event');
-      authLogger.info('Auth event');
-
-      const videoMessage = consoleInfoSpy.mock.calls[0][0];
-      const authMessage = consoleInfoSpy.mock.calls[1][0];
-
-      expect(videoMessage).toContain('"module": "video"');
-      expect(authMessage).toContain('"module": "auth"');
+      logger.child({ module: 'video' });
+      logger.child({ module: 'auth' });
+      expect(mockChild).toHaveBeenCalledTimes(2);
+      expect(mockChild).toHaveBeenCalledWith({ module: 'video' });
+      expect(mockChild).toHaveBeenCalledWith({ module: 'auth' });
     });
 
     it('should allow child logger to use all log levels', () => {
       const childLogger = logger.child({ component: 'test' });
-
       childLogger.debug('Debug');
       childLogger.info('Info');
       childLogger.warn('Warn');
       childLogger.error('Error');
 
-      expect(consoleDebugSpy).toHaveBeenCalled();
-      expect(consoleInfoSpy).toHaveBeenCalled();
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(mockDebug).toHaveBeenCalled();
+      expect(mockInfo).toHaveBeenCalled();
+      expect(mockWarn).toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalled();
     });
   });
 
   describe('Edge Cases', () => {
     it('should handle empty string message', () => {
       logger.info('');
-
-      expect(consoleInfoSpy).toHaveBeenCalled();
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('INFO:');
+      expect(mockInfo).toHaveBeenCalledWith('');
     });
 
     it('should handle very long messages', () => {
       const longMessage = 'A'.repeat(10000);
       logger.info(longMessage);
-
-      expect(consoleInfoSpy).toHaveBeenCalled();
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain(longMessage);
+      expect(mockInfo).toHaveBeenCalledWith(longMessage);
     });
 
     it('should handle special characters in message', () => {
       logger.info('Message with "quotes" and \'apostrophes\' and \n newlines');
-
-      expect(consoleInfoSpy).toHaveBeenCalled();
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('quotes');
+      expect(mockInfo).toHaveBeenCalled();
     });
 
     it('should handle unicode characters in message', () => {
-      logger.info('测试消息 🎥 ⛳️');
-
-      expect(consoleInfoSpy).toHaveBeenCalled();
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('测试消息');
-    });
-
-    it('should handle metadata with circular references gracefully', () => {
-      const circular: any = { name: 'test' };
-      circular.self = circular;
-
-      // This might throw or handle gracefully
-      expect(() => {
-        logger.info('Circular reference', circular);
-      }).toThrow(); // JSON.stringify throws on circular references
-    });
-
-    it('should handle very large metadata objects', () => {
-      const largeMetadata: any = {};
-      for (let i = 0; i < 1000; i++) {
-        largeMetadata[`key${i}`] = `value${i}`;
-      }
-
-      logger.info('Large metadata', largeMetadata);
-
-      expect(consoleInfoSpy).toHaveBeenCalled();
+      logger.info('测试消息');
+      expect(mockInfo).toHaveBeenCalledWith('测试消息');
     });
 
     it('should handle metadata with Date objects', () => {
       const date = new Date('2024-01-01T12:00:00Z');
       logger.info('Date test', { timestamp: date });
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('2024-01-01');
+      expect(mockInfo).toHaveBeenCalledWith({ timestamp: date }, 'Date test');
     });
 
     it('should handle metadata with RegExp objects', () => {
       const regex = /test/gi;
       logger.info('Regex test', { pattern: regex });
-
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('pattern');
+      expect(mockInfo).toHaveBeenCalledWith({ pattern: regex }, 'Regex test');
     });
   });
 
   describe('Different Log Levels', () => {
-    it('should use console.debug for debug level', () => {
+    it('should use pino.debug for debug level', () => {
       logger.debug('Debug message');
-
-      expect(consoleDebugSpy).toHaveBeenCalled();
-      expect(consoleInfoSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(mockDebug).toHaveBeenCalled();
+      expect(mockInfo).not.toHaveBeenCalled();
+      expect(mockWarn).not.toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalled();
     });
 
-    it('should use console.info for info level', () => {
+    it('should use pino.info for info level', () => {
       logger.info('Info message');
-
-      expect(consoleInfoSpy).toHaveBeenCalled();
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(mockInfo).toHaveBeenCalled();
+      expect(mockDebug).not.toHaveBeenCalled();
+      expect(mockWarn).not.toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalled();
     });
 
-    it('should use console.warn for warn level', () => {
+    it('should use pino.warn for warn level', () => {
       logger.warn('Warning message');
-
-      expect(consoleWarnSpy).toHaveBeenCalled();
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-      expect(consoleInfoSpy).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(mockWarn).toHaveBeenCalled();
+      expect(mockDebug).not.toHaveBeenCalled();
+      expect(mockInfo).not.toHaveBeenCalled();
+      expect(mockError).not.toHaveBeenCalled();
     });
 
-    it('should use console.error for error level', () => {
+    it('should use pino.error for error level', () => {
       logger.error('Error message');
-
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      expect(consoleDebugSpy).not.toHaveBeenCalled();
-      expect(consoleInfoSpy).not.toHaveBeenCalled();
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      expect(mockError).toHaveBeenCalled();
+      expect(mockDebug).not.toHaveBeenCalled();
+      expect(mockInfo).not.toHaveBeenCalled();
+      expect(mockWarn).not.toHaveBeenCalled();
     });
   });
 
@@ -467,16 +315,14 @@ describe('Logger', () => {
       logger.info('First');
       logger.info('Second');
       logger.info('Third');
-
-      expect(consoleInfoSpy).toHaveBeenCalledTimes(3);
+      expect(mockInfo).toHaveBeenCalledTimes(3);
     });
 
     it('should handle rapid log calls', () => {
       for (let i = 0; i < 100; i++) {
         logger.info(`Message ${i}`);
       }
-
-      expect(consoleInfoSpy).toHaveBeenCalledTimes(100);
+      expect(mockInfo).toHaveBeenCalledTimes(100);
     });
 
     it('should handle mixed level calls', () => {
@@ -486,10 +332,10 @@ describe('Logger', () => {
       logger.error('Error');
       logger.info('Info again');
 
-      expect(consoleDebugSpy).toHaveBeenCalledTimes(1);
-      expect(consoleInfoSpy).toHaveBeenCalledTimes(2);
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(mockDebug).toHaveBeenCalledTimes(1);
+      expect(mockInfo).toHaveBeenCalledTimes(2);
+      expect(mockWarn).toHaveBeenCalledTimes(1);
+      expect(mockError).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -497,14 +343,14 @@ describe('Logger', () => {
     it('should log video upload started', () => {
       logger.info('Video upload started', {
         fileName: 'golf-swing.mp4',
-        fileSize: 1024 * 1024 * 50, // 50MB
+        fileSize: 1024 * 1024 * 50,
         userId: 'user123',
       });
 
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Video upload started');
-      expect(loggedMessage).toContain('golf-swing.mp4');
-      expect(loggedMessage).toContain('user123');
+      expect(mockInfo).toHaveBeenCalledWith(
+        { fileName: 'golf-swing.mp4', fileSize: 52428800, userId: 'user123' },
+        'Video upload started'
+      );
     });
 
     it('should log API error with details', () => {
@@ -516,25 +362,29 @@ describe('Logger', () => {
         statusCode: 500,
       });
 
-      const loggedMessage = consoleErrorSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('API request failed');
-      expect(loggedMessage).toContain('Network timeout');
-      expect(loggedMessage).toContain('/api/videos');
-      expect(loggedMessage).toContain('POST');
+      expect(mockError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          endpoint: '/api/videos',
+          method: 'POST',
+          statusCode: 500,
+        }),
+        'API request failed'
+      );
     });
 
     it('should log user authentication event', () => {
+      const timestamp = new Date().toISOString();
       logger.info('User authenticated', {
         userId: 'user123',
         method: 'oauth',
         provider: 'google',
-        timestamp: new Date().toISOString(),
+        timestamp,
       });
 
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('User authenticated');
-      expect(loggedMessage).toContain('oauth');
-      expect(loggedMessage).toContain('google');
+      expect(mockInfo).toHaveBeenCalledWith(
+        { userId: 'user123', method: 'oauth', provider: 'google', timestamp },
+        'User authenticated'
+      );
     });
 
     it('should log video processing completion', () => {
@@ -546,10 +396,13 @@ describe('Logger', () => {
         processingTime: 12.5,
       });
 
-      const loggedMessage = consoleInfoSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Video processing completed');
-      expect(loggedMessage).toContain('vid123');
-      expect(loggedMessage).toContain('1920x1080');
+      expect(mockInfo).toHaveBeenCalledWith(
+        expect.objectContaining({
+          videoId: 'vid123',
+          resolution: '1920x1080',
+        }),
+        'Video processing completed'
+      );
     });
 
     it('should log rate limit warning', () => {
@@ -560,10 +413,13 @@ describe('Logger', () => {
         windowReset: new Date(Date.now() + 60000).toISOString(),
       });
 
-      const loggedMessage = consoleWarnSpy.mock.calls[0][0];
-      expect(loggedMessage).toContain('Rate limit approaching');
-      expect(loggedMessage).toContain('192.168.1.1');
-      expect(loggedMessage).toContain('"remainingRequests": 2');
+      expect(mockWarn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ip: '192.168.1.1',
+          remainingRequests: 2,
+        }),
+        'Rate limit approaching'
+      );
     });
   });
 });

--- a/src/media_processing/video_processor/apps/web/lib/__tests__/sanitize.test.ts
+++ b/src/media_processing/video_processor/apps/web/lib/__tests__/sanitize.test.ts
@@ -110,19 +110,31 @@ describe('Sanitization Functions', () => {
   });
 
   describe('sanitizeHTML', () => {
-    it('should strip all HTML by default', () => {
-      expect(sanitizeHTML('<div>Test</div>')).toBe('Test');
-      expect(sanitizeHTML('<script>alert("xss")</script>')).toBe('');
+    it('should allow safe HTML tags (DOMPurify)', () => {
+      expect(sanitizeHTML('<div>Test</div>')).toBe('<div>Test</div>');
+      expect(sanitizeHTML('<b>bold</b>')).toBe('<b>bold</b>');
+      expect(sanitizeHTML('<p>paragraph</p>')).toBe('<p>paragraph</p>');
     });
 
-    it('should remove dangerous tags', () => {
+    it('should strip dangerous tags', () => {
+      expect(sanitizeHTML('<script>alert("xss")</script>')).toBe('');
       expect(sanitizeHTML('<iframe src="evil"></iframe>')).toBe('');
       expect(sanitizeHTML('<object data="evil"></object>')).toBe('');
     });
 
-    // Note: When DOMPurify is added, these tests should be updated
-    it('should handle nested tags', () => {
-      expect(sanitizeHTML('<div><span>Test</span></div>')).toBe('Test');
+    it('should strip event handler attributes', () => {
+      expect(sanitizeHTML('<div onclick="alert(1)">Test</div>')).toBe('<div>Test</div>');
+      expect(sanitizeHTML('<a href="#" onmouseover="alert(1)">link</a>')).toBe('<a href="#">link</a>');
+    });
+
+    it('should handle nested safe tags', () => {
+      expect(sanitizeHTML('<div><span>Test</span></div>')).toBe('<div><span>Test</span></div>');
+    });
+
+    it('should strip data attributes', () => {
+      const result = sanitizeHTML('<div data-evil="payload">Test</div>');
+      expect(result).not.toContain('data-evil');
+      expect(result).toContain('Test');
     });
   });
 

--- a/src/media_processing/video_processor/apps/web/lib/logger.ts
+++ b/src/media_processing/video_processor/apps/web/lib/logger.ts
@@ -3,11 +3,10 @@
  *
  * Structured logging with support for different log levels and metadata.
  * Works in both server and client environments.
- * Uses pino for high-performance logging in production.
- *
- * For now, uses console with structured formatting.
- * TODO: Add pino when ready for production.
+ * Uses pino for high-performance structured logging.
  */
+
+import pino from 'pino';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
@@ -34,47 +33,35 @@ function getLogLevel(): LogLevel {
   }
 }
 
+/**
+ * Create a pino logger instance configured for the current environment
+ */
+function createPinoLogger(): pino.Logger {
+  const level = getLogLevel();
+  const isClient = typeof window !== 'undefined';
+
+  if (isClient) {
+    // Browser: use pino browser mode
+    return pino({
+      level,
+      browser: { asObject: true },
+    });
+  }
+
+  // Server: use pino with ISO timestamps
+  return pino({
+    level,
+    timestamp: pino.stdTimeFunctions.isoTime,
+  });
+}
+
+const pinoInstance = createPinoLogger();
+
 class Logger {
-  private minLevel: LogLevel;
+  private pino: pino.Logger;
 
-  constructor() {
-    this.minLevel = getLogLevel();
-  }
-
-  private shouldLog(level: LogLevel): boolean {
-    const levels: LogLevel[] = ['debug', 'info', 'warn', 'error'];
-    const currentLevelIndex = levels.indexOf(this.minLevel);
-    const messageLevelIndex = levels.indexOf(level);
-    return messageLevelIndex >= currentLevelIndex;
-  }
-
-  private formatMessage(level: LogLevel, message: string, metadata?: LogMetadata): string {
-    const timestamp = new Date().toISOString();
-    const metadataStr = metadata ? `\n${JSON.stringify(metadata, null, 2)}` : '';
-    return `[${timestamp}] ${level.toUpperCase()}: ${message}${metadataStr}`;
-  }
-
-  private log(level: LogLevel, message: string, metadata?: LogMetadata): void {
-    if (!this.shouldLog(level)) {
-      return;
-    }
-
-    const formattedMessage = this.formatMessage(level, message, metadata);
-
-    switch (level) {
-      case 'debug':
-        console.debug(formattedMessage);
-        break;
-      case 'info':
-        console.info(formattedMessage);
-        break;
-      case 'warn':
-        console.warn(formattedMessage);
-        break;
-      case 'error':
-        console.error(formattedMessage);
-        break;
-    }
+  constructor(pinoLogger?: pino.Logger) {
+    this.pino = pinoLogger ?? pinoInstance;
   }
 
   /**
@@ -85,7 +72,11 @@ class Logger {
   debug(metadata: LogMetadata, message: string): void;
   debug(messageOrMetadata: string | LogMetadata, metadataOrMessage?: LogMetadata | string): void {
     const [message, metadata] = this.parseArgs(messageOrMetadata, metadataOrMessage);
-    this.log('debug', message, metadata);
+    if (metadata) {
+      this.pino.debug(metadata, message);
+    } else {
+      this.pino.debug(message);
+    }
   }
 
   /**
@@ -96,7 +87,11 @@ class Logger {
   info(metadata: LogMetadata, message: string): void;
   info(messageOrMetadata: string | LogMetadata, metadataOrMessage?: LogMetadata | string): void {
     const [message, metadata] = this.parseArgs(messageOrMetadata, metadataOrMessage);
-    this.log('info', message, metadata);
+    if (metadata) {
+      this.pino.info(metadata, message);
+    } else {
+      this.pino.info(message);
+    }
   }
 
   /**
@@ -107,7 +102,11 @@ class Logger {
   warn(metadata: LogMetadata, message: string): void;
   warn(messageOrMetadata: string | LogMetadata, metadataOrMessage?: LogMetadata | string): void {
     const [message, metadata] = this.parseArgs(messageOrMetadata, metadataOrMessage);
-    this.log('warn', message, metadata);
+    if (metadata) {
+      this.pino.warn(metadata, message);
+    } else {
+      this.pino.warn(message);
+    }
   }
 
   /**
@@ -128,7 +127,11 @@ class Logger {
       };
     }
 
-    this.log('error', message, metadata);
+    if (metadata) {
+      this.pino.error(metadata, message);
+    } else {
+      this.pino.error(message);
+    }
 
     // Send to error tracking service if configured
     const sentryDsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
@@ -142,7 +145,7 @@ class Logger {
         }
       } catch (error) {
         // Silently fail if Sentry is not available
-        console.error('Failed to send error to Sentry:', error);
+        this.pino.error('Failed to send error to Sentry');
       }
     }
   }
@@ -168,14 +171,8 @@ class Logger {
    * Useful for adding module/component-specific metadata
    */
   child(defaultMetadata: LogMetadata): Logger {
-    const childLogger = new Logger();
-    const originalLog = childLogger.log.bind(childLogger);
-
-    childLogger.log = (level: LogLevel, message: string, metadata?: LogMetadata) => {
-      originalLog(level, message, { ...defaultMetadata, ...metadata });
-    };
-
-    return childLogger;
+    const childPino = this.pino.child(defaultMetadata as pino.Bindings);
+    return new Logger(childPino);
   }
 }
 

--- a/src/media_processing/video_processor/apps/web/lib/sanitize.ts
+++ b/src/media_processing/video_processor/apps/web/lib/sanitize.ts
@@ -4,25 +4,27 @@
  * Sanitizes user input to prevent XSS and other injection attacks.
  * All user-provided text should be sanitized before rendering or storage.
  *
- * For now, uses simple string operations.
- * TODO: Add DOMPurify when ready for production.
+ * Uses DOMPurify for production-grade HTML sanitization.
  *
  * @see PROFESSIONAL_CODE_REVIEW.md section "Security Assessment"
  */
 
+import DOMPurify from 'dompurify';
+
 /**
  * Sanitize plain text input
- * Removes all HTML tags and dangerous characters
+ * Removes all HTML tags and dangerous characters using DOMPurify
  */
 export function sanitizeText(text: string): string {
   if (!text) {
     return '';
   }
 
+  // Use DOMPurify with no allowed tags to strip all HTML
+  const purified = DOMPurify.sanitize(text, { ALLOWED_TAGS: [] });
+
   return (
-    text
-      // Remove HTML tags
-      .replace(/<[^>]*>/g, '')
+    purified
       // Remove null bytes
       .replace(/\0/g, '')
       // Remove control characters (except newlines and tabs)
@@ -81,17 +83,23 @@ export function sanitizeUrl(url: string): string {
 }
 
 /**
- * Sanitize HTML (basic)
- * For production, use DOMPurify instead
+ * Sanitize HTML
+ * Uses DOMPurify to allow safe HTML tags while stripping dangerous content
  */
 export function sanitizeHTML(html: string): string {
   if (!html) {
     return '';
   }
 
-  // For now, just strip all HTML
-  // TODO: Use DOMPurify to allow safe HTML tags
-  return sanitizeText(html);
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: [
+      'b', 'i', 'em', 'strong', 'a', 'p', 'br', 'ul', 'ol', 'li',
+      'span', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+      'blockquote', 'code', 'pre', 'hr', 'sub', 'sup',
+    ],
+    ALLOWED_ATTR: ['href', 'title', 'class', 'id', 'target', 'rel'],
+    ALLOW_DATA_ATTR: false,
+  });
 }
 
 /**

--- a/src/media_processing/video_processor/apps/web/package.json
+++ b/src/media_processing/video_processor/apps/web/package.json
@@ -25,7 +25,9 @@
     "@mediapipe/pose": "^0.5.0",
     "@mediapipe/drawing_utils": "^0.3.0",
     "zod": "^3.22.4",
-    "sonner": "^1.3.1"
+    "sonner": "^1.3.1",
+    "dompurify": "^3.2.4",
+    "pino": "^9.6.0"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",
@@ -46,6 +48,7 @@
     "@vitest/ui": "^1.1.0",
     "vitest": "^1.1.0",
     "jsdom": "^23.0.1",
-    "@playwright/test": "^1.40.1"
+    "@playwright/test": "^1.40.1",
+    "@types/dompurify": "^3.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- Replaced regex-based HTML sanitization with DOMPurify for production-grade XSS protection
- Replaced console.log with pino structured logging for high-performance production logging
- Improved security posture of video processor frontend

## Changes
- **sanitize.ts**: `sanitizeText()` now uses `DOMPurify.sanitize(text, { ALLOWED_TAGS: [] })` instead of regex `/<[^>]*>/g`. `sanitizeHTML()` now uses DOMPurify with an explicit allowlist of safe tags/attributes instead of stripping all HTML.
- **logger.ts**: Replaced console-based Logger with pino-backed Logger. Supports browser mode (`{ browser: { asObject: true } }`) for client-side and ISO timestamps for server-side. Child loggers use `pino.child()`.
- **page.tsx**: Updated database TODO comments with `TODO(#663)` issue references and documented expected API contracts (POST `/api/audio-tracks`, POST `/api/pose-data`).
- **package.json**: Added `dompurify@^3.2.4`, `pino@^9.6.0`, `@types/dompurify@^3.2.0`.
- **sanitize.test.ts**: Updated tests to expect DOMPurify behavior (safe tags preserved, event handlers stripped, data attributes stripped).
- **logger.test.ts**: Rewrote tests to mock pino instead of console spies.

## Test plan
- [ ] Run `npm install` in `apps/web` to install new dependencies
- [ ] Run `npm test` to verify all sanitize and logger tests pass
- [ ] Verify DOMPurify correctly strips `<script>`, `<iframe>`, `onclick` attributes
- [ ] Verify pino logging works in both browser and server environments
- [ ] Verify child loggers correctly inherit context metadata

Closes #663

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-critical XSS sanitization and logging behavior; misconfiguration of DOMPurify allowlists or pino argument ordering could change rendered output or log structure across client/server.
> 
> **Overview**
> Improves the video processor frontend’s security and observability by switching HTML sanitization to **DOMPurify** and replacing the console-based logger with **pino** structured logging (browser mode on client, ISO timestamps on server, and `child()` via `pino.child()`).
> 
> Updates sanitization behavior to preserve an allowlist of safe HTML while stripping dangerous tags/attributes, rewrites logger/sanitize tests to match the new libraries, and adds `dompurify`, `pino`, and `@types/dompurify` dependencies. Also clarifies `TODO(#663)` backend persistence contracts in `page.tsx` for future audio track and pose-data APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1b83ded195afec70ba0d5d324c43b758aaa07aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->