### PR TITLE
feat(ci): add pytest-cov with coverage threshold #737

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -124,10 +124,16 @@ jobs:
           fi
           cat changed_test_files.txt
 
-      - name: Run Tests (Python ${{ matrix.python-version }})
+      - name: Run Tests with Coverage (Python ${{ matrix.python-version }})
         run: |
           if [ -s changed_test_files.txt ]; then
-            pytest $(cat changed_test_files.txt)
+            pytest $(cat changed_test_files.txt) --cov-fail-under=0
           else
-            pytest tests/shared/python/notes/test_storage.py
+            pytest tests/shared/python/notes/test_storage.py --cov-fail-under=0
           fi
+
+      - name: Coverage Summary
+        if: always()
+        run: |
+          echo "## Coverage Report (Python ${{ matrix.python-version }})" >> $GITHUB_STEP_SUMMARY
+          echo "Coverage data collected from changed tests. Full threshold enforcement (10%) applies when running the complete test suite." >> $GITHUB_STEP_SUMMARY

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ addopts = [
     "--strict-markers",
     "--tb=short",
     "-ra",
+    "--cov=src",
+    "--cov-report=term-missing",
+    "--cov-fail-under=10",
 ]
 markers = [
     "unit: mark test as unit test",

--- a/pytest.ini
+++ b/pytest.ini
@@ -79,6 +79,9 @@ addopts =
     --tb=short
     --color=yes
     -ra
+    --cov=src
+    --cov-report=term-missing
+    --cov-fail-under=10
 
 # Show slowest 10 tests
 # Uncomment to enable: --durations=10
@@ -117,12 +120,12 @@ log_file_format = %(asctime)s [%(levelname)8s] %(name)s (%(filename)s:%(lineno)d
 log_file_date_format = %Y-%m-%d %H:%M:%S
 
 # =============================================================================
-# Coverage Configuration (when using pytest-cov)
+# Coverage Configuration (pytest-cov)
 # =============================================================================
 
-# These are suggestions; actual coverage config should be in .coveragerc or pyproject.toml
-# Uncomment to enable coverage by default:
-# addopts = --cov=src --cov-report=term-missing --cov-report=html
+# Coverage is enabled via addopts above (--cov=src --cov-report=term-missing)
+# Minimum coverage threshold: 10% (enforced via --cov-fail-under=10)
+# See also: pyproject.toml [tool.pytest.ini_options] for duplicate config
 
 # =============================================================================
 # Timeout Configuration (when using pytest-timeout)


### PR DESCRIPTION
## Summary
- Enabled `pytest-cov` coverage measurement in `pytest.ini` and `pyproject.toml` (`--cov=src --cov-report=term-missing`)
- Set `--cov-fail-under=10` threshold (current full-suite coverage is ~13%)
- CI overrides threshold to 0 since it only runs changed tests (avoids false failures)
- Added coverage summary step to CI workflow for visibility

## Test plan
- [ ] CI pipeline runs successfully with coverage reporting
- [ ] `pytest-cov` output appears in CI test step logs
- [ ] Full local test suite passes the 10% coverage threshold

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/test configuration-only changes; main risk is unexpected CI/local test failures if coverage settings conflict or `pytest-cov` behavior differs across environments.
> 
> **Overview**
> Pytest runs now collect coverage by default via `pytest-cov` (`--cov=src --cov-report=term-missing`) and enforce a minimal `--cov-fail-under=10` threshold through both `pyproject.toml` and `pytest.ini`.
> 
> CI test jobs keep running only the changed tests but override the threshold to `--cov-fail-under=0` to avoid false failures, and add a `GITHUB_STEP_SUMMARY` note indicating coverage is based on changed tests and that the 10% threshold applies to full-suite runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c8f6522fe1e602912cfb2a7ef009cbb5b5eb745. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->