### PR TITLE
fix(mypy): zero remaining mypy errors

### DIFF
--- a/src/scientific_modeling/solar_system_model/solar_system/visualization/textures.py
+++ b/src/scientific_modeling/solar_system_model/solar_system/visualization/textures.py
@@ -28,7 +28,7 @@ try:  # Optional dependency during headless testing
 
     TEXTURE_BACKEND_AVAILABLE = True
 except ImportError:  # pragma: no cover - OpenGL unavailable in tests
-    pygame = None  # type: ignore[assignment]
+    pygame = None  # type: ignore[assignment,unused-ignore]
     TEXTURE_BACKEND_AVAILABLE = False
 
 


### PR DESCRIPTION
## Summary
- Fix environment-dependent `type: ignore[assignment]` on pygame fallback in `textures.py`
- Added `unused-ignore` suppression so the comment works whether pygame stubs are present or not
- Tools is now **mypy-clean** (0 errors across 438 source files)

## Test plan
- [ ] CI passes (quality-gate, tests)
- [ ] `python3 -m mypy src/ --ignore-missing-imports` returns 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only typing change with no runtime behavior impact; limited to an optional import fallback path.
> 
> **Overview**
> **Fixes a mypy edge case in the optional OpenGL/pygame texture backend.** When the OpenGL import fails in `textures.py`, the `pygame = None` fallback now uses `# type: ignore[assignment,unused-ignore]` so the suppression remains valid whether pygame type stubs are present or not.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91fd0ee43b86dd818aaac9763d1dbe745ae9be9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->