### PR TITLE
Make changed-file quality-gate resilient to deleted paths

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -57,11 +57,11 @@ jobs:
             if [ -z "$BASE_SHA" ]; then
               BASE_SHA="${{ github.event.pull_request.base.sha }}"
             fi
-            git diff --name-only "$BASE_SHA" HEAD -- '*.py' > changed_python_files.txt
+            git diff --diff-filter=ACMRT --name-only "$BASE_SHA" HEAD -- '*.py' > changed_python_files.txt
           elif [ -n "${{ github.event.before }}" ]; then
-            git diff --name-only "${{ github.event.before }}" HEAD -- '*.py' > changed_python_files.txt
+            git diff --diff-filter=ACMRT --name-only "${{ github.event.before }}" HEAD -- '*.py' > changed_python_files.txt
           else
-            git diff --name-only HEAD~1 HEAD -- '*.py' > changed_python_files.txt
+            git diff --diff-filter=ACMRT --name-only HEAD~1 HEAD -- '*.py' > changed_python_files.txt
           fi
           grep -v '^tests/' changed_python_files.txt > changed_mypy_files.txt || true
           cat changed_python_files.txt
@@ -69,7 +69,7 @@ jobs:
       - name: Format Check (Black)
         run: |
           if [ -s changed_python_files.txt ]; then
-            black --check $(cat changed_python_files.txt)
+            xargs -r -d '\n' black --check < changed_python_files.txt
           else
             echo "No changed Python files to format-check."
           fi
@@ -77,7 +77,7 @@ jobs:
       - name: Type Check (Mypy)
         run: |
           if [ -s changed_mypy_files.txt ]; then
-            mypy $(cat changed_mypy_files.txt) --ignore-missing-imports --install-types --non-interactive
+            xargs -r -d '\n' mypy --ignore-missing-imports --install-types --non-interactive < changed_mypy_files.txt
           else
             echo "No changed source Python files to type-check."
           fi


### PR DESCRIPTION
## Summary
- exclude deleted files from changed Python lists via 
- use  for Black/Mypy changed-file invocation (handles spaces safely)
- keep no-op behavior when changed-file sets are empty

Closes #749

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that adjust file selection and CLI invocation for linters/type checks; low risk, with the main impact being which files get checked in CI.
> 
> **Overview**
> The CI `quality-gate` job now collects changed Python files using `git diff --diff-filter=ACMRT`, excluding deleted paths so Black/Mypy don’t fail on removed files.
> 
> Black and Mypy are invoked via `xargs` (`-r -d '\n'`) instead of command substitution, improving handling of filenames with spaces and preserving no-op behavior when the changed-file list is empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e03c3096716c9910f921b7767f56220028c24fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->