### PR TITLE
chore: remove duplicate pytest config from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,43 +104,6 @@ exclude = [
 # =============================================================================
 # Pytest Configuration
 # =============================================================================
-[tool.pytest.ini_options]
-# Add source directories to Python path for imports
-pythonpath = [
-    ".",
-    "src",
-    "src/python/src",
-    "src/shared/python",
-    "src/tools",
-    "src/web_applications",
-    "src/data_processing/data_processor/python",
-    "src/scientific_modeling/solar_system_model",
-]
-testpaths = ["tests"]
-python_files = ["test_*.py", "*_test.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-addopts = [
-    "-v",
-    "--strict-markers",
-    "--tb=short",
-    "-ra",
-    "--cov=src",
-    "--cov-report=term-missing",
-    "--cov-fail-under=10",
-]
-markers = [
-    "unit: mark test as unit test",
-    "integration: mark test as integration test",
-    "e2e: mark test as end-to-end test",
-    "slow: mark test as slow running",
-    "requires_network: mark test as requiring network",
-]
-filterwarnings = [
-    "ignore::DeprecationWarning:pkg_resources",
-    "ignore::DeprecationWarning:setuptools",
-]
-
 [tool.ruff]
 target-version = "py310"
 select = ["E", "F", "B", "UP", "I", "T201"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -125,7 +125,6 @@ log_file_date_format = %Y-%m-%d %H:%M:%S
 
 # Coverage is enabled via addopts above (--cov=src --cov-report=term-missing)
 # Minimum coverage threshold: 10% (enforced via --cov-fail-under=10)
-# See also: pyproject.toml [tool.pytest.ini_options] for duplicate config
 
 # =============================================================================
 # Timeout Configuration (when using pytest-timeout)


### PR DESCRIPTION
## Summary
- remove duplicate `[tool.pytest.ini_options]` block from `pyproject.toml`
- keep `pytest.ini` as the single source of truth for pytest behavior
- remove stale duplicate-config note from `pytest.ini`

## Why
- avoids diverging test config and lowers maintenance overhead

Closes #752

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup that doesn’t change application/runtime code; risk is limited to unintended test behavior changes if the removed `pyproject.toml` settings differed from `pytest.ini`.
> 
> **Overview**
> Removes the duplicated `[tool.pytest.ini_options]` pytest configuration block from `pyproject.toml`, making `pytest.ini` the single source of truth for test discovery, options, markers, and warnings.
> 
> Cleans up `pytest.ini` by deleting the comment that referenced the now-removed duplicate config in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3d001fe176cb776bd7f89cad1de662a09d10e86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->