### PR TITLE
ci: add module-size budget and stronger security gates

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -82,10 +82,19 @@ jobs:
             echo "No changed source Python files to type-check."
           fi
 
-      # CodeQL is explicitly disabled via codeql-analysis.yml to reduce costs.
-      # Security scanning is performed by pip-audit and bandit.
+      - name: Security Scan (bandit)
+        run: bandit -r src -ll -ii -x tests/,archive/,legacy/,experimental/
+
       - name: Security Scan (pip-audit)
         run: pip-audit -r requirements.txt
+
+      - name: Secrets Scan (gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Module Size Budget
+        run: python3 scripts/check_module_size_budget.py --max-lines 1500 --include src
 
   tests:
     needs: quality-gate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -243,7 +243,7 @@ repos:
       - id: pytest-unit
         name: "pytest (Python tests)"
         stages: [pre-push]
-        entry: pytest
+        entry: python3 -m pytest
         args:
           [
             "tests/unit",
@@ -268,6 +268,17 @@ repos:
         args: ["--config", "auto", "--error", "--quiet"]
         types: [python]
         exclude: ^(tests/|archive/|legacy/|experimental/|\.github/)
+
+  # Module size budget check (pre-push)
+  - repo: local
+    hooks:
+      - id: module-size-budget
+        name: "module size budget"
+        stages: [pre-push]
+        entry: python3 scripts/check_module_size_budget.py --max-lines 1500 --include src
+        language: system
+        pass_filenames: false
+        types: [python]
 
   # Radon - Cyclomatic complexity check (pre-push)
   # Note: Using local hook since rubik/radon doesn't provide pre-commit hooks

--- a/config/module_size_budget_baseline.json
+++ b/config/module_size_budget_baseline.json
@@ -1,0 +1,9 @@
+{
+  "src/data_processing/data_processor/python/data_processor/Data_Processor_Integrated.py": 2717,
+  "src/data_processing/data_processor/python/data_processor/ui/pyqt6/analysis_widgets.py": 1557,
+  "src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py": 2734,
+  "src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window.py": 4386,
+  "src/shared/python/signal_toolkit/widget.py": 1794,
+  "src/tools/folder_tools/folder_packer_pro/folder_packer_pro.py": 1911,
+  "src/tools/folder_tools/folder_tool/Folders_Tool_r0.py": 3288
+}

--- a/scripts/check_module_size_budget.py
+++ b/scripts/check_module_size_budget.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Fail when Python source files exceed a configured line-count budget.
+
+Uses a baseline allowlist so existing oversized modules are tracked and frozen,
+while new oversized modules (or growth beyond baseline) fail CI.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_MAX_LINES = 1500
+DEFAULT_INCLUDE = ("src",)
+DEFAULT_BASELINE = Path("config/module_size_budget_baseline.json")
+DEFAULT_EXCLUDE_PARTS = {
+    ".git",
+    ".venv",
+    "venv",
+    "node_modules",
+    "archive",
+    "legacy",
+    "experimental",
+    "__pycache__",
+    "build",
+    "dist",
+    ".mypy_cache",
+    ".pytest_cache",
+}
+
+
+def count_lines(path: Path) -> int:
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        return sum(1 for _ in handle)
+
+
+def should_skip(path: Path, exclude_parts: set[str]) -> bool:
+    return any(part in exclude_parts for part in path.parts)
+
+
+def iter_python_files(include_roots: tuple[str, ...], exclude_parts: set[str]):
+    for root in include_roots:
+        root_path = Path(root)
+        if not root_path.exists():
+            continue
+        for candidate in root_path.rglob("*.py"):
+            if should_skip(candidate, exclude_parts):
+                continue
+            yield candidate
+
+
+def load_baseline(path: Path) -> dict[str, int]:
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return {str(k): int(v) for k, v in data.items()}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--max-lines", type=int, default=DEFAULT_MAX_LINES)
+    parser.add_argument("--include", nargs="+", default=list(DEFAULT_INCLUDE))
+    parser.add_argument("--baseline", default=str(DEFAULT_BASELINE))
+    args = parser.parse_args()
+
+    baseline = load_baseline(Path(args.baseline))
+
+    offenders: list[tuple[Path, int, str]] = []
+    for py_file in iter_python_files(tuple(args.include), DEFAULT_EXCLUDE_PARTS):
+        rel = str(py_file).replace("\\", "/")
+        lines = count_lines(py_file)
+        if lines <= args.max_lines:
+            continue
+
+        allowed = baseline.get(rel)
+        if allowed is None:
+            offenders.append((py_file, lines, "new oversized file (not in baseline)"))
+            continue
+        if lines > allowed:
+            offenders.append((py_file, lines, f"grew beyond baseline ({allowed})"))
+
+    if not offenders:
+        sys.stdout.write(
+            f"Module size budget passed (max {args.max_lines} lines, baseline {args.baseline}).\n"
+        )
+        return 0
+
+    sys.stderr.write(
+        f"Module size budget failed (max {args.max_lines} lines, baseline {args.baseline}).\n"
+    )
+    for file_path, line_count, reason in sorted(offenders):
+        sys.stderr.write(f"  {file_path}: {line_count} lines [{reason}]\n")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- switch pre-push pytest hook entry to `python3 -m pytest` for interpreter-consistent execution
- add ratcheting module-size budget gate script with checked-in baseline
- enforce module-size budget in CI quality-gate job
- add explicit `bandit` and `gitleaks` security scans in CI quality-gate

## Why
- closes critical CI/code-quality gaps without breaking existing oversized legacy files
- blocks new module-size regressions and adds secrets scanning to security baseline

## Validation
- `python3 scripts/check_module_size_budget.py --max-lines 1500 --include src`
- `pre-commit validate-config`
- workflow YAML parsed successfully via `yaml.safe_load`

Closes #739
Closes #728
Closes #722

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI and pre-push enforcement changes may cause unexpected build failures or developer friction, especially due to new secrets scanning and the line-budget gate, but they don’t alter runtime application behavior.
> 
> **Overview**
> **Strengthens CI quality gates** by adding explicit `bandit` scanning, `gitleaks` secrets detection, and a new module line-count budget check to the `quality-gate` job.
> 
> Introduces `scripts/check_module_size_budget.py` plus a checked-in baseline (`config/module_size_budget_baseline.json`) so existing oversized modules are allowed but *new* oversized files or growth beyond baseline fail.
> 
> Updates pre-push tooling by running tests via `python3 -m pytest` and adding the same module-size budget check as a `pre-commit` `pre-push` hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d113df1391cbb6be4eb577b185960ff64c835fb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->