### PR TITLE
docs: establish ADR workflow and docs governance checks

### DIFF
--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -1,0 +1,27 @@
+name: Docs Governance
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "scripts/check_docs_governance.py"
+      - ".github/workflows/docs-governance.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "scripts/check_docs_governance.py"
+      - ".github/workflows/docs-governance.yml"
+
+jobs:
+  docs-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate docs governance
+        run: python3 scripts/check_docs_governance.py

--- a/docs/adr/ADR_TEMPLATE.md
+++ b/docs/adr/ADR_TEMPLATE.md
@@ -1,0 +1,29 @@
+# ADR-XXXX: <Title>
+
+- Status: Proposed | Accepted | Superseded
+- Date: YYYY-MM-DD
+- Decision Makers: <names/roles>
+- Related Issues/PRs: <links>
+
+## Context
+
+Architecture-impacting problem and constraints.
+
+## Decision
+
+Chosen architectural direction.
+
+## Alternatives Considered
+
+1. <Alternative A>
+2. <Alternative B>
+
+## Consequences
+
+- Positive:
+- Negative:
+- Follow-up actions:
+
+## Validation
+
+How this decision is validated in CI, tests, and operation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,16 @@
+# Architecture Decision Records (ADRs)
+
+This directory stores architecture decisions for cross-tool boundaries and shared foundations.
+
+## Policy
+
+- Use `ADR_TEMPLATE.md` for every new ADR.
+- Naming format: `NNNN-short-title.md`.
+- Every ADR must include date, status, and validation approach.
+- Superseded ADRs must point to the replacement ADR.
+
+## Initial ADR Backlog
+
+1. Shared tool skeleton and extension boundaries.
+2. UI/shared/core layering and import direction.
+3. CI gate ownership and blocking scope.

--- a/docs/assessments/README.md
+++ b/docs/assessments/README.md
@@ -1,3 +1,11 @@
+## Canonical Assessment Governance
+
+- Canonical index: `docs/assessments/README.md`
+- Archive location for retired/legacy assessments: `docs/archive/`
+- Assessment updates must include index updates in the same PR.
+
+---
+
 # Assessment Framework v2.0
 
 ## Overview

--- a/docs/governance/DOCS_GOVERNANCE.md
+++ b/docs/governance/DOCS_GOVERNANCE.md
@@ -1,0 +1,13 @@
+# Documentation Governance
+
+## Canonical Indices
+
+- Root docs index: `docs/README.md`
+- Assessment index: `docs/assessments/README.md`
+- ADR index: `docs/adr/README.md`
+
+## Freshness Rules
+
+- Changes under `docs/assessments/**` require updating `docs/assessments/README.md` in the same PR.
+- Changes under `docs/adr/*.md` (excluding template/index) require updating `docs/adr/README.md`.
+- ADRs must use `docs/adr/ADR_TEMPLATE.md`.

--- a/scripts/check_docs_governance.py
+++ b/scripts/check_docs_governance.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_FILES = [
+    ROOT / "docs" / "README.md",
+    ROOT / "docs" / "assessments" / "README.md",
+    ROOT / "docs" / "adr" / "README.md",
+    ROOT / "docs" / "adr" / "ADR_TEMPLATE.md",
+    ROOT / "docs" / "governance" / "DOCS_GOVERNANCE.md",
+]
+
+
+def _changed_files() -> list[str]:
+    cp = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if cp.returncode != 0:
+        return []
+    return [ln.strip() for ln in cp.stdout.splitlines() if ln.strip()]
+
+
+def _fail(msg: str) -> int:
+    sys.stderr.write(msg + "\n")
+    return 1
+
+
+def main() -> int:
+    missing = [str(p.relative_to(ROOT)) for p in REQUIRED_FILES if not p.exists()]
+    if missing:
+        return _fail("Missing docs governance files:\n- " + "\n- ".join(missing))
+
+    changed = _changed_files()
+    changed_set = set(changed)
+
+    if any(
+        p.startswith("docs/assessments/") and p != "docs/assessments/README.md"
+        for p in changed
+    ):
+        if "docs/assessments/README.md" not in changed_set:
+            return _fail(
+                "Assessment docs changed without updating docs/assessments/README.md"
+            )
+
+    if any(
+        p.startswith("docs/adr/")
+        and p not in {"docs/adr/README.md", "docs/adr/ADR_TEMPLATE.md"}
+        for p in changed
+    ):
+        if "docs/adr/README.md" not in changed_set:
+            return _fail("ADR docs changed without updating docs/adr/README.md")
+
+    sys.stdout.write("docs governance checks passed\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add ADR workflow (`docs/adr/README.md`, `docs/adr/ADR_TEMPLATE.md`)
- add docs governance policy (`docs/governance/DOCS_GOVERNANCE.md`)
- add docs governance CI workflow (`.github/workflows/docs-governance.yml`)
- add governance validator script (`scripts/check_docs_governance.py`)
- update assessment index with canonical governance section

## Validation
- `python3 scripts/check_docs_governance.py`
- `python3 -m compileall -q scripts/check_docs_governance.py`
- workflow YAML parse check

Closes #732
Closes #723
Closes #731

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new GitHub Actions check and a small validation script that can block PRs if docs index-update rules aren’t followed; no runtime product code is affected.
> 
> **Overview**
> Establishes a lightweight documentation governance system by adding an ADR template/index plus a `DOCS_GOVERNANCE.md` policy that defines canonical docs indices and freshness rules.
> 
> Adds a new CI workflow (`docs-governance.yml`) that runs `scripts/check_docs_governance.py` on docs-related PRs and main pushes, enforcing that required governance files exist and that updates under `docs/assessments/**` or `docs/adr/**` include corresponding index updates. Also updates `docs/assessments/README.md` to include a canonical governance header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dead6f933cd98ca1a22122969da34bbdd52450ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->