### PR TITLE
ci: add minimum test contract and risk-based regression suite

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -82,6 +82,9 @@ jobs:
             echo "No changed source Python files to type-check."
           fi
 
+      - name: Minimum Test Contract Check
+        run: python3 scripts/check_minimum_test_contract.py
+
       - name: Security Scan (bandit)
         run: bandit -r src -ll -ii -x tests/,archive/,legacy/,experimental/
 
@@ -135,10 +138,11 @@ jobs:
 
       - name: Run Tests with Coverage (Python ${{ matrix.python-version }})
         run: |
+          SMOKE_TESTS="tests/test_path_helpers.py tests/test_error_handling.py tests/shared/python/notes/test_storage.py"
           if [ -s changed_test_files.txt ]; then
-            pytest $(cat changed_test_files.txt) --cov-fail-under=0
+            pytest $(cat changed_test_files.txt) $SMOKE_TESTS --cov-fail-under=0
           else
-            pytest tests/shared/python/notes/test_storage.py --cov-fail-under=0
+            pytest $SMOKE_TESTS --cov-fail-under=0
           fi
 
       - name: Coverage Summary

--- a/scripts/check_minimum_test_contract.py
+++ b/scripts/check_minimum_test_contract.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Enforce minimum test contract for changed source packages.
+
+Rule: if a package is modified in `src/`, it must have at least one test file in
+repo-level `tests/` or package-local `tests/` directories.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def changed_files() -> list[str]:
+    cp = subprocess.run(
+        ["git", "diff", "--name-only", "origin/main...HEAD"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if cp.returncode != 0:
+        return []
+    return [ln.strip() for ln in cp.stdout.splitlines() if ln.strip()]
+
+
+def package_key(path: str) -> str | None:
+    parts = path.split("/")
+    if len(parts) < 3 or parts[0] != "src":
+        return None
+
+    if parts[1] in {"tools", "data_processing", "web_applications"} and len(parts) >= 3:
+        return "/".join(parts[:3])
+
+    if parts[1] == "shared" and len(parts) >= 4 and parts[2] == "python":
+        return "/".join(parts[:4])
+
+    return "/".join(parts[:2])
+
+
+def has_tests(pkg_key: str) -> bool:
+    pkg_path = ROOT / pkg_key
+    if pkg_path.exists():
+        local_tests = list(pkg_path.rglob("tests/test_*.py")) + list(
+            pkg_path.rglob("tests/*_test.py")
+        )
+        if local_tests:
+            return True
+
+    token = pkg_key.split("/")[-1]
+    global_tests = list((ROOT / "tests").rglob(f"*{token}*test*.py")) + list(
+        (ROOT / "tests").rglob(f"test_*{token}*.py")
+    )
+    return bool(global_tests)
+
+
+def main() -> int:
+    changed = changed_files()
+    changed_src = [p for p in changed if p.startswith("src/") and p.endswith(".py")]
+    packages = sorted({k for p in changed_src if (k := package_key(p)) is not None})
+
+    if not packages:
+        sys.stdout.write(
+            "No changed src Python packages; minimum test contract check skipped.\n"
+        )
+        return 0
+
+    violations = [pkg for pkg in packages if not has_tests(pkg)]
+    if violations:
+        sys.stderr.write("Minimum test contract failed for changed packages:\n")
+        for pkg in violations:
+            sys.stderr.write(f"- {pkg}\n")
+        return 1
+
+    sys.stdout.write("Minimum test contract passed for changed packages.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add changed-package minimum test contract gate (`scripts/check_minimum_test_contract.py`)
- run minimum test contract check in CI quality gate
- replace changed-test-only behavior with risk-based execution:
  - always run core smoke regression tests
  - run changed tests on top of smoke tests when present

## Why
- enforces a baseline testing contract on modified source packages
- prevents PRs from bypassing core regressions when no changed tests are detected

## Validation
- `python3 scripts/check_minimum_test_contract.py`
- workflow YAML parse check

Closes #742
Closes #725
Closes #716

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI gating and test execution behavior, which can introduce false positives/negatives and affect developer throughput, but it doesn’t touch production runtime logic.
> 
> **Overview**
> Adds a new CI quality-gate step to enforce a *minimum test contract*: when Python code under `src/` changes, `scripts/check_minimum_test_contract.py` fails the build if it can’t find any matching tests either within the package’s `tests/` tree or in repo-level `tests/`.
> 
> Updates the test job to a risk-based approach by always running a fixed `SMOKE_TESTS` set, and layering any changed tests on top of that set instead of running changed tests alone (or a single fallback test).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac05150af5fb88be7ddf0a130af69fcc25e6d3bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->