### PR TITLE
docs: define and enforce canonical repository topology

### DIFF
--- a/.github/workflows/topology-governance.yml
+++ b/.github/workflows/topology-governance.yml
@@ -1,0 +1,29 @@
+name: Topology Governance
+
+on:
+  pull_request:
+    paths:
+      - "docs/architecture/CANONICAL_TOPOLOGY.md"
+      - "scripts/check_repo_topology.py"
+      - ".github/workflows/topology-governance.yml"
+      - "README.md"
+      - "src/**"
+      - "tests/**"
+      - "config/**"
+  push:
+    branches: [main]
+    paths:
+      - "docs/architecture/CANONICAL_TOPOLOGY.md"
+      - "scripts/check_repo_topology.py"
+      - ".github/workflows/topology-governance.yml"
+
+jobs:
+  topology-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate topology policy
+        run: python3 scripts/check_repo_topology.py

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Welcome to the **Tools Monorepo**. This repository houses a comprehensive collec
 
 ## 📂 Repository Structure
 
+Canonical topology policy: `docs/architecture/CANONICAL_TOPOLOGY.md`.
+
 The repository is organized into several key areas:
 
 ### 🔬 Scientific Computing

--- a/docs/architecture/CANONICAL_TOPOLOGY.md
+++ b/docs/architecture/CANONICAL_TOPOLOGY.md
@@ -1,0 +1,29 @@
+# Canonical Repository Topology
+
+This document defines the canonical top-level structure for the Tools repository.
+
+## Canonical Top-Level Layout
+
+- `src/`: active product code (shared libraries, tools, web apps, data/media processing)
+- `tests/`: repository-level tests and integration contract tests
+- `docs/`: user/dev documentation and assessments
+- `scripts/`: automation and repo maintenance scripts
+- `config/`: policy baselines and runtime/static configuration
+
+## Transitional / Legacy Paths
+
+These paths may exist for compatibility and migration but are not canonical for new work:
+
+- `tools/` (legacy utility subtree)
+- `data_processing/`, `media_processing/`, `web_applications/` at repo root
+- launcher compatibility files retained for migration windows
+
+## Deprecation Timeline
+
+- Q2 2026: stop adding new modules to transitional paths
+- Q3 2026: migrate remaining active modules into `src/` and remove dead roots
+
+## Ownership
+
+- Topology policy owner: repository maintainers
+- CI enforcement owner: platform/quality maintainers

--- a/scripts/check_repo_topology.py
+++ b/scripts/check_repo_topology.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED = [
+    "src",
+    "tests",
+    "docs",
+    "scripts",
+    "config",
+    "docs/architecture/CANONICAL_TOPOLOGY.md",
+]
+
+
+def main() -> int:
+    missing = [p for p in REQUIRED if not (ROOT / p).exists()]
+    if missing:
+        sys.stderr.write("Repository topology check failed. Missing required paths:\n")
+        for path in missing:
+            sys.stderr.write(f"- {path}\n")
+        return 1
+
+    sys.stdout.write("Repository topology check passed.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add canonical topology policy doc under `docs/architecture/`
- add topology validation script (`scripts/check_repo_topology.py`)
- add topology governance workflow (`.github/workflows/topology-governance.yml`)
- align README structure section with canonical topology policy reference

Closes #713

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation and a lightweight CI check; risk is limited to potential workflow noise/false failures if the required paths list doesn’t match the repo’s intended structure.
> 
> **Overview**
> Defines a canonical repository layout via new policy doc `docs/architecture/CANONICAL_TOPOLOGY.md` and links it from the README.
> 
> Adds `scripts/check_repo_topology.py` plus a new `Topology Governance` GitHub Actions workflow that runs on PRs/`main` pushes (when relevant paths change) to fail CI if required directories/files are missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4b31dcf02ba8adba5e6222825012a7b58842f0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->