### PR TITLE
ci: enforce coverage policy gate and trend reporting

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -140,13 +140,22 @@ jobs:
         run: |
           SMOKE_TESTS="tests/test_path_helpers.py tests/test_error_handling.py tests/shared/python/notes/test_storage.py"
           if [ -s changed_test_files.txt ]; then
-            pytest $(cat changed_test_files.txt) $SMOKE_TESTS --cov-fail-under=0
+            pytest $(cat changed_test_files.txt) $SMOKE_TESTS --cov-report=xml:coverage.xml --cov-fail-under=0
           else
-            pytest $SMOKE_TESTS --cov-fail-under=0
+            pytest $SMOKE_TESTS --cov-report=xml:coverage.xml --cov-fail-under=0
           fi
+
+      - name: Coverage Policy Gate
+        run: python3 scripts/check_coverage_policy.py --coverage-file coverage.xml --policy-file config/coverage_policy.json --baseline-file config/coverage_baseline.json --output-json coverage_trend_${{ matrix.python-version }}.json
+
+      - name: Upload Coverage Trend
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-trend-${{ matrix.python-version }}
+          path: coverage_trend_${{ matrix.python-version }}.json
 
       - name: Coverage Summary
         if: always()
         run: |
           echo "## Coverage Report (Python ${{ matrix.python-version }})" >> $GITHUB_STEP_SUMMARY
-          echo "Coverage data collected from changed tests. Full threshold enforcement (10%) applies when running the complete test suite." >> $GITHUB_STEP_SUMMARY
+          echo "Coverage policy gate enforced via scripts/check_coverage_policy.py (minimum + non-regression)." >> $GITHUB_STEP_SUMMARY

--- a/config/coverage_baseline.json
+++ b/config/coverage_baseline.json
@@ -1,0 +1,6 @@
+{
+  "total_percent": 0.63,
+  "package_percent": {
+    "shared/python/notes": 52.96
+  }
+}

--- a/config/coverage_policy.json
+++ b/config/coverage_policy.json
@@ -1,0 +1,7 @@
+{
+  "minimum_total_percent": 0.6,
+  "max_total_drop_percent": 0.1,
+  "tracked_packages": {
+    "shared/python/notes": 50.0
+  }
+}

--- a/docs/ci-cd/COVERAGE_POLICY.md
+++ b/docs/ci-cd/COVERAGE_POLICY.md
@@ -1,0 +1,19 @@
+# Coverage Gate Policy
+
+## Current Gate
+
+Coverage is enforced in CI via `scripts/check_coverage_policy.py` using:
+
+- `config/coverage_policy.json` (minimum + package thresholds)
+- `config/coverage_baseline.json` (non-regression baseline)
+
+## Enforcement
+
+- CI fails if total coverage drops below `minimum_total_percent`.
+- CI fails if total coverage regresses by more than `max_total_drop_percent` from baseline.
+- CI fails if tracked package coverage drops below configured thresholds.
+
+## Trend Reporting
+
+Each CI matrix run uploads `coverage_trend_<python>.json` as an artifact.
+This provides machine-readable trend snapshots for review.

--- a/scripts/check_coverage_policy.py
+++ b/scripts/check_coverage_policy.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def _pct(x: float) -> float:
+    return round(x * 100.0, 2)
+
+
+def parse_coverage(
+    coverage_file: Path, tracked_prefixes: list[str]
+) -> dict[str, object]:
+    root = ET.parse(coverage_file).getroot()
+    total_line_rate = float(root.attrib.get("line-rate", "0"))
+
+    per_prefix = {p: {"covered": 0, "valid": 0} for p in tracked_prefixes}
+
+    for cls in root.findall(".//class"):
+        filename = cls.attrib.get("filename", "")
+        lines = cls.findall("./lines/line")
+        valid = len(lines)
+        covered = sum(1 for ln in lines if int(ln.attrib.get("hits", "0")) > 0)
+        for prefix in tracked_prefixes:
+            if filename.startswith(prefix):
+                per_prefix[prefix]["covered"] += covered
+                per_prefix[prefix]["valid"] += valid
+
+    package_pct: dict[str, float] = {}
+    for prefix, stats in per_prefix.items():
+        valid = stats["valid"]
+        package_pct[prefix] = _pct((stats["covered"] / valid) if valid else 0.0)
+
+    return {"total_percent": _pct(total_line_rate), "package_percent": package_pct}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--coverage-file", default="coverage.xml")
+    ap.add_argument("--policy-file", default="config/coverage_policy.json")
+    ap.add_argument("--baseline-file", default="config/coverage_baseline.json")
+    ap.add_argument("--output-json", default="coverage_trend.json")
+    args = ap.parse_args()
+
+    policy = json.loads(Path(args.policy_file).read_text(encoding="utf-8"))
+    baseline = json.loads(Path(args.baseline_file).read_text(encoding="utf-8"))
+
+    tracked = list(policy.get("tracked_packages", {}).keys())
+    current = parse_coverage(Path(args.coverage_file), tracked)
+
+    min_total = float(policy.get("minimum_total_percent", 0.0))
+    max_drop = float(policy.get("max_total_drop_percent", 0.0))
+    baseline_total = float(baseline.get("total_percent", 0.0))
+
+    failures: list[str] = []
+    total = float(current["total_percent"])
+    if total < min_total:
+        failures.append(f"total coverage {total}% below minimum {min_total}%")
+    if total < (baseline_total - max_drop):
+        failures.append(
+            f"total coverage {total}% regressed beyond allowed drop ({baseline_total}% -> {baseline_total - max_drop}%)"
+        )
+
+    pkg_current: dict[str, float] = current["package_percent"]  # type: ignore[assignment]
+    pkg_min: dict[str, float] = policy.get("tracked_packages", {})
+    for pkg, threshold in pkg_min.items():
+        cur = float(pkg_current.get(pkg, 0.0))
+        if cur < float(threshold):
+            failures.append(
+                f"package {pkg} coverage {cur}% below threshold {threshold}%"
+            )
+
+    Path(args.output_json).write_text(
+        json.dumps(current, indent=2) + "\n", encoding="utf-8"
+    )
+
+    sys.stdout.write("Coverage policy evaluation:\n")
+    sys.stdout.write(f"- total: {total}%\n")
+    for pkg, value in pkg_current.items():
+        sys.stdout.write(f"- {pkg}: {value}%\n")
+
+    if failures:
+        sys.stderr.write("Coverage policy failed:\n")
+        for item in failures:
+            sys.stderr.write(f"- {item}\n")
+        return 1
+
+    sys.stdout.write("Coverage policy passed.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add coverage policy gate script (`scripts/check_coverage_policy.py`)
- add ratcheting policy + baseline (`config/coverage_policy.json`, `config/coverage_baseline.json`)
- update CI tests job to emit `coverage.xml`, enforce policy gate, and upload trend artifact per Python version
- document coverage gate policy in `docs/ci-cd/COVERAGE_POLICY.md`

Closes #717

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes can introduce unexpected build failures due to new coverage thresholds/baselines and XML parsing, but it doesn’t affect runtime code or production data paths.
> 
> **Overview**
> Adds a **coverage policy gate** to CI by generating `coverage.xml` during test runs, evaluating it via new `scripts/check_coverage_policy.py`, and failing the build on minimum-coverage, regression, or per-package threshold violations.
> 
> Introduces policy configuration in `config/coverage_policy.json` plus a baseline in `config/coverage_baseline.json`, uploads a `coverage_trend_<python>.json` artifact for each matrix run, and documents the rules in `docs/ci-cd/COVERAGE_POLICY.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b5e6891c25c414f2846278d39b010249636f43c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->