### PR TITLE
refactor: extract constants and validation from Folders_Tool_r0.py

### DIFF
--- a/src/tools/folder_tools/folder_tool/Folders_Tool_r0.py
+++ b/src/tools/folder_tools/folder_tool/Folders_Tool_r0.py
@@ -1,136 +1,65 @@
 # Standard library imports
 import logging
-
-# Third-party imports
 import tkinter as tk
-from datetime import datetime
-from pathlib import Path
-from tkinter import ttk
-from typing import Final
 
-# Constants for configuration with sources and units
-MAX_LOG_ENTRIES: Final[int] = (
-    20  # Maximum number of log entries to display per operation
-    # - UI performance limit
-)
+from tkinter import ttk
 
 from _bootstrap import bootstrap  # noqa: E402
 
 _REPO_ROOT = bootstrap(__file__)
 
+# Import constants from dedicated module (re-export for backward compat)
+from folder_tool_constants import (  # noqa: E402, F401
+    CHARS_PER_DIALOG_LINE,
+    DEFAULT_CHUNK_SIZE,
+    DIALOG_HEIGHT_OFFSET,
+    DIALOG_WIDTH_OFFSET,
+    ICON_SIZES,
+    LINE_HEIGHT_PIXELS,
+    MAX_ARCHIVE_SIZE_RATIO,
+    MAX_COUNTER_ATTEMPTS,
+    MAX_DIALOG_HEIGHT,
+    MAX_DIALOG_WIDTH,
+    MAX_FALLBACK_CONTENT_SIZE,
+    MAX_FILE_SIZE_MB,
+    MAX_LOG_ENTRIES,
+    MAX_RETRY_ATTEMPTS,
+    MAX_STATUS_LENGTH,
+    MAX_TEXT_CONTENT_SIZE,
+    MAX_TITLE_LENGTH,
+    MAX_TITLE_PREVIEW_LENGTH,
+    MAX_UI_UPDATE_FREQUENCY,
+    MIN_DIALOG_HEIGHT,
+    MIN_DIALOG_WIDTH,
+    MIN_FILE_SIZE_BYTES,
+    PROGRESS_BACKUP_PERCENT,
+    PROGRESS_INCREMENT,
+    PROGRESS_MAIN_OP_PERCENT,
+    PROGRESS_START_MAIN,
+    PROGRESS_START_ZIP,
+    PROGRESS_ZIP_PERCENT,
+    export_constants_documentation,
+    get_constants_info,
+    validate_constants,
+)
+
 try:
-    from utils.file_utils import safe_write_text
+    from utils.file_utils import safe_write_text  # noqa: F401, E402
 except ImportError:
     # Fallback definition if utils not found
-    def safe_write_text(path, content, encoding="utf-8", create_parents=True):
+    from pathlib import Path
+
+    def safe_write_text(  # type: ignore[misc]
+        path: str,
+        content: str,
+        encoding: str = "utf-8",
+        create_parents: bool = True,
+    ) -> None:
         p = Path(path)
         if create_parents:
             p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding=encoding)
 
-
-PROGRESS_INCREMENT: Final[int] = (
-    10  # Progress bar increment percentage [%]
-    # - standard UI update frequency
-)
-MAX_FILE_SIZE_MB: Final[int] = (
-    1024  # Maximum file size limit [MB]
-    # - Windows FAT32 limit per Microsoft docs
-)
-MIN_FILE_SIZE_BYTES: Final[int] = (
-    1  # Minimum file size [bytes]
-    # - 1 byte minimum per filesystem standards
-)
-DEFAULT_CHUNK_SIZE: Final[int] = (
-    8192  # File copy chunk size [bytes]
-    # - optimal for most systems per Python shutil docs
-)
-MAX_RETRY_ATTEMPTS: Final[int] = (
-    3  # Maximum retry attempts for file operations
-    # - industry standard retry limit
-)
-ICON_SIZES: Final[tuple[int, ...]] = (
-    16,
-    32,
-    48,
-    64,
-)  # Standard icon sizes [pixels] per Windows Shell API guidelines
-MAX_STATUS_LENGTH: Final[int] = (
-    200  # Maximum status message length [characters]
-    # - prevents UI overflow
-)
-MAX_UI_UPDATE_FREQUENCY: Final[int] = (
-    10  # Update progress every N files
-    # - balances responsiveness with performance
-)
-MAX_ARCHIVE_SIZE_RATIO: Final[float] = (
-    0.1  # Minimum extracted size ratio [ratio]
-    # - archive size * 0.1 for validation
-)
-MAX_DIALOG_WIDTH: Final[int] = (
-    800  # Maximum dialog width [pixels] - prevents dialog overflow
-)
-MAX_DIALOG_HEIGHT: Final[int] = (
-    600  # Maximum dialog height [pixels] - prevents dialog overflow
-)
-MIN_DIALOG_WIDTH: Final[int] = 400  # Minimum dialog width [pixels] - ensures usability
-MIN_DIALOG_HEIGHT: Final[int] = (
-    300  # Minimum dialog height [pixels] - ensures usability
-)
-
-# Additional constants for improved maintainability
-MAX_TEXT_CONTENT_SIZE: Final[int] = (
-    1000000  # Maximum text content size [characters]
-    # - prevents performance issues
-)
-MAX_TITLE_LENGTH: Final[int] = (
-    100  # Maximum title length [characters]
-    # - prevents window title truncation
-)
-MAX_COUNTER_ATTEMPTS: Final[int] = (
-    1000  # Maximum attempts to generate unique filename [attempts]
-    # - prevents infinite loops
-)
-MAX_FALLBACK_CONTENT_SIZE: Final[int] = (
-    500  # Maximum content size for fallback display [characters]
-    # - prevents UI overflow
-)
-PROGRESS_BACKUP_PERCENT: Final[int] = (
-    20  # Progress percentage allocated to backup operations [%] - UI progress tracking
-)
-PROGRESS_MAIN_OP_PERCENT: Final[int] = (
-    40  # Progress percentage allocated to main operations [%] - UI progress tracking
-)
-PROGRESS_ZIP_PERCENT: Final[int] = (
-    10  # Progress percentage allocated to ZIP creation [%] - UI progress tracking
-)
-PROGRESS_START_MAIN: Final[int] = (
-    30  # Starting progress percentage for main operations [%] - UI progress tracking
-)
-PROGRESS_START_ZIP: Final[int] = (
-    85  # Starting progress percentage for ZIP creation [%] - UI progress tracking
-)
-
-# Dialog layout constants
-CHARS_PER_DIALOG_LINE: Final[int] = (
-    80  # Characters per line for dialog width calculation [characters]
-    # - standard text width
-)
-DIALOG_WIDTH_OFFSET: Final[int] = (
-    100  # Additional width offset for dialog borders [pixels]
-    # - accounts for scrollbars and margins
-)
-DIALOG_HEIGHT_OFFSET: Final[int] = (
-    100  # Additional height offset for dialog borders [pixels]
-    # - accounts for title bar and margins
-)
-LINE_HEIGHT_PIXELS: Final[int] = (
-    20  # Height per line for dialog height calculation [pixels] - standard line height
-)
-MAX_TITLE_PREVIEW_LENGTH: Final[int] = (
-    50  # Maximum title length for preview in logs [characters]
-    # - prevents log overflow
-)
 
 # Set up logging to capture detailed information
 log_filename = "folder_processor.log"
@@ -150,13 +79,10 @@ from folder_tool_ui import UICreationMixin  # noqa: E402
 
 
 class FolderProcessorApp(UICreationMixin, FileOperationsMixin, ProcessingMixin):
-    """
-    An enhanced GUI application for comprehensive folder processing tasks.
-    """
+    """An enhanced GUI application for comprehensive folder processing tasks."""
 
     def __init__(self, root_window: tk.Tk) -> None:
-        """
-        Initializes the application's user interface.
+        """Initialize the application's user interface.
 
         Args:
             root_window: The root Tkinter window
@@ -198,300 +124,26 @@ class FolderProcessorApp(UICreationMixin, FileOperationsMixin, ProcessingMixin):
         style.configure("TLabel", padding=5)
 
         # Validate constants at startup
-        self._validate_constants()
+        validate_constants()
 
         # --- Main Frame with Scrollable Content ---
         self.create_scrollable_interface()
 
+    # ------------------------------------------------------------------
+    # Backward-compatible delegate methods
+    # ------------------------------------------------------------------
+
     def _validate_constants(self) -> None:
-        """Validates that all constants meet the required constraints.
-
-        This method ensures all constants are within valid ranges and follow
-        logical relationships. It validates file sizes, UI dimensions, progress
-        percentages, and other configuration values.
-
-        Raises:
-            ValueError: If any constant violates its constraints
-        """
-        # Validate file size constants
-        if MAX_FILE_SIZE_MB <= 0:
-            raise ValueError(
-                f"MAX_FILE_SIZE_MB must be positive, got {MAX_FILE_SIZE_MB}",
-            )
-        if MIN_FILE_SIZE_BYTES < 0:
-            raise ValueError(
-                f"MIN_FILE_SIZE_BYTES must be non-negative, got {MIN_FILE_SIZE_BYTES}",
-            )
-        if MIN_FILE_SIZE_BYTES >= MAX_FILE_SIZE_MB * 1024 * 1024:
-            raise ValueError(
-                f"MIN_FILE_SIZE_BYTES must be less than MAX_FILE_SIZE_MB, "
-                f"got {MIN_FILE_SIZE_BYTES}",
-            )
-
-        # Validate UI constants
-        if MAX_STATUS_LENGTH <= 0:
-            raise ValueError(
-                f"MAX_STATUS_LENGTH must be positive, got {MAX_STATUS_LENGTH}",
-            )
-        if MAX_UI_UPDATE_FREQUENCY <= 0:
-            raise ValueError(
-                f"MAX_UI_UPDATE_FREQUENCY must be positive, "
-                f"got {MAX_UI_UPDATE_FREQUENCY}",
-            )
-        if MAX_DIALOG_WIDTH <= MIN_DIALOG_WIDTH:
-            raise ValueError(
-                f"MAX_DIALOG_WIDTH must be greater than MIN_DIALOG_WIDTH, "
-                f"got {MAX_DIALOG_WIDTH} <= {MIN_DIALOG_WIDTH}",
-            )
-        if MAX_DIALOG_HEIGHT <= MIN_DIALOG_HEIGHT:
-            raise ValueError(
-                "MAX_DIALOG_HEIGHT must be greater than MIN_DIALOG_HEIGHT, "
-                f"got {MAX_DIALOG_HEIGHT} <= {MIN_DIALOG_HEIGHT}",
-            )
-
-        # Validate archive constants
-        if not 0 < MAX_ARCHIVE_SIZE_RATIO < 1:
-            raise ValueError(
-                f"MAX_ARCHIVE_SIZE_RATIO must be between 0 and 1, "
-                f"got {MAX_ARCHIVE_SIZE_RATIO}",
-            )
-
-        # Validate retry constants
-        if MAX_RETRY_ATTEMPTS <= 0:
-            raise ValueError(
-                f"MAX_RETRY_ATTEMPTS must be positive, got {MAX_RETRY_ATTEMPTS}",
-            )
-
-        # Validate new constants
-        if MAX_TEXT_CONTENT_SIZE <= 0:
-            raise ValueError(
-                f"MAX_TEXT_CONTENT_SIZE must be positive, got {MAX_TEXT_CONTENT_SIZE}",
-            )
-        if MAX_TITLE_LENGTH <= 0:
-            raise ValueError(
-                f"MAX_TITLE_LENGTH must be positive, got {MAX_TITLE_LENGTH}",
-            )
-        if MAX_COUNTER_ATTEMPTS <= 0:
-            raise ValueError(
-                f"MAX_COUNTER_ATTEMPTS must be positive, got {MAX_COUNTER_ATTEMPTS}",
-            )
-
-        # Validate progress constants
-        if PROGRESS_BACKUP_PERCENT < 0 or PROGRESS_BACKUP_PERCENT > 100:
-            raise ValueError(
-                f"PROGRESS_BACKUP_PERCENT must be between 0 and 100, "
-                f"got {PROGRESS_BACKUP_PERCENT}",
-            )
-        if PROGRESS_MAIN_OP_PERCENT < 0 or PROGRESS_MAIN_OP_PERCENT > 100:
-            raise ValueError(
-                f"PROGRESS_MAIN_OP_PERCENT must be between 0 and 100, "
-                f"got {PROGRESS_MAIN_OP_PERCENT}",
-            )
-        if PROGRESS_ZIP_PERCENT < 0 or PROGRESS_ZIP_PERCENT > 100:
-            raise ValueError(
-                f"PROGRESS_ZIP_PERCENT must be between 0 and 100, "
-                f"got {PROGRESS_ZIP_PERCENT}",
-            )
-        if PROGRESS_START_MAIN < 0 or PROGRESS_START_MAIN > 100:
-            raise ValueError(
-                f"PROGRESS_START_MAIN must be between 0 and 100, "
-                f"got {PROGRESS_START_MAIN}",
-            )
-        if PROGRESS_START_ZIP < 0 or PROGRESS_START_ZIP > 100:
-            raise ValueError(
-                f"PROGRESS_START_ZIP must be between 0 and 100, "
-                f"got {PROGRESS_START_ZIP}",
-            )
-
-        # Validate progress flow consistency
-        total_progress = (
-            PROGRESS_BACKUP_PERCENT + PROGRESS_MAIN_OP_PERCENT + PROGRESS_ZIP_PERCENT
-        )
-        if total_progress > 100:
-            raise ValueError(
-                f"Total progress allocation exceeds 100%: {total_progress}",
-            )
-
-        logger.info("All constants validated successfully")
+        """Validate constants — delegates to module-level function."""
+        validate_constants()
 
     def get_constants_info(self) -> dict[str, dict[str, str]]:
-        """Returns information about all constants for debugging and documentation.
-
-        This method provides comprehensive metadata about all constants including
-        their values, units, and sources. This is useful for debugging, documentation,
-        and system validation.
-
-        Returns:
-            Dictionary mapping constant names to their metadata [dict]
-                - includes value, units, and source
-
-        Example:
-            {
-                'MAX_FILE_SIZE_MB': {
-                    'value': '1024',
-                    'units': 'MB',
-                    'source': 'Windows FAT32 limit per Microsoft docs'
-                }
-            }
-        """
-        return {
-            "MAX_LOG_ENTRIES": {
-                "value": str(MAX_LOG_ENTRIES),
-                "units": "entries",
-                "source": "UI performance limit",
-            },
-            "PROGRESS_INCREMENT": {
-                "value": str(PROGRESS_INCREMENT),
-                "units": "%",
-                "source": "Standard UI update frequency",
-            },
-            "MAX_FILE_SIZE_MB": {
-                "value": str(MAX_FILE_SIZE_MB),
-                "units": "MB",
-                "source": "Windows FAT32 limit per Microsoft docs",
-            },
-            "MIN_FILE_SIZE_BYTES": {
-                "value": str(MIN_FILE_SIZE_BYTES),
-                "units": "bytes",
-                "source": "1 byte minimum per filesystem standards",
-            },
-            "DEFAULT_CHUNK_SIZE": {
-                "value": str(DEFAULT_CHUNK_SIZE),
-                "units": "bytes",
-                "source": "Optimal for most systems per Python shutil docs",
-            },
-            "MAX_RETRY_ATTEMPTS": {
-                "value": str(MAX_RETRY_ATTEMPTS),
-                "units": "attempts",
-                "source": "Industry standard retry limit",
-            },
-            "ICON_SIZES": {
-                "value": str(ICON_SIZES),
-                "units": "pixels",
-                "source": "Windows Shell API guidelines",
-            },
-            "MAX_STATUS_LENGTH": {
-                "value": str(MAX_STATUS_LENGTH),
-                "units": "characters",
-                "source": "Prevents UI overflow",
-            },
-            "MAX_UI_UPDATE_FREQUENCY": {
-                "value": str(MAX_UI_UPDATE_FREQUENCY),
-                "units": "files",
-                "source": "Balances responsiveness with performance",
-            },
-            "MAX_ARCHIVE_SIZE_RATIO": {
-                "value": str(MAX_ARCHIVE_SIZE_RATIO),
-                "units": "ratio",
-                "source": "Archive size * 0.1 for validation",
-            },
-            "MAX_DIALOG_WIDTH": {
-                "value": str(MAX_DIALOG_WIDTH),
-                "units": "pixels",
-                "source": "Prevents dialog overflow",
-            },
-            "MAX_DIALOG_HEIGHT": {
-                "value": str(MAX_DIALOG_HEIGHT),
-                "units": "pixels",
-                "source": "Prevents dialog overflow",
-            },
-            "MIN_DIALOG_WIDTH": {
-                "value": str(MIN_DIALOG_WIDTH),
-                "units": "pixels",
-                "source": "Ensures usability",
-            },
-            "MIN_DIALOG_HEIGHT": {
-                "value": str(MIN_DIALOG_HEIGHT),
-                "units": "pixels",
-                "source": "Ensures usability",
-            },
-            "MAX_TEXT_CONTENT_SIZE": {
-                "value": str(MAX_TEXT_CONTENT_SIZE),
-                "units": "characters",
-                "source": "Prevents performance issues in text dialogs",
-            },
-            "MAX_TITLE_LENGTH": {
-                "value": str(MAX_TITLE_LENGTH),
-                "units": "characters",
-                "source": "Prevents window title truncation",
-            },
-            "MAX_COUNTER_ATTEMPTS": {
-                "value": str(MAX_COUNTER_ATTEMPTS),
-                "units": "attempts",
-                "source": "Prevents infinite loops in filename generation",
-            },
-            "MAX_FALLBACK_CONTENT_SIZE": {
-                "value": str(MAX_FALLBACK_CONTENT_SIZE),
-                "units": "characters",
-                "source": "Prevents UI overflow in fallback dialogs",
-            },
-            "PROGRESS_BACKUP_PERCENT": {
-                "value": str(PROGRESS_BACKUP_PERCENT),
-                "units": "%",
-                "source": "UI progress tracking for backup operations",
-            },
-            "PROGRESS_MAIN_OP_PERCENT": {
-                "value": str(PROGRESS_MAIN_OP_PERCENT),
-                "units": "%",
-                "source": "UI progress tracking for main operations",
-            },
-            "PROGRESS_ZIP_PERCENT": {
-                "value": str(PROGRESS_ZIP_PERCENT),
-                "units": "%",
-                "source": "UI progress tracking for ZIP creation",
-            },
-            "PROGRESS_START_MAIN": {
-                "value": str(PROGRESS_START_MAIN),
-                "units": "%",
-                "source": "Starting progress for main operations",
-            },
-            "PROGRESS_START_ZIP": {
-                "value": str(PROGRESS_START_ZIP),
-                "units": "%",
-                "source": "Starting progress for ZIP creation",
-            },
-        }
+        """Return constants metadata — delegates to module-level function."""
+        return get_constants_info()
 
     def export_constants_documentation(self, output_path: str) -> bool:
-        """Exports constants documentation to a file for reference.
-
-        Args:
-            output_path: Path to the output file [str]
-                - will be created if it doesn't exist
-
-        Returns:
-            True if export successful, False otherwise
-
-        Raises:
-            OSError: If file operations fail
-            Exception: If export fails for other reasons
-        """
-        try:
-            constants_info = self.get_constants_info()
-
-            content = [
-                "# Folder Tool Constants Documentation",
-                f"Generated: {datetime.now()}",
-                "",
-                "## Constants Overview",
-                "",
-            ]
-
-            for const_name, info in constants_info.items():
-                content.append(f"### {const_name}")
-                content.append(f"- **Value**: {info['value']}")
-                content.append(f"- **Units**: {info['units']}")
-                content.append(f"- **Source**: {info['source']}")
-                content.append("")
-
-            safe_write_text(output_path, "\n".join(content))
-
-            logger.info(f"Constants documentation exported to: {output_path}")
-            return True
-
-        except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
-            logger.error(f"Failed to export constants documentation: {e}")
-            return False
+        """Export constants docs — delegates to module-level function."""
+        return export_constants_documentation(output_path)
 
 
 if __name__ == "__main__":

--- a/src/tools/folder_tools/folder_tool/folder_tool_constants.py
+++ b/src/tools/folder_tools/folder_tool/folder_tool_constants.py
@@ -1,0 +1,399 @@
+"""Constants and validation for the Folder Tool application.
+
+This module centralizes all configuration constants, their validation,
+documentation metadata, and export functionality. Constants include
+file size limits, UI dimensions, progress tracking values, and
+dialog layout parameters.
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# File operation constants
+# ---------------------------------------------------------------------------
+MAX_LOG_ENTRIES: Final[int] = (
+    20  # Maximum number of log entries to display per operation
+    # - UI performance limit
+)
+
+PROGRESS_INCREMENT: Final[int] = (
+    10  # Progress bar increment percentage [%]
+    # - standard UI update frequency
+)
+MAX_FILE_SIZE_MB: Final[int] = (
+    1024  # Maximum file size limit [MB]
+    # - Windows FAT32 limit per Microsoft docs
+)
+MIN_FILE_SIZE_BYTES: Final[int] = (
+    1  # Minimum file size [bytes]
+    # - 1 byte minimum per filesystem standards
+)
+DEFAULT_CHUNK_SIZE: Final[int] = (
+    8192  # File copy chunk size [bytes]
+    # - optimal for most systems per Python shutil docs
+)
+MAX_RETRY_ATTEMPTS: Final[int] = (
+    3  # Maximum retry attempts for file operations
+    # - industry standard retry limit
+)
+
+# ---------------------------------------------------------------------------
+# UI / dialog constants
+# ---------------------------------------------------------------------------
+ICON_SIZES: Final[tuple[int, ...]] = (
+    16,
+    32,
+    48,
+    64,
+)  # Standard icon sizes [pixels] per Windows Shell API guidelines
+MAX_STATUS_LENGTH: Final[int] = (
+    200  # Maximum status message length [characters]
+    # - prevents UI overflow
+)
+MAX_UI_UPDATE_FREQUENCY: Final[int] = (
+    10  # Update progress every N files
+    # - balances responsiveness with performance
+)
+MAX_ARCHIVE_SIZE_RATIO: Final[float] = (
+    0.1  # Minimum extracted size ratio [ratio]
+    # - archive size * 0.1 for validation
+)
+MAX_DIALOG_WIDTH: Final[int] = (
+    800  # Maximum dialog width [pixels] - prevents dialog overflow
+)
+MAX_DIALOG_HEIGHT: Final[int] = (
+    600  # Maximum dialog height [pixels] - prevents dialog overflow
+)
+MIN_DIALOG_WIDTH: Final[int] = 400  # Minimum dialog width [pixels] - ensures usability
+MIN_DIALOG_HEIGHT: Final[int] = (
+    300  # Minimum dialog height [pixels] - ensures usability
+)
+
+# ---------------------------------------------------------------------------
+# Content / text constants
+# ---------------------------------------------------------------------------
+MAX_TEXT_CONTENT_SIZE: Final[int] = (
+    1000000  # Maximum text content size [characters]
+    # - prevents performance issues
+)
+MAX_TITLE_LENGTH: Final[int] = (
+    100  # Maximum title length [characters]
+    # - prevents window title truncation
+)
+MAX_COUNTER_ATTEMPTS: Final[int] = (
+    1000  # Maximum attempts to generate unique filename [attempts]
+    # - prevents infinite loops
+)
+MAX_FALLBACK_CONTENT_SIZE: Final[int] = (
+    500  # Maximum content size for fallback display [characters]
+    # - prevents UI overflow
+)
+
+# ---------------------------------------------------------------------------
+# Progress tracking constants
+# ---------------------------------------------------------------------------
+PROGRESS_BACKUP_PERCENT: Final[int] = (
+    20  # Progress percentage allocated to backup operations [%]
+)
+PROGRESS_MAIN_OP_PERCENT: Final[int] = (
+    40  # Progress percentage allocated to main operations [%]
+)
+PROGRESS_ZIP_PERCENT: Final[int] = (
+    10  # Progress percentage allocated to ZIP creation [%]
+)
+PROGRESS_START_MAIN: Final[int] = (
+    30  # Starting progress percentage for main operations [%]
+)
+PROGRESS_START_ZIP: Final[int] = 85  # Starting progress percentage for ZIP creation [%]
+
+# ---------------------------------------------------------------------------
+# Dialog layout constants
+# ---------------------------------------------------------------------------
+CHARS_PER_DIALOG_LINE: Final[int] = (
+    80  # Characters per line for dialog width calculation [characters]
+    # - standard text width
+)
+DIALOG_WIDTH_OFFSET: Final[int] = (
+    100  # Additional width offset for dialog borders [pixels]
+    # - accounts for scrollbars and margins
+)
+DIALOG_HEIGHT_OFFSET: Final[int] = (
+    100  # Additional height offset for dialog borders [pixels]
+    # - accounts for title bar and margins
+)
+LINE_HEIGHT_PIXELS: Final[int] = (
+    20  # Height per line for dialog height calculation [pixels]
+)
+MAX_TITLE_PREVIEW_LENGTH: Final[int] = (
+    50  # Maximum title length for preview in logs [characters]
+    # - prevents log overflow
+)
+
+
+def validate_constants() -> None:
+    """Validate that all constants meet the required constraints.
+
+    This function ensures all constants are within valid ranges and follow
+    logical relationships. It validates file sizes, UI dimensions, progress
+    percentages, and other configuration values.
+
+    Raises:
+        ValueError: If any constant violates its constraints
+    """
+    # Validate file size constants
+    if MAX_FILE_SIZE_MB <= 0:
+        raise ValueError(
+            f"MAX_FILE_SIZE_MB must be positive, got {MAX_FILE_SIZE_MB}",
+        )
+    if MIN_FILE_SIZE_BYTES < 0:
+        raise ValueError(
+            f"MIN_FILE_SIZE_BYTES must be non-negative, got {MIN_FILE_SIZE_BYTES}",
+        )
+    if MIN_FILE_SIZE_BYTES >= MAX_FILE_SIZE_MB * 1024 * 1024:
+        raise ValueError(
+            f"MIN_FILE_SIZE_BYTES must be less than MAX_FILE_SIZE_MB, "
+            f"got {MIN_FILE_SIZE_BYTES}",
+        )
+
+    # Validate UI constants
+    if MAX_STATUS_LENGTH <= 0:
+        raise ValueError(
+            f"MAX_STATUS_LENGTH must be positive, got {MAX_STATUS_LENGTH}",
+        )
+    if MAX_UI_UPDATE_FREQUENCY <= 0:
+        raise ValueError(
+            f"MAX_UI_UPDATE_FREQUENCY must be positive, got {MAX_UI_UPDATE_FREQUENCY}",
+        )
+    if MAX_DIALOG_WIDTH <= MIN_DIALOG_WIDTH:
+        raise ValueError(
+            f"MAX_DIALOG_WIDTH must be greater than MIN_DIALOG_WIDTH, "
+            f"got {MAX_DIALOG_WIDTH} <= {MIN_DIALOG_WIDTH}",
+        )
+    if MAX_DIALOG_HEIGHT <= MIN_DIALOG_HEIGHT:
+        raise ValueError(
+            "MAX_DIALOG_HEIGHT must be greater than MIN_DIALOG_HEIGHT, "
+            f"got {MAX_DIALOG_HEIGHT} <= {MIN_DIALOG_HEIGHT}",
+        )
+
+    # Validate archive constants
+    if not 0 < MAX_ARCHIVE_SIZE_RATIO < 1:
+        raise ValueError(
+            f"MAX_ARCHIVE_SIZE_RATIO must be between 0 and 1, "
+            f"got {MAX_ARCHIVE_SIZE_RATIO}",
+        )
+
+    # Validate retry constants
+    if MAX_RETRY_ATTEMPTS <= 0:
+        raise ValueError(
+            f"MAX_RETRY_ATTEMPTS must be positive, got {MAX_RETRY_ATTEMPTS}",
+        )
+
+    # Validate new constants
+    if MAX_TEXT_CONTENT_SIZE <= 0:
+        raise ValueError(
+            f"MAX_TEXT_CONTENT_SIZE must be positive, got {MAX_TEXT_CONTENT_SIZE}",
+        )
+    if MAX_TITLE_LENGTH <= 0:
+        raise ValueError(
+            f"MAX_TITLE_LENGTH must be positive, got {MAX_TITLE_LENGTH}",
+        )
+    if MAX_COUNTER_ATTEMPTS <= 0:
+        raise ValueError(
+            f"MAX_COUNTER_ATTEMPTS must be positive, got {MAX_COUNTER_ATTEMPTS}",
+        )
+
+    # Validate progress constants
+    for name, value in [
+        ("PROGRESS_BACKUP_PERCENT", PROGRESS_BACKUP_PERCENT),
+        ("PROGRESS_MAIN_OP_PERCENT", PROGRESS_MAIN_OP_PERCENT),
+        ("PROGRESS_ZIP_PERCENT", PROGRESS_ZIP_PERCENT),
+        ("PROGRESS_START_MAIN", PROGRESS_START_MAIN),
+        ("PROGRESS_START_ZIP", PROGRESS_START_ZIP),
+    ]:
+        if value < 0 or value > 100:
+            raise ValueError(
+                f"{name} must be between 0 and 100, got {value}",
+            )
+
+    # Validate progress flow consistency
+    total_progress = (
+        PROGRESS_BACKUP_PERCENT + PROGRESS_MAIN_OP_PERCENT + PROGRESS_ZIP_PERCENT
+    )
+    if total_progress > 100:
+        raise ValueError(
+            f"Total progress allocation exceeds 100%: {total_progress}",
+        )
+
+    logger.info("All constants validated successfully")
+
+
+def get_constants_info() -> dict[str, dict[str, str]]:
+    """Return information about all constants for debugging and documentation.
+
+    Returns:
+        Dictionary mapping constant names to their metadata (value, units, source).
+    """
+    return {
+        "MAX_LOG_ENTRIES": {
+            "value": str(MAX_LOG_ENTRIES),
+            "units": "entries",
+            "source": "UI performance limit",
+        },
+        "PROGRESS_INCREMENT": {
+            "value": str(PROGRESS_INCREMENT),
+            "units": "%",
+            "source": "Standard UI update frequency",
+        },
+        "MAX_FILE_SIZE_MB": {
+            "value": str(MAX_FILE_SIZE_MB),
+            "units": "MB",
+            "source": "Windows FAT32 limit per Microsoft docs",
+        },
+        "MIN_FILE_SIZE_BYTES": {
+            "value": str(MIN_FILE_SIZE_BYTES),
+            "units": "bytes",
+            "source": "1 byte minimum per filesystem standards",
+        },
+        "DEFAULT_CHUNK_SIZE": {
+            "value": str(DEFAULT_CHUNK_SIZE),
+            "units": "bytes",
+            "source": "Optimal for most systems per Python shutil docs",
+        },
+        "MAX_RETRY_ATTEMPTS": {
+            "value": str(MAX_RETRY_ATTEMPTS),
+            "units": "attempts",
+            "source": "Industry standard retry limit",
+        },
+        "ICON_SIZES": {
+            "value": str(ICON_SIZES),
+            "units": "pixels",
+            "source": "Windows Shell API guidelines",
+        },
+        "MAX_STATUS_LENGTH": {
+            "value": str(MAX_STATUS_LENGTH),
+            "units": "characters",
+            "source": "Prevents UI overflow",
+        },
+        "MAX_UI_UPDATE_FREQUENCY": {
+            "value": str(MAX_UI_UPDATE_FREQUENCY),
+            "units": "files",
+            "source": "Balances responsiveness with performance",
+        },
+        "MAX_ARCHIVE_SIZE_RATIO": {
+            "value": str(MAX_ARCHIVE_SIZE_RATIO),
+            "units": "ratio",
+            "source": "Archive size * 0.1 for validation",
+        },
+        "MAX_DIALOG_WIDTH": {
+            "value": str(MAX_DIALOG_WIDTH),
+            "units": "pixels",
+            "source": "Prevents dialog overflow",
+        },
+        "MAX_DIALOG_HEIGHT": {
+            "value": str(MAX_DIALOG_HEIGHT),
+            "units": "pixels",
+            "source": "Prevents dialog overflow",
+        },
+        "MIN_DIALOG_WIDTH": {
+            "value": str(MIN_DIALOG_WIDTH),
+            "units": "pixels",
+            "source": "Ensures usability",
+        },
+        "MIN_DIALOG_HEIGHT": {
+            "value": str(MIN_DIALOG_HEIGHT),
+            "units": "pixels",
+            "source": "Ensures usability",
+        },
+        "MAX_TEXT_CONTENT_SIZE": {
+            "value": str(MAX_TEXT_CONTENT_SIZE),
+            "units": "characters",
+            "source": "Prevents performance issues in text dialogs",
+        },
+        "MAX_TITLE_LENGTH": {
+            "value": str(MAX_TITLE_LENGTH),
+            "units": "characters",
+            "source": "Prevents window title truncation",
+        },
+        "MAX_COUNTER_ATTEMPTS": {
+            "value": str(MAX_COUNTER_ATTEMPTS),
+            "units": "attempts",
+            "source": "Prevents infinite loops in filename generation",
+        },
+        "MAX_FALLBACK_CONTENT_SIZE": {
+            "value": str(MAX_FALLBACK_CONTENT_SIZE),
+            "units": "characters",
+            "source": "Prevents UI overflow in fallback dialogs",
+        },
+        "PROGRESS_BACKUP_PERCENT": {
+            "value": str(PROGRESS_BACKUP_PERCENT),
+            "units": "%",
+            "source": "UI progress tracking for backup operations",
+        },
+        "PROGRESS_MAIN_OP_PERCENT": {
+            "value": str(PROGRESS_MAIN_OP_PERCENT),
+            "units": "%",
+            "source": "UI progress tracking for main operations",
+        },
+        "PROGRESS_ZIP_PERCENT": {
+            "value": str(PROGRESS_ZIP_PERCENT),
+            "units": "%",
+            "source": "UI progress tracking for ZIP creation",
+        },
+        "PROGRESS_START_MAIN": {
+            "value": str(PROGRESS_START_MAIN),
+            "units": "%",
+            "source": "Starting progress for main operations",
+        },
+        "PROGRESS_START_ZIP": {
+            "value": str(PROGRESS_START_ZIP),
+            "units": "%",
+            "source": "Starting progress for ZIP creation",
+        },
+    }
+
+
+def export_constants_documentation(output_path: str) -> bool:
+    """Export constants documentation to a file for reference.
+
+    Args:
+        output_path: Path to the output file.
+
+    Returns:
+        True if export successful, False otherwise.
+
+    Raises:
+        OSError: If file operations fail.
+    """
+    try:
+        constants_info = get_constants_info()
+
+        content = [
+            "# Folder Tool Constants Documentation",
+            f"Generated: {datetime.now()}",
+            "",
+            "## Constants Overview",
+            "",
+        ]
+
+        for const_name, info in constants_info.items():
+            content.append(f"### {const_name}")
+            content.append(f"- **Value**: {info['value']}")
+            content.append(f"- **Units**: {info['units']}")
+            content.append(f"- **Source**: {info['source']}")
+            content.append("")
+
+        p = Path(output_path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("\n".join(content), encoding="utf-8")
+
+        logger.info("Constants documentation exported to: %s", output_path)
+        return True
+
+    except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
+        logger.error("Failed to export constants documentation: %s", e)
+        return False

--- a/tests/tools/folder_tools/test_folder_tool_constants.py
+++ b/tests/tools/folder_tools/test_folder_tool_constants.py
@@ -1,0 +1,136 @@
+"""Tests for the folder_tool_constants module."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from folder_tool_constants import (
+    DEFAULT_CHUNK_SIZE,
+    MAX_ARCHIVE_SIZE_RATIO,
+    MAX_COUNTER_ATTEMPTS,
+    MAX_DIALOG_HEIGHT,
+    MAX_DIALOG_WIDTH,
+    MAX_FALLBACK_CONTENT_SIZE,
+    MAX_FILE_SIZE_MB,
+    MAX_LOG_ENTRIES,
+    MAX_RETRY_ATTEMPTS,
+    MAX_STATUS_LENGTH,
+    MAX_TEXT_CONTENT_SIZE,
+    MAX_TITLE_LENGTH,
+    MAX_UI_UPDATE_FREQUENCY,
+    MIN_DIALOG_HEIGHT,
+    MIN_DIALOG_WIDTH,
+    MIN_FILE_SIZE_BYTES,
+    PROGRESS_BACKUP_PERCENT,
+    PROGRESS_INCREMENT,
+    PROGRESS_MAIN_OP_PERCENT,
+    PROGRESS_START_MAIN,
+    PROGRESS_START_ZIP,
+    PROGRESS_ZIP_PERCENT,
+    export_constants_documentation,
+    get_constants_info,
+    validate_constants,
+)
+
+
+class TestConstants:
+    """Test that constants have sensible values."""
+
+    def test_file_size_constants_positive(self) -> None:
+        assert MAX_FILE_SIZE_MB > 0
+        assert MIN_FILE_SIZE_BYTES >= 0
+        assert DEFAULT_CHUNK_SIZE > 0
+
+    def test_ui_constants_positive(self) -> None:
+        assert MAX_LOG_ENTRIES > 0
+        assert PROGRESS_INCREMENT > 0
+        assert MAX_STATUS_LENGTH > 0
+        assert MAX_UI_UPDATE_FREQUENCY > 0
+
+    def test_dialog_size_constraints(self) -> None:
+        assert MAX_DIALOG_WIDTH > MIN_DIALOG_WIDTH
+        assert MAX_DIALOG_HEIGHT > MIN_DIALOG_HEIGHT
+
+    def test_archive_ratio_range(self) -> None:
+        assert 0 < MAX_ARCHIVE_SIZE_RATIO < 1
+
+    def test_retry_constant(self) -> None:
+        assert MAX_RETRY_ATTEMPTS > 0
+
+    def test_text_constants(self) -> None:
+        assert MAX_TEXT_CONTENT_SIZE > 0
+        assert MAX_TITLE_LENGTH > 0
+        assert MAX_COUNTER_ATTEMPTS > 0
+        assert MAX_FALLBACK_CONTENT_SIZE > 0
+
+    def test_progress_constants_in_range(self) -> None:
+        for val in [
+            PROGRESS_BACKUP_PERCENT,
+            PROGRESS_MAIN_OP_PERCENT,
+            PROGRESS_ZIP_PERCENT,
+            PROGRESS_START_MAIN,
+            PROGRESS_START_ZIP,
+        ]:
+            assert 0 <= val <= 100
+
+    def test_progress_total_not_exceeding_100(self) -> None:
+        total = (
+            PROGRESS_BACKUP_PERCENT + PROGRESS_MAIN_OP_PERCENT + PROGRESS_ZIP_PERCENT
+        )
+        assert total <= 100
+
+
+class TestValidateConstants:
+    """Test the validate_constants function."""
+
+    def test_validate_constants_succeeds(self) -> None:
+        """Should not raise any exception with default constants."""
+        validate_constants()
+
+
+class TestGetConstantsInfo:
+    """Test the get_constants_info function."""
+
+    def test_returns_dict(self) -> None:
+        info = get_constants_info()
+        assert isinstance(info, dict)
+        assert len(info) > 0
+
+    def test_all_entries_have_required_keys(self) -> None:
+        info = get_constants_info()
+        for name, meta in info.items():
+            assert "value" in meta, f"{name} missing 'value'"
+            assert "units" in meta, f"{name} missing 'units'"
+            assert "source" in meta, f"{name} missing 'source'"
+
+    def test_known_constant_present(self) -> None:
+        info = get_constants_info()
+        assert "MAX_FILE_SIZE_MB" in info
+        assert info["MAX_FILE_SIZE_MB"]["units"] == "MB"
+
+
+class TestExportConstantsDocumentation:
+    """Test the export_constants_documentation function."""
+
+    def test_export_creates_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = str(Path(tmpdir) / "constants_doc.md")
+            result = export_constants_documentation(out_path)
+            assert result is True
+            assert Path(out_path).exists()
+
+    def test_export_content_has_header(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = str(Path(tmpdir) / "constants_doc.md")
+            export_constants_documentation(out_path)
+            content = Path(out_path).read_text(encoding="utf-8")
+            assert "# Folder Tool Constants Documentation" in content
+            assert "MAX_FILE_SIZE_MB" in content
+
+    def test_export_creates_parent_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = str(Path(tmpdir) / "sub" / "dir" / "doc.md")
+            result = export_constants_documentation(out_path)
+            assert result is True
+            assert Path(out_path).exists()


### PR DESCRIPTION
Extracts all module-level constants, validation logic, metadata retrieval, and documentation export from Folders_Tool_r0.py into a dedicated folder_tool_constants.py module. The main file is slimmed from 501 to ~140 lines with backward-compatible delegates. Adds 15 tests covering constant values, validation, metadata, and docs export.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a reorganization of constants and helper functions with added tests; runtime behavior should remain the same aside from import/module wiring.
> 
> **Overview**
> Refactors `Folders_Tool_r0.py` by extracting its configuration constants, validation logic, metadata lookup, and documentation export into a new `folder_tool_constants.py` module.
> 
> The app now imports/re-exports these constants for backward compatibility, delegates `_validate_constants`, `get_constants_info`, and `export_constants_documentation` to the module functions, and adds focused tests covering constant sanity checks, `validate_constants`, `get_constants_info`, and docs export file creation/content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f0bd550776c3b01dbec150ece299dd79b7c41d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->