### PR TITLE
fix: resolve 3 bugs from decomposition PR (Bugbot findings)

### DIFF
--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/analysis_widgets.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/analysis_widgets.py
@@ -30,23 +30,26 @@ except ImportError:
 
 
 # Re-export all widget classes for backward compatibility
-from .chart_style_panel import ChartStylePanel  # noqa: E402
-from .plot_dialogs import (  # noqa: E402
-    ContourPlotDialog,
-    FilterComparisonDialog,
-    HeatmapDialog,
-)
-from .statistical_widgets import (  # noqa: E402
-    ANOVAWidget,
-    PCAWidget,
-    RegressionWidget,
-    VariableSelector,
-)
-from .visualization_widgets import (  # noqa: E402
-    NeuralNetworkWidget,
-    ScriptGeneratorWidget,
-    SurfacePlotWidget,
-)
+# Only import when PyQt6 is available, as submodules define classes
+# inside PYQT6_AVAILABLE guards
+if PYQT6_AVAILABLE:
+    from .chart_style_panel import ChartStylePanel  # noqa: E402
+    from .plot_dialogs import (  # noqa: E402
+        ContourPlotDialog,
+        FilterComparisonDialog,
+        HeatmapDialog,
+    )
+    from .statistical_widgets import (  # noqa: E402
+        ANOVAWidget,
+        PCAWidget,
+        RegressionWidget,
+        VariableSelector,
+    )
+    from .visualization_widgets import (  # noqa: E402
+        NeuralNetworkWidget,
+        ScriptGeneratorWidget,
+        SurfacePlotWidget,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/visualization_widgets.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/visualization_widgets.py
@@ -46,12 +46,11 @@ except ImportError:
         return None
 
 
-from .statistical_widgets import VariableSelector
-
 logger = logging.getLogger(__name__)
 
 
 if PYQT6_AVAILABLE:
+    from .statistical_widgets import VariableSelector
 
     class SurfacePlotWidget(QWidget):
         """Widget for 3D surface plot configuration."""

--- a/src/tools/folder_tools/folder_tool/file_validation.py
+++ b/src/tools/folder_tools/folder_tool/file_validation.py
@@ -204,4 +204,4 @@ class FileValidationMixin:
             except OSError:
                 dest_path = Path(dest_path) / "Unknown_Date"
 
-        return Path(dest_path) / filename
+        return str(Path(dest_path) / filename)

--- a/src/tools/folder_tools/folder_tool/folder_ops.py
+++ b/src/tools/folder_tools/folder_tool/folder_ops.py
@@ -333,7 +333,7 @@ class FolderOperationsMixin:
                 if not files and not any(
                     any(Path(root, d).iterdir())
                     for d in dirs
-                    if Path(Path(root).exists() / d)
+                    if (Path(root) / d).exists()
                 ):
                     empty_folders_skipped += 1
                     continue


### PR DESCRIPTION
Fixes 3 bugs found by Cursor Bugbot in PR #795:\n\n1. **Broken path expression** in  -  causes TypeError\n2. **Facade imports fail** when PyQt6 unavailable - unconditional imports of guarded classes\n3. **Type mismatch** -  returns Path instead of str, crashing \n\nAll 3 are high-severity runtime crash bugs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized fixes to import gating and path construction; main risk is minor behavior/type change where callers may have relied on a `Path` return value.
> 
> **Overview**
> Prevents runtime crashes when PyQt6 is not installed by guarding the re-export imports in `analysis_widgets.py` and moving the `VariableSelector` import in `visualization_widgets.py` inside the `PYQT6_AVAILABLE` block.
> 
> Fixes two folder-tool path issues: `get_organized_path()` now returns a `str` (not a `Path`), and `_prune_empty_folders()` corrects the empty-folder existence check to use `(Path(root) / d).exists()` instead of an invalid `Path(...exists() / d)` expression.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f917fc9f8fb7ebabad874533581b3b3686bfabad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->