### PR TITLE
feat: Modernize Shared UI Base (v2)

### DIFF
--- a/src/shared/python/upstream_drift_tools/ui/mixins/base_calculator_mixin.py
+++ b/src/shared/python/upstream_drift_tools/ui/mixins/base_calculator_mixin.py
@@ -1,0 +1,49 @@
+"""Base Calculator Widget Mixin
+===========================
+
+Common UI logic for all calculator widgets in the fleet.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from PyQt6.QtWidgets import QWidget
+
+from .calculator_state_mixin import CalculatorStateMixin
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCalculatorMixin(CalculatorStateMixin):
+    """
+    Mixin providing common functionality for calculator widgets.
+    Expected to be mixed into a QWidget or QMainWindow.
+    """
+
+    def __init__(self, calculator_name: str | None = None) -> None:
+        """Initialize the mixin logic."""
+        CalculatorStateMixin.__init__(self, calculator_name)
+        self.calculator_name = calculator_name or self.__class__.__name__
+        self._logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+
+        # Initialize state management attributes if not already present
+        if not hasattr(self, "_splitters"):
+            self._splitters: list[Any] = []
+        if not hasattr(self, "_copyable_widgets"):
+            self._copyable_widgets: list[Any] = []
+        if not hasattr(self, "_state"):
+            self._state: dict[str, Any] = {}
+
+    def log_info(self, message: str) -> None:
+        """Log an info message."""
+        self._logger.info(message)
+
+    def log_warning(self, message: str) -> None:
+        """Log a warning message."""
+        self._logger.warning(message)
+
+    def log_error(self, message: str) -> None:
+        """Log an error message."""
+        self._logger.error(message)

--- a/src/shared/python/upstream_drift_tools/ui/widgets/__init__.py
+++ b/src/shared/python/upstream_drift_tools/ui/widgets/__init__.py
@@ -1,12 +1,13 @@
 """Widget components for Upstream Drift Tools UI."""
 
-from .base_calculator_widget import BaseCalculatorWidget
+from .base_calculator_widget import BaseCalculatorWidget, BaseCalculatorWindow
 from .data_processor_widget import DataProcessorWidget
 from .unit_aware_input import UnitAwareDisplay, UnitAwareInput
 from .unit_converter_widget import UnitConverterWidget
 
 __all__ = [
     "BaseCalculatorWidget",
+    "BaseCalculatorWindow",
     "DataProcessorWidget",
     "UnitAwareDisplay",
     "UnitAwareInput",

--- a/src/shared/python/upstream_drift_tools/ui/widgets/base_calculator_widget.py
+++ b/src/shared/python/upstream_drift_tools/ui/widgets/base_calculator_widget.py
@@ -1,4 +1,4 @@
-"""Base class for all calculator widgets in the fleet."""
+"""Base class for all calculator widgets and windows in the fleet."""
 
 from __future__ import annotations
 
@@ -7,13 +7,33 @@ from typing import Any
 
 from PyQt6.QtWidgets import QMainWindow, QMessageBox, QVBoxLayout, QWidget
 
-from ..mixins.calculator_state_mixin import CalculatorStateMixin
+from ..mixins.base_calculator_mixin import BaseCalculatorMixin
 
 logger = logging.getLogger(__name__)
 
 
-class BaseCalculatorWidget(QMainWindow, CalculatorStateMixin):
-    """Base class for calculator windows providing state management and common UI patterns."""
+class BaseCalculatorWidget(QWidget, BaseCalculatorMixin):
+    """Base QWidget for calculator modules that can be embedded."""
+
+    def __init__(
+        self,
+        calculator_name: str | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        QWidget.__init__(self, parent)
+        BaseCalculatorMixin.__init__(self, calculator_name)
+
+    def show_error(self, title: str, message: str) -> None:
+        """Display an error message box."""
+        QMessageBox.critical(self, title, message)
+
+    def show_info(self, title: str, message: str) -> None:
+        """Display an information message box."""
+        QMessageBox.information(self, title, message)
+
+
+class BaseCalculatorWindow(QMainWindow, BaseCalculatorMixin):
+    """Base QMainWindow for standalone calculator applications."""
 
     def __init__(
         self,
@@ -23,7 +43,7 @@ class BaseCalculatorWidget(QMainWindow, CalculatorStateMixin):
         parent: QWidget | None = None,
     ) -> None:
         QMainWindow.__init__(self, parent)
-        CalculatorStateMixin.__init__(self, calculator_name)
+        BaseCalculatorMixin.__init__(self, calculator_name)
 
         self.setWindowTitle(window_title or calculator_name)
         self.setMinimumSize(*min_size)
@@ -43,11 +63,5 @@ class BaseCalculatorWidget(QMainWindow, CalculatorStateMixin):
 
     def closeEvent(self, event: Any) -> None:
         """Handle window close event with state saving."""
+        # Use handle_close_event from CalculatorStateMixin
         self.handle_close_event(event)
-
-    def get_calculator_specific_state(self) -> dict[str, Any]:
-        """Override to save custom UI state."""
-        return {}
-
-    def set_calculator_specific_state(self, state: dict[str, Any]) -> None:
-        """Override to restore custom UI state."""

--- a/src/shared/python/upstream_drift_tools/ui/widgets/unit_converter_widget.py
+++ b/src/shared/python/upstream_drift_tools/ui/widgets/unit_converter_widget.py
@@ -39,7 +39,7 @@ from PyQt6.QtWidgets import (
 )
 
 from ...calculators.conversion.service import UnitConversionService, get_service
-from .base_calculator_widget import BaseCalculatorWidget
+from .base_calculator_widget import BaseCalculatorWindow
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +135,7 @@ class CaseInsensitiveCompleter(QCompleter):
         self.setModel(model)
 
 
-class UnitConverterWidget(BaseCalculatorWidget):
+class UnitConverterWidget(BaseCalculatorWindow):
     """Shared Unit Converter widget with saved configurations and recent history."""
 
     calculation_finished = pyqtSignal(dict)
@@ -385,9 +385,9 @@ class UnitConverterWidget(BaseCalculatorWidget):
             if not from_u or not to_u:
                 return
 
-            widget.from_value.blockSignals(True)
-            widget.to_value.blockSignals(True)
             try:
+                widget.from_value.blockSignals(True)
+                widget.to_value.blockSignals(True)
                 if direction == "from":
                     val_text = widget.from_value.text().strip()
                     if val_text:
@@ -496,6 +496,8 @@ class UnitConverterWidget(BaseCalculatorWidget):
         cw = self.centralWidget()
         if cw:
             cw.deleteLater()
+        if hasattr(self, "central_widget"):
+            self.central_widget.setFocus()
         self.central_widget = QWidget()
         self.setCentralWidget(self.central_widget)
         self.main_layout = QVBoxLayout(self.central_widget)


### PR DESCRIPTION
This PR provides a split BaseCalculatorWidget (QWidget) and BaseCalculatorWindow (QMainWindow) to support both embedded and standalone use cases, and fixes signal blocking bugs in UnitConverterWidget.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared UI base classes used across calculators and changes inheritance/MRO, which can introduce subtle runtime/UI state regressions; the Unit Converter fixes are localized and low complexity.
> 
> **Overview**
> Refactors the shared calculator UI base by introducing `BaseCalculatorMixin` (wrapping `CalculatorStateMixin` plus common logging/state attributes) and splitting the previous `BaseCalculatorWidget` into an embeddable `BaseCalculatorWidget` (`QWidget`) and a standalone `BaseCalculatorWindow` (`QMainWindow`). Public exports are updated to expose `BaseCalculatorWindow`.
> 
> Updates `UnitConverterWidget` to inherit from `BaseCalculatorWindow`, fixes a conversion signal-blocking issue by ensuring `blockSignals(True/False)` is always paired via `try/finally`, and adjusts UI rebuild logic around resetting the central widget.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e36a78e153248d338c65c3fd391c50590500a2d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->