### PR TITLE
refactor: Wave 4 — DbC input validation for URDF/model editors

### DIFF
--- a/src/shared/python/model_generation/builders/parametric_builder.py
+++ b/src/shared/python/model_generation/builders/parametric_builder.py
@@ -131,8 +131,12 @@ class ParametricBuilder(BaseURDFBuilder):
             Self for method chaining
         """
         if height_m is not None:
+            if height_m <= 0:
+                raise ValueError(f"height_m must be positive, got {height_m}")
             self._height_m = height_m
         if mass_kg is not None:
+            if mass_kg <= 0:
+                raise ValueError(f"mass_kg must be positive, got {mass_kg}")
             self._mass_kg = mass_kg
         if gender_factor is not None:
             self._gender_factor = max(0.0, min(1.0, gender_factor))
@@ -172,7 +176,25 @@ class ParametricBuilder(BaseURDFBuilder):
 
         Returns:
             Self for method chaining
+
+        Raises:
+            ValueError: If name is empty, segment name already exists,
+                or ratios are non-positive.
         """
+        if not name or not name.strip():
+            raise ValueError("Segment name must be a non-empty string")
+        if mass_ratio <= 0:
+            raise ValueError(f"mass_ratio must be positive, got {mass_ratio}")
+        if length_ratio <= 0:
+            raise ValueError(f"length_ratio must be positive, got {length_ratio}")
+        if width_ratio <= 0:
+            raise ValueError(f"width_ratio must be positive, got {width_ratio}")
+
+        # Check for duplicate segment names
+        existing_names = {link.name for link in self._links}
+        if name in existing_names:
+            raise ValueError(f"Segment '{name}' already exists")
+
         # Compute dimensions
         length = self._height_m * length_ratio
         width = length * width_ratio

--- a/src/shared/python/model_generation/builders/urdf_writer.py
+++ b/src/shared/python/model_generation/builders/urdf_writer.py
@@ -7,6 +7,7 @@ including proper formatting, material definitions, and composite joint expansion
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,6 +26,8 @@ from model_generation.core.types import (
     Material,
     Origin,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -63,6 +66,17 @@ class URDFWriter:
         Returns:
             URDF XML string
         """
+        if not robot_name or not robot_name.strip():
+            raise ValueError("robot_name must be a non-empty string")
+        if not links:
+            raise ValueError("At least one link is required")
+
+        logger.debug(
+            "Writing URDF '%s' with %d links and %d joints",
+            robot_name,
+            len(links),
+            len(joints),
+        )
         lines: list[str] = []
 
         # XML declaration

--- a/src/shared/python/model_generation/editor/editor_modifications.py
+++ b/src/shared/python/model_generation/editor/editor_modifications.py
@@ -162,6 +162,13 @@ class ModificationMixin:
         Returns:
             True if renamed
         """
+        if not new_name or not new_name.strip():
+            logger.error("new_name must be a non-empty string")
+            return False
+
+        if old_name == new_name:
+            return True  # No-op
+
         model = self._models.get(model_id)
         if not model:
             logger.error(f"Model '{model_id}' not found")
@@ -217,6 +224,13 @@ class ModificationMixin:
         Returns:
             True if renamed
         """
+        if not new_name or not new_name.strip():
+            logger.error("new_name must be a non-empty string")
+            return False
+
+        if old_name == new_name:
+            return True  # No-op
+
         model = self._models.get(model_id)
         if not model:
             logger.error(f"Model '{model_id}' not found")
@@ -275,16 +289,41 @@ class ModificationMixin:
 
         self._save_state()
 
-        # Update properties
+        # Type-checked property updates
+        _ALLOWED_KEYS = {"origin", "axis", "limits", "dynamics", "joint_type"}
+        unknown_keys = set(kwargs) - _ALLOWED_KEYS
+        if unknown_keys:
+            logger.warning("Ignoring unknown joint properties: %s", unknown_keys)
+
         if "origin" in kwargs:
+            if not isinstance(kwargs["origin"], Origin):
+                logger.error("'origin' must be an Origin instance")
+                return False
             joint.origin = kwargs["origin"]
         if "axis" in kwargs:
-            joint.axis = kwargs["axis"]
+            axis = kwargs["axis"]
+            if not isinstance(axis, tuple) or len(axis) != 3:
+                logger.error("'axis' must be a 3-tuple of floats")
+                return False
+            joint.axis = axis
         if "limits" in kwargs:
+            from model_generation.core.types import JointLimits
+
+            if not isinstance(kwargs["limits"], JointLimits):
+                logger.error("'limits' must be a JointLimits instance")
+                return False
             joint.limits = kwargs["limits"]
         if "dynamics" in kwargs:
+            from model_generation.core.types import JointDynamics
+
+            if not isinstance(kwargs["dynamics"], JointDynamics):
+                logger.error("'dynamics' must be a JointDynamics instance")
+                return False
             joint.dynamics = kwargs["dynamics"]
         if "joint_type" in kwargs:
+            if not isinstance(kwargs["joint_type"], JointType):
+                logger.error("'joint_type' must be a JointType enum value")
+                return False
             joint.joint_type = kwargs["joint_type"]
 
         logger.info(f"Modified joint '{joint_name}'")
@@ -493,6 +532,12 @@ class ModificationMixin:
         Returns:
             List of created link names
         """
+        _VALID_AXES = {"x", "y", "z"}
+        if mirror_axis not in _VALID_AXES:
+            raise ValueError(
+                f"mirror_axis must be one of {_VALID_AXES}, got '{mirror_axis}'"
+            )
+
         # Copy subtree to clipboard
         if not self.copy_subtree(model_id, root_link):
             return []


### PR DESCRIPTION
Adds Design by Contract preconditions and input validation to URDF/model editors.

## Changes

### URDFWriter
- ****: Reject empty/whitespace , reject empty  list, add debug logging

### ParametricBuilder
- ****: Validate , 
- ****: Validate non-empty name, positive ratios, duplicate segment detection

### ModificationMixin (FrankensteinEditor)
- ****: Reject empty/whitespace names, short-circuit no-op renames
- ****: Type-check all kwargs (Origin, tuple, JointLimits, JointDynamics, JointType), warn on unknown keys
- ****: Validate  is one of {x, y, z}

## Testing
- All 1997 tests pass
- Pre-commit hooks (ruff, black, no-print) all pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds input validation and logging; behavior changes are limited to earlier failures on invalid parameters and stricter editor mutation inputs.
> 
> **Overview**
> Tightens Design-by-Contract preconditions across model generation and editing APIs to fail fast on invalid inputs.
> 
> `ParametricBuilder` now rejects non-positive `height_m`/`mass_kg`, enforces non-empty segment names, requires positive segment ratios, and prevents duplicate segment names. `URDFWriter.write` now validates `robot_name` and requires at least one link, and adds debug logging about what’s being written.
> 
> Editor modification operations now reject empty/whitespace rename targets (and treat same-name renames as no-ops), `modify_joint` type-checks supported kwargs while warning on unknown keys, and `mirror_subtree` validates `mirror_axis` against `{x,y,z}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 291272940f2c5fbfe2b983dc81ee104776baf78d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->