### PR TITLE
refactor: Wave 4 - Type hint coverage to 85%+ across shared modules

### DIFF
--- a/src/shared/python/model_generation/api/rest_api.py
+++ b/src/shared/python/model_generation/api/rest_api.py
@@ -121,7 +121,7 @@ class ModelGenerationAPI:
         FastAPIAdapter(api).register(app)
     """
 
-    def __init__(self, prefix: str = "/api/v1"):
+    def __init__(self, prefix: str = "/api/v1") -> None:
         """
         Initialize API.
 
@@ -1024,7 +1024,7 @@ class ModelGenerationAPI:
 class FlaskAdapter:
     """Adapter for Flask framework."""
 
-    def __init__(self, api: ModelGenerationAPI):
+    def __init__(self, api: ModelGenerationAPI) -> None:
         self.api = api
 
     def register(self, app: Any) -> None:
@@ -1035,8 +1035,8 @@ class FlaskAdapter:
         for route in self.api.get_routes():
             endpoint = route.path.replace("/", "_").replace("{", "").replace("}", "")
 
-            def make_handler(r: Route):
-                def handler(**kwargs):
+            def make_handler(r: Route) -> Callable[..., Any]:
+                def handler(**kwargs: Any) -> Any:
                     # Build APIRequest
                     api_request = APIRequest(
                         method=HTTPMethod(flask_request.method),
@@ -1079,7 +1079,7 @@ class FlaskAdapter:
 class FastAPIAdapter:
     """Adapter for FastAPI framework."""
 
-    def __init__(self, api: ModelGenerationAPI):
+    def __init__(self, api: ModelGenerationAPI) -> None:
         self.api = api
 
     def register(self, app: Any) -> None:
@@ -1089,8 +1089,8 @@ class FastAPIAdapter:
 
         for route in self.api.get_routes():
 
-            async def make_handler(r: Route):
-                async def handler(request: Request, **kwargs):
+            async def make_handler(r: Route) -> Callable[..., Any]:
+                async def handler(request: Request, **kwargs: Any) -> Any:
                     body = None
                     try:
                         body = await request.json()

--- a/src/shared/python/model_generation/library/github_importer.py
+++ b/src/shared/python/model_generation/library/github_importer.py
@@ -47,7 +47,7 @@ class GitHubImporter:
         "bulletphysics/bullet3",
     ]
 
-    def __init__(self, library: ModelLibrary | None = None):
+    def __init__(self, library: ModelLibrary | None = None) -> None:
         """Initialize importer."""
         self.library = library or ModelLibrary()
 

--- a/src/shared/python/theme/dialogs/custom_theme_editor.py
+++ b/src/shared/python/theme/dialogs/custom_theme_editor.py
@@ -39,7 +39,9 @@ class ColorPickerButton(QPushButton):
 
     color_changed = pyqtSignal(str)  # Emits hex color string
 
-    def __init__(self, initial_color: str = "#ffffff", parent: QWidget | None = None):
+    def __init__(
+        self, initial_color: str = "#ffffff", parent: QWidget | None = None
+    ) -> None:
         super().__init__(parent)
         self._color = initial_color
         self.setFixedSize(60, 30)
@@ -90,7 +92,7 @@ class ColorPickerButton(QPushButton):
 class ThemePreviewWidget(QWidget):
     """Widget that shows a preview of how the theme will look."""
 
-    def __init__(self, parent: QWidget | None = None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._setup_ui()
 
@@ -173,7 +175,7 @@ class CustomThemeEditor(QDialog):
         theme_manager: ThemeManager,
         parent: QWidget | None = None,
         edit_theme: str | None = None,
-    ):
+    ) -> None:
         super().__init__(parent)
         self.theme_manager = theme_manager
         self.edit_theme = edit_theme

--- a/src/shared/python/upstream_drift_tools/utils/logging.py
+++ b/src/shared/python/upstream_drift_tools/utils/logging.py
@@ -3,6 +3,8 @@
 Uses shared logging configuration from utils.logging_utils.
 """
 
+from __future__ import annotations
+
 import logging
 import sys
 
@@ -48,19 +50,19 @@ def get_logger(
 class LogExecutionTime:
     """Context manager to log execution time of a block."""
 
-    def __init__(self, name: str, logger: logging.Logger | None = None):
+    def __init__(self, name: str, logger: logging.Logger | None = None) -> None:
         self.name = name
         self.logger = logger or get_logger(name)
 
-    def __enter__(self):
+    def __enter__(self) -> LogExecutionTime:
         self.start_time = __import__("time").time()
         self.logger.debug(f"Starting {self.name}...")
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         duration = __import__("time").time() - self.start_time
         self.logger.info(f"{self.name} completed in {duration:.4f}s")
 
 
-def log_execution_time(name: str):
+def log_execution_time(name: str) -> LogExecutionTime:
     return LogExecutionTime(name)


### PR DESCRIPTION
Adds return type annotations to all production files in src/shared/python that were below 85% coverage. All 4 files now at 100%.

## Files Modified

| File | Before | After |
|------|--------|-------|
| upstream_drift_tools/utils/logging.py | 20% | 100% |
| model_generation/library/github_importer.py | 67% | 100% |
| model_generation/api/rest_api.py | 81% | 100% |
| theme/dialogs/custom_theme_editor.py | 84% | 100% |

## Testing
- 1996/1997 tests pass (1 pre-existing flaky perf benchmark)
- All pre-commit hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-annotation-only refactor with minimal logic impact; primary risk is subtle signature/typing mismatches affecting static analysis or framework integration.
> 
> **Overview**
> This PR raises type-hint coverage to 100% in four `src/shared/python` modules by adding missing return type annotations.
> 
> Updates include explicit `-> None` on various constructors, typing nested Flask/FastAPI adapter handler factories in `model_generation/api/rest_api.py`, and improving logging utility typing in `upstream_drift_tools/utils/logging.py` (including `__enter__` return type and `log_execution_time` return type plus `__future__.annotations`). No runtime behavior is intended to change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a27333a683d429e47c574c1852b897e0261fad08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->