### PR TITLE
refactor: Decompose large shared library functions (trc_geometry + scrubber_engine)

### DIFF
--- a/src/shared/python/upstream_drift_tools/calculators/mechanical/trc_geometry.py
+++ b/src/shared/python/upstream_drift_tools/calculators/mechanical/trc_geometry.py
@@ -86,6 +86,101 @@ class VesselGeometryResult:
     interior_height_inches: float = 0.0
 
 
+def _calculate_layer_cylinder_volume(
+    current_radius_sq: float,
+    inner_radius_sq: float,
+    interior_height: float,
+) -> float:
+    """Cylinder side-wall annular volume: π(R² − r²)h."""
+    return _PI * (current_radius_sq - inner_radius_sq) * interior_height
+
+
+def _calculate_layer_cone_volume(
+    current_radius: float,
+    current_radius_sq: float,
+    inner_radius: float,
+    inner_radius_sq: float,
+    cone_bottom_radius: float,
+    radius_offset: float,
+    layer_thickness: float,
+    interior_hole_radius: float,
+    cone_height_factor: float,
+) -> float:
+    """Differential annular truncated-cone volume for one layer."""
+    # Outer frustum at bottom for this layer
+    outer_bottom_r = max(cone_bottom_radius - radius_offset, interior_hole_radius)
+    outer_bottom_sq = outer_bottom_r * outer_bottom_r
+
+    # Inner frustum at bottom for this layer
+    inner_bottom_r = max(outer_bottom_r - layer_thickness, interior_hole_radius)
+    inner_bottom_sq = inner_bottom_r * inner_bottom_r
+
+    # V = (π/3)h(R² + Rr + r²)  for each frustum, take difference
+    cone_outer = cone_height_factor * (
+        current_radius_sq + current_radius * outer_bottom_r + outer_bottom_sq
+    )
+    cone_inner = cone_height_factor * (
+        inner_radius_sq + inner_radius * inner_bottom_r + inner_bottom_sq
+    )
+    return cone_outer - cone_inner
+
+
+def _calculate_layer_surface_area(
+    current_radius: float,
+    cylinder_height: float,
+    cone_bottom_radius: float,
+    radius_offset: float,
+    interior_hole_radius: float,
+    cone_height: float,
+    *,
+    display_cylinder: bool,
+    display_cone: bool,
+) -> float:
+    """Outer surface area for the Metal Shell layer."""
+    area = 0.0
+    if display_cylinder:
+        area += (
+            2.0 * _PI * current_radius * cylinder_height * _SQUARE_INCHES_TO_SQUARE_FEET
+        )
+    if display_cone:
+        bottom_r = max(cone_bottom_radius - radius_offset, interior_hole_radius)
+        radius_diff = current_radius - bottom_r
+        slant = math.sqrt(cone_height * cone_height + radius_diff * radius_diff)
+        area += (
+            _PI * (current_radius + bottom_r) * slant * _SQUARE_INCHES_TO_SQUARE_FEET
+        )
+    return area
+
+
+def _calculate_interior_void(
+    last_inner_radius: float,
+    half_cylinder_diameter: float,
+    cone_bottom_radius: float,
+    interior_hole_radius: float,
+    interior_height: float,
+    cone_height_factor: float,
+    *,
+    display_cylinder: bool,
+    display_cone: bool,
+) -> float:
+    """Interior void volume in cubic inches (cylinder + cone)."""
+    r_sq = last_inner_radius * last_inner_radius
+
+    void_cyl = _PI * r_sq * interior_height if display_cylinder else 0.0
+
+    if display_cone:
+        total_thickness = half_cylinder_diameter - last_inner_radius
+        void_bottom_r = max(cone_bottom_radius - total_thickness, interior_hole_radius)
+        void_bottom_sq = void_bottom_r * void_bottom_r
+        void_cone = cone_height_factor * (
+            r_sq + last_inner_radius * void_bottom_r + void_bottom_sq
+        )
+    else:
+        void_cone = 0.0
+
+    return void_cyl + void_cone
+
+
 class TRCGeometryEngine:
     """Engine for calculating TRC vessel geometry and physics.
 
@@ -98,8 +193,7 @@ class TRCGeometryEngine:
     def calculate_geometry(
         self, dimensions: VesselDimensions, layers: list[LayerConfig]
     ) -> VesselGeometryResult:
-        """
-        Calculate vessel geometry properties.
+        """Calculate vessel geometry properties.
 
         Args:
             dimensions: Vessel dimensions and flags
@@ -109,184 +203,104 @@ class TRCGeometryEngine:
             VesselGeometryResult containing detailed calculations
         """
         results = VesselGeometryResult()
-
-        # Early exit for empty layers
         if not layers:
             return results
 
-        # Pre-compute frequently used values
-        half_cylinder_diameter = dimensions.cylinder_diameter * 0.5
-        current_radius = half_cylinder_diameter
-        interior_hole_radius = dimensions.cone_interior_hole * 0.5
-        cone_bottom_radius = dimensions.cone_bottom_diameter * 0.5
-        cone_height = dimensions.cone_height
-
-        # Interior height is metal height minus the innermost roof thickness
-        interior_height = dimensions.cylinder_height - (
+        half_cyl_d = dimensions.cylinder_diameter * 0.5
+        current_radius = half_cyl_d
+        hole_r = dimensions.cone_interior_hole * 0.5
+        cone_bot_r = dimensions.cone_bottom_diameter * 0.5
+        interior_h = dimensions.cylinder_height - (
             dimensions.top_refractory_thickness if dimensions.display_lid else 0
         )
-
-        # Pre-compute cone height factor for truncated cone formula
-        cone_height_factor = _PI_OVER_3 * cone_height
+        ch_factor = _PI_OVER_3 * dimensions.cone_height
 
         total_mass = 0.0
         total_volume = 0.0
-        outside_surface_area = 0.0
-
-        # Track offset from original radius for cone calculations
+        outside_sa = 0.0
         radius_offset = 0.0
 
         for layer in layers:
             if not layer.visible or layer.thickness <= 0:
                 continue
 
-            layer_thickness = layer.thickness
-            inner_radius = max(current_radius - layer_thickness, interior_hole_radius)
+            t = layer.thickness
+            inner_r = max(current_radius - t, hole_r)
+            r_sq = current_radius * current_radius
+            ir_sq = inner_r * inner_r
 
-            # Pre-compute squared values used multiple times
-            current_radius_sq = current_radius * current_radius
-            inner_radius_sq = inner_radius * inner_radius
-
-            # Cylinder side-wall volume using interior height
-            if dimensions.display_cylinder:
-                # V = π * (R² - r²) * h = π * h * (R² - r²)
-                cyl_vol = _PI * (current_radius_sq - inner_radius_sq) * interior_height
-            else:
-                cyl_vol = 0.0
-
-            # Cone volume (differential annular truncated cone)
-            if dimensions.display_cone:
-                # Outer radius at bottom for this layer
-                layer_cone_bottom_radius_outer = max(
-                    cone_bottom_radius - radius_offset, interior_hole_radius
-                )
-                outer_bottom_sq = (
-                    layer_cone_bottom_radius_outer * layer_cone_bottom_radius_outer
-                )
-
-                # Inner radius at bottom for this layer
-                layer_cone_bottom_radius_inner = max(
-                    layer_cone_bottom_radius_outer - layer_thickness,
-                    interior_hole_radius,
-                )
-                inner_bottom_sq = (
-                    layer_cone_bottom_radius_inner * layer_cone_bottom_radius_inner
-                )
-
-                # Truncated cone volume formula: V = (π/3) * h * (R² + Rr + r²)
-                cone_outer_vol = cone_height_factor * (
-                    current_radius_sq
-                    + current_radius * layer_cone_bottom_radius_outer
-                    + outer_bottom_sq
-                )
-                cone_inner_vol = cone_height_factor * (
-                    inner_radius_sq
-                    + inner_radius * layer_cone_bottom_radius_inner
-                    + inner_bottom_sq
-                )
-                cone_vol = cone_outer_vol - cone_inner_vol
-            else:
-                cone_vol = 0.0
-
-            # Top disk volume for each layer (if lid is displayed)
-            top_disk_vol = (
-                _PI * inner_radius_sq * layer_thickness
-                if dimensions.display_lid
+            cyl_vol = (
+                _calculate_layer_cylinder_volume(r_sq, ir_sq, interior_h)
+                if dimensions.display_cylinder
                 else 0.0
             )
+            cone_vol = (
+                _calculate_layer_cone_volume(
+                    current_radius,
+                    r_sq,
+                    inner_r,
+                    ir_sq,
+                    cone_bot_r,
+                    radius_offset,
+                    t,
+                    hole_r,
+                    ch_factor,
+                )
+                if dimensions.display_cone
+                else 0.0
+            )
+            top_disk = _PI * ir_sq * t if dimensions.display_lid else 0.0
 
-            # Total layer volume (convert to ft³)
-            layer_volume_in3 = cyl_vol + cone_vol + top_disk_vol
-            layer_volume_ft3 = layer_volume_in3 * _CUBIC_INCHES_TO_CUBIC_FEET
+            vol_ft3 = (cyl_vol + cone_vol + top_disk) * _CUBIC_INCHES_TO_CUBIC_FEET
+            mass_lb = vol_ft3 * layer.density
+            total_mass += mass_lb
+            total_volume += vol_ft3
 
-            layer_mass_lb = layer_volume_ft3 * layer.density
-
-            total_mass += layer_mass_lb
-            total_volume += layer_volume_ft3
-
-            # Surface area (only for metal shell)
-            layer_outer_surface = 0.0
+            layer_sa = 0.0
             if layer.name == "Metal Shell":
-                if dimensions.display_cylinder:
-                    # Lateral surface: 2πrh
-                    layer_outer_surface += (
-                        2.0
-                        * _PI
-                        * current_radius
-                        * dimensions.cylinder_height
-                        * _SQUARE_INCHES_TO_SQUARE_FEET
-                    )
-                if dimensions.display_cone:
-                    layer_cone_bottom_radius = max(
-                        cone_bottom_radius - radius_offset, interior_hole_radius
-                    )
-                    # Slant height of cone frustum
-                    radius_diff = current_radius - layer_cone_bottom_radius
-                    slant_height = math.sqrt(
-                        cone_height * cone_height + radius_diff * radius_diff
-                    )
-                    # Lateral surface of frustum: π(R + r) * slant
-                    layer_outer_surface += (
-                        _PI
-                        * (current_radius + layer_cone_bottom_radius)
-                        * slant_height
-                        * _SQUARE_INCHES_TO_SQUARE_FEET
-                    )
-                outside_surface_area += layer_outer_surface
+                layer_sa = _calculate_layer_surface_area(
+                    current_radius,
+                    dimensions.cylinder_height,
+                    cone_bot_r,
+                    radius_offset,
+                    hole_r,
+                    dimensions.cone_height,
+                    display_cylinder=dimensions.display_cylinder,
+                    display_cone=dimensions.display_cone,
+                )
+                outside_sa += layer_sa
 
             results.layers.append(
                 LayerResult(
                     name=layer.name,
-                    volume_ft3=layer_volume_ft3,
-                    mass_lb=layer_mass_lb,
+                    volume_ft3=vol_ft3,
+                    mass_lb=mass_lb,
                     density=layer.density,
-                    outer_surface_area_ft2=(
-                        layer_outer_surface if layer.name == "Metal Shell" else 0.0
-                    ),
+                    outer_surface_area_ft2=layer_sa,
                 )
             )
 
-            # Update for next iteration
-            radius_offset += current_radius - inner_radius
-            current_radius = inner_radius
+            radius_offset += current_radius - inner_r
+            current_radius = inner_r
 
         results.total_volume_ft3 = total_volume
         results.total_mass_lb = total_mass
-        results.outside_surface_area_ft2 = outside_surface_area
+        results.outside_surface_area_ft2 = outside_sa
 
-        # Calculate interior void volume
-        last_inner_radius = current_radius
-        last_inner_radius_sq = last_inner_radius * last_inner_radius
-
-        if dimensions.display_cylinder:
-            void_cyl_vol = _PI * last_inner_radius_sq * interior_height
-        else:
-            void_cyl_vol = 0.0
-
-        if dimensions.display_cone:
-            # Total shell thickness at cylinder wall
-            total_thickness = half_cylinder_diameter - last_inner_radius
-
-            # Void bottom radius
-            void_cone_bottom_radius = max(
-                cone_bottom_radius - total_thickness, interior_hole_radius
-            )
-            void_bottom_sq = void_cone_bottom_radius * void_cone_bottom_radius
-
-            void_cone_vol = cone_height_factor * (
-                last_inner_radius_sq
-                + last_inner_radius * void_cone_bottom_radius
-                + void_bottom_sq
-            )
-        else:
-            void_cone_vol = 0.0
-
-        results.interior_volume_ft3 = (
-            void_cyl_vol + void_cone_vol
-        ) * _CUBIC_INCHES_TO_CUBIC_FEET
-        results.void_radius_inches = last_inner_radius
-        results.void_diameter_inches = last_inner_radius * 2.0
-        results.interior_height_inches = interior_height
+        void_in3 = _calculate_interior_void(
+            current_radius,
+            half_cyl_d,
+            cone_bot_r,
+            hole_r,
+            interior_h,
+            ch_factor,
+            display_cylinder=dimensions.display_cylinder,
+            display_cone=dimensions.display_cone,
+        )
+        results.interior_volume_ft3 = void_in3 * _CUBIC_INCHES_TO_CUBIC_FEET
+        results.void_radius_inches = current_radius
+        results.void_diameter_inches = current_radius * 2.0
+        results.interior_height_inches = interior_h
 
         return results
 

--- a/src/shared/python/upstream_drift_tools/process_calculators/scrubber/engine/scrubber_engine.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/scrubber/engine/scrubber_engine.py
@@ -25,6 +25,163 @@ class ScrubberEngine:
     """Engine for packed bed scrubber design calculations."""
 
     @staticmethod
+    def _calculate_column_sizing(
+        inputs: ScrubberInputs,
+        gas_density: float,
+    ) -> tuple[float, float, float, float, float, list[str]]:
+        """Column diameter and velocity sizing.
+
+        Returns (diameter_m, actual_area, gas_mass_flux,
+                 liquid_mass_flux, design_velocity, warnings).
+        """
+        warnings: list[str] = []
+        liquid_flow_kg_hr = inputs.gas_flow_kg_hr * inputs.lg_ratio
+        liquid_density = 1000.0 + 10.8 * inputs.caustic_concentration_wt_pct
+
+        packing = PACKING_DATABASE.get(inputs.packing_name)
+        if not packing:
+            raise ValueError(f"Unknown packing type: {inputs.packing_name}")
+
+        # Initial liquid flux estimate (assumed 2 m² area)
+        estimated_area = 2.0
+        liquid_mass_flux = (liquid_flow_kg_hr / 3600.0) / estimated_area
+
+        flooding_velocity = calculate_flooding_velocity(
+            liquid_mass_flux=liquid_mass_flux,
+            gas_density=gas_density,
+            liquid_density=liquid_density,
+            packing=packing,
+        )
+
+        column_sizing = calculate_column_diameter(
+            gas_flow_kg_hr=inputs.gas_flow_kg_hr,
+            gas_density=gas_density,
+            flooding_velocity=flooding_velocity,
+            percent_of_flood=inputs.percent_of_flood,
+        )
+        if "warning" in column_sizing:
+            warnings.append(str(column_sizing["warning"]))
+
+        actual_area = float(column_sizing.get("cross_section_m2", 0.0))
+        diameter_m = float(column_sizing.get("diameter_m", 0.0))
+        gas_flow_kg_s = inputs.gas_flow_kg_hr / 3600.0
+
+        if actual_area > 0:
+            liquid_mass_flux = (liquid_flow_kg_hr / 3600.0) / actual_area
+            gas_mass_flux = gas_flow_kg_s / actual_area
+        else:
+            liquid_mass_flux = 0.0
+            gas_mass_flux = 0.0
+
+        design_velocity = float(column_sizing.get("design_velocity_m_s", 0.0))
+        return (
+            diameter_m,
+            actual_area,
+            gas_mass_flux,
+            liquid_mass_flux,
+            design_velocity,
+            warnings,
+        )
+
+    @staticmethod
+    def _calculate_mass_transfer(
+        inputs: ScrubberInputs,
+        gas_density: float,
+        gas_mass_flux: float,
+        liquid_mass_flux: float,
+    ) -> tuple[float, float, list[dict[str, Any]], dict[str, float]]:
+        """NTU/HTU mass-transfer calculations.
+
+        Returns (packed_height, max_ntu, acid_gas_details, acid_gas_removed).
+        """
+        mw_gases = {"HCl": 36.458, "SO2": 64.06, "H2S": 34.08, "HF": 20.01}
+        acid_gas_details: list[dict[str, Any]] = []
+        acid_gas_removed: dict[str, float] = {}
+        max_ntu = 0.0
+
+        for gas_name, inlet_ppmv in inputs.acid_gas_composition_ppmv.items():
+            removal_pct = inputs.acid_gas_removal_pct.get(gas_name, 0.0)
+            if inlet_ppmv > 0 and removal_pct > 0:
+                inlet_frac = inlet_ppmv / 1e6
+                outlet_ppmv = inlet_ppmv * (1 - removal_pct / 100.0)
+                outlet_frac = outlet_ppmv / 1e6
+
+                ntu = calculate_ntu_removal(inlet_frac, outlet_frac)
+                max_ntu = max(max_ntu, ntu)
+
+                gas_molar_flow = inputs.gas_flow_kg_hr / inputs.molecular_weight
+                removed_kmol_hr = gas_molar_flow * (inlet_frac - outlet_frac)
+                mw_gas = mw_gases.get(gas_name, 30.0)
+                removed_kg_hr = removed_kmol_hr * mw_gas
+
+                acid_gas_details.append(
+                    {
+                        "name": gas_name,
+                        "inlet_ppmv": inlet_ppmv,
+                        "outlet_ppmv": outlet_ppmv,
+                        "removed_kg_hr": removed_kg_hr,
+                        "ntu": ntu,
+                    }
+                )
+                acid_gas_removed[gas_name] = removed_kg_hr
+
+        packing = PACKING_DATABASE[inputs.packing_name]
+        htu = calculate_htu(
+            gas_mass_flux=gas_mass_flux,
+            liquid_mass_flux=liquid_mass_flux,
+            gas_density=gas_density,
+            packing=packing,
+            kla=inputs.kla_hr,
+        )
+        packed_height = calculate_required_packed_height(
+            ntu=max_ntu, htu=htu, safety_factor=inputs.height_safety_factor
+        )
+        return packed_height, max_ntu, acid_gas_details, acid_gas_removed
+
+    @staticmethod
+    def _calculate_thermal(
+        inputs: ScrubberInputs,
+        acid_gas_removed: dict[str, float],
+    ) -> tuple[float, float, float, float, list[str]]:
+        """Caustic requirement, heat duty, and cooling water.
+
+        Returns (naoh_pure, naoh_solution, heat_kw, cooling_L_min, warnings).
+        """
+        warnings: list[str] = []
+        caustic_req = calculate_caustic_requirement(
+            acid_gas_removed=acid_gas_removed,
+            caustic_concentration=inputs.caustic_concentration_wt_pct,
+        )
+
+        water_condensed = (
+            inputs.gas_flow_kg_hr
+            * 0.0015
+            * (inputs.inlet_temp_c - inputs.target_outlet_temp_c)
+        )
+        heat_duty = calculate_heat_transfer_duty(
+            gas_flow_kg_hr=inputs.gas_flow_kg_hr,
+            inlet_temp_c=inputs.inlet_temp_c,
+            outlet_temp_c=inputs.target_outlet_temp_c,
+            water_condensed_kg_hr=water_condensed,
+        )
+
+        cooling_water = calculate_cooling_water_requirement(
+            heat_duty_kw=heat_duty["total_heat_kw"],
+            water_inlet_temp_c=inputs.cooling_water_inlet_temp_c,
+            outlet_gas_temp_c=inputs.target_outlet_temp_c,
+        )
+        if "warning" in cooling_water:
+            warnings.append(str(cooling_water["warning"]))
+
+        return (
+            caustic_req.get("naoh_pure_kg_hr", 0.0),
+            caustic_req.get("naoh_solution_L_hr", 0.0),
+            heat_duty["total_heat_kw"],
+            cooling_water.get("water_flow_L_min", 0.0),
+            warnings,
+        )
+
+    @staticmethod
     def calculate(inputs: ScrubberInputs) -> ScrubberResults:
         """Perform full scrubber design calculation."""
         if inputs.gas_flow_kg_hr <= 0:
@@ -43,109 +200,36 @@ class ScrubberEngine:
                 warnings=["Gas flow is zero or negative."],
             )
 
-        warnings = []
-
-        # 1. Physical Properties
+        # 1. Physical properties
         temp_k = inputs.inlet_temp_c + 273.15
         pressure_pa = inputs.pressure_bar * 1e5
         gas_density = calculate_gas_density(
             temp_k, pressure_pa, inputs.molecular_weight
         )
 
-        # 2. Packing and Flooding
-        packing = PACKING_DATABASE.get(inputs.packing_name)
-        if not packing:
-            raise ValueError(f"Unknown packing type: {inputs.packing_name}")
+        # 2. Column sizing
+        (
+            diameter_m,
+            _actual_area,
+            gas_mass_flux,
+            liquid_mass_flux,
+            design_velocity,
+            col_warnings,
+        ) = ScrubberEngine._calculate_column_sizing(inputs, gas_density)
 
-        gas_flow_kg_s = inputs.gas_flow_kg_hr / 3600.0
-        liquid_flow_kg_hr = inputs.gas_flow_kg_hr * inputs.lg_ratio
-        # NaOH solution density approximation: ρ ≈ 1000 + 10.8 * wt%
+        # 3. Mass transfer (NTU / HTU)
+        packed_height, max_ntu, acid_gas_details, acid_gas_removed = (
+            ScrubberEngine._calculate_mass_transfer(
+                inputs,
+                gas_density,
+                gas_mass_flux,
+                liquid_mass_flux,
+            )
+        )
+
+        # 4. Pressure drop
         liquid_density = 1000.0 + 10.8 * inputs.caustic_concentration_wt_pct
-
-        # Initial estimate of liquid mass flux (using an assumed area of 2m²)
-        estimated_area = 2.0
-        liquid_mass_flux = (liquid_flow_kg_hr / 3600.0) / estimated_area
-
-        # Calculate flooding velocity
-        flooding_velocity = calculate_flooding_velocity(
-            liquid_mass_flux=liquid_mass_flux,
-            gas_density=gas_density,
-            liquid_density=liquid_density,
-            packing=packing,
-        )
-
-        # 3. Column Sizing
-        column_sizing = calculate_column_diameter(
-            gas_flow_kg_hr=inputs.gas_flow_kg_hr,
-            gas_density=gas_density,
-            flooding_velocity=flooding_velocity,
-            percent_of_flood=inputs.percent_of_flood,
-        )
-        if "warning" in column_sizing:
-            warnings.append(str(column_sizing["warning"]))
-
-        actual_area = float(column_sizing.get("cross_section_m2", 0.0))
-        diameter_m = float(column_sizing.get("diameter_m", 0.0))
-
-        # Recalculate mass fluxes with actual area
-        if actual_area > 0:
-            liquid_mass_flux = (liquid_flow_kg_hr / 3600.0) / actual_area
-            gas_mass_flux = gas_flow_kg_s / actual_area
-        else:
-            liquid_mass_flux = 0.0
-            gas_mass_flux = 0.0
-
-        # 4. Mass Transfer (NTU/HTU)
-        acid_gas_details: list[dict[str, Any]] = []
-        acid_gas_removed: dict[str, float] = {}
-        max_ntu = 0.0
-
-        # Molecular weights
-        mw_gases = {"HCl": 36.458, "SO2": 64.06, "H2S": 34.08, "HF": 20.01}
-
-        for gas_name, inlet_ppmv in inputs.acid_gas_composition_ppmv.items():
-            removal_pct = inputs.acid_gas_removal_pct.get(gas_name, 0.0)
-            if inlet_ppmv > 0 and removal_pct > 0:
-                inlet_frac = inlet_ppmv / 1e6
-                outlet_ppmv = inlet_ppmv * (1 - removal_pct / 100.0)
-                outlet_frac = outlet_ppmv / 1e6
-
-                ntu = calculate_ntu_removal(inlet_frac, outlet_frac)
-                max_ntu = max(max_ntu, ntu)
-
-                # Mass removal rate
-                gas_molar_flow_kmol_hr = inputs.gas_flow_kg_hr / inputs.molecular_weight
-                removed_kmol_hr = gas_molar_flow_kmol_hr * (inlet_frac - outlet_frac)
-                mw_gas = mw_gases.get(gas_name, 30.0)
-                removed_kg_hr = removed_kmol_hr * mw_gas
-
-                acid_gas_details.append(
-                    {
-                        "name": gas_name,
-                        "inlet_ppmv": inlet_ppmv,
-                        "outlet_ppmv": outlet_ppmv,
-                        "removed_kg_hr": removed_kg_hr,
-                        "ntu": ntu,
-                    }
-                )
-                acid_gas_removed[gas_name] = removed_kg_hr
-
-        # Calculate HTU
-        htu = calculate_htu(
-            gas_mass_flux=gas_mass_flux,
-            liquid_mass_flux=liquid_mass_flux,
-            gas_density=gas_density,
-            packing=packing,
-            kla=inputs.kla_hr,
-        )
-
-        # Required packed height
-        packed_height = calculate_required_packed_height(
-            ntu=max_ntu, htu=htu, safety_factor=inputs.height_safety_factor
-        )
-
-        # 5. Pressure Drop
-        design_velocity = float(column_sizing.get("design_velocity_m_s", 0.0))
+        packing = PACKING_DATABASE[inputs.packing_name]
         pressure_drop_pa = 0.0
         if design_velocity > 0 and packed_height > 0:
             pressure_drop_pa = calculate_pressure_drop(
@@ -157,47 +241,42 @@ class ScrubberEngine:
                 packed_height=packed_height,
             )
 
-        # 6. Caustic Requirement
-        caustic_req = calculate_caustic_requirement(
-            acid_gas_removed=acid_gas_removed,
-            caustic_concentration=inputs.caustic_concentration_wt_pct,
+        # 5. Thermal & caustic
+        naoh_pure, naoh_sol, heat_kw, cw_flow, therm_warnings = (
+            ScrubberEngine._calculate_thermal(inputs, acid_gas_removed)
         )
 
-        # 7. Heat Transfer
-        # Approximate water condensation: 0.15% per 100 degrees C
-        water_condensed_kg_hr = (
-            inputs.gas_flow_kg_hr
-            * 0.0015
-            * (inputs.inlet_temp_c - inputs.target_outlet_temp_c)
-        )
-        heat_duty = calculate_heat_transfer_duty(
-            gas_flow_kg_hr=inputs.gas_flow_kg_hr,
-            inlet_temp_c=inputs.inlet_temp_c,
-            outlet_temp_c=inputs.target_outlet_temp_c,
-            water_condensed_kg_hr=water_condensed_kg_hr,
-        )
+        packing_obj = PACKING_DATABASE.get(inputs.packing_name)
+        flooding_vel = 0.0
+        if packing_obj:
+            flooding_vel = calculate_flooding_velocity(
+                liquid_mass_flux=liquid_mass_flux,
+                gas_density=gas_density,
+                liquid_density=liquid_density,
+                packing=packing_obj,
+            )
 
-        # Cooling water requirement
-        cooling_water = calculate_cooling_water_requirement(
-            heat_duty_kw=heat_duty["total_heat_kw"],
-            water_inlet_temp_c=inputs.cooling_water_inlet_temp_c,
-            outlet_gas_temp_c=inputs.target_outlet_temp_c,
+        # 6. HTU (for result)
+        htu = calculate_htu(
+            gas_mass_flux=gas_mass_flux,
+            liquid_mass_flux=liquid_mass_flux,
+            gas_density=gas_density,
+            packing=packing,
+            kla=inputs.kla_hr,
         )
-        if "warning" in cooling_water:
-            warnings.append(str(cooling_water["warning"]))
 
         return ScrubberResults(
             column_diameter_m=diameter_m,
             packed_height_m=packed_height,
             pressure_drop_kpa=pressure_drop_pa / 1000.0,
-            naoh_pure_kg_hr=caustic_req.get("naoh_pure_kg_hr", 0.0),
-            naoh_solution_L_hr=caustic_req.get("naoh_solution_L_hr", 0.0),
-            total_heat_duty_kw=heat_duty["total_heat_kw"],
-            cooling_water_flow_L_min=cooling_water.get("water_flow_L_min", 0.0),
+            naoh_pure_kg_hr=naoh_pure,
+            naoh_solution_L_hr=naoh_sol,
+            total_heat_duty_kw=heat_kw,
+            cooling_water_flow_L_min=cw_flow,
             gas_density_kg_m3=gas_density,
-            flooding_velocity_m_s=flooding_velocity,
+            flooding_velocity_m_s=flooding_vel,
             htu_m=htu,
             max_ntu=max_ntu,
             acid_gas_details=acid_gas_details,
-            warnings=warnings,
+            warnings=col_warnings + therm_warnings,
         )


### PR DESCRIPTION
## Changes

Decompose two oversized functions in shared utilities:

### TRCGeometryEngine.calculate_geometry (194 -> 113 lines)
Extract 4 helpers:
- _calculate_layer_cylinder_volume (7 lines)
- _calculate_layer_cone_volume (28 lines)
- _calculate_layer_surface_area (25 lines)
- _calculate_interior_void (27 lines)

### ScrubberEngine.calculate (176 -> 98 lines)
Extract 3 stage helpers:
- _calculate_column_sizing (57 lines)
- _calculate_mass_transfer (53 lines)
- _calculate_thermal (41 lines)

### Verification
- All 1997 tests pass (0 failures)
- All pre-commit hooks pass (ruff, black, no-print)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a structural refactor with no new features; risk is limited to potential subtle math/regression issues from reorganized calculation code paths.
> 
> **Overview**
> Refactors TRC vessel geometry calculations by extracting layer volume, cone volume, metal-shell surface area, and interior-void computations into small helpers, simplifying `TRCGeometryEngine.calculate_geometry` without changing outputs.
> 
> Refactors scrubber design calculations by decomposing `ScrubberEngine.calculate` into explicit stages for column sizing, mass transfer, and thermal/caustic sizing, and consolidates warning collection; calculation flow remains the same but is easier to follow and test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1351a7afba3ec1a054d9e05f5fe72ddae5574ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->