### PR TITLE
refactor: decompose 6 large functions (wave 2)

### DIFF
--- a/src/shared/python/model_generation/api/rest_api.py
+++ b/src/shared/python/model_generation/api/rest_api.py
@@ -132,13 +132,11 @@ class ModelGenerationAPI:
         self._routes: list[Route] = []
         self._register_routes()
 
-    def _register_routes(self) -> None:
-        """Register all API routes."""
-        # Health/info
+    def _register_core_routes(self) -> None:
+        """Register health, generation, conversion, validation, and parsing routes."""
         self.add_route(HTTPMethod.GET, "/health", self.health_check, "Health check")
         self.add_route(HTTPMethod.GET, "/info", self.get_api_info, "API information")
 
-        # Generation endpoints
         self.add_route(
             HTTPMethod.POST,
             "/generate/humanoid",
@@ -154,7 +152,6 @@ class ModelGenerationAPI:
             ["generation"],
         )
 
-        # Conversion endpoints
         self.add_route(
             HTTPMethod.POST,
             "/convert/simscape-to-urdf",
@@ -177,7 +174,6 @@ class ModelGenerationAPI:
             ["conversion"],
         )
 
-        # Validation endpoint
         self.add_route(
             HTTPMethod.POST,
             "/validate",
@@ -185,8 +181,6 @@ class ModelGenerationAPI:
             "Validate URDF content",
             ["validation"],
         )
-
-        # Parse endpoint
         self.add_route(
             HTTPMethod.POST,
             "/parse",
@@ -195,7 +189,8 @@ class ModelGenerationAPI:
             ["parsing"],
         )
 
-        # Inertia calculation
+    def _register_inertia_and_library_routes(self) -> None:
+        """Register inertia calculation and library management routes."""
         self.add_route(
             HTTPMethod.POST,
             "/inertia/calculate",
@@ -211,7 +206,6 @@ class ModelGenerationAPI:
             ["inertia"],
         )
 
-        # Library endpoints
         self.add_route(
             HTTPMethod.GET,
             "/library/models",
@@ -248,7 +242,8 @@ class ModelGenerationAPI:
             ["library"],
         )
 
-        # Editor endpoints
+    def _register_editor_routes(self) -> None:
+        """Register editor-related routes."""
         self.add_route(
             HTTPMethod.POST,
             "/editor/compose",
@@ -263,6 +258,12 @@ class ModelGenerationAPI:
             "Compare two URDF files",
             ["editor"],
         )
+
+    def _register_routes(self) -> None:
+        """Register all API routes."""
+        self._register_core_routes()
+        self._register_inertia_and_library_routes()
+        self._register_editor_routes()
 
     def add_route(
         self,

--- a/src/shared/python/model_generation/converters/mjcf_converter.py
+++ b/src/shared/python/model_generation/converters/mjcf_converter.py
@@ -411,6 +411,125 @@ class MJCFConverter:
             materials=proper_materials,
         )
 
+    @staticmethod
+    def _parse_body_inertial(body_elem: ET.Element) -> Inertia:
+        """Parse inertial properties from an MJCF body element."""
+        inertia = Inertia(ixx=0.1, iyy=0.1, izz=0.1, mass=1.0)
+        inertial_elem = body_elem.find("inertial")
+        if inertial_elem is None:
+            return inertia
+
+        mass = float(inertial_elem.get("mass", 1.0))
+        com_str = inertial_elem.get("pos", "0 0 0")
+        com = tuple(float(v) for v in com_str.split())
+
+        diag_str = inertial_elem.get("diaginertia")
+        full_str = inertial_elem.get("fullinertia")
+
+        if diag_str:
+            diag = [float(v) for v in diag_str.split()]
+            return Inertia(
+                ixx=diag[0],
+                iyy=diag[1],
+                izz=diag[2],
+                mass=mass,
+                center_of_mass=com,
+            )
+        elif full_str:
+            full = [float(v) for v in full_str.split()]
+            return Inertia(
+                ixx=full[0],
+                iyy=full[1],
+                izz=full[2],
+                ixy=full[3] if len(full) > 3 else 0,
+                ixz=full[4] if len(full) > 4 else 0,
+                iyz=full[5] if len(full) > 5 else 0,
+                mass=mass,
+                center_of_mass=com,
+            )
+        else:
+            return Inertia(ixx=0.1, iyy=0.1, izz=0.1, mass=mass, center_of_mass=com)
+
+    def _parse_body_visual(
+        self,
+        body_elem: ET.Element,
+        body_name: str,
+    ) -> tuple[Geometry | None, Origin, Any]:
+        """Parse visual geometry and material from an MJCF body element."""
+        from model_generation.core.types import Material
+
+        geom_elems = body_elem.findall("geom")
+        if not geom_elems:
+            return None, Origin(), None
+
+        geom_elem = geom_elems[0]
+        visual_geom, visual_origin = self._parse_mjcf_geom(geom_elem)
+
+        visual_material = None
+        rgba_str = geom_elem.get("rgba")
+        mat_name = geom_elem.get("material")
+        if rgba_str:
+            rgba = tuple(float(v) for v in rgba_str.split())
+            visual_material = Material(name=f"{body_name}_material", color=rgba)
+        elif mat_name:
+            visual_material = Material(name=mat_name)
+
+        return visual_geom, visual_origin, visual_material
+
+    @staticmethod
+    def _parse_body_joint(
+        body_elem: ET.Element,
+        parent_name: str,
+        body_name: str,
+        pos: tuple[float, ...],
+    ) -> Joint:
+        """Parse joint elements and create a URDF joint connecting to parent."""
+        from model_generation.core.types import JointDynamics, JointLimits
+
+        joint_elems = body_elem.findall("joint")
+        if not joint_elems:
+            return Joint(
+                name=f"{parent_name}_to_{body_name}",
+                joint_type=JointType.FIXED,
+                parent=parent_name,
+                child=body_name,
+                origin=Origin(xyz=pos),
+            )
+
+        # Use the first non-free joint, or the first joint
+        primary_joint = joint_elems[0]
+        for je in joint_elems:
+            if je.get("type", "hinge") != "free":
+                primary_joint = je
+                break
+
+        joint_name = primary_joint.get("name", f"{parent_name}_to_{body_name}")
+        mjcf_type = primary_joint.get("type", "hinge")
+        joint_type = MJCF_TO_URDF_JOINT.get(mjcf_type, JointType.REVOLUTE)
+
+        axis_str = primary_joint.get("axis", "0 0 1")
+        axis = tuple(float(v) for v in axis_str.split())
+
+        limits = None
+        range_str = primary_joint.get("range")
+        if range_str:
+            range_vals = [float(v) for v in range_str.split()]
+            limits = JointLimits(lower=range_vals[0], upper=range_vals[1])
+
+        damping = float(primary_joint.get("damping", 0.5))
+        dynamics = JointDynamics(damping=damping)
+
+        return Joint(
+            name=joint_name,
+            joint_type=joint_type,
+            parent=parent_name,
+            child=body_name,
+            origin=Origin(xyz=pos),
+            axis=axis,
+            limits=limits,
+            dynamics=dynamics,
+        )
+
     def _parse_mjcf_body(
         self,
         elem: ET.Element,
@@ -419,70 +538,16 @@ class MJCFConverter:
         joints: list[Joint],
     ) -> None:
         """Recursively parse body elements."""
-        from model_generation.core.types import Material
-
         for body_elem in elem.findall("body"):
             body_name = body_elem.get("name", f"body_{len(links)}")
-
-            # Parse position
             pos_str = body_elem.get("pos", "0 0 0")
             pos = tuple(float(v) for v in pos_str.split())
 
-            # Parse inertial
-            inertia = Inertia(ixx=0.1, iyy=0.1, izz=0.1, mass=1.0)
-            inertial_elem = body_elem.find("inertial")
-            if inertial_elem is not None:
-                mass = float(inertial_elem.get("mass", 1.0))
+            inertia = self._parse_body_inertial(body_elem)
+            visual_geom, visual_origin, visual_material = self._parse_body_visual(
+                body_elem, body_name
+            )
 
-                com_str = inertial_elem.get("pos", "0 0 0")
-                com = tuple(float(v) for v in com_str.split())
-
-                diag_str = inertial_elem.get("diaginertia")
-                full_str = inertial_elem.get("fullinertia")
-
-                if diag_str:
-                    diag = [float(v) for v in diag_str.split()]
-                    inertia = Inertia(
-                        ixx=diag[0],
-                        iyy=diag[1],
-                        izz=diag[2],
-                        mass=mass,
-                        center_of_mass=com,
-                    )
-                elif full_str:
-                    full = [float(v) for v in full_str.split()]
-                    inertia = Inertia(
-                        ixx=full[0],
-                        iyy=full[1],
-                        izz=full[2],
-                        ixy=full[3] if len(full) > 3 else 0,
-                        ixz=full[4] if len(full) > 4 else 0,
-                        iyz=full[5] if len(full) > 5 else 0,
-                        mass=mass,
-                        center_of_mass=com,
-                    )
-                else:
-                    inertia = Inertia(
-                        ixx=0.1, iyy=0.1, izz=0.1, mass=mass, center_of_mass=com
-                    )
-
-            # Parse first geom for visual/collision geometry
-            visual_geom = None
-            visual_origin = Origin()
-            visual_material = None
-            geom_elems = body_elem.findall("geom")
-            if geom_elems:
-                geom_elem = geom_elems[0]
-                visual_geom, visual_origin = self._parse_mjcf_geom(geom_elem)
-                rgba_str = geom_elem.get("rgba")
-                mat_name = geom_elem.get("material")
-                if rgba_str:
-                    rgba = tuple(float(v) for v in rgba_str.split())
-                    visual_material = Material(name=f"{body_name}_material", color=rgba)
-                elif mat_name:
-                    visual_material = Material(name=mat_name)
-
-            # Create link with geometry
             link = Link(
                 name=body_name,
                 inertia=inertia,
@@ -494,64 +559,11 @@ class MJCFConverter:
             )
             links.append(link)
 
-            # Parse joints and create URDF joints to parent
             if parent_name:
-                joint_elems = body_elem.findall("joint")
-                if joint_elems:
-                    # Use the first non-free joint, or the first joint
-                    primary_joint = joint_elems[0]
-                    for je in joint_elems:
-                        jtype = je.get("type", "hinge")
-                        if jtype != "free":
-                            primary_joint = je
-                            break
+                joints.append(
+                    self._parse_body_joint(body_elem, parent_name, body_name, pos)
+                )
 
-                    joint_name = primary_joint.get(
-                        "name", f"{parent_name}_to_{body_name}"
-                    )
-                    mjcf_type = primary_joint.get("type", "hinge")
-                    joint_type = MJCF_TO_URDF_JOINT.get(mjcf_type, JointType.REVOLUTE)
-
-                    axis_str = primary_joint.get("axis", "0 0 1")
-                    axis = tuple(float(v) for v in axis_str.split())
-
-                    from model_generation.core.types import (
-                        JointDynamics,
-                        JointLimits,
-                    )
-
-                    limits = None
-                    range_str = primary_joint.get("range")
-                    if range_str:
-                        range_vals = [float(v) for v in range_str.split()]
-                        limits = JointLimits(lower=range_vals[0], upper=range_vals[1])
-
-                    damping = float(primary_joint.get("damping", 0.5))
-                    dynamics = JointDynamics(damping=damping)
-
-                    joint = Joint(
-                        name=joint_name,
-                        joint_type=joint_type,
-                        parent=parent_name,
-                        child=body_name,
-                        origin=Origin(xyz=pos),
-                        axis=axis,
-                        limits=limits,
-                        dynamics=dynamics,
-                    )
-                    joints.append(joint)
-                else:
-                    # Fixed joint
-                    joint = Joint(
-                        name=f"{parent_name}_to_{body_name}",
-                        joint_type=JointType.FIXED,
-                        parent=parent_name,
-                        child=body_name,
-                        origin=Origin(xyz=pos),
-                    )
-                    joints.append(joint)
-
-            # Recurse into children
             self._parse_mjcf_body(body_elem, body_name, links, joints)
 
     def _parse_mjcf_geom(self, geom_elem: ET.Element) -> tuple[Geometry | None, Origin]:

--- a/src/shared/python/model_generation/core/physics_validation.py
+++ b/src/shared/python/model_generation/core/physics_validation.py
@@ -204,6 +204,104 @@ class PhysicsValidator:
 
         return result
 
+    @staticmethod
+    def _compute_center_of_mass(
+        links: list[Link],
+    ) -> tuple[np.ndarray, float] | None:
+        """Compute overall center of mass from links with inertial data.
+
+        Returns:
+            Tuple of (com_array, total_mass) or None if no mass found.
+        """
+        total_mass = 0.0
+        weighted_position = np.zeros(3)
+
+        for link in links:
+            if hasattr(link, "inertial") and link.inertial:
+                mass = link.inertial.mass
+                origin = link.inertial.origin
+                pos = np.array([origin.x, origin.y, origin.z])
+                weighted_position += mass * pos
+                total_mass += mass
+
+        if total_mass <= 0:
+            return None
+        return weighted_position / total_mass, total_mass
+
+    @staticmethod
+    def _find_support_polygon(
+        links: list[Link],
+        support_link_names: list[str] | None,
+    ) -> tuple[list[tuple[float, float]], list[str] | None]:
+        """Identify support links and extract their 2D positions.
+
+        Returns:
+            Tuple of (support_points, resolved_support_link_names).
+        """
+        if support_link_names is None:
+            link_z_positions = []
+            for link in links:
+                if hasattr(link, "inertial") and link.inertial:
+                    z = link.inertial.origin.z
+                    link_z_positions.append((link.name, z))
+
+            if link_z_positions:
+                min_z = min(z for _, z in link_z_positions)
+                support_link_names = [
+                    name for name, z in link_z_positions if abs(z - min_z) < 0.1
+                ]
+
+        support_points: list[tuple[float, float]] = []
+        for link in links:
+            if link.name in (support_link_names or []):
+                if hasattr(link, "inertial") and link.inertial:
+                    origin = link.inertial.origin
+                    support_points.append((origin.x, origin.y))
+
+        return support_points, support_link_names
+
+    def _evaluate_stability(
+        self,
+        com: np.ndarray,
+        total_mass: float,
+        support_points: list[tuple[float, float]],
+    ) -> tuple[bool, float, list[tuple[float, float]] | None, float]:
+        """Evaluate stability metrics from COM and support polygon.
+
+        Returns:
+            Tuple of (is_stable, margin, support_polygon, tipping_angle_deg).
+        """
+        support_polygon: list[tuple[float, float]] | None = None
+
+        if len(support_points) < 3:
+            is_stable = len(support_points) > 0
+            margin = 0.0 if is_stable else float("inf")
+            support_polygon = list(support_points) if support_points else None
+        else:
+            try:
+                from scipy.spatial import ConvexHull
+
+                points = np.array(support_points)
+                hull = ConvexHull(points)
+                support_polygon = [tuple(points[i].tolist()) for i in hull.vertices]
+
+                com_2d = com[:2]
+                is_stable = self._point_in_polygon(com_2d, support_polygon)
+                margin = self._distance_to_polygon_edge(com_2d, support_polygon)
+
+            except ImportError:
+                is_stable = True
+                support_polygon = list(support_points)
+                margin = 0.0
+
+        if margin > 0 and total_mass > 0:
+            height = com[2] if com[2] > 0 else 1.0
+            tipping_angle = float(np.degrees(np.arctan(margin / height)))
+        else:
+            tipping_angle = 0.0
+
+        return is_stable, margin, support_polygon, tipping_angle
+
     def check_static_stability(
         self,
         links: list[Link],
@@ -230,88 +328,24 @@ class PhysicsValidator:
                 center_of_mass=(0.0, 0.0, 0.0),
             )
 
-        # Compute center of mass
-        total_mass = 0.0
-        weighted_position = np.zeros(3)
-
-        for link in links:
-            if hasattr(link, "inertial") and link.inertial:
-                mass = link.inertial.mass
-                origin = link.inertial.origin
-                pos = np.array([origin.x, origin.y, origin.z])
-                weighted_position += mass * pos
-                total_mass += mass
-
-        if total_mass <= 0:
+        com_result = self._compute_center_of_mass(links)
+        if com_result is None:
             return StabilityResult(
                 is_stable=False,
                 center_of_mass=(0.0, 0.0, 0.0),
             )
 
-        com = weighted_position / total_mass
-        com_tuple = tuple(com.tolist())
-
-        # Find support links (lowest z-position links)
-        if support_link_names is None:
-            link_z_positions = []
-            for link in links:
-                if hasattr(link, "inertial") and link.inertial:
-                    z = link.inertial.origin.z
-                    link_z_positions.append((link.name, z))
-
-            if link_z_positions:
-                min_z = min(z for _, z in link_z_positions)
-                support_link_names = [
-                    name for name, z in link_z_positions if abs(z - min_z) < 0.1
-                ]
-
-        # Compute support polygon (simplified: just bounding box of support links)
-        support_points = []
-        for link in links:
-            if link.name in (support_link_names or []):
-                if hasattr(link, "inertial") and link.inertial:
-                    origin = link.inertial.origin
-                    support_points.append((origin.x, origin.y))
-
-        support_polygon: list[tuple[float, float]] | None = None
-
-        if len(support_points) < 3:
-            # Not enough points for a polygon, check if COM is close to support
-            is_stable = len(support_points) > 0
-            margin = 0.0 if is_stable else float("inf")
-            support_polygon = list(support_points) if support_points else None
-        else:
-            # Compute convex hull of support points
-            try:
-                from scipy.spatial import ConvexHull
-
-                points = np.array(support_points)
-                hull = ConvexHull(points)
-                support_polygon = [tuple(points[i].tolist()) for i in hull.vertices]
-
-                # Check if COM projection is inside polygon
-                com_2d = com[:2]
-                is_stable = self._point_in_polygon(com_2d, support_polygon)
-
-                # Compute margin to edge
-                margin = self._distance_to_polygon_edge(com_2d, support_polygon)
-
-            except ImportError:
-                is_stable = True
-                support_polygon = list(support_points)
-                margin = 0.0
-
-        # Compute tipping angle
-        if margin > 0 and total_mass > 0:
-            # Simplified: tan(angle) = margin / height
-            height = com[2] if com[2] > 0 else 1.0
-            tipping_angle = np.degrees(np.arctan(margin / height))
-        else:
-            tipping_angle = 0.0
+        com, total_mass = com_result
+        support_points, support_link_names = self._find_support_polygon(
+            links, support_link_names
+        )
+        is_stable, margin, support_polygon, tipping_angle = self._evaluate_stability(
+            com, total_mass, support_points
+        )
 
         return StabilityResult(
             is_stable=is_stable,
-            center_of_mass=com_tuple,  # type: ignore
+            center_of_mass=tuple(com.tolist()),  # type: ignore
             support_polygon=support_polygon if support_points else None,
             margin_to_edge=margin,
             tipping_angle_deg=tipping_angle,

--- a/src/shared/python/model_generation/editor/editor_modifications.py
+++ b/src/shared/python/model_generation/editor/editor_modifications.py
@@ -511,6 +511,76 @@ class ModificationMixin:
         logger.info(f"Applied prefix '{prefix}' to model '{model_id}'")
         return True
 
+    @staticmethod
+    def _mirror_links(
+        links: list[Any],
+        name_map: dict[str, str],
+        axis_idx: int,
+        model: Any,
+    ) -> list[str]:
+        """Create mirrored copies of links and add them to the model.
+
+        Returns:
+            List of created link names.
+        """
+        created_links: list[str] = []
+        for link in links:
+            new_link = Link.from_dict(link.to_dict())
+            new_link.name = name_map[link.name]
+
+            if new_link.visual_origin:
+                xyz = list(new_link.visual_origin.xyz)
+                xyz[axis_idx] = -xyz[axis_idx]
+                new_link.visual_origin = Origin(
+                    xyz=tuple(xyz), rpy=new_link.visual_origin.rpy
+                )
+
+            if new_link.collision_origin:
+                xyz = list(new_link.collision_origin.xyz)
+                xyz[axis_idx] = -xyz[axis_idx]
+                new_link.collision_origin = Origin(
+                    xyz=tuple(xyz), rpy=new_link.collision_origin.rpy
+                )
+
+            model.links.append(new_link)
+            created_links.append(new_link.name)
+
+        return created_links
+
+    @staticmethod
+    def _mirror_joints(
+        joints: list[Any],
+        links: list[Any],
+        name_map: dict[str, str],
+        axis_idx: int,
+        parent: str,
+        mirror_name_fn: Any,
+        model: Any,
+    ) -> None:
+        """Create mirrored copies of joints and add them to the model."""
+        for joint in joints:
+            new_joint = Joint.from_dict(joint.to_dict())
+            new_joint.name = mirror_name_fn(joint.name)
+
+            if joint.parent in name_map:
+                new_joint.parent = name_map[joint.parent]
+            elif joint.child == links[0].name:
+                new_joint.parent = parent
+
+            if joint.child in name_map:
+                new_joint.child = name_map[joint.child]
+
+            xyz = list(new_joint.origin.xyz)
+            xyz[axis_idx] = -xyz[axis_idx]
+            new_joint.origin = Origin(xyz=tuple(xyz), rpy=new_joint.origin.rpy)
+
+            if new_joint.joint_type in (JointType.REVOLUTE, JointType.CONTINUOUS):
+                axis = list(new_joint.axis)
+                axis[axis_idx] = -axis[axis_idx]
+                new_joint.axis = tuple(axis)
+
+            model.joints.append(new_joint)
+
     def mirror_subtree(
         self,
         model_id: str,
@@ -538,11 +608,9 @@ class ModificationMixin:
                 f"mirror_axis must be one of {_VALID_AXES}, got '{mirror_axis}'"
             )
 
-        # Copy subtree to clipboard
         if not self.copy_subtree(model_id, root_link):
             return []
 
-        # Get parent for attachment
         model = self._models.get(model_id)
         if not model:
             return []
@@ -552,7 +620,6 @@ class ModificationMixin:
             logger.error("Cannot mirror root link")
             return []
 
-        # Default replacements for left/right
         if name_replacements is None:
             name_replacements = {
                 "left": "right",
@@ -565,84 +632,32 @@ class ModificationMixin:
                 "_R_": "_L_",
             }
 
-        # Paste with mirrored positions
         self._save_state()
 
         comp_type, links, joints, materials = self._clipboard[0]
 
-        # Generate mirrored names
         def mirror_name(name: str) -> str:
             result = name
             for old, new in name_replacements.items():
                 result = result.replace(old, new)
             if result == name:
-                # No replacement found, add suffix
                 result = name + "_mirrored"
             return result
 
-        # Build name map
         name_map: dict[str, str] = {}
         existing_links = {link.name for link in model.links}
-
         for link in links:
             new_name = mirror_name(link.name)
             new_name = self._generate_unique_name(new_name, existing_links)
             name_map[link.name] = new_name
             existing_links.add(new_name)
 
-        # Mirror positions
         axis_idx = {"x": 0, "y": 1, "z": 2}[mirror_axis]
 
-        created_links: list[str] = []
-
-        for link in links:
-            new_link = Link.from_dict(link.to_dict())
-            new_link.name = name_map[link.name]
-
-            # Mirror visual/collision origins
-            if new_link.visual_origin:
-                xyz = list(new_link.visual_origin.xyz)
-                xyz[axis_idx] = -xyz[axis_idx]
-                new_link.visual_origin = Origin(
-                    xyz=tuple(xyz), rpy=new_link.visual_origin.rpy
-                )
-
-            if new_link.collision_origin:
-                xyz = list(new_link.collision_origin.xyz)
-                xyz[axis_idx] = -xyz[axis_idx]
-                new_link.collision_origin = Origin(
-                    xyz=tuple(xyz), rpy=new_link.collision_origin.rpy
-                )
-
-            model.links.append(new_link)
-            created_links.append(new_link.name)
-
-        # Copy and mirror joints
-        for joint in joints:
-            new_joint = Joint.from_dict(joint.to_dict())
-            new_joint.name = mirror_name(joint.name)
-
-            # Update references
-            if joint.parent in name_map:
-                new_joint.parent = name_map[joint.parent]
-            elif joint.child == links[0].name:
-                new_joint.parent = parent  # Attach to same parent
-
-            if joint.child in name_map:
-                new_joint.child = name_map[joint.child]
-
-            # Mirror origin
-            xyz = list(new_joint.origin.xyz)
-            xyz[axis_idx] = -xyz[axis_idx]
-            new_joint.origin = Origin(xyz=tuple(xyz), rpy=new_joint.origin.rpy)
-
-            # Mirror axis for revolute joints
-            if new_joint.joint_type in (JointType.REVOLUTE, JointType.CONTINUOUS):
-                axis = list(new_joint.axis)
-                axis[axis_idx] = -axis[axis_idx]
-                new_joint.axis = tuple(axis)
-
-            model.joints.append(new_joint)
+        created_links = self._mirror_links(links, name_map, axis_idx, model)
+        self._mirror_joints(
+            joints, links, name_map, axis_idx, parent, mirror_name, model
+        )
 
         logger.info(f"Created mirrored subtree with {len(created_links)} links")
         return created_links

--- a/src/shared/python/upstream_drift_tools/calculators/mechanical/trc_geometry.py
+++ b/src/shared/python/upstream_drift_tools/calculators/mechanical/trc_geometry.py
@@ -190,6 +190,101 @@ class TRCGeometryEngine:
     - Reduced redundant radius calculations
     """
 
+    @staticmethod
+    def _calculate_layer_contributions(
+        layer: LayerConfig,
+        current_radius: float,
+        hole_r: float,
+        cone_bot_r: float,
+        radius_offset: float,
+        interior_h: float,
+        ch_factor: float,
+        dimensions: VesselDimensions,
+    ) -> tuple[LayerResult, float, float]:
+        """Calculate volume, mass, and surface area for a single layer.
+
+        Returns:
+            Tuple of (LayerResult, new_radius_offset_delta, inner_radius).
+        """
+        t = layer.thickness
+        inner_r = max(current_radius - t, hole_r)
+        r_sq = current_radius * current_radius
+        ir_sq = inner_r * inner_r
+
+        cyl_vol = (
+            _calculate_layer_cylinder_volume(r_sq, ir_sq, interior_h)
+            if dimensions.display_cylinder
+            else 0.0
+        )
+        cone_vol = (
+            _calculate_layer_cone_volume(
+                current_radius,
+                r_sq,
+                inner_r,
+                ir_sq,
+                cone_bot_r,
+                radius_offset,
+                t,
+                hole_r,
+                ch_factor,
+            )
+            if dimensions.display_cone
+            else 0.0
+        )
+        top_disk = _PI * ir_sq * t if dimensions.display_lid else 0.0
+
+        vol_ft3 = (cyl_vol + cone_vol + top_disk) * _CUBIC_INCHES_TO_CUBIC_FEET
+        mass_lb = vol_ft3 * layer.density
+
+        layer_sa = 0.0
+        if layer.name == "Metal Shell":
+            layer_sa = _calculate_layer_surface_area(
+                current_radius,
+                dimensions.cylinder_height,
+                cone_bot_r,
+                radius_offset,
+                hole_r,
+                dimensions.cone_height,
+                display_cylinder=dimensions.display_cylinder,
+                display_cone=dimensions.display_cone,
+            )
+
+        result = LayerResult(
+            name=layer.name,
+            volume_ft3=vol_ft3,
+            mass_lb=mass_lb,
+            density=layer.density,
+            outer_surface_area_ft2=layer_sa,
+        )
+        return result, current_radius - inner_r, inner_r
+
+    @staticmethod
+    def _finalize_geometry_results(
+        results: VesselGeometryResult,
+        current_radius: float,
+        half_cyl_d: float,
+        cone_bot_r: float,
+        hole_r: float,
+        interior_h: float,
+        ch_factor: float,
+        dimensions: VesselDimensions,
+    ) -> None:
+        """Compute interior void and final geometry dimensions."""
+        void_in3 = _calculate_interior_void(
+            current_radius,
+            half_cyl_d,
+            cone_bot_r,
+            hole_r,
+            interior_h,
+            ch_factor,
+            display_cylinder=dimensions.display_cylinder,
+            display_cone=dimensions.display_cone,
+        )
+        results.interior_volume_ft3 = void_in3 * _CUBIC_INCHES_TO_CUBIC_FEET
+        results.void_radius_inches = current_radius
+        results.void_diameter_inches = current_radius * 2.0
+        results.interior_height_inches = interior_h
+
     def calculate_geometry(
         self, dimensions: VesselDimensions, layers: list[LayerConfig]
     ) -> VesselGeometryResult:
@@ -224,83 +319,38 @@ class TRCGeometryEngine:
             if not layer.visible or layer.thickness <= 0:
                 continue
 
-            t = layer.thickness
-            inner_r = max(current_radius - t, hole_r)
-            r_sq = current_radius * current_radius
-            ir_sq = inner_r * inner_r
-
-            cyl_vol = (
-                _calculate_layer_cylinder_volume(r_sq, ir_sq, interior_h)
-                if dimensions.display_cylinder
-                else 0.0
+            layer_result, offset_delta, inner_r = self._calculate_layer_contributions(
+                layer,
+                current_radius,
+                hole_r,
+                cone_bot_r,
+                radius_offset,
+                interior_h,
+                ch_factor,
+                dimensions,
             )
-            cone_vol = (
-                _calculate_layer_cone_volume(
-                    current_radius,
-                    r_sq,
-                    inner_r,
-                    ir_sq,
-                    cone_bot_r,
-                    radius_offset,
-                    t,
-                    hole_r,
-                    ch_factor,
-                )
-                if dimensions.display_cone
-                else 0.0
-            )
-            top_disk = _PI * ir_sq * t if dimensions.display_lid else 0.0
+            total_mass += layer_result.mass_lb
+            total_volume += layer_result.volume_ft3
+            outside_sa += layer_result.outer_surface_area_ft2
+            results.layers.append(layer_result)
 
-            vol_ft3 = (cyl_vol + cone_vol + top_disk) * _CUBIC_INCHES_TO_CUBIC_FEET
-            mass_lb = vol_ft3 * layer.density
-            total_mass += mass_lb
-            total_volume += vol_ft3
-
-            layer_sa = 0.0
-            if layer.name == "Metal Shell":
-                layer_sa = _calculate_layer_surface_area(
-                    current_radius,
-                    dimensions.cylinder_height,
-                    cone_bot_r,
-                    radius_offset,
-                    hole_r,
-                    dimensions.cone_height,
-                    display_cylinder=dimensions.display_cylinder,
-                    display_cone=dimensions.display_cone,
-                )
-                outside_sa += layer_sa
-
-            results.layers.append(
-                LayerResult(
-                    name=layer.name,
-                    volume_ft3=vol_ft3,
-                    mass_lb=mass_lb,
-                    density=layer.density,
-                    outer_surface_area_ft2=layer_sa,
-                )
-            )
-
-            radius_offset += current_radius - inner_r
+            radius_offset += offset_delta
             current_radius = inner_r
 
         results.total_volume_ft3 = total_volume
         results.total_mass_lb = total_mass
         results.outside_surface_area_ft2 = outside_sa
 
-        void_in3 = _calculate_interior_void(
+        self._finalize_geometry_results(
+            results,
             current_radius,
             half_cyl_d,
             cone_bot_r,
             hole_r,
             interior_h,
             ch_factor,
-            display_cylinder=dimensions.display_cylinder,
-            display_cone=dimensions.display_cone,
+            dimensions,
         )
-        results.interior_volume_ft3 = void_in3 * _CUBIC_INCHES_TO_CUBIC_FEET
-        results.void_radius_inches = current_radius
-        results.void_diameter_inches = current_radius * 2.0
-        results.interior_height_inches = interior_h
 
         return results
 

--- a/src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_model.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_model.py
@@ -157,17 +157,14 @@ class PSAModel:
         default_factory=lambda: list(DEFAULT_COMPONENTS)
     )
 
-    def calculate(self) -> PSAResults:
-        """
-        Perform the PSA mass balance calculation.
+    def _compute_stream_flows(
+        self,
+    ) -> StreamFlows:
+        """Solve the algebraic mass balance for all PSA streams.
 
         Returns:
-            PSAResults containing all stream flows, compositions, and metrics.
+            StreamFlows with computed flow arrays for each stream.
         """
-        n_components = len(self.components)
-        component_names = [c["name"] for c in self.components]
-
-        # Extract component data as arrays
         feed_pct = np.array([c["feed_pct"] for c in self.components], dtype=np.float64)
         r1 = np.array(
             [c["stage1_removal_pct"] / 100.0 for c in self.components], dtype=np.float64
@@ -179,49 +176,20 @@ class PSAModel:
         r_tail = self.s2_tail_recycle_frac
         r_prod = self.product_recycle_frac
 
-        # Calculate fresh feed flows (Stream 1)
-        # F_i = Total_Feed * feed_pct_i / sum(feed_pct)
         fresh_feed = self.total_feed_scfm * feed_pct / np.sum(feed_pct)
-
-        # Calculate mixed feed using algebraic solution (Stream 5A)
-        # M_i = F_i / [1 - (1-R1_i) * (R2_i * r_tail + (1-R2_i) * r_prod)]
         denominator = 1.0 - (1.0 - r1) * (r2 * r_tail + (1.0 - r2) * r_prod)
         mixed_feed = fresh_feed / denominator
 
-        # Calculate exhaust (PSA 1 tail) - Stream 2
-        # Exhaust = Mixed_Feed * R1 (removal fraction)
         exhaust = mixed_feed * r1
-
-        # Calculate interstage (PSA 1 product to PSA 2) - Stream 6
-        # Interstage = Mixed_Feed - Exhaust
         interstage = mixed_feed - exhaust
-
-        # Calculate Stage 2 tail - Stream J
-        # S2_Tail = Interstage * R2 (removal fraction)
         s2_tail = interstage * r2
-
-        # Calculate S2 Tail Recycle (back to feed) - Stream 4/C
-        # S2_Tail_Recycle = S2_Tail * r_tail
         s2_tail_recycle = s2_tail * r_tail
-
-        # Calculate S2 Tail Vent (if not fully recycled) - Stream G
-        # S2_Tail_Vent = S2_Tail * (1 - r_tail)
         s2_tail_vent = s2_tail * (1.0 - r_tail)
-
-        # Calculate Gross Product (before product recycle split) - Stream 3G
-        # Gross_Product = Interstage - S2_Tail
         gross_product = interstage - s2_tail
-
-        # Calculate Product Recycle (back to feed) - Stream 3R
-        # Product_Recycle = Gross_Product * r_prod
         product_recycle = gross_product * r_prod
-
-        # Calculate Net Product (final output) - Stream 3N
-        # Net_Product = Gross_Product * (1 - r_prod)
         net_product = gross_product * (1.0 - r_prod)
 
-        # Create flows dataclass
-        flows = StreamFlows(
+        return StreamFlows(
             fresh_feed=fresh_feed,
             s2_tail_recycle=s2_tail_recycle,
             product_recycle=product_recycle,
@@ -234,7 +202,22 @@ class PSAModel:
             net_product=net_product,
         )
 
-        # Calculate compositions (%)
+    @staticmethod
+    def _compute_performance_metrics(
+        component_names: list[str],
+        flows: StreamFlows,
+        n_components: int,
+    ) -> tuple[
+        StreamCompositions, float, float, float, float, float, float, float, float
+    ]:
+        """Compute compositions and key performance metrics from stream flows.
+
+        Returns:
+            Tuple of (compositions, h2_recovery_pct, h2_purity_pct,
+            total_net_product, total_exhaust, total_s2_tail_vent,
+            mass_balance_error, s2_tail_h2_pct, s2_tail_o2_pct)
+        """
+
         def calc_composition(flow_array: NDArray[np.float64]) -> NDArray[np.float64]:
             total = np.sum(flow_array)
             if total == 0:
@@ -242,42 +225,73 @@ class PSAModel:
             return flow_array / total * 100.0
 
         compositions = StreamCompositions(
-            fresh_feed=calc_composition(fresh_feed),
-            s2_tail_recycle=calc_composition(s2_tail_recycle),
-            product_recycle=calc_composition(product_recycle),
-            mixed_feed=calc_composition(mixed_feed),
-            exhaust=calc_composition(exhaust),
-            s2_tail_vent=calc_composition(s2_tail_vent),
-            interstage=calc_composition(interstage),
-            gross_product=calc_composition(gross_product),
-            s2_tail=calc_composition(s2_tail),
-            net_product=calc_composition(net_product),
+            fresh_feed=calc_composition(flows.fresh_feed),
+            s2_tail_recycle=calc_composition(flows.s2_tail_recycle),
+            product_recycle=calc_composition(flows.product_recycle),
+            mixed_feed=calc_composition(flows.mixed_feed),
+            exhaust=calc_composition(flows.exhaust),
+            s2_tail_vent=calc_composition(flows.s2_tail_vent),
+            interstage=calc_composition(flows.interstage),
+            gross_product=calc_composition(flows.gross_product),
+            s2_tail=calc_composition(flows.s2_tail),
+            net_product=calc_composition(flows.net_product),
         )
 
-        # Calculate totals
-        total_net_product = float(np.sum(net_product))
-        total_exhaust = float(np.sum(exhaust))
-        total_s2_tail_vent = float(np.sum(s2_tail_vent))
+        total_net_product = float(np.sum(flows.net_product))
+        total_exhaust = float(np.sum(flows.exhaust))
+        total_s2_tail_vent = float(np.sum(flows.s2_tail_vent))
 
-        # Mass balance check: Fresh_Feed = Exhaust + S2_Tail_Vent + Net_Product
         mass_balance_error = float(
-            np.sum(fresh_feed)
-            - np.sum(exhaust)
-            - np.sum(s2_tail_vent)
-            - np.sum(net_product)
+            np.sum(flows.fresh_feed)
+            - np.sum(flows.exhaust)
+            - np.sum(flows.s2_tail_vent)
+            - np.sum(flows.net_product)
         )
 
-        # H2 recovery: Net Product H2 / Fresh Feed H2 * 100
         h2_idx = component_names.index("H2")
-        h2_recovery_pct = float(net_product[h2_idx] / fresh_feed[h2_idx] * 100.0)
-
-        # H2 purity in net product
+        h2_recovery_pct = float(
+            flows.net_product[h2_idx] / flows.fresh_feed[h2_idx] * 100.0
+        )
         h2_purity_pct = float(compositions.net_product[h2_idx])
 
-        # S2 Tail composition (for safety analysis)
         s2_tail_h2_pct = float(compositions.s2_tail[h2_idx])
         o2_idx = component_names.index("O2")
         s2_tail_o2_pct = float(compositions.s2_tail[o2_idx])
+
+        return (
+            compositions,
+            h2_recovery_pct,
+            h2_purity_pct,
+            total_net_product,
+            total_exhaust,
+            total_s2_tail_vent,
+            mass_balance_error,
+            s2_tail_h2_pct,
+            s2_tail_o2_pct,
+        )
+
+    def calculate(self) -> PSAResults:
+        """
+        Perform the PSA mass balance calculation.
+
+        Returns:
+            PSAResults containing all stream flows, compositions, and metrics.
+        """
+        component_names = [c["name"] for c in self.components]
+        n_components = len(self.components)
+
+        flows = self._compute_stream_flows()
+        (
+            compositions,
+            h2_recovery_pct,
+            h2_purity_pct,
+            total_net_product,
+            total_exhaust,
+            total_s2_tail_vent,
+            mass_balance_error,
+            s2_tail_h2_pct,
+            s2_tail_o2_pct,
+        ) = self._compute_performance_metrics(component_names, flows, n_components)
 
         return PSAResults(
             component_names=component_names,


### PR DESCRIPTION
Decompose functions exceeding 100 lines into focused helpers:\n\n- **mjcf_converter.py**:  (142 lines) → , , \n- **psa_model.py**:  (136 lines) → , \n- **rest_api.py**:  (131 lines) → , , \n- **editor_modifications.py**:  (135 lines) → , \n- **physics_validation.py**:  (112 lines) → , , \n- **trc_geometry.py**:  (113 lines) → , \n\nAll 1997 tests pass. No public API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily mechanical refactoring with behavior intended to be unchanged; main risk is subtle numerical/flow differences in conversion and calculation paths due to code movement and helper extraction.
> 
> **Overview**
> Refactors several oversized functions into smaller, focused helpers across the codebase, without changing public APIs.
> 
> This splits REST route registration into themed methods (core/inertia+library/editor), decomposes MJCF body parsing into inertial/visual/joint helpers, and breaks static stability analysis into COM/support-polygon/stability-evaluation steps. Similar extractions are applied to editor subtree mirroring, TRC vessel geometry layer calculations/finalization, and PSA model calculations by separating stream-flow solving from performance-metric computation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc5393e274359dcb6c408cbcaaa4432ee7444da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->