### PR TITLE
fix: assessment v6.0 remediation - electrode DRY, func decomp, globals, security, tests, docs

### DIFF
--- a/src/baghouse_calculator/python/baghouse_calculator/ui/pyqt6/main_window.py
+++ b/src/baghouse_calculator/python/baghouse_calculator/ui/pyqt6/main_window.py
@@ -197,13 +197,27 @@ class BaghouseCalculatorMainWindow(BaseCalculatorWindow):
         layout = QVBoxLayout(container)
         layout.setSpacing(15)
 
-        # Title
         title = QLabel("Baghouse Filter Calculator")
         title.setFont(QFont("", 18, QFont.Weight.Bold))
         title.setStyleSheet(f"color: {COLORS['blue']};")
         layout.addWidget(title)
 
-        # Gas Flow Group
+        layout.addWidget(self._create_gas_stream_group())
+        layout.addWidget(self._create_solids_input_group())
+        layout.addWidget(self._create_efficiency_group())
+        layout.addWidget(self._create_equipment_group())
+
+        self.calculate_btn = QPushButton("Calculate Baghouse Performance")
+        self.calculate_btn.setMinimumHeight(50)
+        self.calculate_btn.clicked.connect(self._on_calculate)
+        layout.addWidget(self.calculate_btn)
+
+        layout.addStretch()
+        scroll.setWidget(container)
+        return scroll
+
+    def _create_gas_stream_group(self) -> QGroupBox:
+        """Create the gas stream input group."""
         gas_group = QGroupBox("Gas Stream")
         gas_layout = QFormLayout(gas_group)
 
@@ -216,7 +230,7 @@ class BaghouseCalculatorMainWindow(BaseCalculatorWindow):
         self.inlet_temp_input = QDoubleSpinBox()
         self.inlet_temp_input.setRange(0, 1000)
         self.inlet_temp_input.setValue(200)
-        self.inlet_temp_input.setSuffix(" °C")
+        self.inlet_temp_input.setSuffix(" \u00b0C")
         gas_layout.addRow("Inlet Temperature:", self.inlet_temp_input)
 
         self.pressure_input = QDoubleSpinBox()
@@ -224,10 +238,10 @@ class BaghouseCalculatorMainWindow(BaseCalculatorWindow):
         self.pressure_input.setValue(101.325)
         self.pressure_input.setSuffix(" kPa")
         gas_layout.addRow("Pressure:", self.pressure_input)
+        return gas_group
 
-        layout.addWidget(gas_group)
-
-        # Solids Input Group
+    def _create_solids_input_group(self) -> QGroupBox:
+        """Create the solids input group."""
         solids_group = QGroupBox("Solids Input")
         solids_layout = QFormLayout(solids_group)
 
@@ -242,10 +256,10 @@ class BaghouseCalculatorMainWindow(BaseCalculatorWindow):
         self.ash_input.setValue(20)
         self.ash_input.setSuffix(" kg/hr")
         solids_layout.addRow("Ash Rate:", self.ash_input)
+        return solids_group
 
-        layout.addWidget(solids_group)
-
-        # Efficiency Group
+    def _create_efficiency_group(self) -> QGroupBox:
+        """Create the removal efficiency input group."""
         eff_group = QGroupBox("Removal Efficiency")
         eff_layout = QFormLayout(eff_group)
 
@@ -260,10 +274,10 @@ class BaghouseCalculatorMainWindow(BaseCalculatorWindow):
         self.ash_eff_input.setValue(99)
         self.ash_eff_input.setSuffix(" %")
         eff_layout.addRow("Ash Removal:", self.ash_eff_input)
+        return eff_group
 
-        layout.addWidget(eff_group)
-
-        # Equipment Group
+    def _create_equipment_group(self) -> QGroupBox:
+        """Create the equipment parameters input group."""
         equip_group = QGroupBox("Equipment Parameters")
         equip_layout = QFormLayout(equip_group)
 
@@ -276,33 +290,21 @@ class BaghouseCalculatorMainWindow(BaseCalculatorWindow):
         self.drum_volume_input = QDoubleSpinBox()
         self.drum_volume_input.setRange(0.1, 10)
         self.drum_volume_input.setValue(0.5)
-        self.drum_volume_input.setSuffix(" m³")
+        self.drum_volume_input.setSuffix(" m\u00b3")
         equip_layout.addRow("Drum Volume:", self.drum_volume_input)
 
         self.solid_density_input = QDoubleSpinBox()
         self.solid_density_input.setRange(100, 2000)
         self.solid_density_input.setValue(500)
-        self.solid_density_input.setSuffix(" kg/m³")
+        self.solid_density_input.setSuffix(" kg/m\u00b3")
         equip_layout.addRow("Solid Density:", self.solid_density_input)
 
         self.bag_area_input = QDoubleSpinBox()
         self.bag_area_input.setRange(100, 10000)
         self.bag_area_input.setValue(1000)
-        self.bag_area_input.setSuffix(" ft²")
+        self.bag_area_input.setSuffix(" ft\u00b2")
         equip_layout.addRow("Bag Filter Area:", self.bag_area_input)
-
-        layout.addWidget(equip_group)
-
-        # Calculate Button
-        self.calculate_btn = QPushButton("Calculate Baghouse Performance")
-        self.calculate_btn.setMinimumHeight(50)
-        self.calculate_btn.clicked.connect(self._on_calculate)
-        layout.addWidget(self.calculate_btn)
-
-        layout.addStretch()
-
-        scroll.setWidget(container)
-        return scroll
+        return equip_group
 
     def _create_results_panel(self) -> QWidget:
         """Create the results panel."""

--- a/src/data_processing/data_processor/python/data_processor/cli.py
+++ b/src/data_processing/data_processor/python/data_processor/cli.py
@@ -248,34 +248,38 @@ def run(
     data = loader.load_multiple_files(pipeline.files, combine=pipeline.combine)
 
     if pipeline.combine:
-        dataframe = _process_dataframe(
-            cast("pd.DataFrame", data),
-            pipeline,
-            processor,
-            source_label="combined dataset",
+        _run_combined(data, pipeline, processor, loader)
+    else:
+        _run_uncombined(data, pipeline, processor, loader)
+
+
+def _run_combined(
+    data: object, pipeline: object, processor: object, loader: DataLoader,
+) -> None:
+    """Process a combined dataset and optionally save the result."""
+    dataframe = _process_dataframe(
+        cast("pd.DataFrame", data), pipeline, processor,
+        source_label="combined dataset",
+    )
+    if pipeline.output:
+        output_path = pipeline.output.path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        loader.save_dataframe(
+            dataframe, str(output_path), format_type=pipeline.output.format,
         )
+        console.print(f"[green]Saved processed data to {output_path}[/green]")
+    else:
+        console.print("[cyan]Pipeline completed (no output specified).[/cyan]")
 
-        if pipeline.output:
-            output_path = pipeline.output.path
-            target_format = pipeline.output.format
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            loader.save_dataframe(
-                dataframe,
-                str(output_path),
-                format_type=target_format,
-            )
-            console.print(f"[green]Saved processed data to {output_path}[/green]")
-        else:
-            console.print("[cyan]Pipeline completed (no output specified).[/cyan]")
-        return
 
-    # combine == False => process each file independently
+def _run_uncombined(
+    data: object, pipeline: object, processor: object, loader: DataLoader,
+) -> None:
+    """Process each file independently and optionally save results."""
     processed_frames: dict[str, pd.DataFrame] = {}
     for source_path, frame in cast("dict[str, pd.DataFrame]", data).items():
         processed_frames[source_path] = _process_dataframe(
-            frame,
-            pipeline,
-            processor,
+            frame, pipeline, processor,
             source_label=Path(source_path).name,
         )
 
@@ -286,13 +290,10 @@ def run(
 
         for source_path, processed_df in processed_frames.items():
             destination = output_path / _format_output_filename(
-                source_path,
-                target_format,
+                source_path, target_format,
             )
             loader.save_dataframe(
-                processed_df,
-                str(destination),
-                format_type=target_format,
+                processed_df, str(destination), format_type=target_format,
             )
 
         console.print(

--- a/src/document_processing/pdf_renamer/src/pdf_renamer/cli.py
+++ b/src/document_processing/pdf_renamer/src/pdf_renamer/cli.py
@@ -1,3 +1,5 @@
+"""Command-line interface for the PDF renamer tool."""
+
 import argparse
 import logging
 import sys
@@ -15,6 +17,7 @@ logger = logging.getLogger("pdf_renamer")
 
 
 def apply_style(title: str, style: str) -> str:
+    """Sanitize *title* and convert it to the requested naming *style*."""
     safe_title = sanitize_filename(title)
     if style == "snake_case":
         return safe_title.lower().replace(" ", "_")
@@ -30,6 +33,7 @@ def process_file(
     dry_run: bool,
     style: str,
 ) -> None:
+    """Extract the title from *file_path* and rename it, using cache and optional LLM."""
     try:
         # 1. Hash
         file_hash = sha256_file(file_path)
@@ -83,6 +87,7 @@ def process_file(
 
 
 def main() -> None:
+    """CLI entry point: parse arguments and batch-rename PDFs in a directory."""
     parser = argparse.ArgumentParser(
         description="Advanced PDF Renamer with AI Fallback"
     )

--- a/src/document_processing/pdf_renamer/src/pdf_renamer/extractors.py
+++ b/src/document_processing/pdf_renamer/src/pdf_renamer/extractors.py
@@ -43,6 +43,7 @@ FONT_SCALE_FACTOR = 40.0
 
 # ---------- Layer 0: metadata ----------
 def title_from_metadata(pdf_path: Path) -> TitleResult:
+    """Extract a document title from PDF metadata using pypdf."""
     try:
         from pypdf import PdfReader
 
@@ -60,6 +61,7 @@ def title_from_metadata(pdf_path: Path) -> TitleResult:
 
 # ---------- Layer 1: first-page heuristic (layout-aware) ----------
 def title_from_first_page(pdf_path: Path) -> TitleResult:
+    """Heuristically extract a title from the largest text on the first page."""
     try:
         import fitz
 

--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_paths.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_paths.py
@@ -1,4 +1,7 @@
-"""PathsMixin -- real geometry drawing and conductive path rendering."""
+"""PathsMixin -- real geometry drawing and conductive path rendering.
+
+Delegates duplicated drawing logic to :mod:`~electrode_advisor.utils.shared_drawing`.
+"""
 
 from __future__ import annotations
 
@@ -6,8 +9,14 @@ import logging
 from typing import Any
 
 import numpy as np
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 
+from ...utils.shared_drawing import (
+    annotate_path_value,
+    annotate_resistance_value,
+    build_trapezoidal_prism,
+    compute_wall_position,
+    draw_trapezoidal_path,
+)
 from ...utils.visualization import ElectrodeVisualization
 
 logger = logging.getLogger(__name__)
@@ -48,7 +57,7 @@ class PathsMixin:
     _get_path_resistance: Any
 
     def _draw_3d_real_geometry(self) -> None:
-        """Draw only the real, physically correct geometry in the 3D plot"""
+        """Draw only the real, physically correct geometry in the 3D plot."""
         ax = self.electrode_ax
         if ax is None:
             return
@@ -72,7 +81,29 @@ class PathsMixin:
         if not hasattr(self, "visualizer"):
             self.visualizer = ElectrodeVisualization()
 
-        # Draw refractory (cylinder)
+        self._draw_real_geometry_layers(
+            ax, bath_diameter, glass_depth, metal_depth, refractory_thickness
+        )
+        self._draw_real_geometry_electrodes(ax, positions, tip_diameter)
+        self._draw_real_geometry_paths(
+            ax, results, positions, bath_diameter, glass_depth, metal_depth
+        )
+        self._configure_real_geometry_axes(
+            ax, bath_diameter, refractory_thickness, glass_depth, metal_depth
+        )
+
+        if self.electrode_canvas is not None:
+            self.electrode_canvas.draw()
+
+    def _draw_real_geometry_layers(
+        self,
+        ax: Any,
+        bath_diameter: float,
+        glass_depth: float,
+        metal_depth: float,
+        refractory_thickness: float,
+    ) -> None:
+        """Draw refractory, glass, metal, and shell layers."""
         if self.show_refractory_checkbox.isChecked():
             self.visualizer.draw_cylinder(
                 ax,
@@ -82,8 +113,6 @@ class PathsMixin:
                 color="#bfa46f",
                 alpha=self.refractory_alpha_slider.value() / 100,
             )
-
-        # Draw glass (cylinder)
         if self.show_glass_checkbox.isChecked():
             self.visualizer.draw_cylinder(
                 ax,
@@ -93,8 +122,6 @@ class PathsMixin:
                 color="#ff8c00",
                 alpha=self.glass_alpha_slider.value() / 100,
             )
-
-        # Draw metal (cylinder)
         if self.show_metal_checkbox.isChecked():
             self.visualizer.draw_cylinder(
                 ax,
@@ -104,8 +131,6 @@ class PathsMixin:
                 color="#888888",
                 alpha=self.metal_alpha_slider.value() / 100,
             )
-
-        # Draw shell (thin cylinder)
         if self.show_metal_shell_checkbox.isChecked():
             self.visualizer.draw_cylinder(
                 ax,
@@ -118,87 +143,85 @@ class PathsMixin:
                 wireframe=True,
             )
 
-        # Draw electrodes (cylinders)
-        if self.show_electrodes_checkbox.isChecked():
-            for pos in positions:
-                # Electrode from top to tip
-                base = pos["base"]
-                tip = pos["tip"]
-                self.visualizer.draw_cylinder_between(
-                    ax,
-                    base,
-                    tip,
-                    radius=tip_diameter / 2,
-                    color="#888888",
-                    alpha=self.electrode_alpha_slider.value() / 100,
-                )
-                if self.show_electrode_labels_checkbox.isChecked():
-                    # ax.text expects x, y, z, s
-                    ax.text(
-                        tip[0],
-                        tip[1],
-                        tip[2],
-                        f"{pos['depth']:.1f}",
-                        color="k",
-                        fontsize=10,
-                    )
-
-        # Draw conductive paths (real geometry only)
-        if self.show_paths_checkbox.isChecked() and "current_paths" in results:
-            for phase in results["current_paths"]:
-                i, j = int(phase[0]) - 1, int(phase[2]) - 1
-                positions[i]["tip"]
-                positions[j]["tip"]
-                # Draw direct glass path (trapezoidal prism)
-                self.visualizer.draw_trapezoidal_prism(
-                    ax,
-                    positions[i],
-                    positions[j],
-                    bath_diameter / 2,
-                    glass_depth,
-                    color="#4169E1",
-                    alpha=self.path_alpha_slider.value() / 100,
-                )
-                # Draw via-metal path (composite segments)
-                self.visualizer.draw_via_metal_path(
-                    ax,
-                    positions[i],
-                    positions[j],
-                    bath_diameter / 2,
-                    metal_depth,
-                    glass_depth,
-                    color="#DC143C",
-                    alpha=self.path_alpha_slider.value() / 100,
-                )
-
-        # Axis labels (matplotlib 3d axes use set_xlabel, set_ylabel, set_zlabel,
-        # but some environments may not support set_zlabel directly)
-        ax.set_xlabel("X (in)" if self.show_axis_labels_checkbox.isChecked() else "")
-        ax.set_ylabel("Y (in)" if self.show_axis_labels_checkbox.isChecked() else "")
-        # set_zlabel is not always present, so use hasattr
-        # set_zlabel is not always present, so use try/except
-        try:
-            ax.set_zlabel(
-                "Z (in)" if self.show_axis_labels_checkbox.isChecked() else ""
+    def _draw_real_geometry_electrodes(
+        self, ax: Any, positions: list[dict], tip_diameter: float
+    ) -> None:
+        """Draw electrode cylinders and optional labels."""
+        if not self.show_electrodes_checkbox.isChecked():
+            return
+        for pos in positions:
+            base = pos["base"]
+            tip = pos["tip"]
+            self.visualizer.draw_cylinder_between(
+                ax,
+                base,
+                tip,
+                radius=tip_diameter / 2,
+                color="#888888",
+                alpha=self.electrode_alpha_slider.value() / 100,
             )
-        except (AttributeError, ValueError) as zlabel_error:
-            logger.debug("set_zlabel not available: %s", zlabel_error)
+            if self.show_electrode_labels_checkbox.isChecked():
+                ax.text(
+                    tip[0], tip[1], tip[2],
+                    f"{pos['depth']:.1f}",
+                    color="k", fontsize=10,
+                )
 
-        # Set aspect and limits
+    def _draw_real_geometry_paths(
+        self,
+        ax: Any,
+        results: dict,
+        positions: list[dict],
+        bath_diameter: float,
+        glass_depth: float,
+        metal_depth: float,
+    ) -> None:
+        """Draw conductive paths (real geometry only)."""
+        if not (self.show_paths_checkbox.isChecked() and "current_paths" in results):
+            return
+        for phase in results["current_paths"]:
+            i, j = int(phase[0]) - 1, int(phase[2]) - 1
+            self.visualizer.draw_trapezoidal_prism(
+                ax, positions[i], positions[j],
+                bath_diameter / 2, glass_depth,
+                color="#4169E1",
+                alpha=self.path_alpha_slider.value() / 100,
+            )
+            self.visualizer.draw_via_metal_path(
+                ax, positions[i], positions[j],
+                bath_diameter / 2, metal_depth, glass_depth,
+                color="#DC143C",
+                alpha=self.path_alpha_slider.value() / 100,
+            )
+
+    def _configure_real_geometry_axes(
+        self,
+        ax: Any,
+        bath_diameter: float,
+        refractory_thickness: float,
+        glass_depth: float,
+        metal_depth: float,
+    ) -> None:
+        """Set axis labels, limits, and camera angle."""
+        show_labels = self.show_axis_labels_checkbox.isChecked()
+        ax.set_xlabel("X (in)" if show_labels else "")
+        ax.set_ylabel("Y (in)" if show_labels else "")
+        try:
+            ax.set_zlabel("Z (in)" if show_labels else "")
+        except (AttributeError, ValueError) as e:
+            logger.debug("set_zlabel not available: %s", e)
+
         lim = bath_diameter / 2 + refractory_thickness + 2
         ax.set_xlim(-lim, lim)
         ax.set_ylim(-lim, lim)
-        # set_zlim is not always present, so use hasattr
         try:
             ax.set_zlim(0, glass_depth + metal_depth)
-        except (AttributeError, ValueError) as zlim_error:
-            logger.debug("set_zlim not available: %s", zlim_error)
+        except (AttributeError, ValueError) as e:
+            logger.debug("set_zlim not available: %s", e)
         try:
             ax.view_init(elev=25, azim=45)
-        except (AttributeError, ValueError) as view_error:
-            logger.debug("view_init not available: %s", view_error)
-        if self.electrode_canvas is not None:
-            self.electrode_canvas.draw()
+        except (AttributeError, ValueError) as e:
+            logger.debug("view_init not available: %s", e)
 
     def _draw_3d_conductive_paths_new(
         self,
@@ -208,72 +231,25 @@ class PathsMixin:
         metal_height: float,
         glass_height: float,
     ) -> None:
-        """Draw the new 6-path conductive model with correct geometry"""
+        """Draw the new 6-path conductive model with correct geometry."""
         if self.electrode_ax is None:
             return
-        # Check if metal conductivity is enabled
         metal_conductive = self.metal_conductive_checkbox.isChecked()
-
-        # Get conductive layer height parameter
         conductive_height = self.conductive_layer_height_input.value()
-
-        # Get path alpha from slider
         path_alpha = self.path_alpha_slider.value() / 100.0
 
-        # Electrode positions (120 degrees apart)
-        angles = [0, 120, 240]  # degrees
-        electrode_positions = []
-
-        # Calculate electrode positions with full geometry
-        # Extend electrodes beyond refractory layer
-        refractory_thickness = self.refractory_thickness_input.value()
-        electrode_extension = self.electrode_extension_slider.value()
-        total_electrode_length = (
-            bath_radius + refractory_thickness + electrode_extension
+        electrode_positions = self._compute_electrode_positions(
+            depths, bath_radius, metal_height, glass_height
         )
 
-        for _, (depth, angle) in enumerate(zip(depths, angles, strict=False)):
-            angle_rad = np.radians(angle)
-            electrode_z = metal_height + glass_height / 2
-
-            # Electrode tip position (inside vessel)
-            x_tip = (bath_radius - depth) * np.cos(angle_rad)
-            y_tip = (bath_radius - depth) * np.sin(angle_rad)
-
-            # Electrode base/wall position (extended beyond refractory)
-            x_base = total_electrode_length * np.cos(angle_rad)
-            y_base = total_electrode_length * np.sin(angle_rad)
-
-            electrode_positions.append(
-                {
-                    "tip": np.array([x_tip, y_tip, electrode_z]),
-                    "base": np.array([x_base, y_base, electrode_z]),
-                    "angle": angle_rad,
-                    "depth": depth,
-                }
-            )
-
-        # Draw the paths based on metal conductivity setting
         for i in range(3):
             j = (i + 1) % 3
             phase_key = f"{i + 1}-{j + 1}"
 
-            # Get current values for this phase if available
-            current_paths = (
-                self.calculation_results.get("current_paths", {})
-                if hasattr(self, "calculation_results") and self.calculation_results
-                else {}
-            )
-            actual_currents = (
-                self.calculation_results.get("actual_currents", {})
-                if hasattr(self, "calculation_results") and self.calculation_results
-                else {}
-            )
-
+            current_paths, actual_currents = self._get_phase_data()
             phase_current = actual_currents.get(phase_key, 0.0)
             phase_data = current_paths.get(phase_key, {})
 
-            # Calculate current through each path
             direct_fraction = phase_data.get(
                 "direct_fraction", 1.0 if not metal_conductive else 0.5
             )
@@ -284,39 +260,68 @@ class PathsMixin:
             direct_current = phase_current * direct_fraction
             metal_current = phase_current * metal_fraction if metal_conductive else 0.0
 
-            # Calculate resistance values
             direct_resistance = self._get_path_resistance("direct_glass", i)
             metal_resistance = self._get_path_resistance("via_metal", i)
 
-            # 1. Direct glass conduction path (always draw)
             direct_color = self._get_current_based_color("direct_glass", i)
             self._draw_correct_trapezoidal_path(
-                electrode_positions[i],
-                electrode_positions[j],
-                conductive_height,
-                bath_radius,
-                color=direct_color,
-                alpha=path_alpha * 0.8,
+                electrode_positions[i], electrode_positions[j],
+                conductive_height, bath_radius,
+                color=direct_color, alpha=path_alpha * 0.8,
                 label=f"Direct Glass {i + 1}-{j + 1}",
                 current_value=direct_current,
                 resistance_value=direct_resistance,
             )
 
-            # 2. Via-metal conduction path (only draw if metal conductivity is enabled)
             if metal_conductive:
                 metal_color = self._get_current_based_color("via_metal", i)
                 self._draw_correct_via_metal_path(
-                    electrode_positions[i],
-                    electrode_positions[j],
-                    metal_height,
-                    electrode_radius,
-                    bath_radius,
-                    color=metal_color,
-                    alpha=path_alpha * 0.6,
+                    electrode_positions[i], electrode_positions[j],
+                    metal_height, electrode_radius, bath_radius,
+                    color=metal_color, alpha=path_alpha * 0.6,
                     label=f"Via Metal {i + 1}-{j + 1}",
                     current_value=metal_current,
                     resistance_value=metal_resistance,
                 )
+
+    def _compute_electrode_positions(
+        self,
+        depths: list[float],
+        bath_radius: float,
+        metal_height: float,
+        glass_height: float,
+    ) -> list[dict[str, Any]]:
+        """Compute the 3 electrode positions at 120-degree intervals."""
+        angles = [0, 120, 240]
+        refractory_thickness = self.refractory_thickness_input.value()
+        electrode_extension = self.electrode_extension_slider.value()
+        total_electrode_length = bath_radius + refractory_thickness + electrode_extension
+        electrode_positions: list[dict[str, Any]] = []
+
+        for depth, angle in zip(depths, angles, strict=False):
+            angle_rad = np.radians(angle)
+            electrode_z = metal_height + glass_height / 2
+            x_tip = (bath_radius - depth) * np.cos(angle_rad)
+            y_tip = (bath_radius - depth) * np.sin(angle_rad)
+            x_base = total_electrode_length * np.cos(angle_rad)
+            y_base = total_electrode_length * np.sin(angle_rad)
+            electrode_positions.append({
+                "tip": np.array([x_tip, y_tip, electrode_z]),
+                "base": np.array([x_base, y_base, electrode_z]),
+                "angle": angle_rad,
+                "depth": depth,
+            })
+        return electrode_positions
+
+    def _get_phase_data(self) -> tuple[dict, dict]:
+        """Return (current_paths, actual_currents) from calculation results."""
+        if hasattr(self, "calculation_results") and self.calculation_results:
+            current_paths = self.calculation_results.get("current_paths", {})
+            actual_currents = self.calculation_results.get("actual_currents", {})
+        else:
+            current_paths = {}
+            actual_currents = {}
+        return current_paths, actual_currents
 
     def _draw_correct_trapezoidal_path(
         self,
@@ -330,93 +335,25 @@ class PathsMixin:
         current_value: float = 0.0,
         resistance_value: float = 0.0,
     ) -> None:
-        """
-        Draw the correct trapezoidal prism path where:
-        - The trapezoid is formed ONLY within the glass bath area (not in refractory)
-        - Conductive paths start at the glass bath wall, not at electrode bases
-        - Consists of vertical segments and a horizontal pie slice in metal
+        """Draw the correct trapezoidal prism path within the glass bath area.
+
+        Delegates to :func:`~shared_drawing.draw_trapezoidal_path`.
         """
         if self.electrode_ax is None:
             return
-        ax = self.electrode_ax
-
-        try:
-            e1_tip = electrode1_pos["tip"]
-            e2_tip = electrode2_pos["tip"]
-
-            e1_wall = self._compute_wall_position(
-                electrode1_pos,
-                bath_radius,
-            )
-            e2_wall = self._compute_wall_position(
-                electrode2_pos,
-                bath_radius,
-            )
-
-            effective_height = conductive_height * self.config.vertical_spreading_factor
-            electrode_z = (e1_tip[2] + e2_tip[2]) / 2
-
-            faces = self._build_trapezoidal_prism(
-                e1_wall,
-                e1_tip,
-                e2_tip,
-                e2_wall,
-                electrode_z,
-                effective_height,
-            )
-
-            face_collection = Poly3DCollection(
-                faces,
-                alpha=alpha,
-                facecolors=color,
-                edgecolor="darkblue",
-                linewidth=0.5,
-            )
-            ax.add_collection3d(face_collection)
-
-            # Draw conductive path boundary lines
-            if alpha > 0.3:
-                for wall, tip in [(e1_wall, e1_tip), (e2_wall, e2_tip)]:
-                    ax.plot(
-                        [wall[0], tip[0]],
-                        [wall[1], tip[1]],
-                        [electrode_z, electrode_z],
-                        "k-",
-                        linewidth=2,
-                        alpha=0.8,
-                    )
-
-            # Annotate current and resistance values
-            mid_x = (e1_wall[0] + e2_wall[0]) / 2
-            mid_y = (e1_wall[1] + e2_wall[1]) / 2
-
-            self._annotate_path_value(
-                ax,
-                mid_x,
-                mid_y,
-                electrode_z + 1.5,
-                current_value,
-                "show_current_values_checkbox",
-                "{:.0f}A",
-                "lightyellow",
-                "darkblue",
-            )
-            self._annotate_resistance_value(
-                ax,
-                mid_x,
-                mid_y,
-                electrode_z,
-                resistance_value,
-                current_value,
-                "lightgreen",
-                "darkgreen",
-            )
-
-        except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
-            logger.exception(
-                "Error drawing correct trapezoidal path: %s",
-                e,
-            )
+        draw_trapezoidal_path(
+            owner=self,
+            ax=self.electrode_ax,
+            electrode1_pos=electrode1_pos,
+            electrode2_pos=electrode2_pos,
+            conductive_height=conductive_height,
+            bath_radius=bath_radius,
+            vertical_spreading_factor=self.config.vertical_spreading_factor,
+            color=color,
+            alpha=alpha,
+            current_value=current_value,
+            resistance_value=resistance_value,
+        )
 
     @staticmethod
     def _compute_wall_position(
@@ -424,15 +361,7 @@ class PathsMixin:
         bath_radius: float,
     ) -> np.ndarray:
         """Compute glass bath wall intersection for an electrode."""
-        angle = electrode_pos["angle"]
-        tip_z = electrode_pos["tip"][2]
-        return np.array(
-            [
-                bath_radius * np.cos(angle),
-                bath_radius * np.sin(angle),
-                tip_z,
-            ]
-        )
+        return compute_wall_position(electrode_pos, bath_radius)
 
     @staticmethod
     def _build_trapezoidal_prism(
@@ -444,116 +373,27 @@ class PathsMixin:
         effective_height: float,
     ) -> list[list[list[float]]]:
         """Build 6-face trapezoidal prism vertices from wall/tip positions."""
-        z_top = electrode_z + effective_height / 2
-        z_bottom = electrode_z - effective_height / 2
-
-        # 8 vertices: bottom face (0-3), top face (4-7)
-        v = [
-            [wall1[0], wall1[1], z_bottom],
-            [tip1[0], tip1[1], z_bottom],
-            [tip2[0], tip2[1], z_bottom],
-            [wall2[0], wall2[1], z_bottom],
-            [wall1[0], wall1[1], z_top],
-            [tip1[0], tip1[1], z_top],
-            [tip2[0], tip2[1], z_top],
-            [wall2[0], wall2[1], z_top],
-        ]
-
-        return [
-            [v[0], v[1], v[2], v[3]],  # bottom
-            [v[4], v[5], v[6], v[7]],  # top
-            [v[0], v[1], v[5], v[4]],  # E1 side
-            [v[1], v[2], v[6], v[5]],  # tip-to-tip
-            [v[2], v[3], v[7], v[6]],  # E2 side
-            [v[3], v[0], v[4], v[7]],  # wall-to-wall
-        ]
+        return build_trapezoidal_prism(
+            wall1, tip1, tip2, wall2, electrode_z, effective_height
+        )
 
     def _annotate_path_value(
-        self,
-        ax: Any,
-        mid_x: float,
-        mid_y: float,
-        mid_z: float,
-        value: float,
-        checkbox_name: str,
-        fmt: str,
-        bg_color: str,
-        text_color: str,
+        self, ax: Any, mid_x: float, mid_y: float, mid_z: float,
+        value: float, checkbox_name: str, fmt: str,
+        bg_color: str, text_color: str,
     ) -> None:
         """Annotate a path with a formatted value label."""
-        if not (
-            hasattr(self, checkbox_name)
-            and getattr(self, checkbox_name).isChecked()
-            and value > 0
-        ):
-            return
-
-        ax.text(
-            mid_x,
-            mid_y,
-            mid_z,
-            fmt.format(value),
-            bbox={
-                "boxstyle": "round,pad=0.2",
-                "facecolor": bg_color,
-                "alpha": 0.8,
-            },
-            fontsize=8,
-            ha="center",
-            va="center",
-            color=text_color,
+        annotate_path_value(
+            self, ax, mid_x, mid_y, mid_z, value, checkbox_name, fmt, bg_color, text_color
         )
 
     def _annotate_resistance_value(
-        self,
-        ax: Any,
-        mid_x: float,
-        mid_y: float,
-        electrode_z: float,
-        resistance_value: float,
-        current_value: float,
-        bg_color: str,
-        text_color: str,
+        self, ax: Any, mid_x: float, mid_y: float,
+        electrode_z: float, resistance_value: float, current_value: float,
+        bg_color: str, text_color: str,
     ) -> None:
         """Annotate a path with resistance value."""
-        if not (
-            hasattr(self, "show_resistance_values_checkbox")
-            and self.show_resistance_values_checkbox.isChecked()
-            and resistance_value > 0
-        ):
-            return
-
-        # Offset below current annotation when both visible
-        offset = (
-            -2.0
-            if (
-                hasattr(self, "show_current_values_checkbox")
-                and self.show_current_values_checkbox.isChecked()
-                and current_value > 0
-            )
-            else 1.5
-        )
-        mid_z = electrode_z + offset
-
-        if resistance_value == float("inf"):
-            text = "∞Ω"
-        elif resistance_value >= 1.0:
-            text = f"{resistance_value:.2f}Ω"
-        else:
-            text = f"{resistance_value:.3f}Ω"
-
-        ax.text(
-            mid_x,
-            mid_y,
-            mid_z,
-            text,
-            bbox={
-                "boxstyle": "round,pad=0.2",
-                "facecolor": bg_color,
-                "alpha": 0.8,
-            },
-            fontsize=8,
-            ha="center",
-            va="center",
-            color=text_color,
+        annotate_resistance_value(
+            self, ax, mid_x, mid_y, electrode_z, resistance_value, current_value,
+            bg_color, text_color,
         )

--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_via_metal.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_via_metal.py
@@ -1,4 +1,7 @@
-"""ViaMetalMixin -- via-metal path drawing and electrode extrusion."""
+"""ViaMetalMixin -- via-metal path drawing and electrode extrusion.
+
+Delegates duplicated drawing logic to :mod:`~electrode_advisor.utils.shared_drawing`.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +9,11 @@ import logging
 from typing import Any
 
 import numpy as np
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
+from ...utils.shared_drawing import (
+    draw_electrode_length_extrusion,
+    draw_via_metal_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,118 +38,26 @@ class ViaMetalMixin:
         current_value: float = 0.0,
         resistance_value: float = 0.0,
     ) -> None:
-        """Draw the correct 3-segment via-metal path with vertical extrusions only"""
+        """Draw the correct 3-segment via-metal path with vertical extrusions.
+
+        Delegates to :func:`~shared_drawing.draw_via_metal_path`.
+        """
         if self.electrode_ax is None:
             return
-        ax = self.electrode_ax
-
-        try:
-            # Segment 1: Rectangular extrusion down from E1 glass portion
-            self._draw_electrode_length_extrusion(
-                electrode1_pos,
-                metal_height,
-                electrode_radius,
-                bath_radius,
-                direction="down",
-                color=color,
-                alpha=alpha,
-            )
-
-            # Segment 2: Through metal layer - IMPLIED by metal layer itself
-            # No need to draw horizontal metal connection box
-
-            # Segment 3: Rectangular extrusion up to E2 glass portion
-            self._draw_electrode_length_extrusion(
-                electrode2_pos,
-                metal_height,
-                electrode_radius,
-                bath_radius,
-                direction="up",
-                color=color,
-                alpha=alpha,
-            )
-
-            # Display current value if checkbox is enabled
-            if (
-                hasattr(self, "show_current_values_checkbox")
-                and self.show_current_values_checkbox.isChecked()
-                and current_value > 0
-            ):
-                # Calculate midpoint between electrodes for text placement
-                e1_tip = electrode1_pos["tip"]
-                e2_tip = electrode2_pos["tip"]
-                mid_x = (e1_tip[0] + e2_tip[0]) / 2
-                mid_y = (e1_tip[1] + e2_tip[1]) / 2
-                mid_z = metal_height + 0.5  # Slightly above the metal layer
-
-                # Display current value without decimal points
-                current_text = f"{current_value:.0f}A"
-                ax.text(
-                    mid_x,
-                    mid_y,
-                    mid_z,
-                    current_text,
-                    bbox={
-                        "boxstyle": "round,pad=0.2",
-                        "facecolor": "lightcoral",
-                        "alpha": 0.8,
-                    },
-                    fontsize=8,
-                    ha="center",
-                    va="center",
-                    color="darkred",
-                )
-
-            # Display resistance value if checkbox is enabled
-            if (
-                hasattr(self, "show_resistance_values_checkbox")
-                and self.show_resistance_values_checkbox.isChecked()
-                and resistance_value > 0
-            ):
-                # Calculate position slightly offset from current display
-                e1_tip = electrode1_pos["tip"]
-                e2_tip = electrode2_pos["tip"]
-                mid_x = (e1_tip[0] + e2_tip[0]) / 2
-                mid_y = (e1_tip[1] + e2_tip[1]) / 2
-
-                # Offset resistance display below current display if both are shown
-                offset = (
-                    -1.0
-                    if (
-                        hasattr(self, "show_current_values_checkbox")
-                        and self.show_current_values_checkbox.isChecked()
-                        and current_value > 0
-                    )
-                    else 0.5
-                )
-                mid_z = metal_height + offset
-
-                # Display resistance value with appropriate precision
-                if resistance_value == float("inf"):
-                    resistance_text = "∞Ω"
-                elif resistance_value >= 1.0:
-                    resistance_text = f"{resistance_value:.2f}Ω"
-                else:
-                    resistance_text = f"{resistance_value:.3f}Ω"
-
-                ax.text(
-                    mid_x,
-                    mid_y,
-                    mid_z,
-                    resistance_text,
-                    bbox={
-                        "boxstyle": "round,pad=0.2",
-                        "facecolor": "lightpink",
-                        "alpha": 0.8,
-                    },
-                    fontsize=8,
-                    ha="center",
-                    va="center",
-                    color="darkred",
-                )
-
-        except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
-            logger.exception("Error drawing correct via-metal path: %s", e)
+        draw_via_metal_path(
+            owner=self,
+            ax=self.electrode_ax,
+            electrode1_pos=electrode1_pos,
+            electrode2_pos=electrode2_pos,
+            metal_height=metal_height,
+            electrode_radius=electrode_radius,
+            bath_radius=bath_radius,
+            color=color,
+            alpha=alpha,
+            current_value=current_value,
+            resistance_value=resistance_value,
+            horizontal_spreading_factor=self.config.horizontal_spreading_factor,
+        )
 
     def _draw_electrode_length_extrusion(
         self,
@@ -154,108 +69,23 @@ class ViaMetalMixin:
         color: str,
         alpha: float,
     ) -> None:
-        """Draw rectangular extrusion along electrode length within glass bath
-        with horizontal spreading"""
+        """Draw rectangular extrusion along electrode length within glass bath.
+
+        Delegates to :func:`~shared_drawing.draw_electrode_length_extrusion`.
+        """
         if self.electrode_ax is None:
             return
-        ax = self.electrode_ax
-
-        try:
-            # Get glass wall position for this electrode
-            angle = electrode_pos["angle"]
-            wall_pos = np.array(
-                [
-                    bath_radius * np.cos(angle),
-                    bath_radius * np.sin(angle),
-                    electrode_pos["tip"][2],
-                ]
-            )
-
-            # Get electrode tip
-            tip_pos = electrode_pos["tip"]
-
-            # Apply horizontal spreading factor
-            effective_radius = (
-                electrode_radius * self.config.horizontal_spreading_factor
-            )
-
-            # Calculate extrusion bounds
-            electrode_z = electrode_pos["tip"][2]
-
-            if direction == "down":
-                z_start = electrode_z - electrode_radius
-                z_end = metal_height
-            else:  # up
-                z_start = metal_height
-                z_end = electrode_z - electrode_radius
-
-            # Direction vector along electrode (within glass bath only)
-            electrode_dir = tip_pos - wall_pos
-            electrode_length = np.linalg.norm(electrode_dir[:2])  # Only x,y
-
-            if electrode_length > 0:
-                # Create perpendicular vector for width
-                electrode_unit = electrode_dir[:2] / electrode_length
-                # Get perpendicular in x-y plane
-                perp = np.array([-electrode_unit[1], electrode_unit[0], 0])
-                perp_scaled = perp * effective_radius
-
-                # 8 vertices of the rectangular box
-                vertices = []
-
-                # Bottom face (at z_start)
-                vertices.append(
-                    wall_pos + perp_scaled + np.array([0, 0, z_start - wall_pos[2]])
-                )
-                vertices.append(
-                    wall_pos - perp_scaled + np.array([0, 0, z_start - wall_pos[2]])
-                )
-                vertices.append(
-                    tip_pos - perp_scaled + np.array([0, 0, z_start - tip_pos[2]])
-                )
-                vertices.append(
-                    tip_pos + perp_scaled + np.array([0, 0, z_start - tip_pos[2]])
-                )
-
-                # Top face (at z_end)
-                vertices.append(
-                    wall_pos + perp_scaled + np.array([0, 0, z_end - wall_pos[2]])
-                )
-                vertices.append(
-                    wall_pos - perp_scaled + np.array([0, 0, z_end - wall_pos[2]])
-                )
-                vertices.append(
-                    tip_pos - perp_scaled + np.array([0, 0, z_end - tip_pos[2]])
-                )
-                vertices.append(
-                    tip_pos + perp_scaled + np.array([0, 0, z_end - tip_pos[2]])
-                )
-
-                # Create faces
-                faces = []
-                # Bottom face
-                faces.append([vertices[0], vertices[1], vertices[2], vertices[3]])
-                # Top face
-                faces.append([vertices[4], vertices[5], vertices[6], vertices[7]])
-                # Side faces
-                for i in range(4):
-                    j = (i + 1) % 4
-                    faces.append(
-                        [vertices[i], vertices[j], vertices[j + 4], vertices[i + 4]]
-                    )
-
-                # Draw using Poly3DCollection
-                face_collection = Poly3DCollection(
-                    faces,
-                    alpha=alpha,
-                    facecolors=color,
-                    edgecolor="darkred",
-                    linewidth=0.5,
-                )
-                ax.add_collection3d(face_collection)
-
-        except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
-            logger.exception("Error drawing electrode length extrusion: %s", e)
+        draw_electrode_length_extrusion(
+            ax=self.electrode_ax,
+            electrode_pos=electrode_pos,
+            metal_height=metal_height,
+            electrode_radius=electrode_radius,
+            bath_radius=bath_radius,
+            direction=direction,
+            color=color,
+            alpha=alpha,
+            horizontal_spreading_factor=self.config.horizontal_spreading_factor,
+        )
 
     def _draw_electrode_sphere(
         self,
@@ -266,19 +96,16 @@ class ViaMetalMixin:
         color: Any,
         alpha: float,
     ) -> None:
-        """Draw a spherical tip at the electrode end"""
+        """Draw a spherical tip at the electrode end."""
         if self.electrode_ax is None:
             return
-        # Create sphere
         u = np.linspace(0, 2 * np.pi, 20)
         v = np.linspace(0, np.pi, 15)
 
-        # Sphere coordinates
         x_sphere = radius * np.outer(np.cos(u), np.sin(v)) + x_center
         y_sphere = radius * np.outer(np.sin(u), np.sin(v)) + y_center
         z_sphere = radius * np.outer(np.ones(np.size(u)), np.cos(v)) + z_center
 
-        # Draw sphere
         self.electrode_ax.plot_surface(
             x_sphere, y_sphere, z_sphere, color=color, alpha=alpha, linewidth=0
         )

--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_visualization_update.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_visualization_update.py
@@ -11,9 +11,17 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from PyQt6.QtWidgets import QCheckBox
 
+from ...utils.shared_drawing import (
+    annotate_path_value,
+    annotate_resistance_value,
+    build_trapezoidal_prism,
+    compute_wall_position,
+    draw_electrode_length_extrusion,
+    draw_trapezoidal_path,
+    draw_via_metal_path,
+)
 from ...utils.visualization import ElectrodeVisualization
 
 if TYPE_CHECKING:
@@ -30,7 +38,7 @@ class VisualizationUpdateMixin:
     """
 
     def _draw_3d_real_geometry(self) -> None:
-        """Draw only the real, physically correct geometry in the 3D plot"""
+        """Draw only the real, physically correct geometry in the 3D plot."""
         ax = self.electrode_ax
         if ax is None:
             return
@@ -42,7 +50,6 @@ class VisualizationUpdateMixin:
                 self.electrode_canvas.draw()
             return
 
-        # Get geometry
         positions = results["electrode_positions"]
         bath_diameter = self.bath_diameter_input.value()
         tip_diameter = float(self.electrode_diameter_combo.currentText())
@@ -50,137 +57,113 @@ class VisualizationUpdateMixin:
         metal_depth = self.metal_layer_height_input.value()
         refractory_thickness = self.refractory_thickness_input.value()
 
-        # Initialize visualization utility
         if not hasattr(self, "visualizer"):
             self.visualizer = ElectrodeVisualization()
 
-        # Draw refractory (cylinder)
+        self._draw_real_geom_layers(
+            ax, bath_diameter, glass_depth, metal_depth, refractory_thickness
+        )
+        self._draw_real_geom_electrodes(ax, positions, tip_diameter)
+        self._draw_real_geom_paths(
+            ax, results, positions, bath_diameter, glass_depth, metal_depth
+        )
+        self._configure_real_geom_axes(
+            ax, bath_diameter, refractory_thickness, glass_depth, metal_depth
+        )
+
+        if self.electrode_canvas is not None:
+            self.electrode_canvas.draw()
+
+    def _draw_real_geom_layers(
+        self, ax: Any, bath_diameter: float,
+        glass_depth: float, metal_depth: float, refractory_thickness: float,
+    ) -> None:
+        """Draw refractory, glass, metal, and shell layers for real geometry."""
         if self.show_refractory_checkbox.isChecked():
             self.visualizer.draw_cylinder(
-                ax,
-                radius=(bath_diameter / 2 + refractory_thickness),
-                height=glass_depth + metal_depth,
-                z0=0,
-                color="#bfa46f",
+                ax, radius=(bath_diameter / 2 + refractory_thickness),
+                height=glass_depth + metal_depth, z0=0, color="#bfa46f",
                 alpha=self.refractory_alpha_slider.value() / 100,
             )
-
-        # Draw glass (cylinder)
         if self.show_glass_checkbox.isChecked():
             self.visualizer.draw_cylinder(
-                ax,
-                radius=bath_diameter / 2,
-                height=glass_depth,
-                z0=metal_depth,
-                color="#ff8c00",
+                ax, radius=bath_diameter / 2, height=glass_depth,
+                z0=metal_depth, color="#ff8c00",
                 alpha=self.glass_alpha_slider.value() / 100,
             )
-
-        # Draw metal (cylinder)
         if self.show_metal_checkbox.isChecked():
             self.visualizer.draw_cylinder(
-                ax,
-                radius=bath_diameter / 2,
-                height=metal_depth,
-                z0=0,
-                color="#888888",
+                ax, radius=bath_diameter / 2, height=metal_depth,
+                z0=0, color="#888888",
                 alpha=self.metal_alpha_slider.value() / 100,
             )
-
-        # Draw shell (thin cylinder)
         if self.show_metal_shell_checkbox.isChecked():
             self.visualizer.draw_cylinder(
-                ax,
-                radius=(bath_diameter / 2 + refractory_thickness + 1),
-                height=glass_depth + metal_depth,
-                z0=0,
-                color="#444444",
+                ax, radius=(bath_diameter / 2 + refractory_thickness + 1),
+                height=glass_depth + metal_depth, z0=0, color="#444444",
                 alpha=self.metal_shell_alpha_slider.value() / 100,
-                linewidth=1,
-                wireframe=True,
+                linewidth=1, wireframe=True,
             )
 
-        # Draw electrodes (cylinders)
-        if self.show_electrodes_checkbox.isChecked():
-            for pos in positions:
-                # Electrode from top to tip
-                base = pos["base"]
-                tip = pos["tip"]
-                self.visualizer.draw_cylinder_between(
-                    ax,
-                    base,
-                    tip,
-                    radius=tip_diameter / 2,
-                    color="#888888",
-                    alpha=self.electrode_alpha_slider.value() / 100,
-                )
-                if self.show_electrode_labels_checkbox.isChecked():
-                    # ax.text expects x, y, z, s
-                    ax.text(
-                        tip[0],
-                        tip[1],
-                        tip[2],
-                        f"{pos['depth']:.1f}",
-                        color="k",
-                        fontsize=10,
-                    )
+    def _draw_real_geom_electrodes(
+        self, ax: Any, positions: list[dict], tip_diameter: float,
+    ) -> None:
+        """Draw electrode cylinders and optional labels for real geometry."""
+        if not self.show_electrodes_checkbox.isChecked():
+            return
+        for pos in positions:
+            base, tip = pos["base"], pos["tip"]
+            self.visualizer.draw_cylinder_between(
+                ax, base, tip, radius=tip_diameter / 2, color="#888888",
+                alpha=self.electrode_alpha_slider.value() / 100,
+            )
+            if self.show_electrode_labels_checkbox.isChecked():
+                ax.text(tip[0], tip[1], tip[2], f"{pos['depth']:.1f}",
+                        color="k", fontsize=10)
 
-        # Draw conductive paths (real geometry only)
-        if self.show_paths_checkbox.isChecked() and "current_paths" in results:
-            for phase in results["current_paths"]:
-                i, j = int(phase[0]) - 1, int(phase[2]) - 1
-                positions[i]["tip"]
-                positions[j]["tip"]
-                # Draw direct glass path (trapezoidal prism)
-                self.visualizer.draw_trapezoidal_prism(
-                    ax,
-                    positions[i],
-                    positions[j],
-                    bath_diameter / 2,
-                    glass_depth,
-                    color="#4169E1",
-                    alpha=self.path_alpha_slider.value() / 100,
-                )
-                # Draw via-metal path (composite segments)
-                self.visualizer.draw_via_metal_path(
-                    ax,
-                    positions[i],
-                    positions[j],
-                    bath_diameter / 2,
-                    metal_depth,
-                    glass_depth,
-                    color="#DC143C",
-                    alpha=self.path_alpha_slider.value() / 100,
-                )
+    def _draw_real_geom_paths(
+        self, ax: Any, results: dict, positions: list[dict],
+        bath_diameter: float, glass_depth: float, metal_depth: float,
+    ) -> None:
+        """Draw conductive paths for real geometry view."""
+        if not (self.show_paths_checkbox.isChecked() and "current_paths" in results):
+            return
+        for phase in results["current_paths"]:
+            i, j = int(phase[0]) - 1, int(phase[2]) - 1
+            self.visualizer.draw_trapezoidal_prism(
+                ax, positions[i], positions[j], bath_diameter / 2, glass_depth,
+                color="#4169E1", alpha=self.path_alpha_slider.value() / 100,
+            )
+            self.visualizer.draw_via_metal_path(
+                ax, positions[i], positions[j], bath_diameter / 2,
+                metal_depth, glass_depth, color="#DC143C",
+                alpha=self.path_alpha_slider.value() / 100,
+            )
 
-        # Axis labels (matplotlib 3d axes use set_xlabel, set_ylabel, set_zlabel,
-        # but some environments may not support set_zlabel directly)
-        ax.set_xlabel("X (in)" if self.show_axis_labels_checkbox.isChecked() else "")
-        ax.set_ylabel("Y (in)" if self.show_axis_labels_checkbox.isChecked() else "")
-        # set_zlabel is not always present, so use hasattr
-        # set_zlabel is not always present, so use try/except
+    def _configure_real_geom_axes(
+        self, ax: Any, bath_diameter: float, refractory_thickness: float,
+        glass_depth: float, metal_depth: float,
+    ) -> None:
+        """Set axis labels, limits, and camera angle for real geometry."""
+        show_labels = self.show_axis_labels_checkbox.isChecked()
+        ax.set_xlabel("X (in)" if show_labels else "")
+        ax.set_ylabel("Y (in)" if show_labels else "")
         try:
-            ax.set_zlabel(
-                "Z (in)" if self.show_axis_labels_checkbox.isChecked() else ""
-            )
-        except (AttributeError, ValueError) as zlabel_error:
-            logger.debug("set_zlabel not available: %s", zlabel_error)
+            ax.set_zlabel("Z (in)" if show_labels else "")
+        except (AttributeError, ValueError) as e:
+            logger.debug("set_zlabel not available: %s", e)
 
-        # Set aspect and limits
         lim = bath_diameter / 2 + refractory_thickness + 2
         ax.set_xlim(-lim, lim)
         ax.set_ylim(-lim, lim)
-        # set_zlim is not always present, so use hasattr
         try:
             ax.set_zlim(0, glass_depth + metal_depth)
-        except (AttributeError, ValueError) as zlim_error:
-            logger.debug("set_zlim not available: %s", zlim_error)
+        except (AttributeError, ValueError) as e:
+            logger.debug("set_zlim not available: %s", e)
         try:
             ax.view_init(elev=25, azim=45)
-        except (AttributeError, ValueError) as view_error:
-            logger.debug("view_init not available: %s", view_error)
-        if self.electrode_canvas is not None:
-            self.electrode_canvas.draw()
+        except (AttributeError, ValueError) as e:
+            logger.debug("view_init not available: %s", e)
 
     def _update_3d_visualization(self) -> None:
         """Update the 3D electrode visualization with new path geometry."""
@@ -351,72 +334,25 @@ class VisualizationUpdateMixin:
         metal_height: float,
         glass_height: float,
     ) -> None:
-        """Draw the new 6-path conductive model with correct geometry"""
+        """Draw the new 6-path conductive model with correct geometry."""
         if self.electrode_ax is None:
             return
-        # Check if metal conductivity is enabled
         metal_conductive = self.metal_conductive_checkbox.isChecked()
-
-        # Get conductive layer height parameter
         conductive_height = self.conductive_layer_height_input.value()
-
-        # Get path alpha from slider
         path_alpha = self.path_alpha_slider.value() / 100.0
 
-        # Electrode positions (120 degrees apart)
-        angles = [0, 120, 240]  # degrees
-        electrode_positions = []
-
-        # Calculate electrode positions with full geometry
-        # Extend electrodes beyond refractory layer
-        refractory_thickness = self.refractory_thickness_input.value()
-        electrode_extension = self.electrode_extension_slider.value()
-        total_electrode_length = (
-            bath_radius + refractory_thickness + electrode_extension
+        electrode_positions = self._compute_electrode_positions_for_paths(
+            depths, bath_radius, metal_height, glass_height
         )
 
-        for _, (depth, angle) in enumerate(zip(depths, angles, strict=False)):
-            angle_rad = np.radians(angle)
-            electrode_z = metal_height + glass_height / 2
-
-            # Electrode tip position (inside vessel)
-            x_tip = (bath_radius - depth) * np.cos(angle_rad)
-            y_tip = (bath_radius - depth) * np.sin(angle_rad)
-
-            # Electrode base/wall position (extended beyond refractory)
-            x_base = total_electrode_length * np.cos(angle_rad)
-            y_base = total_electrode_length * np.sin(angle_rad)
-
-            electrode_positions.append(
-                {
-                    "tip": np.array([x_tip, y_tip, electrode_z]),
-                    "base": np.array([x_base, y_base, electrode_z]),
-                    "angle": angle_rad,
-                    "depth": depth,
-                }
-            )
-
-        # Draw the paths based on metal conductivity setting
         for i in range(3):
             j = (i + 1) % 3
             phase_key = f"{i + 1}-{j + 1}"
 
-            # Get current values for this phase if available
-            current_paths = (
-                self.calculation_results.get("current_paths", {})
-                if hasattr(self, "calculation_results") and self.calculation_results
-                else {}
-            )
-            actual_currents = (
-                self.calculation_results.get("actual_currents", {})
-                if hasattr(self, "calculation_results") and self.calculation_results
-                else {}
-            )
-
+            current_paths, actual_currents = self._get_phase_current_data()
             phase_current = actual_currents.get(phase_key, 0.0)
             phase_data = current_paths.get(phase_key, {})
 
-            # Calculate current through each path
             direct_fraction = phase_data.get(
                 "direct_fraction", 1.0 if not metal_conductive else 0.5
             )
@@ -427,39 +363,66 @@ class VisualizationUpdateMixin:
             direct_current = phase_current * direct_fraction
             metal_current = phase_current * metal_fraction if metal_conductive else 0.0
 
-            # Calculate resistance values
             direct_resistance = self._get_path_resistance("direct_glass", i)
-            metal_resistance = self._get_path_resistance("via_metal", i)
 
-            # 1. Direct glass conduction path (always draw)
             direct_color = self._get_current_based_color("direct_glass", i)
             self._draw_correct_trapezoidal_path(
-                electrode_positions[i],
-                electrode_positions[j],
-                conductive_height,
-                bath_radius,
-                color=direct_color,
+                electrode_positions[i], electrode_positions[j],
+                conductive_height, bath_radius, color=direct_color,
                 alpha=path_alpha * 0.8,
                 label=f"Direct Glass {i + 1}-{j + 1}",
                 current_value=direct_current,
                 resistance_value=direct_resistance,
             )
 
-            # 2. Via-metal conduction path (only draw if metal conductivity is enabled)
             if metal_conductive:
                 metal_color = self._get_current_based_color("via_metal", i)
                 self._draw_correct_via_metal_path(
-                    electrode_positions[i],
-                    electrode_positions[j],
-                    metal_height,
-                    electrode_radius,
-                    bath_radius,
-                    color=metal_color,
-                    alpha=path_alpha * 0.6,
+                    electrode_positions[i], electrode_positions[j],
+                    metal_height, electrode_radius, bath_radius,
+                    color=metal_color, alpha=path_alpha * 0.6,
                     label=f"Via Metal {i + 1}-{j + 1}",
                     current_value=metal_current,
-                    resistance_value=metal_resistance,
+                    resistance_value=self._get_path_resistance("via_metal", i),
                 )
+
+    def _compute_electrode_positions_for_paths(
+        self,
+        depths: list[float],
+        bath_radius: float,
+        metal_height: float,
+        glass_height: float,
+    ) -> list[dict[str, Any]]:
+        """Compute electrode positions at 120-degree intervals for path drawing."""
+        angles = [0, 120, 240]
+        refractory_thickness = self.refractory_thickness_input.value()
+        electrode_extension = self.electrode_extension_slider.value()
+        total_length = bath_radius + refractory_thickness + electrode_extension
+        positions: list[dict[str, Any]] = []
+
+        for depth, angle in zip(depths, angles, strict=False):
+            angle_rad = np.radians(angle)
+            electrode_z = metal_height + glass_height / 2
+            x_tip = (bath_radius - depth) * np.cos(angle_rad)
+            y_tip = (bath_radius - depth) * np.sin(angle_rad)
+            x_base = total_length * np.cos(angle_rad)
+            y_base = total_length * np.sin(angle_rad)
+            positions.append({
+                "tip": np.array([x_tip, y_tip, electrode_z]),
+                "base": np.array([x_base, y_base, electrode_z]),
+                "angle": angle_rad,
+                "depth": depth,
+            })
+        return positions
+
+    def _get_phase_current_data(self) -> tuple[dict, dict]:
+        """Return (current_paths, actual_currents) from calculation results."""
+        if hasattr(self, "calculation_results") and self.calculation_results:
+            return (
+                self.calculation_results.get("current_paths", {}),
+                self.calculation_results.get("actual_currents", {}),
+            )
+        return {}, {}
 
     def _draw_correct_trapezoidal_path(
         self,
@@ -473,93 +436,25 @@ class VisualizationUpdateMixin:
         current_value: float = 0.0,
         resistance_value: float = 0.0,
     ) -> None:
-        """
-        Draw the correct trapezoidal prism path where:
-        - The trapezoid is formed ONLY within the glass bath area (not in refractory)
-        - Conductive paths start at the glass bath wall, not at electrode bases
-        - Consists of vertical segments and a horizontal pie slice in metal
+        """Draw the correct trapezoidal prism path within the glass bath area.
+
+        Delegates to :func:`~shared_drawing.draw_trapezoidal_path`.
         """
         if self.electrode_ax is None:
             return
-        ax = self.electrode_ax
-
-        try:
-            e1_tip = electrode1_pos["tip"]
-            e2_tip = electrode2_pos["tip"]
-
-            e1_wall = self._compute_wall_position(
-                electrode1_pos,
-                bath_radius,
-            )
-            e2_wall = self._compute_wall_position(
-                electrode2_pos,
-                bath_radius,
-            )
-
-            effective_height = conductive_height * self.config.vertical_spreading_factor
-            electrode_z = (e1_tip[2] + e2_tip[2]) / 2
-
-            faces = self._build_trapezoidal_prism(
-                e1_wall,
-                e1_tip,
-                e2_tip,
-                e2_wall,
-                electrode_z,
-                effective_height,
-            )
-
-            face_collection = Poly3DCollection(
-                faces,
-                alpha=alpha,
-                facecolors=color,
-                edgecolor="darkblue",
-                linewidth=0.5,
-            )
-            ax.add_collection3d(face_collection)
-
-            # Draw conductive path boundary lines
-            if alpha > 0.3:
-                for wall, tip in [(e1_wall, e1_tip), (e2_wall, e2_tip)]:
-                    ax.plot(
-                        [wall[0], tip[0]],
-                        [wall[1], tip[1]],
-                        [electrode_z, electrode_z],
-                        "k-",
-                        linewidth=2,
-                        alpha=0.8,
-                    )
-
-            # Annotate current and resistance values
-            mid_x = (e1_wall[0] + e2_wall[0]) / 2
-            mid_y = (e1_wall[1] + e2_wall[1]) / 2
-
-            self._annotate_path_value(
-                ax,
-                mid_x,
-                mid_y,
-                electrode_z + 1.5,
-                current_value,
-                "show_current_values_checkbox",
-                "{:.0f}A",
-                "lightyellow",
-                "darkblue",
-            )
-            self._annotate_resistance_value(
-                ax,
-                mid_x,
-                mid_y,
-                electrode_z,
-                resistance_value,
-                current_value,
-                "lightgreen",
-                "darkgreen",
-            )
-
-        except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
-            logger.exception(
-                "Error drawing correct trapezoidal path: %s",
-                e,
-            )
+        draw_trapezoidal_path(
+            owner=self,
+            ax=self.electrode_ax,
+            electrode1_pos=electrode1_pos,
+            electrode2_pos=electrode2_pos,
+            conductive_height=conductive_height,
+            bath_radius=bath_radius,
+            vertical_spreading_factor=self.config.vertical_spreading_factor,
+            color=color,
+            alpha=alpha,
+            current_value=current_value,
+            resistance_value=resistance_value,
+        )
 
     @staticmethod
     def _compute_wall_position(
@@ -567,15 +462,7 @@ class VisualizationUpdateMixin:
         bath_radius: float,
     ) -> np.ndarray:
         """Compute glass bath wall intersection for an electrode."""
-        angle = electrode_pos["angle"]
-        tip_z = electrode_pos["tip"][2]
-        return np.array(
-            [
-                bath_radius * np.cos(angle),
-                bath_radius * np.sin(angle),
-                tip_z,
-            ]
-        )
+        return compute_wall_position(electrode_pos, bath_radius)
 
     @staticmethod
     def _build_trapezoidal_prism(
@@ -587,29 +474,9 @@ class VisualizationUpdateMixin:
         effective_height: float,
     ) -> list[list[list[float]]]:
         """Build 6-face trapezoidal prism vertices from wall/tip positions."""
-        z_top = electrode_z + effective_height / 2
-        z_bottom = electrode_z - effective_height / 2
-
-        # 8 vertices: bottom face (0-3), top face (4-7)
-        v = [
-            [wall1[0], wall1[1], z_bottom],
-            [tip1[0], tip1[1], z_bottom],
-            [tip2[0], tip2[1], z_bottom],
-            [wall2[0], wall2[1], z_bottom],
-            [wall1[0], wall1[1], z_top],
-            [tip1[0], tip1[1], z_top],
-            [tip2[0], tip2[1], z_top],
-            [wall2[0], wall2[1], z_top],
-        ]
-
-        return [
-            [v[0], v[1], v[2], v[3]],  # bottom
-            [v[4], v[5], v[6], v[7]],  # top
-            [v[0], v[1], v[5], v[4]],  # E1 side
-            [v[1], v[2], v[6], v[5]],  # tip-to-tip
-            [v[2], v[3], v[7], v[6]],  # E2 side
-            [v[3], v[0], v[4], v[7]],  # wall-to-wall
-        ]
+        return build_trapezoidal_prism(
+            wall1, tip1, tip2, wall2, electrode_z, effective_height
+        )
 
     def _annotate_path_value(
         self,
@@ -624,27 +491,8 @@ class VisualizationUpdateMixin:
         text_color: str,
     ) -> None:
         """Annotate a path with a formatted value label."""
-        if not (
-            hasattr(self, checkbox_name)
-            and getattr(self, checkbox_name).isChecked()
-            and value > 0
-        ):
-            return
-
-        ax.text(
-            mid_x,
-            mid_y,
-            mid_z,
-            fmt.format(value),
-            bbox={
-                "boxstyle": "round,pad=0.2",
-                "facecolor": bg_color,
-                "alpha": 0.8,
-            },
-            fontsize=8,
-            ha="center",
-            va="center",
-            color=text_color,
+        annotate_path_value(
+            self, ax, mid_x, mid_y, mid_z, value, checkbox_name, fmt, bg_color, text_color
         )
 
     def _annotate_resistance_value(
@@ -659,46 +507,9 @@ class VisualizationUpdateMixin:
         text_color: str,
     ) -> None:
         """Annotate a path with resistance value."""
-        if not (
-            hasattr(self, "show_resistance_values_checkbox")
-            and self.show_resistance_values_checkbox.isChecked()
-            and resistance_value > 0
-        ):
-            return
-
-        # Offset below current annotation when both visible
-        offset = (
-            -2.0
-            if (
-                hasattr(self, "show_current_values_checkbox")
-                and self.show_current_values_checkbox.isChecked()
-                and current_value > 0
-            )
-            else 1.5
-        )
-        mid_z = electrode_z + offset
-
-        if resistance_value == float("inf"):
-            text = "∞Ω"
-        elif resistance_value >= 1.0:
-            text = f"{resistance_value:.2f}Ω"
-        else:
-            text = f"{resistance_value:.3f}Ω"
-
-        ax.text(
-            mid_x,
-            mid_y,
-            mid_z,
-            text,
-            bbox={
-                "boxstyle": "round,pad=0.2",
-                "facecolor": bg_color,
-                "alpha": 0.8,
-            },
-            fontsize=8,
-            ha="center",
-            va="center",
-            color=text_color,
+        annotate_resistance_value(
+            self, ax, mid_x, mid_y, electrode_z, resistance_value, current_value,
+            bg_color, text_color,
         )
 
     def _draw_correct_via_metal_path(
@@ -714,118 +525,26 @@ class VisualizationUpdateMixin:
         current_value: float = 0.0,
         resistance_value: float = 0.0,
     ) -> None:
-        """Draw the correct 3-segment via-metal path with vertical extrusions only"""
+        """Draw the correct 3-segment via-metal path with vertical extrusions.
+
+        Delegates to :func:`~shared_drawing.draw_via_metal_path`.
+        """
         if self.electrode_ax is None:
             return
-        ax = self.electrode_ax
-
-        try:
-            # Segment 1: Rectangular extrusion down from E1 glass portion
-            self._draw_electrode_length_extrusion(
-                electrode1_pos,
-                metal_height,
-                electrode_radius,
-                bath_radius,
-                direction="down",
-                color=color,
-                alpha=alpha,
-            )
-
-            # Segment 2: Through metal layer - IMPLIED by metal layer itself
-            # No need to draw horizontal metal connection box
-
-            # Segment 3: Rectangular extrusion up to E2 glass portion
-            self._draw_electrode_length_extrusion(
-                electrode2_pos,
-                metal_height,
-                electrode_radius,
-                bath_radius,
-                direction="up",
-                color=color,
-                alpha=alpha,
-            )
-
-            # Display current value if checkbox is enabled
-            if (
-                hasattr(self, "show_current_values_checkbox")
-                and self.show_current_values_checkbox.isChecked()
-                and current_value > 0
-            ):
-                # Calculate midpoint between electrodes for text placement
-                e1_tip = electrode1_pos["tip"]
-                e2_tip = electrode2_pos["tip"]
-                mid_x = (e1_tip[0] + e2_tip[0]) / 2
-                mid_y = (e1_tip[1] + e2_tip[1]) / 2
-                mid_z = metal_height + 0.5  # Slightly above the metal layer
-
-                # Display current value without decimal points
-                current_text = f"{current_value:.0f}A"
-                ax.text(
-                    mid_x,
-                    mid_y,
-                    mid_z,
-                    current_text,
-                    bbox={
-                        "boxstyle": "round,pad=0.2",
-                        "facecolor": "lightcoral",
-                        "alpha": 0.8,
-                    },
-                    fontsize=8,
-                    ha="center",
-                    va="center",
-                    color="darkred",
-                )
-
-            # Display resistance value if checkbox is enabled
-            if (
-                hasattr(self, "show_resistance_values_checkbox")
-                and self.show_resistance_values_checkbox.isChecked()
-                and resistance_value > 0
-            ):
-                # Calculate position slightly offset from current display
-                e1_tip = electrode1_pos["tip"]
-                e2_tip = electrode2_pos["tip"]
-                mid_x = (e1_tip[0] + e2_tip[0]) / 2
-                mid_y = (e1_tip[1] + e2_tip[1]) / 2
-
-                # Offset resistance display below current display if both are shown
-                offset = (
-                    -1.0
-                    if (
-                        hasattr(self, "show_current_values_checkbox")
-                        and self.show_current_values_checkbox.isChecked()
-                        and current_value > 0
-                    )
-                    else 0.5
-                )
-                mid_z = metal_height + offset
-
-                # Display resistance value with appropriate precision
-                if resistance_value == float("inf"):
-                    resistance_text = "∞Ω"
-                elif resistance_value >= 1.0:
-                    resistance_text = f"{resistance_value:.2f}Ω"
-                else:
-                    resistance_text = f"{resistance_value:.3f}Ω"
-
-                ax.text(
-                    mid_x,
-                    mid_y,
-                    mid_z,
-                    resistance_text,
-                    bbox={
-                        "boxstyle": "round,pad=0.2",
-                        "facecolor": "lightpink",
-                        "alpha": 0.8,
-                    },
-                    fontsize=8,
-                    ha="center",
-                    va="center",
-                    color="darkred",
-                )
-
-        except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
-            logger.exception("Error drawing correct via-metal path: %s", e)
+        draw_via_metal_path(
+            owner=self,
+            ax=self.electrode_ax,
+            electrode1_pos=electrode1_pos,
+            electrode2_pos=electrode2_pos,
+            metal_height=metal_height,
+            electrode_radius=electrode_radius,
+            bath_radius=bath_radius,
+            color=color,
+            alpha=alpha,
+            current_value=current_value,
+            resistance_value=resistance_value,
+            horizontal_spreading_factor=self.config.horizontal_spreading_factor,
+        )
 
     def _draw_electrode_length_extrusion(
         self,
@@ -837,105 +556,20 @@ class VisualizationUpdateMixin:
         color: str,
         alpha: float,
     ) -> None:
-        """Draw rectangular extrusion along electrode length within glass bath
-        with horizontal spreading"""
+        """Draw rectangular extrusion along electrode length within glass bath.
+
+        Delegates to :func:`~shared_drawing.draw_electrode_length_extrusion`.
+        """
         if self.electrode_ax is None:
             return
-        ax = self.electrode_ax
-
-        try:
-            # Get glass wall position for this electrode
-            angle = electrode_pos["angle"]
-            wall_pos = np.array(
-                [
-                    bath_radius * np.cos(angle),
-                    bath_radius * np.sin(angle),
-                    electrode_pos["tip"][2],
-                ]
-            )
-
-            # Get electrode tip
-            tip_pos = electrode_pos["tip"]
-
-            # Apply horizontal spreading factor
-            effective_radius = (
-                electrode_radius * self.config.horizontal_spreading_factor
-            )
-
-            # Calculate extrusion bounds
-            electrode_z = electrode_pos["tip"][2]
-
-            if direction == "down":
-                z_start = electrode_z - electrode_radius
-                z_end = metal_height
-            else:  # up
-                z_start = metal_height
-                z_end = electrode_z - electrode_radius
-
-            # Direction vector along electrode (within glass bath only)
-            electrode_dir = tip_pos - wall_pos
-            electrode_length = np.linalg.norm(electrode_dir[:2])  # Only x,y
-
-            if electrode_length > 0:
-                # Create perpendicular vector for width
-                electrode_unit = electrode_dir[:2] / electrode_length
-                # Get perpendicular in x-y plane
-                perp = np.array([-electrode_unit[1], electrode_unit[0], 0])
-                perp_scaled = perp * effective_radius
-
-                # 8 vertices of the rectangular box
-                vertices = []
-
-                # Bottom face (at z_start)
-                vertices.append(
-                    wall_pos + perp_scaled + np.array([0, 0, z_start - wall_pos[2]])
-                )
-                vertices.append(
-                    wall_pos - perp_scaled + np.array([0, 0, z_start - wall_pos[2]])
-                )
-                vertices.append(
-                    tip_pos - perp_scaled + np.array([0, 0, z_start - tip_pos[2]])
-                )
-                vertices.append(
-                    tip_pos + perp_scaled + np.array([0, 0, z_start - tip_pos[2]])
-                )
-
-                # Top face (at z_end)
-                vertices.append(
-                    wall_pos + perp_scaled + np.array([0, 0, z_end - wall_pos[2]])
-                )
-                vertices.append(
-                    wall_pos - perp_scaled + np.array([0, 0, z_end - wall_pos[2]])
-                )
-                vertices.append(
-                    tip_pos - perp_scaled + np.array([0, 0, z_end - tip_pos[2]])
-                )
-                vertices.append(
-                    tip_pos + perp_scaled + np.array([0, 0, z_end - tip_pos[2]])
-                )
-
-                # Create faces
-                faces = []
-                # Bottom face
-                faces.append([vertices[0], vertices[1], vertices[2], vertices[3]])
-                # Top face
-                faces.append([vertices[4], vertices[5], vertices[6], vertices[7]])
-                # Side faces
-                for i in range(4):
-                    j = (i + 1) % 4
-                    faces.append(
-                        [vertices[i], vertices[j], vertices[j + 4], vertices[i + 4]]
-                    )
-
-                # Draw using Poly3DCollection
-                face_collection = Poly3DCollection(
-                    faces,
-                    alpha=alpha,
-                    facecolors=color,
-                    edgecolor="darkred",
-                    linewidth=0.5,
-                )
-                ax.add_collection3d(face_collection)
-
-        except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
-            logger.exception("Error drawing electrode length extrusion: %s", e)
+        draw_electrode_length_extrusion(
+            ax=self.electrode_ax,
+            electrode_pos=electrode_pos,
+            metal_height=metal_height,
+            electrode_radius=electrode_radius,
+            bath_radius=bath_radius,
+            direction=direction,
+            color=color,
+            alpha=alpha,
+            horizontal_spreading_factor=self.config.horizontal_spreading_factor,
+        )

--- a/src/electrode_advisor/python/electrode_advisor/utils/shared_drawing.py
+++ b/src/electrode_advisor/python/electrode_advisor/utils/shared_drawing.py
@@ -1,0 +1,507 @@
+"""Shared 3D drawing helpers for electrode visualization.
+
+Extracted from VisualizationUpdateMixin, PathsMixin, and ViaMetalMixin
+to eliminate code duplication (DRY).  Every mixin now delegates to
+these pure / static helper functions.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers (pure functions -- no widget state)
+# ---------------------------------------------------------------------------
+
+
+def compute_wall_position(
+    electrode_pos: dict[str, Any],
+    bath_radius: float,
+) -> np.ndarray:
+    """Compute glass bath wall intersection for an electrode."""
+    angle = electrode_pos["angle"]
+    tip_z = electrode_pos["tip"][2]
+    return np.array(
+        [
+            bath_radius * np.cos(angle),
+            bath_radius * np.sin(angle),
+            tip_z,
+        ]
+    )
+
+
+def build_trapezoidal_prism(
+    wall1: np.ndarray,
+    tip1: np.ndarray,
+    tip2: np.ndarray,
+    wall2: np.ndarray,
+    electrode_z: float,
+    effective_height: float,
+) -> list[list[list[float]]]:
+    """Build 6-face trapezoidal prism vertices from wall/tip positions."""
+    z_top = electrode_z + effective_height / 2
+    z_bottom = electrode_z - effective_height / 2
+
+    # 8 vertices: bottom face (0-3), top face (4-7)
+    v = [
+        [wall1[0], wall1[1], z_bottom],
+        [tip1[0], tip1[1], z_bottom],
+        [tip2[0], tip2[1], z_bottom],
+        [wall2[0], wall2[1], z_bottom],
+        [wall1[0], wall1[1], z_top],
+        [tip1[0], tip1[1], z_top],
+        [tip2[0], tip2[1], z_top],
+        [wall2[0], wall2[1], z_top],
+    ]
+
+    return [
+        [v[0], v[1], v[2], v[3]],  # bottom
+        [v[4], v[5], v[6], v[7]],  # top
+        [v[0], v[1], v[5], v[4]],  # E1 side
+        [v[1], v[2], v[6], v[5]],  # tip-to-tip
+        [v[2], v[3], v[7], v[6]],  # E2 side
+        [v[3], v[0], v[4], v[7]],  # wall-to-wall
+    ]
+
+
+def build_extrusion_faces(
+    wall_pos: np.ndarray,
+    tip_pos: np.ndarray,
+    perp_scaled: np.ndarray,
+    z_start: float,
+    z_end: float,
+) -> list[list[np.ndarray]]:
+    """Build the 6 faces for a rectangular electrode extrusion box.
+
+    Parameters
+    ----------
+    wall_pos : np.ndarray
+        Glass wall intersection position.
+    tip_pos : np.ndarray
+        Electrode tip position.
+    perp_scaled : np.ndarray
+        Perpendicular direction vector scaled by effective radius.
+    z_start, z_end : float
+        Vertical extents of the extrusion.
+
+    Returns
+    -------
+    list[list[np.ndarray]]
+        Six faces (bottom, top, 4 sides) for ``Poly3DCollection``.
+    """
+    vertices: list[np.ndarray] = []
+
+    # Bottom face (at z_start)
+    vertices.append(wall_pos + perp_scaled + np.array([0, 0, z_start - wall_pos[2]]))
+    vertices.append(wall_pos - perp_scaled + np.array([0, 0, z_start - wall_pos[2]]))
+    vertices.append(tip_pos - perp_scaled + np.array([0, 0, z_start - tip_pos[2]]))
+    vertices.append(tip_pos + perp_scaled + np.array([0, 0, z_start - tip_pos[2]]))
+
+    # Top face (at z_end)
+    vertices.append(wall_pos + perp_scaled + np.array([0, 0, z_end - wall_pos[2]]))
+    vertices.append(wall_pos - perp_scaled + np.array([0, 0, z_end - wall_pos[2]]))
+    vertices.append(tip_pos - perp_scaled + np.array([0, 0, z_end - tip_pos[2]]))
+    vertices.append(tip_pos + perp_scaled + np.array([0, 0, z_end - tip_pos[2]]))
+
+    faces: list[list[np.ndarray]] = []
+    faces.append([vertices[0], vertices[1], vertices[2], vertices[3]])  # Bottom
+    faces.append([vertices[4], vertices[5], vertices[6], vertices[7]])  # Top
+    for i in range(4):
+        j = (i + 1) % 4
+        faces.append([vertices[i], vertices[j], vertices[j + 4], vertices[i + 4]])
+
+    return faces
+
+
+# ---------------------------------------------------------------------------
+# Annotation helpers (read widget state via *owner* parameter)
+# ---------------------------------------------------------------------------
+
+
+def annotate_path_value(
+    owner: Any,
+    ax: Any,
+    mid_x: float,
+    mid_y: float,
+    mid_z: float,
+    value: float,
+    checkbox_name: str,
+    fmt: str,
+    bg_color: str,
+    text_color: str,
+) -> None:
+    """Annotate a path with a formatted value label."""
+    if not (
+        hasattr(owner, checkbox_name)
+        and getattr(owner, checkbox_name).isChecked()
+        and value > 0
+    ):
+        return
+
+    ax.text(
+        mid_x,
+        mid_y,
+        mid_z,
+        fmt.format(value),
+        bbox={
+            "boxstyle": "round,pad=0.2",
+            "facecolor": bg_color,
+            "alpha": 0.8,
+        },
+        fontsize=8,
+        ha="center",
+        va="center",
+        color=text_color,
+    )
+
+
+def annotate_resistance_value(
+    owner: Any,
+    ax: Any,
+    mid_x: float,
+    mid_y: float,
+    electrode_z: float,
+    resistance_value: float,
+    current_value: float,
+    bg_color: str,
+    text_color: str,
+) -> None:
+    """Annotate a path with a resistance value label."""
+    if not (
+        hasattr(owner, "show_resistance_values_checkbox")
+        and owner.show_resistance_values_checkbox.isChecked()
+        and resistance_value > 0
+    ):
+        return
+
+    # Offset below current annotation when both visible
+    offset = (
+        -2.0
+        if (
+            hasattr(owner, "show_current_values_checkbox")
+            and owner.show_current_values_checkbox.isChecked()
+            and current_value > 0
+        )
+        else 1.5
+    )
+    mid_z = electrode_z + offset
+
+    if resistance_value == float("inf"):
+        text = "\u221e\u03a9"
+    elif resistance_value >= 1.0:
+        text = f"{resistance_value:.2f}\u03a9"
+    else:
+        text = f"{resistance_value:.3f}\u03a9"
+
+    ax.text(
+        mid_x,
+        mid_y,
+        mid_z,
+        text,
+        bbox={
+            "boxstyle": "round,pad=0.2",
+            "facecolor": bg_color,
+            "alpha": 0.8,
+        },
+        fontsize=8,
+        ha="center",
+        va="center",
+        color=text_color,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drawing helpers (render to a matplotlib axis)
+# ---------------------------------------------------------------------------
+
+
+def draw_electrode_length_extrusion(
+    ax: Any,
+    electrode_pos: dict[str, Any],
+    metal_height: float,
+    electrode_radius: float,
+    bath_radius: float,
+    direction: str,
+    color: str,
+    alpha: float,
+    horizontal_spreading_factor: float,
+) -> None:
+    """Draw rectangular extrusion along electrode length within glass bath.
+
+    Parameters
+    ----------
+    ax : matplotlib 3D axis
+        Target axis for rendering.
+    electrode_pos : dict
+        Electrode position dict with ``tip``, ``angle``, and ``depth`` keys.
+    metal_height, electrode_radius, bath_radius : float
+        Geometry dimensions.
+    direction : str
+        ``"down"`` or ``"up"`` -- the extrusion direction.
+    color, alpha : str, float
+        Visual styling.
+    horizontal_spreading_factor : float
+        Multiplier from ``config.horizontal_spreading_factor``.
+    """
+    try:
+        # Get glass wall position for this electrode
+        angle = electrode_pos["angle"]
+        wall_pos = np.array(
+            [
+                bath_radius * np.cos(angle),
+                bath_radius * np.sin(angle),
+                electrode_pos["tip"][2],
+            ]
+        )
+
+        tip_pos = electrode_pos["tip"]
+        effective_radius = electrode_radius * horizontal_spreading_factor
+        electrode_z = electrode_pos["tip"][2]
+
+        if direction == "down":
+            z_start = electrode_z - electrode_radius
+            z_end = metal_height
+        else:  # up
+            z_start = metal_height
+            z_end = electrode_z - electrode_radius
+
+        electrode_dir = tip_pos - wall_pos
+        electrode_length = np.linalg.norm(electrode_dir[:2])
+
+        if electrode_length > 0:
+            electrode_unit = electrode_dir[:2] / electrode_length
+            perp = np.array([-electrode_unit[1], electrode_unit[0], 0])
+            perp_scaled = perp * effective_radius
+
+            faces = build_extrusion_faces(
+                wall_pos, tip_pos, perp_scaled, z_start, z_end
+            )
+
+            face_collection = Poly3DCollection(
+                faces,
+                alpha=alpha,
+                facecolors=color,
+                edgecolor="darkred",
+                linewidth=0.5,
+            )
+            ax.add_collection3d(face_collection)
+
+    except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
+        logger.exception("Error drawing electrode length extrusion: %s", e)
+
+
+def draw_via_metal_path(
+    owner: Any,
+    ax: Any,
+    electrode1_pos: dict[str, Any],
+    electrode2_pos: dict[str, Any],
+    metal_height: float,
+    electrode_radius: float,
+    bath_radius: float,
+    color: str,
+    alpha: float,
+    current_value: float,
+    resistance_value: float,
+    horizontal_spreading_factor: float,
+) -> None:
+    """Draw the correct 3-segment via-metal path with vertical extrusions.
+
+    Renders two vertical extrusions (down from electrode 1, up to electrode 2)
+    and annotates current / resistance values when their checkboxes are ticked.
+    """
+    try:
+        # Segment 1: down from E1
+        draw_electrode_length_extrusion(
+            ax,
+            electrode1_pos,
+            metal_height,
+            electrode_radius,
+            bath_radius,
+            direction="down",
+            color=color,
+            alpha=alpha,
+            horizontal_spreading_factor=horizontal_spreading_factor,
+        )
+
+        # Segment 2: through metal layer -- implied by metal layer itself
+
+        # Segment 3: up to E2
+        draw_electrode_length_extrusion(
+            ax,
+            electrode2_pos,
+            metal_height,
+            electrode_radius,
+            bath_radius,
+            direction="up",
+            color=color,
+            alpha=alpha,
+            horizontal_spreading_factor=horizontal_spreading_factor,
+        )
+
+        # Annotate current
+        if (
+            hasattr(owner, "show_current_values_checkbox")
+            and owner.show_current_values_checkbox.isChecked()
+            and current_value > 0
+        ):
+            e1_tip = electrode1_pos["tip"]
+            e2_tip = electrode2_pos["tip"]
+            mid_x = (e1_tip[0] + e2_tip[0]) / 2
+            mid_y = (e1_tip[1] + e2_tip[1]) / 2
+            mid_z = metal_height + 0.5
+
+            ax.text(
+                mid_x,
+                mid_y,
+                mid_z,
+                f"{current_value:.0f}A",
+                bbox={
+                    "boxstyle": "round,pad=0.2",
+                    "facecolor": "lightcoral",
+                    "alpha": 0.8,
+                },
+                fontsize=8,
+                ha="center",
+                va="center",
+                color="darkred",
+            )
+
+        # Annotate resistance
+        if (
+            hasattr(owner, "show_resistance_values_checkbox")
+            and owner.show_resistance_values_checkbox.isChecked()
+            and resistance_value > 0
+        ):
+            e1_tip = electrode1_pos["tip"]
+            e2_tip = electrode2_pos["tip"]
+            mid_x = (e1_tip[0] + e2_tip[0]) / 2
+            mid_y = (e1_tip[1] + e2_tip[1]) / 2
+
+            offset = (
+                -1.0
+                if (
+                    hasattr(owner, "show_current_values_checkbox")
+                    and owner.show_current_values_checkbox.isChecked()
+                    and current_value > 0
+                )
+                else 0.5
+            )
+            mid_z = metal_height + offset
+
+            if resistance_value == float("inf"):
+                resistance_text = "\u221e\u03a9"
+            elif resistance_value >= 1.0:
+                resistance_text = f"{resistance_value:.2f}\u03a9"
+            else:
+                resistance_text = f"{resistance_value:.3f}\u03a9"
+
+            ax.text(
+                mid_x,
+                mid_y,
+                mid_z,
+                resistance_text,
+                bbox={
+                    "boxstyle": "round,pad=0.2",
+                    "facecolor": "lightpink",
+                    "alpha": 0.8,
+                },
+                fontsize=8,
+                ha="center",
+                va="center",
+                color="darkred",
+            )
+
+    except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
+        logger.exception("Error drawing correct via-metal path: %s", e)
+
+
+def draw_trapezoidal_path(
+    owner: Any,
+    ax: Any,
+    electrode1_pos: dict[str, Any],
+    electrode2_pos: dict[str, Any],
+    conductive_height: float,
+    bath_radius: float,
+    vertical_spreading_factor: float,
+    color: str = "blue",
+    alpha: float = 0.4,
+    current_value: float = 0.0,
+    resistance_value: float = 0.0,
+) -> None:
+    """Draw the correct trapezoidal prism path between two electrodes.
+
+    The trapezoid is formed ONLY within the glass bath area (not in refractory).
+    Conductive paths start at the glass bath wall, not at electrode bases.
+    """
+    try:
+        e1_tip = electrode1_pos["tip"]
+        e2_tip = electrode2_pos["tip"]
+
+        e1_wall = compute_wall_position(electrode1_pos, bath_radius)
+        e2_wall = compute_wall_position(electrode2_pos, bath_radius)
+
+        effective_height = conductive_height * vertical_spreading_factor
+        electrode_z = (e1_tip[2] + e2_tip[2]) / 2
+
+        faces = build_trapezoidal_prism(
+            e1_wall, e1_tip, e2_tip, e2_wall, electrode_z, effective_height
+        )
+
+        face_collection = Poly3DCollection(
+            faces,
+            alpha=alpha,
+            facecolors=color,
+            edgecolor="darkblue",
+            linewidth=0.5,
+        )
+        ax.add_collection3d(face_collection)
+
+        # Boundary lines
+        if alpha > 0.3:
+            for wall, tip in [(e1_wall, e1_tip), (e2_wall, e2_tip)]:
+                ax.plot(
+                    [wall[0], tip[0]],
+                    [wall[1], tip[1]],
+                    [electrode_z, electrode_z],
+                    "k-",
+                    linewidth=2,
+                    alpha=0.8,
+                )
+
+        # Annotate current and resistance
+        mid_x = (e1_wall[0] + e2_wall[0]) / 2
+        mid_y = (e1_wall[1] + e2_wall[1]) / 2
+
+        annotate_path_value(
+            owner,
+            ax,
+            mid_x,
+            mid_y,
+            electrode_z + 1.5,
+            current_value,
+            "show_current_values_checkbox",
+            "{:.0f}A",
+            "lightyellow",
+            "darkblue",
+        )
+        annotate_resistance_value(
+            owner,
+            ax,
+            mid_x,
+            mid_y,
+            electrode_z,
+            resistance_value,
+            current_value,
+            "lightgreen",
+            "darkgreen",
+        )
+
+    except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
+        logger.exception("Error drawing correct trapezoidal path: %s", e)

--- a/src/shared/python/humanoid_character_builder/validation/physics_validator.py
+++ b/src/shared/python/humanoid_character_builder/validation/physics_validator.py
@@ -27,21 +27,26 @@ class ValidationResult:
 
     @classmethod
     def ok(cls) -> ValidationResult:
+        """Create a passing validation result with no messages."""
         return cls(True, [])
 
     @classmethod
     def error(cls, msg: str) -> ValidationResult:
+        """Create a failing validation result with a single error *msg*."""
         return cls(False, [f"ERROR: {msg}"])
 
     @classmethod
     def warning(cls, msg: str) -> ValidationResult:
+        """Create a passing validation result carrying a single warning *msg*."""
         return cls(True, [f"WARNING: {msg}"])
 
     def add_error(self, msg: str) -> None:
+        """Append an error message and mark the result as invalid."""
         self.is_valid = False
         self.messages.append(f"ERROR: {msg}")
 
     def add_warning(self, msg: str) -> None:
+        """Append a warning message without changing validity status."""
         self.messages.append(f"WARNING: {msg}")
 
 

--- a/src/shared/python/model_generation/api/rest_api.py
+++ b/src/shared/python/model_generation/api/rest_api.py
@@ -51,18 +51,22 @@ class APIResponse:
 
     @classmethod
     def ok(cls, data: dict[str, Any]) -> APIResponse:
+        """Create a 200 OK response with *data* as the JSON body."""
         return cls(status_code=200, body=data)
 
     @classmethod
     def created(cls, data: dict[str, Any]) -> APIResponse:
+        """Create a 201 Created response with *data* as the JSON body."""
         return cls(status_code=201, body=data)
 
     @classmethod
     def error(cls, message: str, status_code: int = 400) -> APIResponse:
+        """Create an error response with the given *status_code* (default 400)."""
         return cls(status_code=status_code, body={"error": message})
 
     @classmethod
     def not_found(cls, message: str = "Not found") -> APIResponse:
+        """Create a 404 Not Found response with *message*."""
         return cls(status_code=404, body={"error": message})
 
     @classmethod
@@ -72,6 +76,7 @@ class APIResponse:
         filename: str,
         content_type: str = "application/xml",
     ) -> APIResponse:
+        """Create a file-download response with a Content-Disposition header."""
         return cls(
             status_code=200,
             body=content if isinstance(content, bytes) else content.encode(),

--- a/src/shared/python/notes/notes_dock_widget.py
+++ b/src/shared/python/notes/notes_dock_widget.py
@@ -71,19 +71,23 @@ class NotesDockWidget(QDockWidget):
         self.setWidget(container)
 
     def save_notes(self) -> None:
+        """Persist the current editor contents to the notes file on disk."""
         text = self._require_editor().toPlainText()
         self.storage.save_text(text)
         self._set_status("Saved")
 
     def reload_from_disk(self) -> None:
+        """Reload the editor contents from the notes file on disk."""
         self._require_editor().setPlainText(self.storage.load_text())
 
     def clear_editor(self) -> None:
+        """Clear the editor and remove the notes file from storage."""
         self._require_editor().setPlainText("")
         self.storage.clear()
         self._set_status("Cleared")
 
     def delete_to_recycle_bin(self) -> bool:
+        """Save, then move the notes file to the recycle bin. Return True on success."""
         self.save_notes()
         try:
             self.storage.move_to_recycle(reason="user_delete")
@@ -96,6 +100,7 @@ class NotesDockWidget(QDockWidget):
         return True
 
     def restore_latest_deleted(self) -> bool:
+        """Restore the most recently recycled notes file. Return True on success."""
         item_id = self.storage.latest_recycled_id()
         if item_id is None:
             self._set_status("Recycle bin empty")
@@ -111,10 +116,12 @@ class NotesDockWidget(QDockWidget):
         return True
 
     def pop_out(self) -> None:
+        """Detach the dock widget into a floating window."""
         self.setFloating(True)
         self.show()
 
     def embed_in(self, main_window: QWidget, area: Qt.DockWidgetArea) -> None:
+        """Re-dock the widget into *main_window* at the given *area*."""
         if not hasattr(main_window, "addDockWidget"):
             raise ValueError("main_window must support addDockWidget")
         main_window.addDockWidget(area, self)

--- a/src/shared/python/signal_toolkit/series.py
+++ b/src/shared/python/signal_toolkit/series.py
@@ -494,6 +494,7 @@ def exp_series(
     """
 
     def exp_func(x: ArrayLike) -> float | NDArray[np.floating]:
+        """Compute the exponential series approximation for *x*."""
         x_arr = np.asarray(x, dtype=np.float64)
         result = np.zeros_like(x_arr)
         term = np.ones_like(x_arr)
@@ -522,6 +523,7 @@ def sin_series(
     """
 
     def sin_func(x: ArrayLike) -> float | NDArray[np.floating]:
+        """Compute the sine series approximation for *x*."""
         x_arr = np.asarray(x, dtype=np.float64)
         result = np.zeros_like(x_arr)
         term = x_arr.copy()  # First term is x
@@ -551,6 +553,7 @@ def cos_series(
     """
 
     def cos_func(x: ArrayLike) -> float | NDArray[np.floating]:
+        """Compute the cosine series approximation for *x*."""
         x_arr = np.asarray(x, dtype=np.float64)
         result = np.zeros_like(x_arr)
         term = np.ones_like(x_arr)  # First term is 1
@@ -582,6 +585,7 @@ def ln_series(
     """
 
     def ln_func(x: ArrayLike) -> float | NDArray[np.floating]:
+        """Compute the natural logarithm series ln(1+x) for *x*."""
         x_arr = np.asarray(x, dtype=np.float64)
         result = np.zeros_like(x_arr)
         term = x_arr.copy()  # First term is x
@@ -613,6 +617,7 @@ def geometric_series(
     """
 
     def geo_func(x: ArrayLike) -> float | NDArray[np.floating]:
+        """Compute the geometric series 1/(1-x) for *x*."""
         x_arr = np.asarray(x, dtype=np.float64)
         result = np.zeros_like(x_arr)
         term = np.ones_like(x_arr)
@@ -643,6 +648,7 @@ def arctan_series(
     """
 
     def arctan_func(x: ArrayLike) -> float | NDArray[np.floating]:
+        """Compute the arctangent series approximation for *x*."""
         x_arr = np.asarray(x, dtype=np.float64)
         result = np.zeros_like(x_arr)
         term = x_arr.copy()  # First term is x
@@ -673,6 +679,7 @@ def sinh_series(
     """
 
     def sinh_func(x: ArrayLike) -> float | NDArray[np.floating]:
+        """Compute the hyperbolic sine series approximation for *x*."""
         x_arr = np.asarray(x, dtype=np.float64)
         result = np.zeros_like(x_arr)
         term = x_arr.copy()  # First term is x
@@ -702,6 +709,7 @@ def cosh_series(
     """
 
     def cosh_func(x: ArrayLike) -> float | NDArray[np.floating]:
+        """Compute the hyperbolic cosine series approximation for *x*."""
         x_arr = np.asarray(x, dtype=np.float64)
         result = np.zeros_like(x_arr)
         term = np.ones_like(x_arr)  # First term is 1

--- a/src/shared/python/theme/dialogs/custom_theme_editor.py
+++ b/src/shared/python/theme/dialogs/custom_theme_editor.py
@@ -199,27 +199,47 @@ class CustomThemeEditor(QDialog):
         """Set up the dialog UI."""
         layout = QHBoxLayout(self)
 
-        # Left side - Color editor
+        left_widget = self._build_left_panel()
+        layout.addWidget(left_widget, 1)
+
+        right_widget = self._build_right_panel()
+        layout.addWidget(right_widget, 1)
+
+        button_box = self._build_dialog_buttons()
+        main_layout = QVBoxLayout()
+        main_layout.addLayout(layout)
+        main_layout.addWidget(button_box)
+
+        container = QWidget()
+        container.setLayout(main_layout)
+        dialog_layout = QVBoxLayout(self)
+        dialog_layout.addWidget(container)
+
+    def _build_left_panel(self) -> QWidget:
+        """Build the left panel with name input, color editor, and presets."""
         left_widget = QWidget()
         left_layout = QVBoxLayout(left_widget)
 
         # Theme name input
         name_group = QGroupBox("Theme Name")
         name_layout = QFormLayout(name_group)
-
         self.name_edit = QLineEdit()
         if self.edit_theme:
             self.name_edit.setText(self.edit_theme)
             self.name_edit.setEnabled(False)
         else:
             self.name_edit.setPlaceholderText("Enter theme name...")
-
         name_layout.addRow("Name:", self.name_edit)
         left_layout.addWidget(name_group)
 
-        # Color editor section
+        left_layout.addWidget(self._build_color_editor())
+        left_layout.addWidget(self._build_preset_buttons())
+        left_layout.addStretch()
+        return left_widget
+
+    def _build_color_editor(self) -> QGroupBox:
+        """Build the scrollable color picker section."""
         colors_group = QGroupBox("Theme Colors")
-        colors_scroll = QScrollArea()
         colors_widget = QWidget()
         colors_layout = QFormLayout(colors_widget)
 
@@ -244,19 +264,20 @@ class CustomThemeEditor(QDialog):
             color_button = ColorPickerButton()
             color_button.setToolTip(tooltip)
             color_button.color_changed.connect(partial(self._on_color_changed, key))
-
             self.color_buttons[key] = color_button
             colors_layout.addRow(f"{name}:", color_button)
 
+        colors_scroll = QScrollArea()
         colors_scroll.setWidget(colors_widget)
         colors_scroll.setWidgetResizable(True)
         colors_scroll.setMaximumHeight(400)
 
         colors_group_layout = QVBoxLayout(colors_group)
         colors_group_layout.addWidget(colors_scroll)
-        left_layout.addWidget(colors_group)
+        return colors_group
 
-        # Preset buttons
+    def _build_preset_buttons(self) -> QGroupBox:
+        """Build the quick-start preset theme buttons."""
         preset_group = QGroupBox("Quick Start")
         preset_layout = QVBoxLayout(preset_group)
 
@@ -273,12 +294,10 @@ class CustomThemeEditor(QDialog):
             preset_buttons_layout.addWidget(btn)
 
         preset_layout.addLayout(preset_buttons_layout)
-        left_layout.addWidget(preset_group)
+        return preset_group
 
-        left_layout.addStretch()
-        layout.addWidget(left_widget, 1)
-
-        # Right side - Preview
+    def _build_right_panel(self) -> QWidget:
+        """Build the right panel with live preview."""
         right_widget = QWidget()
         right_layout = QVBoxLayout(right_widget)
 
@@ -288,35 +307,24 @@ class CustomThemeEditor(QDialog):
 
         self.preview_widget = ThemePreviewWidget()
         right_layout.addWidget(self.preview_widget, 1)
+        return right_widget
 
-        layout.addWidget(right_widget, 1)
-
-        # Dialog buttons
+    def _build_dialog_buttons(self) -> QDialogButtonBox:
+        """Build Save/Cancel/Save&Apply button box and connect signals."""
         button_box = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Save
             | QDialogButtonBox.StandardButton.Cancel
         )
-
         self.save_btn = button_box.button(QDialogButtonBox.StandardButton.Save)
-
         self.save_apply_btn = button_box.addButton(
             "Save && Apply", QDialogButtonBox.ButtonRole.AcceptRole
         )
-
-        main_layout = QVBoxLayout()
-        main_layout.addLayout(layout)
-        main_layout.addWidget(button_box)
-
-        container = QWidget()
-        container.setLayout(main_layout)
-
-        dialog_layout = QVBoxLayout(self)
-        dialog_layout.addWidget(container)
 
         button_box.accepted.connect(self._save_theme)
         button_box.rejected.connect(self.reject)
         if self.save_apply_btn is not None:
             self.save_apply_btn.clicked.connect(self._save_and_apply_theme)
+        return button_box
 
     def _load_initial_colors(self) -> None:
         """Load initial colors from existing theme or defaults."""

--- a/src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_gui.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/psa_package/psa_gui.py
@@ -310,14 +310,21 @@ class ResultsPanel(QWidget):
 
     def update_results(self, results: PSAResults) -> None:
         """Update display with calculation results."""
-        # Key metrics
+        self._update_key_metrics(results)
+        self._update_safety_metrics(results)
+        self._update_flows_table(results)
+        self._update_compositions_table(results)
+
+    def _update_key_metrics(self, results: PSAResults) -> None:
+        """Update key performance metric labels."""
         self.h2_recovery_label.setText(f"{results.h2_recovery_pct:.2f}%")
         self.h2_purity_label.setText(f"{results.h2_purity_pct:.5f}%")
         self.net_product_label.setText(f"{results.total_net_product_scfm:.2f} SCFM")
         self.exhaust_label.setText(f"{results.total_exhaust_scfm:.2f} SCFM")
         self.mass_balance_label.setText(f"{results.mass_balance_error:.2e}")
 
-        # Safety metrics
+    def _update_safety_metrics(self, results: PSAResults) -> None:
+        """Update safety/flammability metric labels and styling."""
         self.s2_tail_h2_label.setText(f"{results.s2_tail_h2_pct:.2f}%")
         self.s2_tail_o2_label.setText(f"{results.s2_tail_o2_pct:.2f}%")
 
@@ -337,89 +344,57 @@ class ResultsPanel(QWidget):
                 "font-weight: bold; color: green; background-color: #ccffcc;"
             )
 
-        # Flows table
+    def _update_flows_table(self, results: PSAResults) -> None:
+        """Populate the flows table with component flow data and totals."""
         n_comp = len(results.component_names)
         self.flows_table.setRowCount(n_comp + 1)
 
+        flow_columns = [
+            results.flows.fresh_feed, results.flows.mixed_feed,
+            results.flows.exhaust, results.flows.interstage,
+            results.flows.s2_tail, results.flows.s2_tail_recycle,
+            results.flows.gross_product, results.flows.net_product,
+        ]
+
         for i, name in enumerate(results.component_names):
             self.flows_table.setItem(i, 0, QTableWidgetItem(name))
-            self.flows_table.setItem(
-                i, 1, QTableWidgetItem(f"{results.flows.fresh_feed[i]:.4f}")
-            )
-            self.flows_table.setItem(
-                i, 2, QTableWidgetItem(f"{results.flows.mixed_feed[i]:.4f}")
-            )
-            self.flows_table.setItem(
-                i, 3, QTableWidgetItem(f"{results.flows.exhaust[i]:.4f}")
-            )
-            self.flows_table.setItem(
-                i, 4, QTableWidgetItem(f"{results.flows.interstage[i]:.4f}")
-            )
-            self.flows_table.setItem(
-                i, 5, QTableWidgetItem(f"{results.flows.s2_tail[i]:.4f}")
-            )
-            self.flows_table.setItem(
-                i, 6, QTableWidgetItem(f"{results.flows.s2_tail_recycle[i]:.4f}")
-            )
-            self.flows_table.setItem(
-                i, 7, QTableWidgetItem(f"{results.flows.gross_product[i]:.4f}")
-            )
-            self.flows_table.setItem(
-                i, 8, QTableWidgetItem(f"{results.flows.net_product[i]:.4f}")
-            )
+            for col_idx, col_data in enumerate(flow_columns):
+                self.flows_table.setItem(
+                    i, col_idx + 1, QTableWidgetItem(f"{col_data[i]:.4f}")
+                )
 
         # Totals row
         self.flows_table.setItem(n_comp, 0, QTableWidgetItem("TOTAL"))
-        self.flows_table.setItem(
-            n_comp, 1, QTableWidgetItem(f"{results.total_feed_scfm:.2f}")
-        )
-        self.flows_table.setItem(
-            n_comp, 2, QTableWidgetItem(f"{np.sum(results.flows.mixed_feed):.2f}")
-        )
-        self.flows_table.setItem(
-            n_comp, 3, QTableWidgetItem(f"{results.total_exhaust_scfm:.2f}")
-        )
-        self.flows_table.setItem(
-            n_comp, 4, QTableWidgetItem(f"{np.sum(results.flows.interstage):.2f}")
-        )
-        self.flows_table.setItem(
-            n_comp, 5, QTableWidgetItem(f"{np.sum(results.flows.s2_tail):.2f}")
-        )
-        self.flows_table.setItem(
-            n_comp, 6, QTableWidgetItem(f"{np.sum(results.flows.s2_tail_recycle):.2f}")
-        )
-        self.flows_table.setItem(
-            n_comp, 7, QTableWidgetItem(f"{np.sum(results.flows.gross_product):.2f}")
-        )
-        self.flows_table.setItem(
-            n_comp, 8, QTableWidgetItem(f"{results.total_net_product_scfm:.2f}")
-        )
+        totals = [
+            results.total_feed_scfm, np.sum(results.flows.mixed_feed),
+            results.total_exhaust_scfm, np.sum(results.flows.interstage),
+            np.sum(results.flows.s2_tail), np.sum(results.flows.s2_tail_recycle),
+            np.sum(results.flows.gross_product), results.total_net_product_scfm,
+        ]
+        for col_idx, total in enumerate(totals):
+            self.flows_table.setItem(
+                n_comp, col_idx + 1, QTableWidgetItem(f"{total:.2f}")
+            )
 
         self.flows_table.resizeColumnsToContents()
 
-        # Compositions table
+    def _update_compositions_table(self, results: PSAResults) -> None:
+        """Populate the compositions table with component percentage data."""
+        n_comp = len(results.component_names)
         self.comp_table.setRowCount(n_comp + 1)
+
+        comp_columns = [
+            results.compositions.fresh_feed, results.compositions.mixed_feed,
+            results.compositions.exhaust, results.compositions.interstage,
+            results.compositions.s2_tail, results.compositions.net_product,
+        ]
 
         for i, name in enumerate(results.component_names):
             self.comp_table.setItem(i, 0, QTableWidgetItem(name))
-            self.comp_table.setItem(
-                i, 1, QTableWidgetItem(f"{results.compositions.fresh_feed[i]:.4f}")
-            )
-            self.comp_table.setItem(
-                i, 2, QTableWidgetItem(f"{results.compositions.mixed_feed[i]:.4f}")
-            )
-            self.comp_table.setItem(
-                i, 3, QTableWidgetItem(f"{results.compositions.exhaust[i]:.4f}")
-            )
-            self.comp_table.setItem(
-                i, 4, QTableWidgetItem(f"{results.compositions.interstage[i]:.4f}")
-            )
-            self.comp_table.setItem(
-                i, 5, QTableWidgetItem(f"{results.compositions.s2_tail[i]:.4f}")
-            )
-            self.comp_table.setItem(
-                i, 6, QTableWidgetItem(f"{results.compositions.net_product[i]:.4f}")
-            )
+            for col_idx, col_data in enumerate(comp_columns):
+                self.comp_table.setItem(
+                    i, col_idx + 1, QTableWidgetItem(f"{col_data[i]:.4f}")
+                )
 
         # Totals row
         self.comp_table.setItem(n_comp, 0, QTableWidgetItem("TOTAL"))

--- a/src/shared/python/upstream_drift_tools/ui/widgets/data_processor_widget.py
+++ b/src/shared/python/upstream_drift_tools/ui/widgets/data_processor_widget.py
@@ -234,6 +234,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
         return tabs
 
     def _create_statistics_tab(self) -> QWidget:
+        """Build the statistics tab with data summary and per-column stats."""
         tab = QWidget()
         layout = QVBoxLayout(tab)
         group = QGroupBox("Data Summary")
@@ -263,6 +264,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
         return tab
 
     def _create_filter_tab(self) -> QWidget:
+        """Build the filter tab with quick-filter, query, and aggregation tools."""
         tab = QWidget()
         layout = QVBoxLayout(tab)
         group = QGroupBox("Quick Filter")
@@ -309,6 +311,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
         return tab
 
     def _create_column_tab(self) -> QWidget:
+        """Build the column management tab with add, transform, and rename tools."""
         tab = QWidget()
         layout = QVBoxLayout(tab)
         add = QGroupBox("Add")
@@ -368,6 +371,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
         return tab
 
     def _create_fit_tab(self) -> QWidget:
+        """Build the curve fitting tab with fit type selector and results display."""
         tab = QWidget()
         layout = QVBoxLayout(tab)
         fit = QGroupBox("Fit")
@@ -393,10 +397,12 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
         return tab
 
     def setup_connections(self) -> None:
+        """Wire internal signals to their handler slots."""
         self.data_loaded.connect(self._on_data_loaded)
         self.data_modified.connect(self._on_data_modified)
 
     def setup_shortcuts(self) -> None:
+        """Register keyboard shortcuts for file, undo, and redo operations."""
         from PyQt6.QtGui import QShortcut
 
         QShortcut(QKeySequence.StandardKey.Open, self, self.open_file)
@@ -405,6 +411,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
         QShortcut(QKeySequence.StandardKey.Redo, self, self.redo)
 
     def open_file(self) -> None:
+        """Prompt the user to select a data file and load it into the engine."""
         path, _ = QFileDialog.getOpenFileName(self, "Open", "", "All (*.*)")
         if path:
             res = self.engine.load_file(path)
@@ -419,6 +426,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
                 QMessageBox.warning(self, "Error", res.message)
 
     def save_file(self) -> None:
+        """Save data to the current file, or prompt for export if no file loaded."""
         if not self.engine.has_data():
             return
         if self.current_file:
@@ -431,6 +439,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
             self.export_file()
 
     def export_file(self) -> None:
+        """Prompt for a destination path and export the current data as CSV."""
         path, _ = QFileDialog.getSaveFileName(self, "Export", "", "CSV (*.csv)")
         if path:
             res = self.engine.export_data(path)
@@ -439,6 +448,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
                 self._set_status("Exported")
 
     def undo(self) -> None:
+        """Undo the last data operation and refresh the view."""
         res = self.engine.undo()
         if res.success:
             self._update_table()
@@ -446,6 +456,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
             self._set_status("Undo")
 
     def redo(self) -> None:
+        """Re-apply the previously undone data operation and refresh the view."""
         res = self.engine.redo()
         if res.success:
             self._update_table()
@@ -453,6 +464,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
             self._set_status("Redo")
 
     def reset_data(self) -> None:
+        """Reset all data transformations back to the originally loaded state."""
         if self.engine.reset().success:
             self._update_table()
             self.refresh_statistics()
@@ -516,6 +528,7 @@ class DataProcessorWidget(DataProcessorOpsMixin, BaseCalculatorWidget):
                 s.setCurrentText(curr)
 
     def refresh_statistics(self) -> None:
+        """Recalculate and display summary statistics for the loaded data."""
         if not self.engine.has_data():
             return
         stats = self.engine.get_statistics()

--- a/src/web_applications/calculator/calculator.py
+++ b/src/web_applications/calculator/calculator.py
@@ -166,11 +166,13 @@ class TI89Calculator:
 
     @property
     def allowed_functions(self) -> Mapping[str, object]:
+        """Return the dictionary of allowed symbolic functions."""
         assert self._allowed_functions is not None
         return self._allowed_functions
 
     @property
     def safe_globals(self) -> Mapping[str, object]:
+        """Return the sandboxed global dict used during expression parsing."""
         assert self._SAFE_GLOBALS_CACHE is not None
         return self._SAFE_GLOBALS_CACHE
 
@@ -461,6 +463,7 @@ class TI89Calculator:
     def parse_expression(
         expression: str, symbols: Mapping[str, sp.Symbol | sp.Expr]
     ) -> sp.Expr:
+        """Parse a mathematical expression string into a validated SymPy tree."""
         # Optimization: fast-path for simple numbers to avoid expensive parse_expr
         if expression:
             # Strip whitespace for accurate numeric checks
@@ -519,6 +522,7 @@ class TI89Calculator:
     def parse_equation(
         equation: str, symbols: Mapping[str, sp.Symbol | sp.Expr]
     ) -> sp.Eq:
+        """Parse an equation string (``lhs = rhs``) into a SymPy ``Eq`` object."""
         if "=" in equation:
             lhs, rhs = equation.split("=", maxsplit=1)
         else:
@@ -635,70 +639,72 @@ class TI89Calculator:
         return sp.diag(*matrices)
 
     def _build_allowed_functions(self) -> Mapping[str, object]:
+        """Build the complete mapping of allowed functions/constants for the calculator."""
+        result: dict[str, object] = {}
+        result.update(self._trig_functions())
+        result.update(self._complex_and_elementary_functions())
+        result.update(self._algebra_functions())
+        result.update(self._linear_algebra_functions())
+        result.update(self._robotics_functions())
+        result.update(self._constants())
+        return result
+
+    @staticmethod
+    def _trig_functions() -> dict[str, object]:
+        """Return trigonometric and hyperbolic function mappings."""
         return {
-            "I": sp.I,
-            "i": sp.I,
-            "sin": sp.sin,
-            "cos": sp.cos,
-            "tan": sp.tan,
-            "csc": sp.csc,
-            "sec": sp.sec,
-            "cot": sp.cot,
-            "asin": sp.asin,
-            "acos": sp.acos,
-            "atan": sp.atan,
-            "acsc": sp.acsc,
-            "asec": sp.asec,
-            "acot": sp.acot,
-            "sinh": sp.sinh,
-            "cosh": sp.cosh,
-            "tanh": sp.tanh,
-            "asinh": sp.asinh,
-            "acosh": sp.acosh,
-            "atanh": sp.atanh,
-            "csch": sp.csch,
-            "sech": sp.sech,
-            "coth": sp.coth,
-            "re": sp.re,
-            "im": sp.im,
-            "real": sp.re,
-            "imag": sp.im,
+            "I": sp.I, "i": sp.I,
+            "sin": sp.sin, "cos": sp.cos, "tan": sp.tan,
+            "csc": sp.csc, "sec": sp.sec, "cot": sp.cot,
+            "asin": sp.asin, "acos": sp.acos, "atan": sp.atan,
+            "acsc": sp.acsc, "asec": sp.asec, "acot": sp.acot,
+            "sinh": sp.sinh, "cosh": sp.cosh, "tanh": sp.tanh,
+            "asinh": sp.asinh, "acosh": sp.acosh, "atanh": sp.atanh,
+            "csch": sp.csch, "sech": sp.sech, "coth": sp.coth,
+        }
+
+    @staticmethod
+    def _complex_and_elementary_functions() -> dict[str, object]:
+        """Return complex number, elementary, and rounding function mappings."""
+        return {
+            "re": sp.re, "im": sp.im,
+            "real": sp.re, "imag": sp.im,
             "arg": sp.arg,
-            "conj": sp.conjugate,
-            "conjugate": sp.conjugate,
+            "conj": sp.conjugate, "conjugate": sp.conjugate,
             "abs": sp.Abs,
             "norm": lambda vector, **k: sp.Matrix(vector).norm(),
-            "exp": sp.exp,
-            "log": sp.log,
-            "ln": sp.log,
+            "exp": sp.exp, "log": sp.log, "ln": sp.log,
             "sqrt": sp.sqrt,
             "cbrt": lambda value, **k: sp.root(value, 3),
-            "floor": sp.floor,
-            "ceiling": sp.ceiling,
+            "floor": sp.floor, "ceiling": sp.ceiling,
             "round": lambda value, ndigits=0, **k: round(value, ndigits),
             "cis": lambda theta, **k: sp.exp(sp.I * theta),
             "rect": lambda radius, theta, **k: radius * sp.exp(sp.I * theta),
             "polar": lambda complex_value, **k: sp.Tuple(
                 sp.Abs(complex_value), sp.arg(complex_value)
             ),
-            "gcd": sp.gcd,
-            "lcm": sp.lcm,
-            "factor": sp.factor,
-            "factor_terms": sp.factor_terms,
-            "expand": sp.expand,
-            "cancel": sp.cancel,
-            "collect": sp.collect,
-            "together": sp.together,
-            "ratsimp": sp.ratsimp,
-            "trigsimp": sp.trigsimp,
-            "apart": sp.apart,
-            "simplify": sp.simplify,
+        }
+
+    @staticmethod
+    def _algebra_functions() -> dict[str, object]:
+        """Return algebraic manipulation and combinatorics function mappings."""
+        return {
+            "gcd": sp.gcd, "lcm": sp.lcm,
+            "factor": sp.factor, "factor_terms": sp.factor_terms,
+            "expand": sp.expand, "cancel": sp.cancel,
+            "collect": sp.collect, "together": sp.together,
+            "ratsimp": sp.ratsimp, "trigsimp": sp.trigsimp,
+            "apart": sp.apart, "simplify": sp.simplify,
             "factorial": TI89Calculator._safe_factorial,
             "nCr": sp.binomial,
             "nPr": lambda n, r, **k: TI89Calculator._safe_factorial(n)
             / TI89Calculator._safe_factorial(n - r),
-            "sum": sp.summation,
-            "product": sp.product,
+            "sum": sp.summation, "product": sp.product,
+        }
+
+    def _linear_algebra_functions(self) -> dict[str, object]:
+        """Return matrix and linear algebra function mappings."""
+        return {
             "Matrix": sp.Matrix,
             "dot": lambda vector_a, vector_b, **k: sp.Matrix(vector_a).dot(
                 sp.Matrix(vector_b)
@@ -716,17 +722,13 @@ class TI89Calculator:
             "rank": lambda matrix, **k: sp.Matrix(matrix).rank(),
             "diag": sp.diag,
             "block_diag": self._block_diag,
-            "eye": sp.eye,
-            "ones": sp.ones,
-            "zeros": sp.zeros,
-            "matrix_exp": self._matrix_exp,
-            "expm": self._matrix_exp,
-            "matrix_log": self._matrix_log,
-            "logm": self._matrix_log,
+            "eye": sp.eye, "ones": sp.ones, "zeros": sp.zeros,
+            "matrix_exp": self._matrix_exp, "expm": self._matrix_exp,
+            "matrix_log": self._matrix_log, "logm": self._matrix_log,
             "matrix_power": self._matrix_power,
             "eigenvals": lambda matrix, **k: sp.Matrix(matrix).eigenvals(),
             "eigenvects": lambda matrix, **k: sp.Matrix(matrix).eigenvects(),
-            "charpoly": lambda matrix, symbol="λ", **k: sp.Matrix(matrix)
+            "charpoly": lambda matrix, symbol="\u03bb", **k: sp.Matrix(matrix)
             .charpoly(sp.Symbol(symbol))
             .as_expr(),
             "nullspace": lambda matrix, **k: sp.Matrix(matrix).nullspace(),
@@ -739,20 +741,24 @@ class TI89Calculator:
                 sp.Matrix(rhs)
             ),
             "linsolve": sp.linsolve,
-            "hat": self._hat,
-            "vee": self._vee,
-            "skew": self._hat,
-            "unskew": self._vee,
-            "se3_hat": self._se3_hat,
-            "se3_vee": self._se3_vee,
+        }
+
+    def _robotics_functions(self) -> dict[str, object]:
+        """Return robotics/Lie algebra function mappings."""
+        return {
+            "hat": self._hat, "vee": self._vee,
+            "skew": self._hat, "unskew": self._vee,
+            "se3_hat": self._se3_hat, "se3_vee": self._se3_vee,
             "screw_axis": self._screw_axis,
             "twist_exp": self._twist_exponential,
             "adjoint": self._adjoint_transform,
-            "pi": sp.pi,
-            "E": sp.E,
-            "e": sp.E,
-            "oo": sp.oo,
-            "Infinity": sp.oo,
-            "inf": sp.oo,
+        }
+
+    @staticmethod
+    def _constants() -> dict[str, object]:
+        """Return mathematical constant mappings."""
+        return {
+            "pi": sp.pi, "E": sp.E, "e": sp.E,
+            "oo": sp.oo, "Infinity": sp.oo, "inf": sp.oo,
             "nan": sp.nan,
         }

--- a/tests/shared/python/calculators/conversion/test_flow_rate_converter.py
+++ b/tests/shared/python/calculators/conversion/test_flow_rate_converter.py
@@ -27,27 +27,21 @@ from upstream_drift_tools.calculators.conversion.flow_rate_converter import (
 class TestMolarToMolar:
     """Test molar flow rate conversions."""
 
-    def test_same_unit_returns_value(self):
-        """Test that converting to the same unit returns the original value."""
-        assert molar_to_molar(100.0, "kmol/s", "kmol/s") == pytest.approx(100.0)
-        assert molar_to_molar(50.0, "mol/h", "mol/h") == pytest.approx(50.0)
-
-    def test_mol_per_s_to_mol_per_h(self):
-        """Test conversion from mol/s to mol/h."""
-        result = molar_to_molar(1.0, "mol/s", "mol/h")
-        assert result == pytest.approx(3600.0)
-
-    def test_kmol_per_h_to_mol_per_s(self):
-        """Test conversion from kmol/h to mol/s."""
-        result = molar_to_molar(1.0, "kmol/h", "mol/s")
-        expected = 1000.0 / 3600.0
-        assert result == pytest.approx(expected, rel=1e-5)
-
-    def test_lbmol_per_h_to_mol_per_s(self):
-        """Test conversion from lbmol/h to mol/s."""
-        result = molar_to_molar(1.0, "lbmol/h", "mol/s")
-        # lbmol = 453.59237 mol
-        expected = 453.59237 / 3600.0
+    @pytest.mark.parametrize(
+        "value, from_unit, to_unit, expected",
+        [
+            (100.0, "kmol/s", "kmol/s", 100.0),
+            (50.0, "mol/h", "mol/h", 50.0),
+            (1.0, "mol/s", "mol/h", 3600.0),
+            (1.0, "kmol/h", "mol/s", 1000.0 / 3600.0),
+            (1.0, "lbmol/h", "mol/s", 453.59237 / 3600.0),
+        ],
+        ids=["same-kmol/s", "same-mol/h", "mol/s-to-mol/h",
+             "kmol/h-to-mol/s", "lbmol/h-to-mol/s"],
+    )
+    def test_molar_conversions(self, value, from_unit, to_unit, expected):
+        """Test molar flow rate unit conversions."""
+        result = molar_to_molar(value, from_unit, to_unit)
         assert result == pytest.approx(expected, rel=1e-5)
 
 

--- a/tests/test_dependency_checker.py
+++ b/tests/test_dependency_checker.py
@@ -6,6 +6,8 @@ Design by Contract principles.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 
 class TestDependencyStatusContract:
     """Design by Contract tests for DependencyStatus dataclass."""
@@ -76,19 +78,21 @@ class TestHasModuleContract:
 class TestHasModule:
     """Functional tests for has_module."""
 
-    def test_returns_true_for_stdlib(self):
-        """Test returning True for standard library modules."""
+    @pytest.mark.parametrize(
+        "module_name, expected",
+        [
+            ("sys", True),
+            ("os", True),
+            ("pathlib", True),
+            ("definitely_not_a_real_module_xyz", False),
+        ],
+        ids=["sys", "os", "pathlib", "nonexistent"],
+    )
+    def test_module_availability(self, module_name, expected):
+        """Test has_module returns correct bool for stdlib and nonexistent modules."""
         from utils.dependency_checker import has_module
 
-        assert has_module("sys") is True
-        assert has_module("os") is True
-        assert has_module("pathlib") is True
-
-    def test_returns_false_for_nonexistent(self):
-        """Test returning False for nonexistent modules."""
-        from utils.dependency_checker import has_module
-
-        assert has_module("definitely_not_a_real_module_xyz") is False
+        assert has_module(module_name) is expected
 
     def test_uses_custom_spec_finder(self):
         """Test using custom spec finder."""

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -78,25 +78,27 @@ class TestGetEnvBoolContract:
 class TestGetEnvBool:
     """Functional tests for get_env_bool."""
 
-    def test_true_values(self):
+    @pytest.mark.parametrize(
+        "env_val",
+        ["true", "TRUE", "True", "1", "yes", "YES", "on", "ON"],
+    )
+    def test_true_values(self, env_val):
         """Test recognizing true values."""
         from utils.env_utils import get_env_bool
 
-        true_values = ["true", "TRUE", "True", "1", "yes", "YES", "on", "ON"]
+        with patch.dict(os.environ, {"BOOL_VAR": env_val}):
+            assert get_env_bool("BOOL_VAR") is True
 
-        for val in true_values:
-            with patch.dict(os.environ, {"BOOL_VAR": val}):
-                assert get_env_bool("BOOL_VAR") is True, f"Failed for: {val}"
-
-    def test_false_values(self):
+    @pytest.mark.parametrize(
+        "env_val",
+        ["false", "FALSE", "0", "no", "off", "", "anything_else"],
+    )
+    def test_false_values(self, env_val):
         """Test recognizing false values."""
         from utils.env_utils import get_env_bool
 
-        false_values = ["false", "FALSE", "0", "no", "off", "", "anything_else"]
-
-        for val in false_values:
-            with patch.dict(os.environ, {"BOOL_VAR": val}):
-                assert get_env_bool("BOOL_VAR") is False, f"Failed for: {val}"
+        with patch.dict(os.environ, {"BOOL_VAR": env_val}):
+            assert get_env_bool("BOOL_VAR") is False
 
     def test_default_is_false(self):
         """Test default is False."""
@@ -135,21 +137,18 @@ class TestGetEnvIntContract:
 class TestGetEnvInt:
     """Functional tests for get_env_int."""
 
-    def test_parses_integer(self):
-        """Test parsing integer value."""
+    @pytest.mark.parametrize(
+        "env_val, expected",
+        [("8080", 8080), ("-5", -5), ("0", 0), ("999999", 999999)],
+        ids=["positive", "negative", "zero", "large"],
+    )
+    def test_parses_integer(self, env_val, expected):
+        """Test parsing integer values from environment."""
         from utils.env_utils import get_env_int
 
-        with patch.dict(os.environ, {"PORT": "8080"}):
-            result = get_env_int("PORT")
-            assert result == 8080
-
-    def test_parses_negative_integer(self):
-        """Test parsing negative integer."""
-        from utils.env_utils import get_env_int
-
-        with patch.dict(os.environ, {"OFFSET": "-5"}):
-            result = get_env_int("OFFSET")
-            assert result == -5
+        with patch.dict(os.environ, {"INT_VAR": env_val}):
+            result = get_env_int("INT_VAR")
+            assert result == expected
 
     def test_default_is_zero(self):
         """Test default is zero."""

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -53,45 +53,25 @@ class TestHandleFileErrors:
 
         assert successful_func() == "success"
 
-    def test_returns_default_on_file_not_found(self):
-        """Test that FileNotFoundError returns default."""
+    @pytest.mark.parametrize(
+        "exc_cls, exc_msg, default_val",
+        [
+            (FileNotFoundError, "test file not found", "default_value"),
+            (PermissionError, "access denied", None),
+            (OSError, "disk error", -1),
+            (ValueError, "unexpected", "fallback"),
+        ],
+        ids=["FileNotFoundError", "PermissionError", "OSError", "ValueError"],
+    )
+    def test_returns_default_on_error(self, exc_cls, exc_msg, default_val):
+        """Test that handled errors return the configured default."""
         from utils.error_handling import handle_file_errors
 
-        @handle_file_errors(default="default_value", log_error=False)
-        def file_error_func():
-            raise FileNotFoundError("test file not found")
+        @handle_file_errors(default=default_val, log_error=False)
+        def error_func():
+            raise exc_cls(exc_msg)
 
-        assert file_error_func() == "default_value"
-
-    def test_returns_default_on_permission_error(self):
-        """Test that PermissionError returns default."""
-        from utils.error_handling import handle_file_errors
-
-        @handle_file_errors(default=None, log_error=False)
-        def permission_func():
-            raise PermissionError("access denied")
-
-        assert permission_func() is None
-
-    def test_returns_default_on_os_error(self):
-        """Test that OSError returns default."""
-        from utils.error_handling import handle_file_errors
-
-        @handle_file_errors(default=-1, log_error=False)
-        def os_error_func():
-            raise OSError("disk error")
-
-        assert os_error_func() == -1
-
-    def test_returns_default_on_unexpected_error(self):
-        """Test that unexpected errors return default."""
-        from utils.error_handling import handle_file_errors
-
-        @handle_file_errors(default="fallback", log_error=False)
-        def unexpected_error_func():
-            raise ValueError("unexpected")
-
-        assert unexpected_error_func() == "fallback"
+        assert error_func() == default_val
 
     def test_reraise_option_works(self):
         """Test that reraise=True re-raises exceptions."""


### PR DESCRIPTION
## Summary
- **#874 DRY**: Extracted `shared_drawing.py` with 8 pure helper functions, eliminating code duplication across 3 electrode visualization mixins; decomposed 2 large drawing functions (152 and 117 lines)
- **#875 Function Size**: Decomposed 6 large functions (>100 lines each) in calculator.py, psa_gui.py, cli.py, custom_theme_editor.py, and baghouse main_window.py using Extract Method
- **#876 Orthogonality**: Verified 0 global statements exist (already clean from prior waves)
- **#877 Security**: Verified 0 raw eval() calls and all XML parsing uses defusedxml (already clean)
- **#878 Test Quality**: Converted 15+ repetitive test methods into 4 `@pytest.mark.parametrize` blocks across 4 test files
- **#879 Comment Quality**: Added 52 docstrings to undocumented public functions across 8 source files

Closes #874, Closes #875, Closes #876, Closes #877, Closes #878, Closes #879

## Test plan
- [x] All 2144 tests pass (1 pre-existing Hypothesis edge case excluded: `test_parseval_theorem` with 4e-159 values)
- [x] ruff check passes with zero violations
- [x] No workflow files modified (absolute rule)
- [x] No config files modified

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly refactoring/extract-method changes across UI/CLI and visualization code; primary risk is behavioral drift in rendering paths or pipeline output routing due to moved logic and new shared helpers.
> 
> **Overview**
> **Refactors electrode visualization drawing** by extracting duplicated 3D geometry/annotation/rendering code into new `electrode_advisor/utils/shared_drawing.py`, and updating multiple PyQt6 mixins (`main_window_paths`, `main_window_via_metal`, `main_window_visualization_update`) to delegate to these helpers.
> 
> **Decomposes oversized UI/CLI methods** into smaller helpers across the baghouse calculator UI (input groups), data processor CLI (split combined vs per-file run paths), PSA GUI results update (split into metrics/table helpers), and theme editor dialog (split UI construction into panel/button builders). Also restructures calculator allowed-function construction into categorized builders and adds docstrings/Unicode suffix fixes and parameterized tests cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e8f385459ff78545f90c5ef27433b398a760555. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->