### PR TITLE
feat: add famous NASA missions simulation with interactive selection

### DIFF
--- a/src/scientific_modeling/solar_system_model/solar_system/data/famous_missions.py
+++ b/src/scientific_modeling/solar_system_model/solar_system/data/famous_missions.py
@@ -230,12 +230,129 @@ def get_pioneer10_trajectory() -> list[StateVector]:
     return waypoints
 
 
+def get_mariner2_trajectory() -> list[StateVector]:
+    """Simplified Mariner 2 trajectory: Earth to Venus flyby.
+
+    Approximate Julian dates:
+        Launch: 1962-08-27 (JD 2437894.5)
+        Venus flyby: 1962-12-14 (JD 2438012.5)
+    """
+    earth_launch = np.array([0.9, 0.45, 0.0]) * AU
+    venus_flyby = np.array([0.65, -0.3, 0.01]) * AU
+
+    waypoints = [
+        StateVector(earth_launch, np.array([-15000, 25000, 0]), 2437894.5),
+        StateVector(venus_flyby, np.array([-22000, -10000, 200]), 2438012.5),
+        StateVector(venus_flyby * 1.5, np.array([-20000, -15000, 300]), 2438100.0),
+    ]
+    return waypoints
+
+
+def get_mariner10_trajectory() -> list[StateVector]:
+    """Simplified Mariner 10 trajectory: Earth to Venus to Mercury.
+
+    Approximate Julian dates:
+        Launch: 1973-11-03 (JD 2441989.5)
+        Venus flyby: 1974-02-05 (JD 2442083.5)
+        Mercury 1: 1974-03-29 (JD 2442135.5)
+        Mercury 2: 1974-09-21 (JD 2442311.5)
+        Mercury 3: 1975-03-16 (JD 2442487.5)
+    """
+    earth_launch = np.array([0.15, 0.98, 0.0]) * AU
+    venus_flyby = np.array([-0.68, 0.25, 0.02]) * AU
+    mercury_1 = np.array([-0.35, -0.15, 0.01]) * AU
+    mercury_2 = np.array([0.38, 0.1, -0.01]) * AU
+    mercury_3 = np.array([-0.3, 0.25, 0.02]) * AU
+
+    waypoints = [
+        StateVector(earth_launch, np.array([-30000, 5000, 0]), 2441989.5),
+        StateVector(venus_flyby, np.array([-10000, -25000, 500]), 2442083.5),
+        StateVector(mercury_1, np.array([30000, -15000, -200]), 2442135.5),
+        StateVector(mercury_2, np.array([-25000, 30000, 300]), 2442311.5),
+        StateVector(mercury_3, np.array([35000, -10000, -400]), 2442487.5),
+    ]
+    return waypoints
+
+
+def get_galileo_trajectory() -> list[StateVector]:
+    """Simplified Galileo trajectory: complex gravity assists.
+
+    Approximate Julian dates:
+        Launch: 1989-10-18 (JD 2447817.5)
+        Venus: 1990-02-10 (JD 2447932.5)
+        Earth 1: 1990-12-08 (JD 2448233.5)
+        Earth 2: 1992-12-08 (JD 2448964.5)
+        Jupiter: 1995-12-07 (JD 2450058.5)
+    """
+    waypoints = [
+        StateVector(
+            np.array([-0.9, -0.3, 0.0]) * AU, np.array([0, 30000, 0]), 2447817.5
+        ),  # Earth launch
+        StateVector(
+            np.array([0.4, 0.6, 0.01]) * AU, np.array([30000, -10000, 0]), 2447932.5
+        ),  # Venus
+        StateVector(
+            np.array([0.2, 0.95, 0.0]) * AU, np.array([-30000, 10000, 0]), 2448233.5
+        ),  # Earth 1
+        StateVector(
+            np.array([1.0, 0.1, 0.0]) * AU, np.array([-5000, 30000, 0]), 2448964.5
+        ),  # Earth 2
+        StateVector(
+            np.array([3.0, -4.0, 0.1]) * AU, np.array([10000, 5000, 100]), 2450058.5
+        ),  # Jupiter
+    ]
+    return waypoints
+
+
 FAMOUS_MISSIONS = {
-    "Voyager 1": get_voyager1_trajectory,
-    "Voyager 2": get_voyager2_trajectory,
-    "Apollo 11": get_apollo11_trajectory,
-    "Cassini-Huygens": get_cassini_trajectory,
-    "New Horizons": get_new_horizons_trajectory,
-    "Curiosity": get_curiosity_trajectory,
-    "Pioneer 10": get_pioneer10_trajectory,
+    "Voyager 1": {
+        "get_trajectory": get_voyager1_trajectory,
+        "description": "Explored Jupiter and Saturn. First spacecraft to enter interstellar space.",
+        "launch_date": "1977-09-05",
+    },
+    "Voyager 2": {
+        "get_trajectory": get_voyager2_trajectory,
+        "description": "Only spacecraft to visit Uranus and Neptune. Utilized a rare planetary alignment.",
+        "launch_date": "1977-08-20",
+    },
+    "Apollo 11": {
+        "get_trajectory": get_apollo11_trajectory,
+        "description": "First crewed lunar landing. Neil Armstrong and Buzz Aldrin walked on the Moon.",
+        "launch_date": "1969-07-16",
+    },
+    "Cassini-Huygens": {
+        "get_trajectory": get_cassini_trajectory,
+        "description": "Studied Saturn and its moons for 13 years. Deployed Huygens probe to Titan.",
+        "launch_date": "1997-10-15",
+    },
+    "New Horizons": {
+        "get_trajectory": get_new_horizons_trajectory,
+        "description": "First mission to Pluto and the Kuiper Belt. Fastest spacecraft ever launched.",
+        "launch_date": "2006-01-19",
+    },
+    "Curiosity": {
+        "get_trajectory": get_curiosity_trajectory,
+        "description": "Mars Science Laboratory rover. Searching for past habitable environments on Mars.",
+        "launch_date": "2011-11-26",
+    },
+    "Pioneer 10": {
+        "get_trajectory": get_pioneer10_trajectory,
+        "description": "First spacecraft to travel through the asteroid belt and visit Jupiter.",
+        "launch_date": "1972-03-03",
+    },
+    "Mariner 2": {
+        "get_trajectory": get_mariner2_trajectory,
+        "description": "First successful planetary flyby (Venus). Confirmed the planet's high surface temperature.",
+        "launch_date": "1962-08-27",
+    },
+    "Mariner 10": {
+        "get_trajectory": get_mariner10_trajectory,
+        "description": "First to use gravity assist (Venus to Mercury). Visited Mercury three times.",
+        "launch_date": "1973-11-03",
+    },
+    "Galileo": {
+        "get_trajectory": get_galileo_trajectory,
+        "description": "Complex mission to Jupiter using Venus and Earth gravity assists.",
+        "launch_date": "1989-10-18",
+    },
 }

--- a/src/scientific_modeling/solar_system_model/solar_system/ui/widgets.py
+++ b/src/scientific_modeling/solar_system_model/solar_system/ui/widgets.py
@@ -855,9 +855,10 @@ class SidebarPanel:
         self.current_tab_index = 0
         self.tabs = [
             Tab("Info", "educational"),
-            Tab("Planets", "planets"),
-            Tab("Guide", "checklist"),
+            Tab("Missions", "missions"),
             Tab("History", "history"),
+            Tab("Guide", "checklist"),
+            Tab("Planets", "planets"),
         ]
 
     def set_tab(self, index: int) -> None:
@@ -957,6 +958,36 @@ class UnifiedControlPanel:
             "buttons": self.buttons,
             "modes": self.modes,
             "current_mode_index": self.current_mode_index,
+            "style": self.style,
+            "visible": self.visible,
+        }
+
+
+class MissionListPanel:
+    """Panel for selecting famous NASA missions."""
+
+    def __init__(
+        self, position: tuple[int, int] = (0, 0), style: PanelStyle | None = None
+    ):
+        self.position = position
+        self.style = style or PanelStyle()
+        self.visible = True
+        self.scroll_offset = 0
+
+    def get_render_data(self, missions_dict: dict[str, Any]) -> dict[str, Any]:
+        missions_info = []
+        for name, data in missions_dict.items():
+            missions_info.append(
+                {
+                    "name": name,
+                    "description": data.get("description", ""),
+                    "launch_date": data.get("launch_date", ""),
+                }
+            )
+
+        return {
+            "position": self.position,
+            "missions": missions_info,
             "style": self.style,
             "visible": self.visible,
         }

--- a/src/scientific_modeling/solar_system_model/solar_system/visualization/scene.py
+++ b/src/scientific_modeling/solar_system_model/solar_system/visualization/scene.py
@@ -44,6 +44,7 @@ from ..ui.widgets import (
     HelpOverlay,
     HistoricalEventsPanel,
     ImmersionChecklistPanel,
+    MissionListPanel,
     NavigationPanel,
     SettingsPanel,
     SidebarPanel,
@@ -176,6 +177,7 @@ class SolarSystemScene(SceneEventMixin, SceneRenderMixin):
         self.educational_panel: EducationalInfoPanel | None = None
         self.historical_events: HistoricalEventsPanel | None = None
         self.immersion_checklist: ImmersionChecklistPanel | None = None
+        self.missions_panel: MissionListPanel | None = None
 
         # Legacy references
         self.settings_panel: SettingsPanel | None = None
@@ -284,6 +286,7 @@ class SolarSystemScene(SceneEventMixin, SceneRenderMixin):
             position=(self.renderer.settings.window_width - 350, 20)
         )
         self.help_overlay.set_controls(self.controls)
+        self.missions_panel = MissionListPanel()
 
     # ================================================================
     # Solar System Creation
@@ -334,10 +337,12 @@ class SolarSystemScene(SceneEventMixin, SceneRenderMixin):
 
     def _load_famous_missions(self) -> None:
         """Load historical famous missions into the scene."""
-        for name, get_traj in FAMOUS_MISSIONS.items():
-            trajectory = get_traj()
-            craft = Spacecraft(name, trajectory)
-            self.spacecraft[name] = craft
+        for name, mission_data in FAMOUS_MISSIONS.items():
+            getter = mission_data.get("get_trajectory")
+            if getter and callable(getter):
+                trajectory = getter()
+                craft = Spacecraft(name, trajectory)
+                self.spacecraft[name] = craft
 
     # ================================================================
     # Body Queries & Selection
@@ -360,7 +365,11 @@ class SolarSystemScene(SceneEventMixin, SceneRenderMixin):
         if name == "Sun":
             return self.sun
         for collection in (
-            self.planets, self.moons, self.asteroids, self.comets, self.spacecraft
+            self.planets,
+            self.moons,
+            self.asteroids,
+            self.comets,
+            self.spacecraft,
         ):
             if name in collection:
                 return collection[name]

--- a/src/scientific_modeling/solar_system_model/solar_system/visualization/scene_event_mixin.py
+++ b/src/scientific_modeling/solar_system_model/solar_system/visualization/scene_event_mixin.py
@@ -133,9 +133,7 @@ class SceneEventMixin:
         if key == K_d and self.date_picker:
             self.date_picker.toggle()
             if self.date_picker.visible:
-                self.date_picker.set_date(
-                    self.time_manager.current_time.datetime_utc
-                )
+                self.date_picker.set_date(self.time_manager.current_time.datetime_utc)
                 self._mark_immersion_task("navigate_time")
         elif key == K_n and self.time_nav_panel:
             self.time_nav_panel.toggle()
@@ -298,8 +296,10 @@ class SceneEventMixin:
             return False
 
         sx, sy = self.sidebar_panel.position
-        if not (sx <= x <= sx + self.sidebar_panel.width
-                and sy <= y <= sy + self.sidebar_panel.height):
+        if not (
+            sx <= x <= sx + self.sidebar_panel.width
+            and sy <= y <= sy + self.sidebar_panel.height
+        ):
             return False
 
         rel_x, rel_y = x - sx, y - sy
@@ -307,21 +307,36 @@ class SceneEventMixin:
         if action == "tab_changed":
             return True
 
-        current_tab = self.sidebar_panel.tabs[
-            self.sidebar_panel.current_tab_index
-        ]
+        current_tab = self.sidebar_panel.tabs[self.sidebar_panel.current_tab_index]
         if current_tab.content_renderer_key == "planets":
             list_start_y = 75
             if rel_y > list_start_y:
                 idx = (rel_y - list_start_y) // 25
-                bodies = ["Sun"] + [
-                    p for p in PLANET_ORDER if p in self.planets
-                ]
+                bodies = ["Sun"] + [p for p in PLANET_ORDER if p in self.planets]
                 if 0 <= idx < len(bodies):
                     name = bodies[idx]
                     body = self.get_body_by_name(name)
                     if body:
                         self.select_body(body)
+                        self._focus_on_selected()
+        elif current_tab.content_renderer_key == "missions":
+            list_start_y = 75
+            if rel_y > list_start_y:
+                # Approximate 90 pixels per mission entry in the list
+                idx = (rel_y - list_start_y) // 90
+                mission_names = list(FAMOUS_MISSIONS.keys())
+                if 0 <= idx < len(mission_names):
+                    name = mission_names[idx]
+                    data = FAMOUS_MISSIONS[name]
+                    launch_str = data.get("launch_date", "")
+                    if launch_str:
+                        launch_dt = datetime.strptime(launch_str, "%Y-%m-%d")
+                        self.time_manager.set_datetime(launch_dt)
+                        self._action_message = f"Simulating {name} launch..."
+
+                    # Focus on spacecraft if available
+                    if name in self.spacecraft:
+                        self.select_body(self.spacecraft[name])
                         self._focus_on_selected()
         return True
 

--- a/src/scientific_modeling/solar_system_model/solar_system/visualization/scene_render_mixin.py
+++ b/src/scientific_modeling/solar_system_model/solar_system/visualization/scene_render_mixin.py
@@ -18,6 +18,7 @@ from ..core.constants import (
     OUTER_PLANETS,
     PLANET_ORDER,
 )
+from ..data.famous_missions import FAMOUS_MISSIONS
 
 if TYPE_CHECKING:
     pass
@@ -234,6 +235,9 @@ class SceneRenderMixin:
 
         if content_key == "history" and self.historical_events:
             return self.historical_events.get_render_data()
+
+        if content_key == "missions" and self.missions_panel:
+            return self.missions_panel.get_render_data(FAMOUS_MISSIONS)
 
         if content_key == "planets":
             bodies: list[dict[str, Any]] = []

--- a/src/scientific_modeling/solar_system_model/solar_system/visualization/ui_renderer.py
+++ b/src/scientific_modeling/solar_system_model/solar_system/visualization/ui_renderer.py
@@ -400,6 +400,59 @@ class UIRenderer:
                 self.render_historical_events(content_data)
             elif content_key == "planets":  # New Planet Selector
                 self.render_planet_selector(content_data)
+            elif content_key == "missions":
+                self.render_mission_list(content_data)
+
+    def render_mission_list(self, data: dict[str, Any]) -> None:
+        """Render the list of famous space missions."""
+        if not data.get("visible", False):
+            return
+
+        x, y = data.get("position", (0, 0))
+        missions = data.get("missions", [])
+
+        self.begin_2d()
+        current_y = y
+        self.text_cache.render(
+            "NASA Famous Missions", x, current_y, "default", self.theme.text_highlight
+        )
+        current_y += 35
+
+        for mission in missions:
+            name = mission.get("name", "Unknown")
+            launch = mission.get("launch_date", "")
+            desc = mission.get("description", "")
+
+            # Mission Title
+            self.text_cache.render(name, x, current_y, "default", (255, 255, 100))
+            current_y += 28
+
+            # Launch Date
+            self.text_cache.render(
+                f"Launched: {launch}", x + 10, current_y, "small", (150, 200, 255)
+            )
+            current_y += 20
+
+            # Description (wrapped)
+            words = desc.split()
+            line = ""
+            for word in words:
+                test_line = f"{line} {word}".strip()
+                if len(test_line) > 40:
+                    self.text_cache.render(
+                        line, x + 15, current_y, "small", (220, 220, 220)
+                    )
+                    current_y += 18
+                    line = word
+                else:
+                    line = test_line
+            if line:
+                self.text_cache.render(
+                    line, x + 15, current_y, "small", (220, 220, 220)
+                )
+                current_y += 25
+
+        self.end_2d()
 
     def render_educational_panel(self, edu_data: dict[str, Any]) -> None:
         """Render educational information about selected body."""


### PR DESCRIPTION
Adds an interactive famous missions feature to the solar system model.

## Changes
- **Mission Data**: Added Mariner 2, Mariner 10, and Galileo trajectory data. Restructured  dict with descriptions and launch dates for all missions.
- **UI**: New  widget and **Missions** sidebar tab for browsing the catalog of historical missions.
- **Interactivity**: Clicking a mission auto-jumps the simulation to its launch date and focuses the camera on its spacecraft trajectory.
- **Rendering**: New  method in  for rich mission display with text wrapping.

## Files Changed
-  - 3 new trajectory functions + restructured dict
-  -  class + Missions tab
-  - Initialized missions panel
-  - Missions tab content data
-  - Mission click handler with time-jump
-  - Mission list rendering

## Testing
- All 4 existing solar system tests pass.
- Syntax verified on all changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches UI rendering and input handling, and changes the shape of the shared `FAMOUS_MISSIONS` data consumed by scene initialization; mistakes could break mission loading or sidebar interactions but are not security-sensitive.
> 
> **Overview**
> Adds an interactive **Missions** experience to the solar system simulation: a new sidebar tab renders a catalog of famous missions (name, launch date, description) and allows selecting a mission to jump the simulation time to its launch and focus on the associated spacecraft.
> 
> Expands mission data by adding simplified trajectories for `Mariner 2`, `Mariner 10`, and `Galileo`, and restructures `FAMOUS_MISSIONS` from a simple name→trajectory-function map into a metadata dictionary (`get_trajectory`, `description`, `launch_date`), updating mission loading to handle the new shape safely.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1282e720c41a5a2bcae73b9bf77603d6c01e0031. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->