### PR TITLE
[codex] Conversion wave 2: deeper DbC and DRY hardening

### DIFF
--- a/src/shared/python/upstream_drift_tools/calculators/conversion/flow_rate_converter.py
+++ b/src/shared/python/upstream_drift_tools/calculators/conversion/flow_rate_converter.py
@@ -108,6 +108,12 @@ def _require_known_unit(unit: str, units: dict[str, float], kind: str) -> None:
         raise ValueError(f"Unknown {kind} unit: {unit}")
 
 
+def _require_known_standard(standard: str) -> None:
+    """Ensure a standard condition label is supported."""
+    if standard not in STANDARD_CONDITIONS:
+        raise ValueError(f"Unknown standard condition: {standard}")
+
+
 # ============================================================================
 # FLOW RATE CONVERSION FUNCTIONS
 # ============================================================================
@@ -289,12 +295,12 @@ def volumetric_actual_to_mass(
         >>> m_dot = volumetric_actual_to_mass(1000, 'm3/h', 1.2, 'kg/h')
         >>> print(f"{m_dot:.1f} kg/h")
     """
-    if not math.isfinite(vol_flow):
-        raise ValueError(f"vol_flow must be finite, got {vol_flow}")
-    if not math.isfinite(density) or density <= 0:
-        raise ValueError(f"density must be positive and finite, got {density}")
-    if vol_unit not in VOLUMETRIC_FLOW_CONVERSIONS_TO_M3_S:
-        raise ValueError(f"Unknown volumetric flow unit: {vol_unit}")
+    _require_finite(vol_flow, "vol_flow")
+    _require_positive_finite(density, "density")
+    _require_known_unit(
+        vol_unit, VOLUMETRIC_FLOW_CONVERSIONS_TO_M3_S, "volumetric flow"
+    )
+    _require_known_unit(mass_unit, MASS_FLOW_CONVERSIONS, "mass flow")
 
     # Convert to m³/s
     m3_per_s = vol_flow * VOLUMETRIC_FLOW_CONVERSIONS_TO_M3_S[vol_unit]
@@ -335,12 +341,12 @@ def mass_to_volumetric_actual(
         >>> Q = mass_to_volumetric_actual(100, 'kg/h', 1.2, 'm3/h')
         >>> print(f"{Q:.1f} m³/h")
     """
-    if not math.isfinite(mass_flow):
-        raise ValueError(f"mass_flow must be finite, got {mass_flow}")
-    if not math.isfinite(density) or density <= 0:
-        raise ValueError(f"density must be positive and finite, got {density}")
-    if vol_unit not in VOLUMETRIC_FLOW_CONVERSIONS_TO_M3_S:
-        raise ValueError(f"Unknown volumetric flow unit: {vol_unit}")
+    _require_finite(mass_flow, "mass_flow")
+    _require_positive_finite(density, "density")
+    _require_known_unit(mass_unit, MASS_FLOW_CONVERSIONS, "mass flow")
+    _require_known_unit(
+        vol_unit, VOLUMETRIC_FLOW_CONVERSIONS_TO_M3_S, "volumetric flow"
+    )
 
     # Convert to kg/s
     kg_per_s = mass_flow * MASS_FLOW_CONVERSIONS[mass_unit]
@@ -533,12 +539,10 @@ def scfm_to_acfm(
         >>> acfm = scfm_to_acfm(1000, 533, 5e5, 'SCFM')
         >>> print(f"{acfm:.0f} ACFM")
     """
-    if not math.isfinite(scfm):
-        raise ValueError(f"scfm must be finite, got {scfm}")
-    if not math.isfinite(temperature) or temperature <= 0:
-        raise ValueError(f"temperature must be positive and finite, got {temperature}")
-    if not math.isfinite(pressure) or pressure <= 0:
-        raise ValueError(f"pressure must be positive and finite, got {pressure}")
+    _require_finite(scfm, "scfm")
+    _require_positive_finite(temperature, "temperature")
+    _require_positive_finite(pressure, "pressure")
+    _require_known_standard(standard)
     T_std, P_std, _ = STANDARD_CONDITIONS[standard]
 
     acfm = scfm * (temperature / T_std) * (P_std / pressure)
@@ -568,12 +572,10 @@ def acfm_to_scfm(
     Raises:
         ValueError: If temperature or pressure is not positive and finite.
     """
-    if not math.isfinite(acfm):
-        raise ValueError(f"acfm must be finite, got {acfm}")
-    if not math.isfinite(temperature) or temperature <= 0:
-        raise ValueError(f"temperature must be positive and finite, got {temperature}")
-    if not math.isfinite(pressure) or pressure <= 0:
-        raise ValueError(f"pressure must be positive and finite, got {pressure}")
+    _require_finite(acfm, "acfm")
+    _require_positive_finite(temperature, "temperature")
+    _require_positive_finite(pressure, "pressure")
+    _require_known_standard(standard)
     T_std, P_std, _ = STANDARD_CONDITIONS[standard]
 
     scfm = acfm * (T_std / temperature) * (pressure / P_std)
@@ -617,12 +619,15 @@ def convert_flow_rate_to_mass(
         >>> m_dot = convert_flow_rate_to_mass(1000, 'SCFM', 29.0, standard='SCFM')
         >>> print(f"{m_dot:.3f} kg/s")
     """
+    _require_finite(value, "value")
+
     # Check if it's a mass flow unit
     if from_unit in MASS_FLOW_CONVERSIONS:
         return value * MASS_FLOW_CONVERSIONS[from_unit]
 
     # Check if it's a molar flow unit
     if from_unit in MOLAR_FLOW_CONVERSIONS:
+        _require_positive_finite(molecular_weight, "molecular_weight")
         mol_per_s = value * MOLAR_FLOW_CONVERSIONS[from_unit]
         return (mol_per_s * molecular_weight) / 1000.0
 

--- a/src/shared/python/upstream_drift_tools/calculators/conversion/service.py
+++ b/src/shared/python/upstream_drift_tools/calculators/conversion/service.py
@@ -83,6 +83,13 @@ class UnitConversionService:
             .replace("_", "")
         )
 
+    @staticmethod
+    def _require_positive_finite(value: float, name: str) -> None:
+        """Validate positive scalar physical parameters."""
+        if not math.isfinite(value) or value <= 0:
+            msg = f"{name} must be positive and finite, got {value}"
+            raise ValueError(msg)
+
     def _init_tables(self) -> None:
         """Initialize conversion tables from constants."""
         self.category_map = {
@@ -463,6 +470,9 @@ class UnitConversionService:
         gas_density_stp: float | None = None,
     ) -> float:
         """Convert heating value."""
+        if gas_density_stp is not None:
+            self._require_positive_finite(gas_density_stp, "Gas density")
+
         from_key = from_unit.lower()
         to_key = to_unit.lower()
         conversions = self.heating_value_conversions
@@ -540,6 +550,13 @@ class UnitConversionService:
         if from_key == to_key:
             return value
 
+        requires_molecular_weight = from_key == "ppm_mass" or to_key == "ppm_mass"
+        if requires_molecular_weight:
+            if molecular_weight is None:
+                msg = "Molecular weight required for ppm conversion"
+                raise ValueError(msg)
+            self._require_positive_finite(molecular_weight, "Molecular weight")
+
         conversions = self.concentration_conversions
         if from_key not in conversions:
             msg = f"Unknown concentration unit: {from_unit}"
@@ -556,9 +573,7 @@ class UnitConversionService:
                 value * 1000.0 * (temperature / 273.15) * (101.325 / pressure)
             )
         elif from_key == "ppm_mass":
-            if molecular_weight is None:
-                msg = "Molecular weight required for ppm conversion"
-                raise ValueError(msg)
+            assert molecular_weight is not None
             mg_nm3_value = value * molecular_weight / 24.45
         else:
             msg = f"Conversion from {from_unit} not implemented"
@@ -578,9 +593,7 @@ class UnitConversionService:
         if to_key in {"g/m³", "g/m3"}:
             return mg_nm3_value / 1000.0 * (273.15 / temperature) * (pressure / 101.325)
         if to_key == "ppm_mass":
-            if molecular_weight is None:
-                msg = "Molecular weight required for ppm conversion"
-                raise ValueError(msg)
+            assert molecular_weight is not None
             return mg_nm3_value * 24.45 / molecular_weight
 
         msg = f"Conversion to {to_unit} not implemented"

--- a/tests/shared/python/calculators/conversion/test_flow_rate_converter.py
+++ b/tests/shared/python/calculators/conversion/test_flow_rate_converter.py
@@ -147,6 +147,11 @@ class TestVolumetricActualToMass:
 
         assert result_high == pytest.approx(result_low * 2.0, rel=0.01)
 
+    def test_unknown_mass_target_unit_raises_error(self):
+        """Test unknown mass target unit reports domain error."""
+        with pytest.raises(ValueError, match="Unknown mass flow unit"):
+            volumetric_actual_to_mass(10.0, "m3/s", 1.2, "bad_unit")
+
 
 class TestMassToVolumetricActual:
     """Test mass to actual volumetric flow conversions."""
@@ -168,6 +173,11 @@ class TestMassToVolumetricActual:
         mass_back = volumetric_actual_to_mass(vol_flow, "m3/s", density, "kg/s")
 
         assert mass_back == pytest.approx(mass_flow, rel=1e-10)
+
+    def test_unknown_mass_source_unit_raises_error(self):
+        """Test unknown mass source unit reports domain error."""
+        with pytest.raises(ValueError, match="Unknown mass flow unit"):
+            mass_to_volumetric_actual(10.0, "bad_unit", 1.2, "m3/s")
 
 
 class TestStandardVolumetricToMass:
@@ -289,6 +299,11 @@ class TestSCFMToACFM:
 
         assert acfm_high < acfm_low
 
+    def test_scfm_to_acfm_unknown_standard_raises_error(self):
+        """Test unknown standard condition reports domain error."""
+        with pytest.raises(ValueError, match="Unknown standard condition"):
+            scfm_to_acfm(100.0, 300.0, 101325.0, standard="BAD_STD")
+
 
 class TestACFMToSCFM:
     """Test ACFM to SCFM conversions."""
@@ -313,6 +328,11 @@ class TestACFMToSCFM:
         scfm = acfm_to_scfm(acfm, temp_k, pressure_pa, standard="STP")
         # Higher P and T partially cancel, but SCFM should be different from ACFM
         assert scfm != acfm
+
+    def test_acfm_to_scfm_unknown_standard_raises_error(self):
+        """Test unknown standard condition reports domain error."""
+        with pytest.raises(ValueError, match="Unknown standard condition"):
+            acfm_to_scfm(100.0, 300.0, 101325.0, standard="BAD_STD")
 
 
 class TestConvertFlowRateToMass:
@@ -345,6 +365,16 @@ class TestConvertFlowRateToMass:
             value=1000.0, from_unit="SCFM", molecular_weight=mw, standard="SCFM"
         )
         assert result > 0
+
+    def test_non_finite_value_raises_error(self):
+        """Test finite input contract for value."""
+        with pytest.raises(ValueError, match="value must be finite"):
+            convert_flow_rate_to_mass(float("nan"), "kg/s", 29.0)
+
+    def test_non_finite_molecular_weight_raises_error(self):
+        """Test finite molecular weight contract on molar path."""
+        with pytest.raises(ValueError, match="molecular_weight must be positive"):
+            convert_flow_rate_to_mass(10.0, "mol/s", float("inf"))
 
 
 class TestConstants:

--- a/tests/shared/python/calculators/conversion/test_service.py
+++ b/tests/shared/python/calculators/conversion/test_service.py
@@ -174,11 +174,25 @@ def test_heating_value_volumetric_roundtrip(service: UnitConversionService) -> N
     assert mj_per_nm3 == pytest.approx(20.0)
 
 
+def test_heating_value_nonpositive_density_raises(
+    service: UnitConversionService,
+) -> None:
+    with pytest.raises(ValueError, match="Gas density must be positive"):
+        service.heating_value(20.0, "mj/nm3", "mj/kg", gas_density_stp=0.0)
+
+
 def test_tar_concentration_ppm_requires_molecular_weight(
     service: UnitConversionService,
 ) -> None:
     with pytest.raises(ValueError, match="Molecular weight required"):
         service.tar_concentration(100.0, "ppm_mass", "mg/nm3")
+
+
+def test_tar_concentration_nonpositive_molecular_weight_raises(
+    service: UnitConversionService,
+) -> None:
+    with pytest.raises(ValueError, match="Molecular weight must be positive"):
+        service.tar_concentration(100.0, "ppm_mass", "mg/nm3", molecular_weight=0.0)
 
 
 def test_tar_concentration_pressure_temperature_adjustment(


### PR DESCRIPTION
## Summary
Second wave of conversion-stack quality upgrades focused on additional DbC, DRY, and test-driven hardening.

## What this PR improves
- Adds missing precondition checks in flow-rate conversion paths that previously surfaced low-level `KeyError` or silent non-finite propagation.
- Deduplicates validation by expanding reusable helper guards in `flow_rate_converter.py`.
- Strengthens service-level physical-parameter contracts for heating value and tar concentration conversions.
- Adds RED->GREEN test coverage for all newly enforced contracts.

## Root issues addressed
- Unknown standards in SCFM/ACFM functions raised `KeyError` instead of clear domain errors.
- Some conversion functions accepted invalid unit arguments and failed later with `KeyError`.
- Universal converter accepted non-finite values and non-finite molecular weight in molar path.
- Heating value with zero/invalid density and tar concentration with invalid molecular weight had unsafe math behavior.

## Fix details
- `flow_rate_converter.py`
  - Added `_require_known_standard()` and reused validator helpers across more functions.
  - Added explicit mass-unit validation in volumetric<->mass conversions.
  - Added explicit standard-condition validation in `scfm_to_acfm` and `acfm_to_scfm`.
  - Added finite-value and molar-path molecular-weight validation in `convert_flow_rate_to_mass`.
- `service.py`
  - Added reusable positive-finite validator in service class.
  - Enforced positive finite `gas_density_stp` when provided in `heating_value`.
  - Enforced positive finite `molecular_weight` in ppm tar-concentration paths.

## Tests added
- New tests for:
  - Unknown mass unit handling in volumetric/mass conversions.
  - Unknown standard handling in SCFM/ACFM helpers.
  - Non-finite value and molecular-weight contracts in universal converter.
  - Non-positive density in heating value conversion.
  - Non-positive molecular weight in tar concentration conversion.

## Local validation
- `pytest -q tests/shared/python/calculators/conversion`
- `ruff check` on touched files
- `mypy` on touched source files

All passed locally.