### PR TITLE
refactor(tools): DbC+TDD for launch_utils; fix mypy+pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
 addopts = "--strict-markers"
+pythonpath = ["src"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks integration tests",
@@ -155,7 +156,10 @@ exclude_lines = [
 ]
 
 [tool.mypy]
-files = "src/shared/python"
+python_version = "3.10"
+files = ["src"]
+mypy_path = "src"
 ignore_missing_imports = true
 check_untyped_defs = true
 disallow_untyped_defs = false
+explicit_package_bases = true

--- a/src/tools/launch_utils.py
+++ b/src/tools/launch_utils.py
@@ -8,6 +8,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import IO, Any
 
+from src.shared.python.contracts import require
+
 
 def get_repo_root() -> Path:
     """Get the absolute path to the repository root.
@@ -65,6 +67,12 @@ def validate_and_sanitize_path(path_str: str, repo_root: Path) -> Path:
         SecurityError: If path is invalid or outside repository.
         ToolNotFoundError: If file does not exist.
     """
+    require(
+        isinstance(path_str, str) and path_str, "path_str must be a non-empty string"
+    )
+    require(isinstance(repo_root, Path), "repo_root must be a Path")
+    require(repo_root.is_absolute(), f"repo_root must be absolute, got: {repo_root}")
+
     try:
         path = Path(path_str)
     except (TypeError, ValueError) as e:
@@ -98,6 +106,10 @@ def launch_python_tool(
     log_func: Callable[[str], None] | None = None,
 ) -> None:
     """Launch a Python tool."""
+    require(isinstance(path, Path), "path must be a Path")
+    require(
+        isinstance(tool_name, str) and tool_name, "tool_name must be a non-empty string"
+    )
     if log_func:
         log_func(f"Launching Python tool: {tool_name}")
 
@@ -157,6 +169,10 @@ def launch_matlab_tool(
     log_func: Callable[[str], None] | None = None,
 ) -> None:
     """Launch a MATLAB tool."""
+    require(isinstance(path, Path), "path must be a Path")
+    require(
+        isinstance(tool_name, str) and tool_name, "tool_name must be a non-empty string"
+    )
     if log_func:
         log_func(f"Launching MATLAB tool: {tool_name}")
 
@@ -193,6 +209,10 @@ def launch_octave_tool(
     log_func: Callable[[str], None] | None = None,
 ) -> None:
     """Launch an Octave tool."""
+    require(isinstance(path, Path), "path must be a Path")
+    require(
+        isinstance(tool_name, str) and tool_name, "tool_name must be a non-empty string"
+    )
     if log_func:
         log_func(f"Launching Octave tool: {tool_name}")
 
@@ -226,6 +246,7 @@ def launch_browser_tool(
     path: Path, log_func: Callable[[str], None] | None = None
 ) -> None:
     """Launch a browser tool."""
+    require(isinstance(path, Path), "path must be a Path")
     try:
         uri = path.as_uri()
         webbrowser.open(uri)
@@ -242,6 +263,10 @@ def launch_batch_tool(
     log_func: Callable[[str], None] | None = None,
 ) -> None:
     """Launch a batch script."""
+    require(isinstance(path, Path), "path must be a Path")
+    require(
+        isinstance(tool_name, str) and tool_name, "tool_name must be a non-empty string"
+    )
     if sys.platform == "win32":
         if path.suffix.lower() not in [".bat", ".cmd"]:
             raise SecurityError("File must be .bat or .cmd to execute as batch script")
@@ -282,6 +307,9 @@ def launch_tool(
     Raises:
         LaunchError, ToolNotFoundError, SecurityError, PlatformError
     """
+    require(isinstance(tool_info, dict), "tool_info must be a dict")
+    require(isinstance(repo_root, Path), "repo_root must be a Path")
+
     name = tool_info.get("name", "Unknown")
     path_str = tool_info.get("path")
     tool_type = tool_info.get("type")

--- a/tests/tools/test_launch_utils.py
+++ b/tests/tools/test_launch_utils.py
@@ -1,0 +1,140 @@
+"""Comprehensive TDD suite for launch_utils.py.
+
+Tests cover validate_and_sanitize_path, launch_tool dispatch,
+and all DbC contract violations (PreconditionError).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.shared.python.contracts import PreconditionError
+from src.tools.launch_utils import (
+    LaunchError,
+    PlatformError,
+    SecurityError,
+    ToolNotFoundError,
+    validate_and_sanitize_path,
+    launch_browser_tool,
+    launch_tool,
+)
+
+
+# ─── validate_and_sanitize_path ────────────────────────────────
+
+
+def test_validate_path_success(tmp_path):
+    f = tmp_path / "tool.py"
+    f.write_text("x = 1")
+    result = validate_and_sanitize_path("tool.py", tmp_path)
+    assert result == f.resolve()
+
+
+def test_validate_path_traversal_blocked(tmp_path):
+    with pytest.raises(SecurityError, match="traversal"):
+        validate_and_sanitize_path("../escape.py", tmp_path)
+
+
+def test_validate_path_missing_file(tmp_path):
+    with pytest.raises(ToolNotFoundError):
+        validate_and_sanitize_path("nonexistent.py", tmp_path)
+
+
+def test_validate_path_directory_rejected(tmp_path):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    with pytest.raises(ToolNotFoundError, match="not a file"):
+        validate_and_sanitize_path("subdir", tmp_path)
+
+
+def test_validate_path_dbc_empty_string(tmp_path):
+    with pytest.raises(PreconditionError):
+        validate_and_sanitize_path("", tmp_path)
+
+
+def test_validate_path_dbc_non_path_root(tmp_path):
+    f = tmp_path / "tool.py"
+    f.write_text("x = 1")
+    with pytest.raises(PreconditionError):
+        validate_and_sanitize_path("tool.py", str(tmp_path))  # type: ignore[arg-type]
+
+
+def test_validate_path_dbc_relative_root():
+    with pytest.raises(PreconditionError, match="absolute"):
+        validate_and_sanitize_path("tool.py", Path("relative/path"))
+
+
+# ─── launch_browser_tool ───────────────────────────────────────
+
+
+@patch("webbrowser.open")
+def test_launch_browser_tool_success(mock_open, tmp_path):
+    f = tmp_path / "index.html"
+    f.write_text("<html/>")
+    logs = []
+    launch_browser_tool(f, log_func=logs.append)
+    assert mock_open.called
+    assert any("browser" in msg.lower() or "opened" in msg.lower() for msg in logs)
+
+
+def test_launch_browser_tool_dbc_non_path():
+    with pytest.raises(PreconditionError):
+        launch_browser_tool("not_a_path.html")  # type: ignore[arg-type]
+
+
+# ─── launch_tool dispatch ──────────────────────────────────────
+
+
+def test_launch_tool_missing_path_key():
+    with pytest.raises(LaunchError, match="missing 'path'"):
+        launch_tool({"name": "foo", "type": "python"}, Path.cwd())
+
+
+def test_launch_tool_unknown_type(tmp_path):
+    f = tmp_path / "tool.py"
+    f.write_text("x = 1")
+    with pytest.raises(LaunchError, match="Unknown tool type"):
+        launch_tool({"name": "foo", "path": "tool.py", "type": "unknown"}, tmp_path)
+
+
+@patch("subprocess.Popen")
+def test_launch_tool_python_dispatch(mock_popen, tmp_path):
+    f = tmp_path / "tool.py"
+    f.write_text("x = 1")
+    mock_proc = MagicMock()
+    mock_proc.pid = 1234
+    mock_popen.return_value = mock_proc
+    logs = []
+    launch_tool(
+        {"name": "Tool", "path": "tool.py", "type": "python"},
+        tmp_path,
+        log_func=logs.append,
+    )
+    assert mock_popen.called
+
+
+def test_launch_tool_dbc_rejects_non_dict():
+    with pytest.raises(PreconditionError):
+        launch_tool("not a dict", Path.cwd())  # type: ignore[arg-type]
+
+
+def test_launch_tool_dbc_rejects_non_path():
+    with pytest.raises(PreconditionError):
+        launch_tool({"name": "x"}, "/not/a/Path/object")  # type: ignore[arg-type]
+
+
+# ─── Platform errors ───────────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="Batch tools only fail on non-Windows"
+)
+def test_launch_batch_tool_fails_on_non_windows(tmp_path):
+    from src.tools.launch_utils import launch_batch_tool
+
+    f = tmp_path / "script.bat"
+    f.write_text("echo hello")
+    with pytest.raises(PlatformError):
+        launch_batch_tool(f, "script")


### PR DESCRIPTION
Injects require() guards into all 7 launch_utils public functions, adds a 14-test TDD suite covering security, platform, dispatch, and PreconditionError violations. Fixes pyproject.toml so pytest resolves src pythonpath and mypy resolves contracts module.