### PR TITLE
refactor(tools): DbC+TDD for icon_utils

### DIFF
--- a/src/tools/icon_utils.py
+++ b/src/tools/icon_utils.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from PIL import Image
 
+from src.shared.python.contracts import require
+
 logger = logging.getLogger(__name__)
 
 
@@ -95,6 +97,10 @@ def create_resized_images(
     Returns:
         List of resized images.
     """
+    require(
+        isinstance(sizes, list) and len(sizes) > 0, "sizes must be a non-empty list"
+    )
+
     from PIL import Image
 
     # Pillow >= 9.1.0 uses Image.Resampling; older versions use Image.LANCZOS
@@ -115,6 +121,9 @@ def convert_png_to_ico(
     Returns:
         True if successful, False otherwise.
     """
+    require(isinstance(png_path, Path), "png_path must be a Path")
+    require(isinstance(ico_path, Path), "ico_path must be a Path")
+
     ensure_pil_installed()
     from PIL import Image  # Ensure import is available
 

--- a/tests/tools/test_icon_utils.py
+++ b/tests/tools/test_icon_utils.py
@@ -1,0 +1,79 @@
+"""TDD suite for icon_utils.py.
+
+Tests cover check_pil_installed, create_resized_images sizes validation,
+convert_png_to_ico path handling, and DbC contract violations.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.python.contracts import PreconditionError
+from src.tools.icon_utils import (
+    ICO_SIZES,
+    check_pil_installed,
+    convert_png_to_ico,
+    create_resized_images,
+)
+
+
+def test_check_pil_installed_returns_bool():
+    result = check_pil_installed()
+    assert isinstance(result, bool)
+
+
+def test_create_resized_images_dbc_empty_sizes():
+    """create_resized_images must reject empty size list."""
+    mock_img = MagicMock()
+    with pytest.raises(PreconditionError):
+        create_resized_images(mock_img, [])
+
+
+def test_create_resized_images_dbc_non_list():
+    """create_resized_images must reject non-list sizes."""
+    mock_img = MagicMock()
+    with pytest.raises(PreconditionError):
+        create_resized_images(mock_img, "not_a_list")  # type: ignore[arg-type]
+
+
+def test_convert_png_to_ico_dbc_non_path_input(tmp_path):
+    """convert_png_to_ico must reject string paths."""
+    with pytest.raises(PreconditionError):
+        convert_png_to_ico("input.png", tmp_path / "out.ico")  # type: ignore[arg-type]
+
+
+def test_convert_png_to_ico_dbc_non_path_output(tmp_path):
+    """convert_png_to_ico must reject string output paths."""
+    with pytest.raises(PreconditionError):
+        convert_png_to_ico(tmp_path / "in.png", "out.ico")  # type: ignore[arg-type]
+
+
+def test_convert_png_to_ico_missing_file_returns_false(tmp_path):
+    """Missing PNG returns False gracefully (no crash)."""
+    result = convert_png_to_ico(tmp_path / "missing.png", tmp_path / "out.ico")
+    assert result is False
+
+
+@pytest.mark.skipif(not check_pil_installed(), reason="PIL not installed")
+def test_convert_png_to_ico_success(tmp_path):
+    """Integration test: converts a real PNG when PIL is available."""
+    from PIL import Image
+
+    # Create a minimal PNG
+    png = tmp_path / "test.png"
+    ico = tmp_path / "test.ico"
+    img = Image.new("RGBA", (256, 256), color=(255, 0, 0, 255))
+    img.save(png, format="PNG")
+
+    result = convert_png_to_ico(png, ico, sizes=[(16, 16), (32, 32)])
+    assert result is True
+    assert ico.exists()
+
+
+def test_ico_sizes_constant():
+    """Verify ICO_SIZES constant contains valid tuples."""
+    assert isinstance(ICO_SIZES, list)
+    assert len(ICO_SIZES) >= 4
+    for size in ICO_SIZES:
+        assert len(size) == 2
+        assert all(isinstance(dim, int) and dim > 0 for dim in size)

--- a/tests/tools/test_launch_utils.py
+++ b/tests/tools/test_launch_utils.py
@@ -16,11 +16,10 @@ from src.tools.launch_utils import (
     PlatformError,
     SecurityError,
     ToolNotFoundError,
-    validate_and_sanitize_path,
     launch_browser_tool,
     launch_tool,
+    validate_and_sanitize_path,
 )
-
 
 # ─── validate_and_sanitize_path ────────────────────────────────
 


### PR DESCRIPTION
Injects require() guards into convert_png_to_ico and create_resized_images. Adds 8-test TDD suite.