### PR TITLE
chore(tools): fix __init__.py to remove DeprecationWarning

### DIFF
--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,6 +1,6 @@
 """Tools package initialization."""
 
-from tools.logger import setup_logging
+from utils.logging_utils import setup_logging
 
 # Expose setup_logging at package level
 __all__ = ["setup_logging"]


### PR DESCRIPTION
Imports setup_logging from utils.logging_utils directly instead of the deprecated tools.logger shim. Eliminates DeprecationWarning appearing in every test run output.