### PR TITLE
feat(shared): add DbC guards + contract tests to GUIRegistry

### DIFF
--- a/src/shared/python/gui_launcher/registry.py
+++ b/src/shared/python/gui_launcher/registry.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from src.shared.python.contracts import require
+
 from .launcher import GUIType, LaunchConfig
 
 logger = logging.getLogger(__name__)
@@ -66,6 +68,23 @@ class GUIRegistry:
             icon: Optional path to icon file
             repository: Optional repository identifier
         """
+        require(
+            isinstance(tool_name, str) and tool_name,
+            "tool_name must be a non-empty string",
+        )
+        require(
+            isinstance(display_name, str) and display_name,
+            "display_name must be a non-empty string",
+        )
+        require(isinstance(description, str), "description must be a string")
+        require(
+            isinstance(gui_configs, dict) and gui_configs,
+            "gui_configs must be a non-empty dict",
+        )
+        require(
+            isinstance(category, str) and category,
+            "category must be a non-empty string",
+        )
         registration = GUIRegistration(
             tool_name=tool_name,
             display_name=display_name,
@@ -87,6 +106,10 @@ class GUIRegistry:
         Returns:
             True if the tool was found and removed
         """
+        require(
+            isinstance(tool_name, str) and tool_name,
+            "tool_name must be a non-empty string",
+        )
         if tool_name in self._registrations:
             del self._registrations[tool_name]
             return True
@@ -101,6 +124,10 @@ class GUIRegistry:
         Returns:
             GUIRegistration or None if not found
         """
+        require(
+            isinstance(tool_name, str) and tool_name,
+            "tool_name must be a non-empty string",
+        )
         return self._registrations.get(tool_name)
 
     def get_config(
@@ -117,6 +144,11 @@ class GUIRegistry:
         Returns:
             LaunchConfig or None if not found
         """
+        require(
+            isinstance(tool_name, str) and tool_name,
+            "tool_name must be a non-empty string",
+        )
+        require(isinstance(gui_type, GUIType), "gui_type must be a GUIType enum member")
         registration = self._registrations.get(tool_name)
         if registration:
             return registration.gui_configs.get(gui_type)
@@ -273,6 +305,7 @@ def auto_discover_guis(search_paths: list[Path]) -> int:
     Returns:
         Number of GUIs registered
     """
+    require(isinstance(search_paths, list), "search_paths must be a list of Paths")
     import importlib.util
 
     count = 0

--- a/tests/shared/python/gui_launcher/test_registry.py
+++ b/tests/shared/python/gui_launcher/test_registry.py
@@ -202,3 +202,116 @@ class TestSingleton:
 
         # Cleanup
         singleton.unregister("conv_test")
+
+
+# ── DbC Contract Violations ──────────────────────────────────────────────
+
+
+class TestGUIRegistryContracts:
+    """Tests that verify DbC preconditions on GUIRegistry methods."""
+
+    @pytest.fixture()
+    def registry(self) -> GUIRegistry:
+        """Fresh (non-singleton) registry for isolation."""
+        return GUIRegistry()
+
+    # register contracts
+
+    def test_register_empty_tool_name(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.register("", "My Tool", "desc", _sample_config())
+
+    def test_register_non_string_tool_name(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.register(123, "My Tool", "desc", _sample_config())  # type: ignore[arg-type]
+
+    def test_register_empty_display_name(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.register("tool_x", "", "desc", _sample_config())
+
+    def test_register_non_dict_configs(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.register("tool_x", "Name", "desc", [])  # type: ignore[arg-type]
+
+    def test_register_empty_configs(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.register("tool_x", "Name", "desc", {})
+
+    def test_register_non_string_description(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.register("tool_x", "Name", None, _sample_config())  # type: ignore[arg-type]
+
+    def test_register_empty_category(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.register("tool_x", "Name", "desc", _sample_config(), category="")
+
+    # unregister contracts
+
+    def test_unregister_empty_name(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.unregister("")
+
+    def test_unregister_non_string(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.unregister(None)  # type: ignore[arg-type]
+
+    # get contracts
+
+    def test_get_empty_name(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.get("")
+
+    def test_get_non_string(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.get(42)  # type: ignore[arg-type]
+
+    # get_config contracts
+
+    def test_get_config_empty_tool_name(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.get_config("", GUIType.PYQT6)
+
+    def test_get_config_non_guitype(self, registry: GUIRegistry) -> None:
+        from src.shared.python.contracts import PreconditionError
+
+        with pytest.raises(PreconditionError):
+            registry.get_config("tool_x", "pyqt6")  # type: ignore[arg-type]
+
+    # auto_discover_guis contracts
+
+    def test_auto_discover_non_list(self) -> None:
+        from src.shared.python.contracts import PreconditionError
+        from src.shared.python.gui_launcher.registry import auto_discover_guis
+
+        with pytest.raises(PreconditionError):
+            auto_discover_guis("/not/a/list")  # type: ignore[arg-type]
+
+    def test_auto_discover_empty_list_returns_zero(self) -> None:
+        from src.shared.python.gui_launcher.registry import auto_discover_guis
+
+        count = auto_discover_guis([])
+        assert count == 0


### PR DESCRIPTION
registry.py: require() guards on all public methods (register, unregister, get, get_config, auto_discover_guis). test_registry.py: 15 new contract violation tests. Total: 16→31 tests.