### PR TITLE
fix(arch): register upstream_drift_tools→theme as allowed dependency

### DIFF
--- a/tests/architecture/test_layer_boundaries.py
+++ b/tests/architecture/test_layer_boundaries.py
@@ -413,10 +413,13 @@ class TestNoCrossCouplingInShared:
     # calc_backend routers depend on upstream_drift_tools calculators
     # plot_engine depends on plot_theme for colour palettes
     # model_generation.humanoid bridges to humanoid_character_builder
+    # upstream_drift_tools.theme is a deliberate re-export wrapper for
+    # the sibling `theme` package (PR #896 — intentional coupling)
     ALLOWED_DEPS: dict[str, set[str]] = {
         "calc_backend": {"upstream_drift_tools"},
         "plot_engine": {"plot_theme"},
         "model_generation": {"humanoid_character_builder"},
+        "upstream_drift_tools": {"theme"},
     }
 
     def test_no_unauthorized_cross_package_imports(self) -> None:


### PR DESCRIPTION
The upstream_drift_tools/theme/__init__.py intentionally re-exports from the sibling theme package (PR #896). Added to ALLOWED_DEPS so TestNoCrossCouplingInShared passes. All 14 architecture tests now pass.