### PR TITLE
feat(pendulum): add driven double-pendulum simulator with damping and friction

### DIFF
--- a/src/pendulum_simulator/README.md
+++ b/src/pendulum_simulator/README.md
@@ -1,0 +1,127 @@
+# Double Pendulum Golf Swing Simulator
+
+A PyQt6-based visualization tool for exploring the dynamics of a **driven double pendulum** 
+modeled as a simplified golf swing. Uses **Lagrangian mechanics with relative (generalized) 
+coordinates** to show how off-diagonal mass matrix terms enable passive energy transfer in 
+kinematic chains.
+
+## Key Concepts
+
+This simulator demonstrates a fundamental insight about multi-body dynamics:
+
+- **Diagonal mass matrix terms** (M11, M22) represent each joint's "self-inertia" — the 
+  resistance of each segment to its own angular acceleration.
+- **Off-diagonal terms** (M12 = M21) represent **cross-coupling** — how torque at one joint 
+  accelerates the other segment through the physical linkage.
+
+In a golf swing, the off-diagonal coupling is what allows the arm's rotation to drive the 
+club's acceleration **without requiring wrist torque**. The coupling is maximized when the 
+segments are aligned (phi ≈ 0), which is exactly the configuration at impact.
+
+## Coordinates
+
+```
+    Shoulder (fixed pivot)
+        |
+        | segment 1 (arm): angle θ₁ from vertical
+        |
+    Wrist (joint)
+        |
+        | segment 2 (club): angle φ relative to arm
+        |
+    Club tip
+```
+
+- `θ₁ = 0, φ = 0` → both segments hanging straight down (equilibrium)
+- Positive angles = counterclockwise
+
+## Installation
+
+```bash
+# Clone or copy to your repo, then:
+cd double_pendulum_golf
+pip install -e ".[dev]"
+```
+
+## Usage
+
+```bash
+# Run the GUI
+python -m double_pendulum_golf
+
+# Or use the console script
+pendulum-golf
+```
+
+### GUI Layout
+
+| Panel | Description |
+|-------|-------------|
+| **Left** | Parameter inputs, initial conditions, torque polynomials, presets |
+| **Center** | Animated pendulum with tip trail |
+| **Right** | Real-time mass matrix display, force balance, energy |
+
+### Torque Polynomials
+
+Torques are specified as polynomial coefficients: `c0, c1, c2, ...`
+
+This evaluates as: `τ(t) = c0 + c1·t + c2·t² + ...`
+
+Example: `-25, 10` gives `τ(t) = -25 + 10t` (strong initial torque that decreases)
+
+### Presets
+
+- **Golf Swing (passive wrist)**: Shoulder-driven swing with zero wrist torque — 
+  demonstrates passive release through coupling
+- **Golf Swing (active wrist)**: Adds small wrist torque for comparison
+- **Free Double Pendulum**: No torques, chaotic dynamics
+- **Straight Drop**: Near-vertical release
+
+## Running Tests
+
+```bash
+pytest
+pytest --cov=double_pendulum_golf --cov-report=term-missing
+```
+
+## Architecture
+
+```
+src/double_pendulum_golf/
+├── physics.py          # Core EOM: mass matrix, Coriolis, gravity
+├── simulation.py       # Integration engine, polynomial torques
+├── gui/
+│   ├── main_window.py      # Top-level orchestration
+│   ├── pendulum_widget.py  # Animation canvas
+│   ├── matrix_widget.py    # Real-time matrix display
+│   └── controls_widget.py  # Input panel with presets
+```
+
+### Design Principles
+
+- **DRY**: Common patterns extracted (LabeledInput widget, shared coordinate transforms)
+- **DbC** (Design by Contract): Preconditions/postconditions via assertions throughout physics code
+- **TDD**: Comprehensive test suite covering mass matrix properties, energy conservation, 
+  known analytical values, and contract violations
+
+## Physics Reference
+
+### Mass Matrix (point masses at tips)
+
+```
+M11 = (m1 + m2)·L1² + m2·L2² + 2·m2·L1·L2·cos(φ)
+M12 = M21 = m2·L2² + m2·L1·L2·cos(φ)
+M22 = m2·L2²
+```
+
+### Equations of Motion
+
+```
+M(q)·q̈ = τ - C(q,q̇)·q̇ - G(q)
+```
+
+where C contains Coriolis/centrifugal terms and G contains gravitational torques.
+
+## License
+
+MIT

--- a/src/pendulum_simulator/perf_test.py
+++ b/src/pendulum_simulator/perf_test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Measure simulation performance."""
+
+import time
+import numpy as np
+from src.double_pendulum_golf.physics import PendulumParams
+from src.double_pendulum_golf.simulation import make_polynomial_torque, run_simulation
+
+# Default preset params
+params = PendulumParams(
+    m1=5.0, m2=0.5,
+    L1=0.6, L2=1.0,
+)
+
+initial_state = np.array([
+    np.radians(120.0),
+    np.radians(-90.0),
+    0.0,
+    0.0,
+])
+
+torque_func = make_polynomial_torque([-25, 10], [0])
+
+print("Running simulation 10 times to measure performance...")
+times = []
+for i in range(10):
+    start = time.time()
+    result = run_simulation(
+        params=params,
+        initial_state=initial_state,
+        t_end=2.0,
+        torque_func=torque_func,
+        dt=0.005,
+    )
+    elapsed = time.time() - start
+    times.append(elapsed)
+    print(f"  Run {i+1}: {elapsed:.3f}s")
+
+print(f"\nAverage: {np.mean(times):.3f}s")
+print(f"Min: {np.min(times):.3f}s")
+print(f"Max: {np.max(times):.3f}s")

--- a/src/pendulum_simulator/pyproject.toml
+++ b/src/pendulum_simulator/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "double-pendulum-golf"
+version = "0.1.0"
+description = "Double pendulum golf swing dynamics simulator with PyQt6 GUI"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+dependencies = [
+    "numpy>=1.24",
+    "scipy>=1.10",
+    "PyQt6>=6.5",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
+]
+plots = [
+    "pyqtgraph>=0.13",
+]
+
+[project.scripts]
+pendulum-golf = "double_pendulum_golf.__main__:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short"
+
+[tool.ruff]
+line-length = 95
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true

--- a/src/pendulum_simulator/requirements.txt
+++ b/src/pendulum_simulator/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.24
+scipy>=1.10
+PyQt6>=6.5
+pytest>=7.0
+pytest-cov>=4.0

--- a/src/pendulum_simulator/signal_test.py
+++ b/src/pendulum_simulator/signal_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Minimal test to verify PyQt signals work."""
+
+import sys
+from PyQt6.QtWidgets import QApplication, QMainWindow, QPushButton, QVBoxLayout, QWidget, QMessageBox
+from PyQt6.QtCore import pyqtSignal
+
+class TestWindow(QMainWindow):
+    run_requested = pyqtSignal()
+    
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Signal Test")
+        self.setGeometry(100, 100, 300, 200)
+        
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        
+        button = QPushButton("Click Me")
+        button.clicked.connect(self.run_requested.emit)
+        layout.addWidget(button)
+        
+        self.setCentralWidget(widget)
+        
+        # Connect our own handler
+        self.run_requested.connect(self.on_run)
+    
+    def on_run(self):
+        print("[TEST] Signal received!")
+        QMessageBox.information(self, "Success", "Signal was received!")
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = TestWindow()
+    window.show()
+    sys.exit(app.exec())

--- a/src/pendulum_simulator/src/double_pendulum_golf/__init__.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/__init__.py
@@ -1,0 +1,9 @@
+"""Double Pendulum Golf Swing Simulator.
+
+A PyQt6-based visualization tool for exploring the dynamics of a driven
+double pendulum using Lagrangian mechanics with relative (generalized)
+coordinates. Demonstrates how off-diagonal mass matrix terms enable
+passive energy transfer in kinematic chains like the golf swing.
+"""
+
+__version__ = "0.1.0"

--- a/src/pendulum_simulator/src/double_pendulum_golf/__main__.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/__main__.py
@@ -1,0 +1,25 @@
+"""Entry point for running the application.
+
+Usage:
+    python -m double_pendulum_golf
+"""
+
+import sys
+
+from PyQt6.QtWidgets import QApplication
+
+from .gui import MainWindow
+
+
+def main():
+    app = QApplication(sys.argv)
+    app.setStyle("Fusion")  # consistent cross-platform look
+
+    window = MainWindow()
+    window.show()
+
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/__init__.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/__init__.py
@@ -1,0 +1,5 @@
+"""GUI components for the double pendulum simulator."""
+
+from .main_window import MainWindow
+
+__all__ = ["MainWindow"]

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/controls_widget.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/controls_widget.py
@@ -1,0 +1,436 @@
+"""
+Control panel widget with parameter inputs, initial conditions,
+torque polynomial editors, and playback controls.
+
+Provides golf-swing presets alongside fully customizable inputs.
+"""
+
+import numpy as np
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QGridLayout,
+    QLabel, QLineEdit, QPushButton, QSlider, QGroupBox,
+    QComboBox, QSpinBox, QDoubleSpinBox, QSizePolicy,
+)
+
+from .torque_preview_widget import TorquePreviewWidget
+
+
+class LabeledInput(QWidget):
+    """A label + line-edit pair used throughout the control panel.
+
+    DRY: This avoids repeating the label-edit pattern dozens of times.
+    """
+
+    def __init__(self, label: str, default: str, tooltip: str = "",
+                 parent=None):
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        lbl = QLabel(label)
+        lbl.setFixedWidth(90)
+        lbl.setStyleSheet("color: #b0b0c0; font-size: 11px;")
+        layout.addWidget(lbl)
+
+        self.edit = QLineEdit(default)
+        self.edit.setStyleSheet(
+            "background: #2a2a38; color: #e0e0f0; border: 1px solid #505068;"
+            "border-radius: 3px; padding: 3px 6px; font-family: monospace;"
+        )
+        if tooltip:
+            self.edit.setToolTip(tooltip)
+        layout.addWidget(self.edit)
+
+    @property
+    def value(self) -> str:
+        return self.edit.text().strip()
+
+    def set_value(self, text: str) -> None:
+        self.edit.setText(text)
+
+
+class ControlsWidget(QWidget):
+    """Parameter input panel with presets and playback controls.
+
+    Signals
+    -------
+    run_requested : emitted when user clicks "Run Simulation"
+    reset_requested : emitted when user clicks "Reset"
+    play_toggled(bool) : emitted when play/pause toggled (True = play)
+    speed_changed(float) : emitted when playback speed changes
+    frame_changed(int) : emitted when user drags the timeline slider
+    """
+
+    run_requested = pyqtSignal()
+    reset_requested = pyqtSignal()
+    play_toggled = pyqtSignal(bool)
+    speed_changed = pyqtSignal(float)
+    frame_changed = pyqtSignal(int)
+    export_data_requested = pyqtSignal()
+    export_video_requested = pyqtSignal()
+
+    # Presets: (name, theta1_deg, phi_deg, dtheta1, dphi,
+    #           shoulder_coeffs, wrist_coeffs, t_end,
+    #           m1, m2, L1, L2)
+    PRESETS = {
+        "Golf Swing (passive wrist)": (
+            120.0, -90.0, 0.0, 0.0,
+            "-25, 10", "0",
+            2.0, 5.0, 0.5, 0.6, 1.0,
+        ),
+        "Golf Swing (active wrist)": (
+            120.0, -90.0, 0.0, 0.0,
+            "-25, 10", "-2, 3",
+            2.0, 5.0, 0.5, 0.6, 1.0,
+        ),
+        "Free Double Pendulum": (
+            90.0, 90.0, 0.0, 0.0,
+            "0", "0",
+            5.0, 1.0, 1.0, 1.0, 1.0,
+        ),
+        "Straight Drop": (
+            0.1, 0.1, 0.0, 0.0,
+            "0", "0",
+            3.0, 1.0, 1.0, 0.8, 0.8,
+        ),
+    }
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumWidth(300)
+        self.setMaximumWidth(360)
+        self._is_playing = False
+        self._build_ui()
+        self._apply_preset("Golf Swing (passive wrist)")
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(8, 8, 8, 8)
+        main_layout.setSpacing(6)
+
+        style_group = (
+            "QGroupBox { color: #c0c0d8; border: 1px solid #404058;"
+            "border-radius: 5px; margin-top: 8px; padding-top: 14px;"
+            "font-weight: bold; }"
+            "QGroupBox::title { subcontrol-origin: margin;"
+            "left: 10px; padding: 0 4px; }"
+        )
+
+        # Preset selector
+        preset_group = QGroupBox("Preset")
+        preset_group.setStyleSheet(style_group)
+        pl = QVBoxLayout(preset_group)
+        self.preset_combo = QComboBox()
+        self.preset_combo.setStyleSheet(
+            "background: #2a2a38; color: #e0e0f0; border: 1px solid #505068;"
+            "border-radius: 3px; padding: 4px;"
+        )
+        for name in self.PRESETS:
+            self.preset_combo.addItem(name)
+        self.preset_combo.currentTextChanged.connect(self._apply_preset)
+        pl.addWidget(self.preset_combo)
+        main_layout.addWidget(preset_group)
+
+        # Physical parameters
+        phys_group = QGroupBox("Physical Parameters")
+        phys_group.setStyleSheet(style_group)
+        pl2 = QVBoxLayout(phys_group)
+        self.inp_m1 = LabeledInput("m1 (kg)", "5.0", "Mass of arm segment")
+        self.inp_m2 = LabeledInput("m2 (kg)", "0.5", "Mass of club segment")
+        self.inp_L1 = LabeledInput("L1 (m)", "0.6", "Length of arm segment")
+        self.inp_L2 = LabeledInput("L2 (m)", "1.0", "Length of club segment")
+        for w in [self.inp_m1, self.inp_m2, self.inp_L1, self.inp_L2]:
+            pl2.addWidget(w)
+        main_layout.addWidget(phys_group)
+
+        # Initial conditions
+        ic_group = QGroupBox("Initial Conditions")
+        ic_group.setStyleSheet(style_group)
+        pl3 = QVBoxLayout(ic_group)
+        self.inp_theta1 = LabeledInput("\u03b81 (deg)", "120", "Arm angle from vertical")
+        self.inp_phi = LabeledInput("\u03c6 (deg)", "-90", "Club angle relative to arm")
+        self.inp_dtheta1 = LabeledInput("d\u03b81 (rad/s)", "0", "Arm angular velocity")
+        self.inp_dphi = LabeledInput("d\u03c6 (rad/s)", "0", "Club angular velocity")
+        for w in [self.inp_theta1, self.inp_phi, self.inp_dtheta1, self.inp_dphi]:
+            pl3.addWidget(w)
+        main_layout.addWidget(ic_group)
+
+        # Torque polynomials
+        torque_group = QGroupBox("Torque Polynomials (c0, c1, c2, ...)")
+        torque_group.setStyleSheet(style_group)
+        pl4 = QVBoxLayout(torque_group)
+        self.inp_tau_shoulder = LabeledInput("Shoulder", "-25, 10",
+            "Polynomial coefficients: \u03c4(t) = c0 + c1*t + c2*t\u00b2 + ...")
+        self.inp_tau_wrist = LabeledInput("Wrist", "0",
+            "Polynomial coefficients: \u03c4(t) = c0 + c1*t + c2*t\u00b2 + ...")
+        pl4.addWidget(self.inp_tau_shoulder)
+        pl4.addWidget(self.inp_tau_wrist)
+        main_layout.addWidget(torque_group)
+
+        preview_group = QGroupBox("Torque Preview")
+        preview_group.setStyleSheet(style_group)
+        preview_layout = QVBoxLayout(preview_group)
+        self.torque_preview = TorquePreviewWidget()
+        preview_layout.addWidget(self.torque_preview)
+        main_layout.addWidget(preview_group)
+
+        # Simulation duration
+        time_group = QGroupBox("Simulation")
+        time_group.setStyleSheet(style_group)
+        pl5 = QVBoxLayout(time_group)
+        self.inp_tend = LabeledInput("Duration (s)", "2.0", "Total simulation time")
+        pl5.addWidget(self.inp_tend)
+        main_layout.addWidget(time_group)
+
+        # Dissipation parameters
+        diss_group = QGroupBox("Dissipation (optional)")
+        diss_group.setStyleSheet(style_group)
+        pl_diss = QVBoxLayout(diss_group)
+        self.inp_b1 = LabeledInput(
+            "b1 (N·m·s)", "0.0",
+            "Viscous damping at joint 1 (shoulder) — proportional to angular velocity"
+        )
+        self.inp_b2 = LabeledInput(
+            "b2 (N·m·s)", "0.0",
+            "Viscous damping at joint 2 (wrist) — proportional to angular velocity"
+        )
+        self.inp_mu1 = LabeledInput(
+            "\u03bc1 (N·m)", "0.0",
+            "Coulomb friction at joint 1 (shoulder) — constant magnitude opposing motion"
+        )
+        self.inp_mu2 = LabeledInput(
+            "\u03bc2 (N·m)", "0.0",
+            "Coulomb friction at joint 2 (wrist) — constant magnitude opposing motion"
+        )
+        for w in [self.inp_b1, self.inp_b2, self.inp_mu1, self.inp_mu2]:
+            pl_diss.addWidget(w)
+        main_layout.addWidget(diss_group)
+
+        # Run / Reset buttons
+        btn_layout = QHBoxLayout()
+        self.btn_run = QPushButton("▶  Run Simulation")
+        self.btn_run.setStyleSheet(
+            "QPushButton { background: #2d6b3f; color: white; border: none;"
+            "border-radius: 5px; padding: 10px; font-size: 13px; font-weight: bold; }"
+            "QPushButton:hover { background: #3a8a52; }"
+            "QPushButton:pressed { background: #1f5030; }"
+        )
+        self.btn_run.clicked.connect(self.run_requested.emit)
+
+        self.btn_reset = QPushButton("Reset")
+        self.btn_reset.setStyleSheet(
+            "QPushButton { background: #5a3030; color: white; border: none;"
+            "border-radius: 5px; padding: 10px; font-size: 13px; }"
+            "QPushButton:hover { background: #7a4040; }"
+        )
+        self.btn_reset.clicked.connect(self.reset_requested.emit)
+
+        btn_layout.addWidget(self.btn_run, stretch=2)
+        btn_layout.addWidget(self.btn_reset, stretch=1)
+        main_layout.addLayout(btn_layout)
+
+        # Playback controls
+        play_group = QGroupBox("Playback")
+        play_group.setStyleSheet(style_group)
+        pl6 = QVBoxLayout(play_group)
+
+        # Play/Pause + Speed
+        ctrl_row = QHBoxLayout()
+        self.btn_play = QPushButton("▶ Play")
+        self.btn_play.setCheckable(True)
+        self.btn_play.setStyleSheet(
+            "QPushButton { background: #303050; color: #c0c0e0; border: 1px solid #505068;"
+            "border-radius: 4px; padding: 6px 12px; }"
+            "QPushButton:checked { background: #504030; color: #f0d080; }"
+        )
+        self.btn_play.toggled.connect(self._on_play_toggled)
+        ctrl_row.addWidget(self.btn_play)
+
+        ctrl_row.addWidget(QLabel("Speed:"))
+        self.speed_spin = QDoubleSpinBox()
+        self.speed_spin.setRange(0.1, 5.0)
+        self.speed_spin.setSingleStep(0.1)
+        self.speed_spin.setValue(1.0)
+        self.speed_spin.setStyleSheet(
+            "background: #2a2a38; color: #e0e0f0; border: 1px solid #505068;"
+        )
+        self.speed_spin.valueChanged.connect(
+            lambda v: self.speed_changed.emit(v)
+        )
+        ctrl_row.addWidget(self.speed_spin)
+        pl6.addLayout(ctrl_row)
+
+        # Timeline slider
+        self.slider = QSlider(Qt.Orientation.Horizontal)
+        self.slider.setRange(0, 100)
+        self.slider.setStyleSheet(
+            "QSlider::groove:horizontal { background: #303048; height: 6px;"
+            "border-radius: 3px; }"
+            "QSlider::handle:horizontal { background: #7070a0; width: 14px;"
+            "margin: -5px 0; border-radius: 7px; }"
+        )
+        self.slider.valueChanged.connect(self.frame_changed.emit)
+        pl6.addWidget(self.slider)
+        main_layout.addWidget(play_group)
+
+        # Export controls
+        export_group = QGroupBox("Export")
+        export_group.setStyleSheet(style_group)
+        export_layout = QHBoxLayout(export_group)
+
+        self.btn_export_data = QPushButton("Export Data")
+        self.btn_export_data.setStyleSheet(
+            "QPushButton { background: #303050; color: #c0c0e0; border: 1px solid #505068;"
+            "border-radius: 4px; padding: 6px 10px; }"
+            "QPushButton:hover { background: #3a3a60; }"
+        )
+        self.btn_export_data.clicked.connect(self.export_data_requested.emit)
+
+        self.btn_export_video = QPushButton("Export Video")
+        self.btn_export_video.setStyleSheet(
+            "QPushButton { background: #303050; color: #c0c0e0; border: 1px solid #505068;"
+            "border-radius: 4px; padding: 6px 10px; }"
+            "QPushButton:hover { background: #3a3a60; }"
+        )
+        self.btn_export_video.clicked.connect(self.export_video_requested.emit)
+
+        export_layout.addWidget(self.btn_export_data)
+        export_layout.addWidget(self.btn_export_video)
+        main_layout.addWidget(export_group)
+
+        main_layout.addStretch()
+
+        self.inp_tau_shoulder.edit.textChanged.connect(self._update_torque_preview)
+        self.inp_tau_wrist.edit.textChanged.connect(self._update_torque_preview)
+        self.inp_tend.edit.textChanged.connect(self._update_torque_preview)
+
+    # ------------------------------------------------------------------
+    # Preset application
+    # ------------------------------------------------------------------
+
+    def _apply_preset(self, name: str) -> None:
+        """Load a named preset into all input fields."""
+        if name not in self.PRESETS:
+            return
+        (theta1, phi, dth, dph,
+         tau_sh, tau_wr, tend,
+         m1, m2, L1, L2) = self.PRESETS[name]
+
+        self.inp_theta1.set_value(str(theta1))
+        self.inp_phi.set_value(str(phi))
+        self.inp_dtheta1.set_value(str(dth))
+        self.inp_dphi.set_value(str(dph))
+        self.inp_tau_shoulder.set_value(tau_sh)
+        self.inp_tau_wrist.set_value(tau_wr)
+        self.inp_tend.set_value(str(tend))
+        self.inp_m1.set_value(str(m1))
+        self.inp_m2.set_value(str(m2))
+        self.inp_L1.set_value(str(L1))
+        self.inp_L2.set_value(str(L2))
+        self._update_torque_preview()
+
+    # ------------------------------------------------------------------
+    # Value parsing (with validation)
+    # ------------------------------------------------------------------
+
+    def get_params(self) -> dict:
+        """Parse all input fields and return as a dict.
+
+        Returns
+        -------
+        dict with keys: m1, m2, L1, L2, theta1_rad, phi_rad,
+            dtheta1, dphi, shoulder_coeffs, wrist_coeffs, t_end
+
+        Raises
+        ------
+        ValueError if any input cannot be parsed.
+        """
+        def parse_float(widget: LabeledInput, name: str) -> float:
+            try:
+                return float(widget.value)
+            except ValueError:
+                raise ValueError(f"Cannot parse '{name}': '{widget.value}'")
+
+        def parse_coeffs(widget: LabeledInput, name: str) -> list:
+            try:
+                parts = widget.value.split(",")
+                return [float(p.strip()) for p in parts if p.strip()]
+            except ValueError:
+                raise ValueError(
+                    f"Cannot parse '{name}' coefficients: '{widget.value}'"
+                )
+
+        return {
+            "m1": parse_float(self.inp_m1, "m1"),
+            "m2": parse_float(self.inp_m2, "m2"),
+            "L1": parse_float(self.inp_L1, "L1"),
+            "L2": parse_float(self.inp_L2, "L2"),
+            "theta1_rad": np.radians(parse_float(self.inp_theta1, "θ1")),
+            "phi_rad": np.radians(parse_float(self.inp_phi, "φ")),
+            "dtheta1": parse_float(self.inp_dtheta1, "dθ1"),
+            "dphi": parse_float(self.inp_dphi, "dφ"),
+            "shoulder_coeffs": parse_coeffs(self.inp_tau_shoulder, "Shoulder torque"),
+            "wrist_coeffs": parse_coeffs(self.inp_tau_wrist, "Wrist torque"),
+            "t_end": parse_float(self.inp_tend, "Duration"),
+            "b1": parse_float(self.inp_b1, "b1"),
+            "b2": parse_float(self.inp_b2, "b2"),
+            "mu1": parse_float(self.inp_mu1, "μ1"),
+            "mu2": parse_float(self.inp_mu2, "μ2"),
+        }
+
+    def _update_torque_preview(self) -> None:
+        try:
+            t_end = float(self.inp_tend.value)
+        except ValueError:
+            t_end = 2.0
+
+        def parse_coeffs(widget: LabeledInput) -> list:
+            parts = widget.value.split(",")
+            coeffs = []
+            for part in parts:
+                part = part.strip()
+                if not part:
+                    continue
+                try:
+                    coeffs.append(float(part))
+                except ValueError:
+                    return []
+            return coeffs or [0.0]
+
+        shoulder = parse_coeffs(self.inp_tau_shoulder)
+        wrist = parse_coeffs(self.inp_tau_wrist)
+
+        self.torque_preview.set_duration(t_end)
+        self.torque_preview.set_profiles([
+            ("Shoulder", shoulder, QColor(230, 120, 50)),
+            ("Wrist", wrist, QColor(120, 180, 230)),
+        ])
+
+    # ------------------------------------------------------------------
+    # Playback
+    # ------------------------------------------------------------------
+
+    def _on_play_toggled(self, checked: bool) -> None:
+        self._is_playing = checked
+        self.btn_play.setText("⏸ Pause" if checked else "▶ Play")
+        self.play_toggled.emit(checked)
+
+    def set_slider_range(self, max_val: int) -> None:
+        """Update the timeline slider range after simulation runs."""
+        self.slider.setRange(0, max_val)
+
+    def set_slider_value(self, val: int) -> None:
+        """Update slider position without emitting signal (for animation)."""
+        self.slider.blockSignals(True)
+        self.slider.setValue(val)
+        self.slider.blockSignals(False)
+
+    def stop_playback(self) -> None:
+        """Force stop playback state."""
+        self.btn_play.setChecked(False)

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/controls_widget_triple.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/controls_widget_triple.py
@@ -1,0 +1,328 @@
+"""
+Control panel widget for triple pendulum inputs and playback.
+"""
+
+import numpy as np
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtGui import QColor
+from PyQt6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QLabel, QPushButton,
+    QSlider, QGroupBox, QComboBox, QDoubleSpinBox,
+)
+
+from .controls_widget import LabeledInput
+from .torque_preview_widget import TorquePreviewWidget
+
+
+class ControlsWidgetTriple(QWidget):
+    """Parameter input panel for the triple pendulum."""
+
+    run_requested = pyqtSignal()
+    reset_requested = pyqtSignal()
+    play_toggled = pyqtSignal(bool)
+    speed_changed = pyqtSignal(float)
+    frame_changed = pyqtSignal(int)
+    export_data_requested = pyqtSignal()
+    export_video_requested = pyqtSignal()
+
+    PRESETS = {
+        "Triple Swing": (
+            120.0, -60.0, -30.0, 0.0, 0.0, 0.0,
+            "-25, 10", "0", "0",
+            2.0, 5.0, 0.5, 0.4, 0.6, 0.6, 0.3,
+        ),
+        "Free Triple Pendulum": (
+            90.0, 60.0, -45.0, 0.0, 0.0, 0.0,
+            "0", "0", "0",
+            5.0, 1.0, 0.5, 0.2, 1.0, 1.0, 0.5,
+        ),
+    }
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumWidth(300)
+        self.setMaximumWidth(360)
+        self._is_playing = False
+        self._build_ui()
+        self._apply_preset("Triple Swing")
+
+    def _build_ui(self) -> None:
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(8, 8, 8, 8)
+        main_layout.setSpacing(6)
+
+        style_group = (
+            "QGroupBox { color: #c0c0d8; border: 1px solid #404058;"
+            "border-radius: 5px; margin-top: 8px; padding-top: 14px;"
+            "font-weight: bold; }"
+            "QGroupBox::title { subcontrol-origin: margin;"
+            "left: 10px; padding: 0 4px; }"
+        )
+
+        preset_group = QGroupBox("Preset")
+        preset_group.setStyleSheet(style_group)
+        pl = QVBoxLayout(preset_group)
+        self.preset_combo = QComboBox()
+        self.preset_combo.setStyleSheet(
+            "background: #2a2a38; color: #e0e0f0; border: 1px solid #505068;"
+            "border-radius: 3px; padding: 4px;"
+        )
+        for name in self.PRESETS:
+            self.preset_combo.addItem(name)
+        self.preset_combo.currentTextChanged.connect(self._apply_preset)
+        pl.addWidget(self.preset_combo)
+        main_layout.addWidget(preset_group)
+
+        phys_group = QGroupBox("Physical Parameters")
+        phys_group.setStyleSheet(style_group)
+        pl2 = QVBoxLayout(phys_group)
+        self.inp_m1 = LabeledInput("m1 (kg)", "5.0", "Mass of segment 1")
+        self.inp_m2 = LabeledInput("m2 (kg)", "0.5", "Mass of segment 2")
+        self.inp_m3 = LabeledInput("m3 (kg)", "0.4", "Mass of segment 3")
+        self.inp_L1 = LabeledInput("L1 (m)", "0.6", "Length of segment 1")
+        self.inp_L2 = LabeledInput("L2 (m)", "0.6", "Length of segment 2")
+        self.inp_L3 = LabeledInput("L3 (m)", "0.6", "Length of segment 3")
+        for w in [self.inp_m1, self.inp_m2, self.inp_m3, self.inp_L1, self.inp_L2, self.inp_L3]:
+            pl2.addWidget(w)
+        main_layout.addWidget(phys_group)
+
+        ic_group = QGroupBox("Initial Conditions")
+        ic_group.setStyleSheet(style_group)
+        pl3 = QVBoxLayout(ic_group)
+        self.inp_theta1 = LabeledInput("theta1 (deg)", "120", "Segment 1 angle")
+        self.inp_phi1 = LabeledInput("phi1 (deg)", "-60", "Segment 2 relative angle")
+        self.inp_phi2 = LabeledInput("phi2 (deg)", "-30", "Segment 3 relative angle")
+        self.inp_dtheta1 = LabeledInput("dtheta1 (rad/s)", "0", "Segment 1 velocity")
+        self.inp_dphi1 = LabeledInput("dphi1 (rad/s)", "0", "Segment 2 velocity")
+        self.inp_dphi2 = LabeledInput("dphi2 (rad/s)", "0", "Segment 3 velocity")
+        for w in [self.inp_theta1, self.inp_phi1, self.inp_phi2, self.inp_dtheta1, self.inp_dphi1, self.inp_dphi2]:
+            pl3.addWidget(w)
+        main_layout.addWidget(ic_group)
+
+        torque_group = QGroupBox("Torque Polynomials (c0, c1, c2, ...)")
+        torque_group.setStyleSheet(style_group)
+        pl4 = QVBoxLayout(torque_group)
+        self.inp_tau_shoulder = LabeledInput("Shoulder", "-25, 10",
+            "Polynomial coefficients: tau(t) = c0 + c1*t + c2*t^2 + ...")
+        self.inp_tau_elbow = LabeledInput("Elbow", "0",
+            "Polynomial coefficients: tau(t) = c0 + c1*t + c2*t^2 + ...")
+        self.inp_tau_wrist = LabeledInput("Wrist", "0",
+            "Polynomial coefficients: tau(t) = c0 + c1*t + c2*t^2 + ...")
+        pl4.addWidget(self.inp_tau_shoulder)
+        pl4.addWidget(self.inp_tau_elbow)
+        pl4.addWidget(self.inp_tau_wrist)
+        main_layout.addWidget(torque_group)
+
+        preview_group = QGroupBox("Torque Preview")
+        preview_group.setStyleSheet(style_group)
+        preview_layout = QVBoxLayout(preview_group)
+        self.torque_preview = TorquePreviewWidget()
+        preview_layout.addWidget(self.torque_preview)
+        main_layout.addWidget(preview_group)
+
+        time_group = QGroupBox("Simulation")
+        time_group.setStyleSheet(style_group)
+        pl5 = QVBoxLayout(time_group)
+        self.inp_tend = LabeledInput("Duration (s)", "2.0", "Total simulation time")
+        pl5.addWidget(self.inp_tend)
+        main_layout.addWidget(time_group)
+
+        btn_layout = QHBoxLayout()
+        self.btn_run = QPushButton("Run Simulation")
+        self.btn_run.setStyleSheet(
+            "QPushButton { background: #2d6b3f; color: white; border: none;"
+            "border-radius: 5px; padding: 10px; font-size: 13px; font-weight: bold; }"
+            "QPushButton:hover { background: #3a8a52; }"
+            "QPushButton:pressed { background: #1f5030; }"
+        )
+        self.btn_run.clicked.connect(self.run_requested.emit)
+
+        self.btn_reset = QPushButton("Reset")
+        self.btn_reset.setStyleSheet(
+            "QPushButton { background: #5a3030; color: white; border: none;"
+            "border-radius: 5px; padding: 10px; font-size: 13px; }"
+            "QPushButton:hover { background: #7a4040; }"
+        )
+        self.btn_reset.clicked.connect(self.reset_requested.emit)
+
+        btn_layout.addWidget(self.btn_run, stretch=2)
+        btn_layout.addWidget(self.btn_reset, stretch=1)
+        main_layout.addLayout(btn_layout)
+
+        play_group = QGroupBox("Playback")
+        play_group.setStyleSheet(style_group)
+        pl6 = QVBoxLayout(play_group)
+
+        ctrl_row = QHBoxLayout()
+        self.btn_play = QPushButton("Play")
+        self.btn_play.setCheckable(True)
+        self.btn_play.setStyleSheet(
+            "QPushButton { background: #303050; color: #c0c0e0; border: 1px solid #505068;"
+            "border-radius: 4px; padding: 6px 12px; }"
+            "QPushButton:checked { background: #504030; color: #f0d080; }"
+        )
+        self.btn_play.toggled.connect(self._on_play_toggled)
+        ctrl_row.addWidget(self.btn_play)
+
+        ctrl_row.addWidget(QLabel("Speed:"))
+        self.speed_spin = QDoubleSpinBox()
+        self.speed_spin.setRange(0.1, 5.0)
+        self.speed_spin.setSingleStep(0.1)
+        self.speed_spin.setValue(1.0)
+        self.speed_spin.setStyleSheet(
+            "background: #2a2a38; color: #e0e0f0; border: 1px solid #505068;"
+        )
+        self.speed_spin.valueChanged.connect(
+            lambda v: self.speed_changed.emit(v)
+        )
+        ctrl_row.addWidget(self.speed_spin)
+        pl6.addLayout(ctrl_row)
+
+        self.slider = QSlider(Qt.Orientation.Horizontal)
+        self.slider.setRange(0, 100)
+        self.slider.setStyleSheet(
+            "QSlider::groove:horizontal { background: #303048; height: 6px;"
+            "border-radius: 3px; }"
+            "QSlider::handle:horizontal { background: #7070a0; width: 14px;"
+            "margin: -5px 0; border-radius: 7px; }"
+        )
+        self.slider.valueChanged.connect(self.frame_changed.emit)
+        pl6.addWidget(self.slider)
+        main_layout.addWidget(play_group)
+
+        export_group = QGroupBox("Export")
+        export_group.setStyleSheet(style_group)
+        export_layout = QHBoxLayout(export_group)
+
+        self.btn_export_data = QPushButton("Export Data")
+        self.btn_export_data.setStyleSheet(
+            "QPushButton { background: #303050; color: #c0c0e0; border: 1px solid #505068;"
+            "border-radius: 4px; padding: 6px 10px; }"
+            "QPushButton:hover { background: #3a3a60; }"
+        )
+        self.btn_export_data.clicked.connect(self.export_data_requested.emit)
+
+        self.btn_export_video = QPushButton("Export Video")
+        self.btn_export_video.setStyleSheet(
+            "QPushButton { background: #303050; color: #c0c0e0; border: 1px solid #505068;"
+            "border-radius: 4px; padding: 6px 10px; }"
+            "QPushButton:hover { background: #3a3a60; }"
+        )
+        self.btn_export_video.clicked.connect(self.export_video_requested.emit)
+
+        export_layout.addWidget(self.btn_export_data)
+        export_layout.addWidget(self.btn_export_video)
+        main_layout.addWidget(export_group)
+
+        main_layout.addStretch()
+
+        self.inp_tau_shoulder.edit.textChanged.connect(self._update_torque_preview)
+        self.inp_tau_elbow.edit.textChanged.connect(self._update_torque_preview)
+        self.inp_tau_wrist.edit.textChanged.connect(self._update_torque_preview)
+        self.inp_tend.edit.textChanged.connect(self._update_torque_preview)
+
+    def _apply_preset(self, name: str) -> None:
+        if name not in self.PRESETS:
+            return
+        (theta1, phi1, phi2, dth, dph1, dph2,
+         tau_sh, tau_el, tau_wr, tend,
+         m1, m2, m3, L1, L2, L3) = self.PRESETS[name]
+
+        self.inp_theta1.set_value(str(theta1))
+        self.inp_phi1.set_value(str(phi1))
+        self.inp_phi2.set_value(str(phi2))
+        self.inp_dtheta1.set_value(str(dth))
+        self.inp_dphi1.set_value(str(dph1))
+        self.inp_dphi2.set_value(str(dph2))
+        self.inp_tau_shoulder.set_value(tau_sh)
+        self.inp_tau_elbow.set_value(tau_el)
+        self.inp_tau_wrist.set_value(tau_wr)
+        self.inp_tend.set_value(str(tend))
+        self.inp_m1.set_value(str(m1))
+        self.inp_m2.set_value(str(m2))
+        self.inp_m3.set_value(str(m3))
+        self.inp_L1.set_value(str(L1))
+        self.inp_L2.set_value(str(L2))
+        self.inp_L3.set_value(str(L3))
+        self._update_torque_preview()
+
+    def get_params(self) -> dict:
+        def parse_float(widget: LabeledInput, name: str) -> float:
+            try:
+                return float(widget.value)
+            except ValueError:
+                raise ValueError(f"Cannot parse '{name}': '{widget.value}'")
+
+        def parse_coeffs(widget: LabeledInput, name: str) -> list:
+            try:
+                parts = widget.value.split(",")
+                return [float(p.strip()) for p in parts if p.strip()]
+            except ValueError:
+                raise ValueError(
+                    f"Cannot parse '{name}' coefficients: '{widget.value}'"
+                )
+
+        return {
+            "m1": parse_float(self.inp_m1, "m1"),
+            "m2": parse_float(self.inp_m2, "m2"),
+            "m3": parse_float(self.inp_m3, "m3"),
+            "L1": parse_float(self.inp_L1, "L1"),
+            "L2": parse_float(self.inp_L2, "L2"),
+            "L3": parse_float(self.inp_L3, "L3"),
+            "theta1_rad": np.radians(parse_float(self.inp_theta1, "theta1")),
+            "phi1_rad": np.radians(parse_float(self.inp_phi1, "phi1")),
+            "phi2_rad": np.radians(parse_float(self.inp_phi2, "phi2")),
+            "dtheta1": parse_float(self.inp_dtheta1, "dtheta1"),
+            "dphi1": parse_float(self.inp_dphi1, "dphi1"),
+            "dphi2": parse_float(self.inp_dphi2, "dphi2"),
+            "shoulder_coeffs": parse_coeffs(self.inp_tau_shoulder, "Shoulder torque"),
+            "elbow_coeffs": parse_coeffs(self.inp_tau_elbow, "Elbow torque"),
+            "wrist_coeffs": parse_coeffs(self.inp_tau_wrist, "Wrist torque"),
+            "t_end": parse_float(self.inp_tend, "Duration"),
+        }
+
+    def _update_torque_preview(self) -> None:
+        try:
+            t_end = float(self.inp_tend.value)
+        except ValueError:
+            t_end = 2.0
+
+        def parse_coeffs(widget: LabeledInput) -> list:
+            parts = widget.value.split(",")
+            coeffs = []
+            for part in parts:
+                part = part.strip()
+                if not part:
+                    continue
+                try:
+                    coeffs.append(float(part))
+                except ValueError:
+                    return []
+            return coeffs or [0.0]
+
+        shoulder = parse_coeffs(self.inp_tau_shoulder)
+        elbow = parse_coeffs(self.inp_tau_elbow)
+        wrist = parse_coeffs(self.inp_tau_wrist)
+
+        self.torque_preview.set_duration(t_end)
+        self.torque_preview.set_profiles([
+            ("Shoulder", shoulder, QColor(230, 120, 50)),
+            ("Elbow", elbow, QColor(120, 200, 140)),
+            ("Wrist", wrist, QColor(120, 180, 230)),
+        ])
+
+    def _on_play_toggled(self, checked: bool) -> None:
+        self._is_playing = checked
+        self.btn_play.setText("Pause" if checked else "Play")
+        self.play_toggled.emit(checked)
+
+    def set_slider_range(self, max_val: int) -> None:
+        self.slider.setRange(0, max_val)
+
+    def set_slider_value(self, val: int) -> None:
+        self.slider.blockSignals(True)
+        self.slider.setValue(val)
+        self.slider.blockSignals(False)
+
+    def stop_playback(self) -> None:
+        self.btn_play.setChecked(False)

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/main_window.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/main_window.py
@@ -1,0 +1,156 @@
+"""
+Main application window for the Double Pendulum Golf Swing Simulator.
+
+Orchestrates the three sub-widgets (PendulumWidget, MatrixWidget,
+ControlsWidget), manages the simulation lifecycle, and drives the
+animation timer.
+"""
+
+import numpy as np
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QFont
+from PyQt6.QtWidgets import (
+    QMainWindow, QWidget, QVBoxLayout,
+    QStatusBar, QLabel, QTabWidget,
+)
+
+from ..physics import PendulumParams
+from ..physics_triple import TriplePendulumParams
+from ..simulation import make_polynomial_torque, run_simulation
+from ..simulation_triple import make_polynomial_torque as make_polynomial_torque_triple
+from ..simulation_triple import run_simulation as run_simulation_triple
+from .controls_widget import ControlsWidget
+from .controls_widget_triple import ControlsWidgetTriple
+from .matrix_widget import MatrixWidget
+from .matrix_widget_triple import TripleMatrixWidget
+from .pendulum_widget import PendulumWidget
+from .simulation_panel import SimulationPanel
+from .torque_history_widget import TorqueHistoryWidget
+
+
+class MainWindow(QMainWindow):
+    """Top-level window for the double pendulum simulator.
+
+    Layout:
+        ┌───────────────────────────────────────────────────┐
+        │  Title Bar                                         │
+        ├──────────┬──────────────────┬─────────────────────┤
+        │ Controls │  Pendulum Canvas │  Mass Matrix Panel   │
+        │  (input  │  (animation)     │  (real-time values) │
+        │   panel) │                  │                      │
+        ├──────────┴──────────────────┴─────────────────────┤
+        │  Status Bar                                        │
+        └───────────────────────────────────────────────────┘
+    """
+
+    WINDOW_TITLE = "Double Pendulum — Golf Swing Dynamics"
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle(self.WINDOW_TITLE)
+        self.resize(1200, 700)
+        self.setMinimumSize(900, 550)
+        self._set_dark_theme()
+
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _set_dark_theme(self) -> None:
+        self.setStyleSheet("""
+            QMainWindow { background: #1a1a24; }
+            QStatusBar { background: #1a1a24; color: #9090b0; font-size: 11px; }
+            QSplitter::handle { background: #303048; width: 3px; }
+            QLabel { color: #c0c0d8; }
+        """)
+
+    def _build_ui(self) -> None:
+        # Central widget
+        central = QWidget()
+        self.setCentralWidget(central)
+        main_layout = QVBoxLayout(central)
+        main_layout.setContentsMargins(6, 6, 6, 6)
+
+        # Title
+        title = QLabel(self.WINDOW_TITLE)
+        title.setFont(QFont("Sans", 16, QFont.Weight.Bold))
+        title.setStyleSheet("color: #d0d0e8; padding: 4px;")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        main_layout.addWidget(title)
+
+        tabs = QTabWidget()
+        tabs.addTab(self._build_double_panel(), "Double Pendulum")
+        tabs.addTab(self._build_triple_panel(), "Triple Pendulum")
+        main_layout.addWidget(tabs, stretch=1)
+
+        # Status bar
+        self.status = QStatusBar()
+        self.setStatusBar(self.status)
+        self.status.showMessage("Ready — configure parameters and run simulation")
+
+    def _build_double_panel(self) -> SimulationPanel:
+        controls = ControlsWidget()
+        pendulum = PendulumWidget()
+        matrix = MatrixWidget()
+        torque_history = TorqueHistoryWidget()
+
+        def build_params(p: dict) -> PendulumParams:
+            return PendulumParams(
+                m1=p["m1"], m2=p["m2"],
+                L1=p["L1"], L2=p["L2"],
+                b1=p.get("b1", 0.0), b2=p.get("b2", 0.0),
+                mu1=p.get("mu1", 0.0), mu2=p.get("mu2", 0.0),
+            )
+
+        def build_state(p: dict) -> np.ndarray:
+            return np.array([
+                p["theta1_rad"], p["phi_rad"],
+                p["dtheta1"], p["dphi"],
+            ])
+
+        def build_torque(p: dict):
+            return make_polynomial_torque(p["shoulder_coeffs"], p["wrist_coeffs"])
+
+        return SimulationPanel(
+            controls=controls,
+            pendulum=pendulum,
+            matrix=matrix,
+            params_builder=build_params,
+            torque_builder=build_torque,
+            state_builder=build_state,
+            run_simulation=run_simulation,
+            torque_history=torque_history,
+        )
+
+    def _build_triple_panel(self) -> SimulationPanel:
+        controls = ControlsWidgetTriple()
+        pendulum = PendulumWidget()
+        matrix = TripleMatrixWidget()
+
+        def build_params(p: dict) -> TriplePendulumParams:
+            return TriplePendulumParams(
+                m1=p["m1"], m2=p["m2"], m3=p["m3"],
+                L1=p["L1"], L2=p["L2"], L3=p["L3"],
+            )
+
+        def build_state(p: dict) -> np.ndarray:
+            return np.array([
+                p["theta1_rad"], p["phi1_rad"], p["phi2_rad"],
+                p["dtheta1"], p["dphi1"], p["dphi2"],
+            ])
+
+        def build_torque(p: dict):
+            return make_polynomial_torque_triple(
+                p["shoulder_coeffs"], p["elbow_coeffs"], p["wrist_coeffs"]
+            )
+
+        return SimulationPanel(
+            controls=controls,
+            pendulum=pendulum,
+            matrix=matrix,
+            params_builder=build_params,
+            torque_builder=build_torque,
+            state_builder=build_state,
+            run_simulation=run_simulation_triple,
+        )

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/matrix_widget.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/matrix_widget.py
@@ -1,0 +1,244 @@
+"""
+Widget that displays the 2x2 mass matrix with real-time values,
+color-coded to distinguish diagonal (self-coupling) from off-diagonal
+(cross-coupling) terms.
+
+Also displays Coriolis/centrifugal and gravity vectors, plus applied
+torques, giving a complete picture of the force balance at each instant.
+"""
+
+from typing import Optional
+
+import numpy as np
+from PyQt6.QtCore import Qt, QRectF
+from PyQt6.QtGui import QPainter, QPen, QBrush, QColor, QFont
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel, QGroupBox, QGridLayout
+
+from ..simulation import SimulationResult
+
+
+class MatrixWidget(QWidget):
+    """Displays the mass matrix and force decomposition in real time.
+
+    The mass matrix is rendered as a 2x2 grid:
+        - Diagonal terms (M11, M22) in blue — self-coupling
+        - Off-diagonal terms (M12, M21) in orange — cross-coupling
+
+    Below the matrix, the current torque balance is shown:
+        M * qddot = tau - C(q,qdot)*qdot - G(q)
+    """
+
+    COLOR_DIAGONAL = QColor(70, 130, 230)
+    COLOR_OFFDIAG = QColor(230, 160, 50)
+    COLOR_BG = QColor(30, 30, 40)
+    COLOR_CELL_BG_DIAG = QColor(40, 55, 80)
+    COLOR_CELL_BG_OFF = QColor(80, 60, 30)
+    COLOR_TEXT = QColor(220, 220, 235)
+    COLOR_LABEL = QColor(160, 160, 180)
+    COLOR_BRACKET = QColor(120, 120, 140)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumSize(340, 500)
+        self._result: Optional[SimulationResult] = None
+        self._current_idx: int = 0
+
+    def set_simulation(self, result: SimulationResult) -> None:
+        self._result = result
+        self._current_idx = 0
+        self.update()
+
+    def set_frame(self, idx: int) -> None:
+        if self._result is None:
+            return
+        self._current_idx = max(0, min(idx, self._result.n_steps - 1))
+        self.update()
+
+    def clear(self) -> None:
+        self._result = None
+        self._current_idx = 0
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.fillRect(self.rect(), self.COLOR_BG)
+
+        if self._result is None:
+            painter.setPen(self.COLOR_LABEL)
+            painter.setFont(QFont("Sans", 11))
+            painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter,
+                             "No simulation loaded")
+            painter.end()
+            return
+
+        mc = self._result.mass_matrix_at(self._current_idx)
+        y_cursor = 10
+
+        y_cursor = self._draw_section_title(painter, "Mass Matrix M(q)", y_cursor)
+        y_cursor = self._draw_matrix(painter, mc, y_cursor)
+        y_cursor += 10
+
+        y_cursor = self._draw_section_title(painter, "Coupling Ratio", y_cursor)
+        y_cursor = self._draw_coupling_ratio(painter, mc, y_cursor)
+        y_cursor += 10
+
+        y_cursor = self._draw_section_title(painter, "Force Balance", y_cursor)
+        y_cursor = self._draw_force_balance(painter, y_cursor)
+        y_cursor += 10
+
+        y_cursor = self._draw_section_title(painter, "Energy", y_cursor)
+        y_cursor = self._draw_energy(painter, y_cursor)
+
+        painter.end()
+
+    # ------------------------------------------------------------------
+    # Drawing helpers
+    # ------------------------------------------------------------------
+
+    def _draw_section_title(self, painter: QPainter, title: str,
+                            y: int) -> int:
+        """Draw a section title and return new y cursor."""
+        painter.setPen(self.COLOR_TEXT)
+        font = QFont("Sans", 11, QFont.Weight.Bold)
+        painter.setFont(font)
+        painter.drawText(15, y + 16, title)
+        # underline
+        painter.setPen(QPen(self.COLOR_BRACKET, 1))
+        painter.drawLine(15, y + 20, self.width() - 15, y + 20)
+        return y + 28
+
+    def _draw_matrix(self, painter: QPainter, mc: dict, y: int) -> int:
+        """Draw the 2x2 mass matrix as colored cells."""
+        cell_w = 130
+        cell_h = 50
+        margin_x = (self.width() - 2 * cell_w - 30) // 2
+        bracket_w = 8
+
+        entries = [
+            (0, 0, "M11", mc["M11"], True),
+            (0, 1, "M12", mc["M12"], False),
+            (1, 0, "M21", mc["M21"], False),
+            (1, 1, "M22", mc["M22"], True),
+        ]
+
+        # Draw bracket lines
+        bx_left = margin_x - bracket_w - 4
+        bx_right = margin_x + 2 * cell_w + 10 + bracket_w + 4
+        by_top = y
+        by_bot = y + 2 * cell_h + 10
+
+        painter.setPen(QPen(self.COLOR_BRACKET, 2))
+        # Left bracket
+        painter.drawLine(bx_left + bracket_w, by_top, bx_left, by_top)
+        painter.drawLine(bx_left, by_top, bx_left, by_bot)
+        painter.drawLine(bx_left, by_bot, bx_left + bracket_w, by_bot)
+        # Right bracket
+        painter.drawLine(bx_right - bracket_w, by_top, bx_right, by_top)
+        painter.drawLine(bx_right, by_top, bx_right, by_bot)
+        painter.drawLine(bx_right, by_bot, bx_right - bracket_w, by_bot)
+
+        for row, col, label, value, is_diag in entries:
+            cx = margin_x + col * (cell_w + 10)
+            cy = y + row * (cell_h + 10)
+
+            bg = self.COLOR_CELL_BG_DIAG if is_diag else self.COLOR_CELL_BG_OFF
+            border = self.COLOR_DIAGONAL if is_diag else self.COLOR_OFFDIAG
+
+            # Cell background
+            rect = QRectF(cx, cy, cell_w, cell_h)
+            painter.setPen(QPen(border, 2))
+            painter.setBrush(QBrush(bg))
+            painter.drawRoundedRect(rect, 6, 6)
+
+            # Label
+            painter.setPen(self.COLOR_LABEL)
+            font_label = QFont("Monospace", 8)
+            painter.setFont(font_label)
+            painter.drawText(cx + 5, cy + 14, label)
+
+            # Value
+            painter.setPen(self.COLOR_TEXT)
+            font_val = QFont("Monospace", 14, QFont.Weight.Bold)
+            painter.setFont(font_val)
+            painter.drawText(cx + 5, cy + 38, f"{value:.3f}")
+
+        # Legend
+        ly = y + 2 * cell_h + 20
+        painter.setFont(QFont("Sans", 9))
+
+        painter.setPen(self.COLOR_DIAGONAL)
+        painter.drawText(margin_x, ly, "\u25a0 Diagonal (self-coupling)")
+
+        painter.setPen(self.COLOR_OFFDIAG)
+        painter.drawText(margin_x, ly + 16, "\u25a0 Off-diagonal (cross-coupling)")
+
+        return ly + 32
+
+    def _draw_coupling_ratio(self, painter: QPainter, mc: dict,
+                             y: int) -> int:
+        """Draw the ratio |M12/M11| as a bar and percentage."""
+        ratio = abs(mc["M12"]) / mc["M11"] if mc["M11"] > 1e-12 else 0.0
+        ratio = min(ratio, 1.0)
+
+        bar_x = 20
+        bar_w = self.width() - 40
+        bar_h = 22
+
+        # Background bar
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QBrush(QColor(50, 50, 60)))
+        painter.drawRoundedRect(QRectF(bar_x, y, bar_w, bar_h), 4, 4)
+
+        # Filled portion
+        painter.setBrush(QBrush(self.COLOR_OFFDIAG))
+        painter.drawRoundedRect(QRectF(bar_x, y, bar_w * ratio, bar_h), 4, 4)
+
+        # Text
+        painter.setPen(self.COLOR_TEXT)
+        painter.setFont(QFont("Monospace", 10, QFont.Weight.Bold))
+        painter.drawText(
+            QRectF(bar_x, y, bar_w, bar_h),
+            Qt.AlignmentFlag.AlignCenter,
+            f"|M12/M11| = {ratio:.1%}",
+        )
+
+        return y + bar_h + 6
+
+    def _draw_force_balance(self, painter: QPainter, y: int) -> int:
+        """Draw the torque, Coriolis, and gravity vectors."""
+        idx = self._current_idx
+        tau = self._result.torques_at(idx)
+        C = self._result.coriolis_at(idx)
+        G = self._result.gravity_at(idx)
+
+        painter.setFont(QFont("Monospace", 10))
+        lines = [
+            (f"\u03c41 (shoulder) = {tau[0]:+8.2f} N\u00b7m", self.COLOR_TEXT),
+            (f"\u03c42 (wrist)    = {tau[1]:+8.2f} N\u00b7m", self.COLOR_TEXT),
+            (f"C1 (Coriolis)  = {C[0]:+8.2f} N\u00b7m", QColor(180, 130, 200)),
+            (f"C2 (Coriolis)  = {C[1]:+8.2f} N\u00b7m", QColor(180, 130, 200)),
+            (f"G1 (gravity)   = {G[0]:+8.2f} N\u00b7m", QColor(130, 200, 130)),
+            (f"G2 (gravity)   = {G[1]:+8.2f} N\u00b7m", QColor(130, 200, 130)),
+        ]
+        for text, color in lines:
+            painter.setPen(color)
+            painter.drawText(20, y + 14, text)
+            y += 18
+
+        return y + 4
+
+    def _draw_energy(self, painter: QPainter, y: int) -> int:
+        """Draw kinetic, potential, and total energy."""
+        e = self._result.energy_at(self._current_idx)
+        painter.setFont(QFont("Monospace", 10))
+        lines = [
+            (f"Kinetic    = {e['kinetic']:+8.2f} J", QColor(230, 160, 80)),
+            (f"Potential  = {e['potential']:+8.2f} J", QColor(80, 180, 230)),
+            (f"Total      = {e['total']:+8.2f} J", self.COLOR_TEXT),
+        ]
+        for text, color in lines:
+            painter.setPen(color)
+            painter.drawText(20, y + 14, text)
+            y += 18
+        return y + 4

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/matrix_widget_triple.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/matrix_widget_triple.py
@@ -1,0 +1,223 @@
+"""
+Widget that displays the 3x3 mass matrix with real-time values,
+color-coded to distinguish diagonal (self-coupling) from off-diagonal
+(cross-coupling) terms.
+"""
+
+from typing import Optional
+
+import numpy as np
+from PyQt6.QtCore import Qt, QRectF
+from PyQt6.QtGui import QPainter, QPen, QBrush, QColor, QFont
+from PyQt6.QtWidgets import QWidget
+
+from ..simulation_triple import TripleSimulationResult
+
+
+class TripleMatrixWidget(QWidget):
+    """Displays the mass matrix and force decomposition in real time."""
+
+    COLOR_DIAGONAL = QColor(70, 130, 230)
+    COLOR_OFFDIAG = QColor(230, 160, 50)
+    COLOR_BG = QColor(30, 30, 40)
+    COLOR_CELL_BG_DIAG = QColor(40, 55, 80)
+    COLOR_CELL_BG_OFF = QColor(80, 60, 30)
+    COLOR_TEXT = QColor(220, 220, 235)
+    COLOR_LABEL = QColor(160, 160, 180)
+    COLOR_BRACKET = QColor(120, 120, 140)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumSize(360, 520)
+        self._result: Optional[TripleSimulationResult] = None
+        self._current_idx: int = 0
+
+    def set_simulation(self, result: TripleSimulationResult) -> None:
+        self._result = result
+        self._current_idx = 0
+        self.update()
+
+    def set_frame(self, idx: int) -> None:
+        if self._result is None:
+            return
+        self._current_idx = max(0, min(idx, self._result.n_steps - 1))
+        self.update()
+
+    def clear(self) -> None:
+        self._result = None
+        self._current_idx = 0
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.fillRect(self.rect(), self.COLOR_BG)
+
+        if self._result is None:
+            painter.setPen(self.COLOR_LABEL)
+            painter.setFont(QFont("Sans", 11))
+            painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter,
+                             "No simulation loaded")
+            painter.end()
+            return
+
+        mc = self._result.mass_matrix_at(self._current_idx)
+        y_cursor = 10
+
+        y_cursor = self._draw_section_title(painter, "Mass Matrix M(q)", y_cursor)
+        y_cursor = self._draw_matrix(painter, mc, y_cursor)
+        y_cursor += 10
+
+        y_cursor = self._draw_section_title(painter, "Coupling Ratio", y_cursor)
+        y_cursor = self._draw_coupling_ratio(painter, mc, y_cursor)
+        y_cursor += 10
+
+        y_cursor = self._draw_section_title(painter, "Force Balance", y_cursor)
+        y_cursor = self._draw_force_balance(painter, y_cursor)
+        y_cursor += 10
+
+        y_cursor = self._draw_section_title(painter, "Energy", y_cursor)
+        y_cursor = self._draw_energy(painter, y_cursor)
+
+        painter.end()
+
+    def _draw_section_title(self, painter: QPainter, title: str,
+                            y: int) -> int:
+        painter.setPen(self.COLOR_TEXT)
+        painter.setFont(QFont("Sans", 11, QFont.Weight.Bold))
+        painter.drawText(15, y + 16, title)
+        painter.setPen(QPen(self.COLOR_BRACKET, 1))
+        painter.drawLine(15, y + 20, self.width() - 15, y + 20)
+        return y + 28
+
+    def _draw_matrix(self, painter: QPainter, mc: dict, y: int) -> int:
+        cell_w = 100
+        cell_h = 44
+        gap = 8
+        grid_w = 3 * cell_w + 2 * gap
+        margin_x = (self.width() - grid_w) // 2
+        bracket_w = 8
+
+        entries = [
+            (0, 0, "M11", mc["M11"], True),
+            (0, 1, "M12", mc["M12"], False),
+            (0, 2, "M13", mc["M13"], False),
+            (1, 0, "M21", mc["M21"], False),
+            (1, 1, "M22", mc["M22"], True),
+            (1, 2, "M23", mc["M23"], False),
+            (2, 0, "M31", mc["M31"], False),
+            (2, 1, "M32", mc["M32"], False),
+            (2, 2, "M33", mc["M33"], True),
+        ]
+
+        bx_left = margin_x - bracket_w - 4
+        bx_right = margin_x + grid_w + bracket_w + 4
+        by_top = y
+        by_bot = y + 3 * cell_h + 2 * gap
+
+        painter.setPen(QPen(self.COLOR_BRACKET, 2))
+        painter.drawLine(bx_left + bracket_w, by_top, bx_left, by_top)
+        painter.drawLine(bx_left, by_top, bx_left, by_bot)
+        painter.drawLine(bx_left, by_bot, bx_left + bracket_w, by_bot)
+        painter.drawLine(bx_right - bracket_w, by_top, bx_right, by_top)
+        painter.drawLine(bx_right, by_top, bx_right, by_bot)
+        painter.drawLine(bx_right, by_bot, bx_right - bracket_w, by_bot)
+
+        for row, col, label, value, is_diag in entries:
+            cx = margin_x + col * (cell_w + gap)
+            cy = y + row * (cell_h + gap)
+
+            bg = self.COLOR_CELL_BG_DIAG if is_diag else self.COLOR_CELL_BG_OFF
+            border = self.COLOR_DIAGONAL if is_diag else self.COLOR_OFFDIAG
+
+            rect = QRectF(cx, cy, cell_w, cell_h)
+            painter.setPen(QPen(border, 2))
+            painter.setBrush(QBrush(bg))
+            painter.drawRoundedRect(rect, 6, 6)
+
+            painter.setPen(self.COLOR_LABEL)
+            painter.setFont(QFont("Monospace", 8))
+            painter.drawText(cx + 5, cy + 14, label)
+
+            painter.setPen(self.COLOR_TEXT)
+            painter.setFont(QFont("Monospace", 12, QFont.Weight.Bold))
+            painter.drawText(cx + 5, cy + 34, f"{value:.3f}")
+
+        ly = y + 3 * cell_h + 2 * gap + 16
+        painter.setFont(QFont("Sans", 9))
+        painter.setPen(self.COLOR_DIAGONAL)
+        painter.drawText(margin_x, ly, "[ ] Diagonal (self-coupling)")
+        painter.setPen(self.COLOR_OFFDIAG)
+        painter.drawText(margin_x, ly + 16, "[ ] Off-diagonal (cross-coupling)")
+
+        return ly + 32
+
+    def _draw_coupling_ratio(self, painter: QPainter, mc: dict,
+                             y: int) -> int:
+        diag = np.array([mc["M11"], mc["M22"], mc["M33"]])
+        off = np.array([
+            mc["M12"], mc["M13"], mc["M21"],
+            mc["M23"], mc["M31"], mc["M32"],
+        ])
+        denom = np.mean(np.abs(diag)) if np.any(diag) else 1.0
+        ratio = min(np.mean(np.abs(off)) / max(denom, 1e-12), 1.0)
+
+        bar_x = 20
+        bar_w = self.width() - 40
+        bar_h = 22
+
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QBrush(QColor(50, 50, 60)))
+        painter.drawRoundedRect(QRectF(bar_x, y, bar_w, bar_h), 4, 4)
+
+        painter.setBrush(QBrush(self.COLOR_OFFDIAG))
+        painter.drawRoundedRect(QRectF(bar_x, y, bar_w * ratio, bar_h), 4, 4)
+
+        painter.setPen(self.COLOR_TEXT)
+        painter.setFont(QFont("Monospace", 10, QFont.Weight.Bold))
+        painter.drawText(
+            QRectF(bar_x, y, bar_w, bar_h),
+            Qt.AlignmentFlag.AlignCenter,
+            f"avg |Moff|/|Mdiag| = {ratio:.1%}",
+        )
+
+        return y + bar_h + 6
+
+    def _draw_force_balance(self, painter: QPainter, y: int) -> int:
+        idx = self._current_idx
+        tau = self._result.torques_at(idx)
+        C = self._result.coriolis_at(idx)
+        G = self._result.gravity_at(idx)
+
+        painter.setFont(QFont("Monospace", 10))
+        lines = [
+            (f"tau1 (shoulder) = {tau[0]:+8.2f} N*m", self.COLOR_TEXT),
+            (f"tau2 (elbow)    = {tau[1]:+8.2f} N*m", self.COLOR_TEXT),
+            (f"tau3 (wrist)    = {tau[2]:+8.2f} N*m", self.COLOR_TEXT),
+            (f"C1 (Coriolis)   = {C[0]:+8.2f} N*m", QColor(180, 130, 200)),
+            (f"C2 (Coriolis)   = {C[1]:+8.2f} N*m", QColor(180, 130, 200)),
+            (f"C3 (Coriolis)   = {C[2]:+8.2f} N*m", QColor(180, 130, 200)),
+            (f"G1 (gravity)    = {G[0]:+8.2f} N*m", QColor(130, 200, 130)),
+            (f"G2 (gravity)    = {G[1]:+8.2f} N*m", QColor(130, 200, 130)),
+            (f"G3 (gravity)    = {G[2]:+8.2f} N*m", QColor(130, 200, 130)),
+        ]
+        for text, color in lines:
+            painter.setPen(color)
+            painter.drawText(20, y + 14, text)
+            y += 18
+
+        return y + 4
+
+    def _draw_energy(self, painter: QPainter, y: int) -> int:
+        e = self._result.energy_at(self._current_idx)
+        painter.setFont(QFont("Monospace", 10))
+        lines = [
+            (f"Kinetic    = {e['kinetic']:+8.2f} J", QColor(230, 160, 80)),
+            (f"Potential  = {e['potential']:+8.2f} J", QColor(80, 180, 230)),
+            (f"Total      = {e['total']:+8.2f} J", self.COLOR_TEXT),
+        ]
+        for text, color in lines:
+            painter.setPen(color)
+            painter.drawText(20, y + 14, text)
+            y += 18
+        return y + 4

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/pendulum_widget.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/pendulum_widget.py
@@ -1,0 +1,317 @@
+"""
+Custom QWidget that draws the double pendulum animation.
+
+Renders the two segments, joint markers, a tip trail, and
+optional ghosted past positions.  Coordinate mapping converts
+physics-frame meters into pixel space with configurable scale.
+"""
+
+from collections import deque
+from typing import Optional
+
+from PyQt6.QtCore import Qt, QPointF, QRectF
+from PyQt6.QtGui import QPainter, QPen, QBrush, QColor, QFont, QPainterPath
+from PyQt6.QtWidgets import QWidget
+
+from ..simulation import SimulationResult
+
+
+class PendulumWidget(QWidget):
+    """Animated visualization of the double pendulum.
+
+    Draws shoulder (fixed pivot), arm segment, wrist joint, club segment,
+    and club tip with a fading trail showing recent trajectory.
+    """
+
+    # Color palette
+    COLOR_BG = QColor(20, 20, 30)
+    COLOR_ARM = QColor(70, 130, 230)
+    COLOR_CLUB = QColor(230, 120, 50)
+    COLOR_SHOULDER = QColor(200, 200, 200)
+    COLOR_WRIST = QColor(255, 220, 80)
+    COLOR_WRIST2 = QColor(120, 220, 180)
+    COLOR_TIP = QColor(255, 80, 80)
+    COLOR_TRAIL = QColor(255, 80, 80, 120)
+    COLOR_GRID = QColor(50, 50, 65)
+    COLOR_TEXT = QColor(180, 180, 200)
+    COLOR_GROUND = QColor(40, 100, 40, 80)
+
+    TRAIL_LENGTH = 200
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumSize(400, 500)
+
+        self._result: Optional[SimulationResult] = None
+        self._current_idx: int = 0
+        self._trail: deque = deque(maxlen=self.TRAIL_LENGTH)
+        self._pixels_per_meter: float = 120.0
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def set_simulation(self, result: SimulationResult) -> None:
+        """Load a new simulation result and reset display."""
+        assert result is not None
+        self._result = result
+        self._current_idx = 0
+        self._trail.clear()
+        self.update()
+
+    def set_frame(self, idx: int) -> None:
+        """Advance to frame idx and update the trail."""
+        if self._result is None:
+            return
+        idx = max(0, min(idx, self._result.n_steps - 1))
+
+        # Build trail: add tip position
+        pos = self._result.positions_at(idx)
+        self._trail.append(pos["tip"])
+        self._current_idx = idx
+        self.update()
+
+    def clear(self) -> None:
+        """Reset to blank state."""
+        self._result = None
+        self._current_idx = 0
+        self._trail.clear()
+        self.update()
+
+    # ------------------------------------------------------------------
+    # Coordinate mapping
+    # ------------------------------------------------------------------
+
+    def _world_to_pixel(self, x_world: float, y_world: float) -> QPointF:
+        """Convert physics (x_right, y_up) to widget pixel coords (x_right, y_down).
+
+        Origin (shoulder) is placed at top-center of the widget.
+        """
+        cx = self.width() / 2.0
+        cy = self.height() * 0.2  # shoulder 20% down from top
+        px = cx + x_world * self._pixels_per_meter
+        py = cy - y_world * self._pixels_per_meter  # flip y
+        return QPointF(px, py)
+
+    # ------------------------------------------------------------------
+    # Painting
+    # ------------------------------------------------------------------
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
+        # Background
+        painter.fillRect(self.rect(), self.COLOR_BG)
+
+        self._draw_grid(painter)
+        self._draw_ground_line(painter)
+
+        if self._result is None:
+            self._draw_placeholder(painter)
+            painter.end()
+            return
+
+        self._draw_trail(painter)
+        self._draw_pendulum(painter)
+        self._draw_info(painter)
+        painter.end()
+
+    def _draw_grid(self, painter: QPainter) -> None:
+        """Draw subtle reference grid lines every 0.5m."""
+        pen = QPen(self.COLOR_GRID, 1, Qt.PenStyle.DotLine)
+        painter.setPen(pen)
+
+        max_range = 3.0  # meters
+        step = 0.5
+        r = max_range
+        while r > -max_range:
+            # Horizontal lines
+            p1 = self._world_to_pixel(-max_range, r)
+            p2 = self._world_to_pixel(max_range, r)
+            painter.drawLine(p1, p2)
+            # Vertical lines
+            p1 = self._world_to_pixel(r, max_range)
+            p2 = self._world_to_pixel(r, -max_range)
+            painter.drawLine(p1, p2)
+            r -= step
+
+    def _draw_ground_line(self, painter: QPainter) -> None:
+        """Draw a ground reference at y = -(L1+L2) to show full extension."""
+        if self._result is None:
+            return
+        L_total = self._result.params.L1 + self._result.params.L2
+        p1 = self._world_to_pixel(-3.0, -L_total)
+        p2 = self._world_to_pixel(3.0, -L_total)
+        pen = QPen(self.COLOR_GROUND, 2, Qt.PenStyle.DashLine)
+        painter.setPen(pen)
+        painter.drawLine(p1, p2)
+
+    def _draw_trail(self, painter: QPainter) -> None:
+        """Draw fading trail of the club tip."""
+        n = len(self._trail)
+        if n < 2:
+            return
+        for i in range(1, n):
+            alpha = int(40 + 160 * (i / n))
+            color = QColor(255, 80, 80, alpha)
+            width = 1.0 + 2.0 * (i / n)
+            pen = QPen(color, width)
+            painter.setPen(pen)
+            x0, y0 = self._trail[i - 1]
+            x1, y1 = self._trail[i]
+            painter.drawLine(
+                self._world_to_pixel(x0, y0),
+                self._world_to_pixel(x1, y1),
+            )
+
+    def _draw_pendulum(self, painter: QPainter) -> None:
+        """Draw the segments and joint markers."""
+        pos = self._result.positions_at(self._current_idx)
+        shoulder = self._world_to_pixel(*pos["shoulder"])
+        tip = self._world_to_pixel(*pos["tip"])
+
+        wrist2 = None
+        if "wrist2" in pos:
+            wrist1 = self._world_to_pixel(*pos["wrist1"])
+            wrist2 = self._world_to_pixel(*pos["wrist2"])
+        else:
+            wrist1 = self._world_to_pixel(*pos["wrist"])
+
+        # Arm segment
+        pen = QPen(self.COLOR_ARM, 5, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap)
+        painter.setPen(pen)
+        painter.drawLine(shoulder, wrist1)
+
+        if wrist2 is None:
+            # Club segment
+            pen = QPen(self.COLOR_CLUB, 4, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap)
+            painter.setPen(pen)
+            painter.drawLine(wrist1, tip)
+        else:
+            # Segment 2
+            pen = QPen(self.COLOR_CLUB, 4, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap)
+            painter.setPen(pen)
+            painter.drawLine(wrist1, wrist2)
+
+            # Segment 3
+            pen = QPen(self.COLOR_TIP, 3, Qt.PenStyle.SolidLine, Qt.PenCapStyle.RoundCap)
+            painter.setPen(pen)
+            painter.drawLine(wrist2, tip)
+
+        # Joint markers
+        self._draw_joint(painter, shoulder, 8, self.COLOR_SHOULDER)
+        self._draw_joint(painter, wrist1, 6, self.COLOR_WRIST)
+        if wrist2 is not None:
+            self._draw_joint(painter, wrist2, 5, self.COLOR_WRIST2)
+        self._draw_joint(painter, tip, 5, self.COLOR_TIP)
+
+        self._draw_force_vectors(painter, pos)
+
+    def _draw_joint(self, painter: QPainter, pos: QPointF,
+                    radius: int, color: QColor) -> None:
+        """Draw a filled circle at a joint position."""
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QBrush(color))
+        painter.drawEllipse(pos, radius, radius)
+
+    def _draw_info(self, painter: QPainter) -> None:
+        """Draw time and angle readout in the corner."""
+        t = self._result.t[self._current_idx]
+        s = self._result.states[self._current_idx]
+        theta1_deg = np.degrees(s[0])
+        phi_deg = np.degrees(s[1])
+
+        font = QFont("Monospace", 10)
+        painter.setFont(font)
+        painter.setPen(self.COLOR_TEXT)
+
+        lines = [f"t = {t:.3f} s", f"\u03b81 = {theta1_deg:+.1f}\u00b0"]
+
+        if s.shape[0] >= 6:
+            phi2_deg = np.degrees(s[2])
+            lines += [
+                f"\u03c61 = {phi_deg:+.1f}\u00b0",
+                f"\u03c62 = {phi2_deg:+.1f}\u00b0",
+                f"d\u03b81 = {s[3]:+.2f} rad/s",
+                f"d\u03c61 = {s[4]:+.2f} rad/s",
+                f"d\u03c62 = {s[5]:+.2f} rad/s",
+            ]
+        else:
+            lines += [
+                f"\u03c6  = {phi_deg:+.1f}\u00b0",
+                f"d\u03b81 = {s[2]:+.2f} rad/s",
+                f"d\u03c6  = {s[3]:+.2f} rad/s",
+            ]
+
+        y = 20
+        for line in lines:
+            painter.drawText(10, y, line)
+            y += 18
+
+    def _draw_placeholder(self, painter: QPainter) -> None:
+        """Draw message when no simulation is loaded."""
+        font = QFont("Sans", 14)
+        painter.setFont(font)
+        painter.setPen(self.COLOR_TEXT)
+        painter.drawText(
+            self.rect(), Qt.AlignmentFlag.AlignCenter,
+            "Configure parameters\nand click 'Run Simulation'"
+        )
+
+    def _draw_force_vectors(self, painter: QPainter, pos: dict) -> None:
+        """Draw net force vectors at joints (proximal acting on distal)."""
+        if not hasattr(self._result, "joint_forces_at"):
+            return
+        forces = self._result.joint_forces_at(self._current_idx)
+        if not forces:
+            return
+
+        magnitudes = [np.hypot(f[0], f[1]) for f in forces.values()]
+        max_mag = max(1.0, max(magnitudes))
+        scale = 0.3 * self._pixels_per_meter / max_mag
+
+        joint_map = {
+            "shoulder": pos.get("shoulder"),
+            "wrist": pos.get("wrist"),
+            "wrist1": pos.get("wrist1"),
+            "wrist2": pos.get("wrist2"),
+        }
+
+        painter.setPen(QPen(QColor(200, 240, 120), 2))
+        for key, force in forces.items():
+            if key not in joint_map or joint_map[key] is None:
+                continue
+            fx, fy = force
+            origin = joint_map[key]
+            end = (origin[0] + fx * scale / self._pixels_per_meter,
+                   origin[1] + fy * scale / self._pixels_per_meter)
+            self._draw_arrow(painter, origin, end)
+
+    def _draw_arrow(self, painter: QPainter, origin: tuple, end: tuple) -> None:
+        """Draw an arrow from origin to end in world coordinates."""
+        p0 = self._world_to_pixel(origin[0], origin[1])
+        p1 = self._world_to_pixel(end[0], end[1])
+        painter.drawLine(p0, p1)
+
+        dx = p1.x() - p0.x()
+        dy = p1.y() - p0.y()
+        length = max(1.0, (dx * dx + dy * dy) ** 0.5)
+        ux = dx / length
+        uy = dy / length
+        size = 8.0
+
+        left = QPointF(
+            p1.x() - size * (ux * 0.7 + uy * 0.7),
+            p1.y() - size * (uy * 0.7 - ux * 0.7),
+        )
+        right = QPointF(
+            p1.x() - size * (ux * 0.7 - uy * 0.7),
+            p1.y() - size * (uy * 0.7 + ux * 0.7),
+        )
+        painter.drawLine(p1, left)
+        painter.drawLine(p1, right)
+
+
+# Need numpy for degrees conversion in _draw_info
+import numpy as np

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/simulation_panel.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/simulation_panel.py
@@ -1,0 +1,334 @@
+"""
+Shared simulation panel for double and triple pendulum tabs.
+"""
+
+import csv
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Callable
+
+import numpy as np
+from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtWidgets import (
+    QWidget, QHBoxLayout, QMessageBox, QSplitter,
+    QFileDialog, QApplication,
+)
+
+
+class SimulationPanel(QWidget):
+    """Reusable panel that hosts controls, pendulum, and matrix widgets."""
+
+    ANIMATION_INTERVAL_MS = 16  # ~60 fps
+
+    def __init__(
+        self,
+        controls: QWidget,
+        pendulum: QWidget,
+        matrix: QWidget,
+        params_builder: Callable[[dict], object],
+        torque_builder: Callable[[dict], Callable],
+        state_builder: Callable[[dict], np.ndarray],
+        run_simulation: Callable,
+        torque_history: QWidget | None = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.controls = controls
+        self.pendulum = pendulum
+        self.matrix = matrix
+        self.torque_history = torque_history
+        self._params_builder = params_builder
+        self._torque_builder = torque_builder
+        self._state_builder = state_builder
+        self._run_simulation = run_simulation
+
+        self._result = None
+        self._anim_idx = 0
+        self._playback_speed = 1.0
+
+        self._build_ui()
+        self._connect_signals()
+        self._setup_timer()
+
+    def _build_ui(self) -> None:
+        main_layout = QHBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        splitter.addWidget(self.controls)
+        splitter.addWidget(self.pendulum)
+        splitter.addWidget(self.matrix)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 3)
+        splitter.setStretchFactor(2, 1)
+
+        if self.torque_history is not None:
+            splitter.addWidget(self.torque_history)
+            splitter.setStretchFactor(3, 1)
+            splitter.setSizes([320, 520, 280, 280])
+        else:
+            splitter.setSizes([320, 520, 360])
+
+        main_layout.addWidget(splitter)
+
+    def _connect_signals(self) -> None:
+        self.controls.run_requested.connect(self._on_run)
+        self.controls.reset_requested.connect(self._on_reset)
+        self.controls.play_toggled.connect(self._on_play_toggle)
+        self.controls.speed_changed.connect(self._on_speed_change)
+        self.controls.frame_changed.connect(self._on_frame_change)
+        self.controls.export_data_requested.connect(self._on_export_data)
+        self.controls.export_video_requested.connect(self._on_export_video)
+
+    def _setup_timer(self) -> None:
+        self._timer = QTimer(self)
+        self._timer.setInterval(self.ANIMATION_INTERVAL_MS)
+        self._timer.timeout.connect(self._advance_frame)
+
+    def _on_run(self) -> None:
+        try:
+            p = self.controls.get_params()
+        except ValueError as e:
+            QMessageBox.warning(self, "Input Error", str(e))
+            return
+
+        try:
+            params = self._params_builder(p)
+        except AssertionError as e:
+            QMessageBox.warning(self, "Parameter Error", str(e))
+            return
+
+        if p["t_end"] <= 0:
+            QMessageBox.warning(self, "Input Error", "Duration must be positive")
+            return
+
+        initial_state = self._state_builder(p)
+        torque_func = self._torque_builder(p)
+
+        self.controls.btn_run.setEnabled(False)
+
+        try:
+            result = self._run_simulation(
+                params=params,
+                initial_state=initial_state,
+                t_end=p["t_end"],
+                torque_func=torque_func,
+                dt=0.005,
+            )
+        except Exception as e:
+            QMessageBox.critical(self, "Simulation Error", str(e))
+            self.controls.btn_run.setEnabled(True)
+            return
+
+        self._result = result
+        self._anim_idx = 0
+
+        self.pendulum.set_simulation(result)
+        self.matrix.set_simulation(result)
+        if self.torque_history is not None:
+            self.torque_history.set_simulation(result)
+        self.controls.set_slider_range(result.n_steps - 1)
+        self.controls.set_slider_value(0)
+        self._display_frame(0)
+        self.controls.btn_run.setEnabled(True)
+
+        # Auto-play the simulation
+        self.controls.btn_play.setChecked(True)
+
+    def _on_reset(self) -> None:
+        self._timer.stop()
+        self._result = None
+        self._anim_idx = 0
+        self.pendulum.clear()
+        self.matrix.clear()
+        if self.torque_history is not None:
+            self.torque_history.clear()
+        self.controls.stop_playback()
+        self.controls.set_slider_value(0)
+
+    def _on_play_toggle(self, playing: bool) -> None:
+        if self._result is None:
+            self.controls.stop_playback()
+            return
+        if playing:
+            if self._anim_idx >= self._result.n_steps - 1:
+                self._anim_idx = 0
+                if hasattr(self.pendulum, "_trail"):
+                    self.pendulum._trail.clear()
+            self._timer.start()
+        else:
+            self._timer.stop()
+
+    def _on_speed_change(self, speed: float) -> None:
+        self._playback_speed = speed
+
+    def _on_frame_change(self, frame: int) -> None:
+        if self._result is None:
+            return
+        self._anim_idx = frame
+        if hasattr(self.pendulum, "_trail"):
+            self.pendulum._trail.clear()
+            trail_start = max(0, frame - getattr(self.pendulum, "TRAIL_LENGTH", 0))
+            for i in range(trail_start, frame + 1):
+                pos = self._result.positions_at(i)
+                tip = pos.get("tip")
+                if tip is not None:
+                    self.pendulum._trail.append(tip)
+        self._display_frame(frame)
+
+    def _advance_frame(self) -> None:
+        if self._result is None:
+            self._timer.stop()
+            return
+
+        frames_per_tick = max(1, int(self._playback_speed * 3))
+        self._anim_idx += frames_per_tick
+
+        if self._anim_idx >= self._result.n_steps:
+            self._anim_idx = self._result.n_steps - 1
+            self._timer.stop()
+            self.controls.stop_playback()
+
+        self._display_frame(self._anim_idx)
+        self.controls.set_slider_value(self._anim_idx)
+
+    def _display_frame(self, idx: int) -> None:
+        assert self._result is not None
+        idx = max(0, min(idx, self._result.n_steps - 1))
+        self.pendulum.set_frame(idx)
+        self.matrix.set_frame(idx)
+        if self.torque_history is not None:
+            self.torque_history.set_frame(idx)
+
+    def _on_export_data(self) -> None:
+        if self._result is None:
+            QMessageBox.information(self, "Export Data", "Run a simulation first.")
+            return
+
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export Data", "", "CSV Files (*.csv)"
+        )
+        if not path:
+            return
+
+        headers = ["t"]
+        if self._result.states.shape[1] == 4:
+            headers += [
+                "tau_drive_1", "tau_drive_2",
+                "tau_friction_1", "tau_friction_2",
+                "tau_total_1", "tau_total_2",
+                "shoulder_fx", "shoulder_fy",
+                "wrist_fx", "wrist_fy",
+            ]
+        else:
+            headers += [
+                "tau_drive_1", "tau_drive_2", "tau_drive_3",
+                "tau_friction_1", "tau_friction_2", "tau_friction_3",
+                "tau_total_1", "tau_total_2", "tau_total_3",
+                "shoulder_fx", "shoulder_fy",
+                "wrist1_fx", "wrist1_fy",
+                "wrist2_fx", "wrist2_fy",
+            ]
+
+        try:
+            with open(path, "w", newline="", encoding="utf-8") as f:
+                writer = csv.writer(f)
+                writer.writerow(headers)
+                for i in range(self._result.n_steps):
+                    t = self._result.t[i]
+                    tau_drive = self._result.torques_at(i)
+                    forces = self._result.joint_forces_at(i)
+
+                    if self._result.states.shape[1] == 4:
+                        tau_friction = self._result.friction_torques_at(i)
+                        tau_total = self._result.total_torques_at(i)
+                        row = [
+                            t,
+                            tau_drive[0], tau_drive[1],
+                            tau_friction[0], tau_friction[1],
+                            tau_total[0], tau_total[1],
+                            forces["shoulder"][0], forces["shoulder"][1],
+                            forces["wrist"][0], forces["wrist"][1],
+                        ]
+                    else:
+                        row = [
+                            t,
+                            tau_drive[0], tau_drive[1], tau_drive[2],
+                            0.0, 0.0, 0.0,  # friction not yet in triple model
+                            tau_drive[0], tau_drive[1], tau_drive[2],
+                            forces["shoulder"][0], forces["shoulder"][1],
+                            forces["wrist1"][0], forces["wrist1"][1],
+                            forces["wrist2"][0], forces["wrist2"][1],
+                        ]
+                    writer.writerow(row)
+
+        except OSError as e:
+            QMessageBox.critical(self, "Export Data", f"Failed to write file: {e}")
+            return
+
+        QMessageBox.information(self, "Export Data", f"Saved data to:\n{path}")
+
+    def _on_export_video(self) -> None:
+        if self._result is None:
+            QMessageBox.information(self, "Export Video", "Run a simulation first.")
+            return
+
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export Video", "", "MP4 Video (*.mp4);;GIF (*.gif)"
+        )
+        if not path:
+            return
+
+        ffmpeg_path = shutil.which("ffmpeg")
+        was_playing = self._timer.isActive()
+        self._timer.stop()
+
+        tmp_dir = tempfile.mkdtemp(prefix="pendulum_frames_")
+        try:
+            for i in range(self._result.n_steps):
+                self._display_frame(i)
+                QApplication.processEvents()
+                pix = self.pendulum.grab()
+                frame_path = os.path.join(tmp_dir, f"frame_{i:05d}.png")
+                pix.save(frame_path)
+
+            if ffmpeg_path is None:
+                out_dir = os.path.splitext(path)[0] + "_frames"
+                os.makedirs(out_dir, exist_ok=True)
+                for name in os.listdir(tmp_dir):
+                    shutil.move(os.path.join(tmp_dir, name), os.path.join(out_dir, name))
+                QMessageBox.warning(
+                    self,
+                    "Export Video",
+                    "ffmpeg not found. Exported PNG frames instead:\n" + out_dir,
+                )
+                return
+
+            fps = int(1000 / self.ANIMATION_INTERVAL_MS)
+            cmd = [
+                ffmpeg_path,
+                "-y",
+                "-framerate",
+                str(fps),
+                "-i",
+                os.path.join(tmp_dir, "frame_%05d.png"),
+                "-pix_fmt",
+                "yuv420p",
+                path,
+            ]
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            if result.returncode != 0:
+                QMessageBox.critical(
+                    self,
+                    "Export Video",
+                    "ffmpeg failed. Check your ffmpeg installation.",
+                )
+                return
+
+            QMessageBox.information(self, "Export Video", f"Saved video to:\n{path}")
+        finally:
+            if was_playing:
+                self._timer.start()
+            shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/torque_history_widget.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/torque_history_widget.py
@@ -1,0 +1,208 @@
+"""
+Torque history plot widget.
+
+Displays the full time history of driving, friction, and total applied torques
+at each joint after the simulation completes. This provides a post-simulation
+analysis view showing how the frictional dissipation compares to the user-driven
+torque at each instant.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QLabel, QSizePolicy, QVBoxLayout, QWidget
+
+if TYPE_CHECKING:
+    from ..simulation import SimulationResult
+
+try:
+    import pyqtgraph as pg  # type: ignore[import-untyped]
+
+    _HAS_PYQTGRAPH = True
+except ImportError:
+    _HAS_PYQTGRAPH = False
+
+
+# ---------------------------------------------------------------------------
+# Colour scheme
+# ---------------------------------------------------------------------------
+_COLOR_DRIVE_1 = (230, 120, 50)    # warm orange — shoulder drive
+_COLOR_DRIVE_2 = (120, 180, 230)   # cool blue   — wrist drive
+_COLOR_FRICTION_1 = (200, 80, 80)   # red         — shoulder friction
+_COLOR_FRICTION_2 = (80, 160, 160)  # teal        — wrist friction
+_COLOR_TOTAL_1 = (255, 220, 80)     # gold        — shoulder total
+_COLOR_TOTAL_2 = (180, 255, 180)    # pale green  — wrist total
+
+
+class TorqueHistoryWidget(QWidget):
+    """Post-simulation torque breakdown chart.
+
+    Shows three torque series per joint over the full simulation time:
+        * Driving torque   — from the user-specified polynomial torque function
+        * Friction torque  — viscous damping + Coulomb friction (always ≤ 0 N·m
+                             in magnitude when resisting motion)
+        * Total torque     — driving + friction (net torque entering EOM)
+
+    When pyqtgraph is available the chart is rendered with hardware-accelerated
+    line plots. If pyqtgraph is missing a plain text fallback is shown.
+
+    Contract:
+        - set_simulation() must be called before set_frame() or clear().
+        - clear() resets to an empty state without crashing.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._result: SimulationResult | None = None
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(4)
+
+        title = QLabel("Torque History")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        title.setStyleSheet(
+            "color: #c0c0d8; font-size: 12px; font-weight: bold;"
+        )
+        layout.addWidget(title)
+
+        if not _HAS_PYQTGRAPH:
+            fallback = QLabel(
+                "Install pyqtgraph for torque plots:\n  pip install pyqtgraph"
+            )
+            fallback.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            fallback.setStyleSheet("color: #808090; font-size: 11px;")
+            layout.addWidget(fallback)
+            return
+
+        # Two stacked plot widgets (joint 1 top, joint 2 bottom)
+        self._plot_j1 = pg.PlotWidget(title="Joint 1 — Shoulder")
+        self._plot_j2 = pg.PlotWidget(title="Joint 2 — Wrist")
+
+        for pw in (self._plot_j1, self._plot_j2):
+            pw.setBackground("#1a1a28")
+            pw.getPlotItem().setLabel("bottom", "Time (s)")
+            pw.getPlotItem().setLabel("left", "Torque (N·m)")
+            pw.getPlotItem().addLegend(offset=(10, 10))
+            pw.setSizePolicy(
+                QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding
+            )
+            layout.addWidget(pw)
+
+        # Pre-create curve objects (hidden until data loaded)
+        pen_kwargs = {"width": 2}
+        self._curves_j1: dict[str, pg.PlotDataItem] = {
+            "drive": self._plot_j1.plot(
+                name="Drive", pen=pg.mkPen(*_COLOR_DRIVE_1, **pen_kwargs)
+            ),
+            "friction": self._plot_j1.plot(
+                name="Friction",
+                pen=pg.mkPen(*_COLOR_FRICTION_1, style=Qt.PenStyle.DashLine, **pen_kwargs),
+            ),
+            "total": self._plot_j1.plot(
+                name="Total",
+                pen=pg.mkPen(*_COLOR_TOTAL_1, style=Qt.PenStyle.DotLine, **pen_kwargs),
+            ),
+        }
+        self._curves_j2: dict[str, pg.PlotDataItem] = {
+            "drive": self._plot_j2.plot(
+                name="Drive", pen=pg.mkPen(*_COLOR_DRIVE_2, **pen_kwargs)
+            ),
+            "friction": self._plot_j2.plot(
+                name="Friction",
+                pen=pg.mkPen(*_COLOR_FRICTION_2, style=Qt.PenStyle.DashLine, **pen_kwargs),
+            ),
+            "total": self._plot_j2.plot(
+                name="Total",
+                pen=pg.mkPen(*_COLOR_TOTAL_2, style=Qt.PenStyle.DotLine, **pen_kwargs),
+            ),
+        }
+
+        # Vertical time cursor (updates with animation frame)
+        self._cursor_j1 = pg.InfiniteLine(angle=90, movable=False,
+                                           pen=pg.mkPen("w", width=1, style=Qt.PenStyle.DashLine))
+        self._cursor_j2 = pg.InfiniteLine(angle=90, movable=False,
+                                           pen=pg.mkPen("w", width=1, style=Qt.PenStyle.DashLine))
+        self._plot_j1.addItem(self._cursor_j1)
+        self._plot_j2.addItem(self._cursor_j2)
+
+    # ------------------------------------------------------------------
+    # Public interface (mirrors matrix_widget.py contract)
+    # ------------------------------------------------------------------
+
+    def set_simulation(self, result: SimulationResult) -> None:
+        """Load simulation result and compute full torque history arrays.
+
+        All N timesteps' torques are computed once here so that set_frame()
+        can do only an O(1) cursor update during animation.
+
+        Preconditions:
+            - result is a completed SimulationResult with n_steps >= 2.
+        """
+        assert result.n_steps >= 2, "Result must have at least 2 time steps"
+        self._result = result
+
+        if not _HAS_PYQTGRAPH:
+            return
+
+        t = result.t
+        n = result.n_steps
+
+        # Pre-allocate arrays for all torque components
+        drive = np.empty((n, 2))
+        friction = np.empty((n, 2))
+        total = np.empty((n, 2))
+
+        for i in range(n):
+            drive[i] = result.torques_at(i)
+            friction[i] = result.friction_torques_at(i)
+            total[i] = result.total_torques_at(i)
+
+        # Joint 1 (shoulder)
+        self._curves_j1["drive"].setData(t, drive[:, 0])
+        self._curves_j1["friction"].setData(t, friction[:, 0])
+        self._curves_j1["total"].setData(t, total[:, 0])
+
+        # Joint 2 (wrist)
+        self._curves_j2["drive"].setData(t, drive[:, 1])
+        self._curves_j2["friction"].setData(t, friction[:, 1])
+        self._curves_j2["total"].setData(t, total[:, 1])
+
+        # Reset cursors to t=0
+        self._cursor_j1.setValue(t[0])
+        self._cursor_j2.setValue(t[0])
+
+    def set_frame(self, idx: int) -> None:
+        """Move the time cursor to the frame at index idx.
+
+        Called every animation tick — must be O(1).
+
+        Preconditions:
+            - set_simulation() has been called.
+            - 0 <= idx < result.n_steps.
+        """
+        if self._result is None or not _HAS_PYQTGRAPH:
+            return
+        assert 0 <= idx < self._result.n_steps
+        t_now = self._result.t[idx]
+        self._cursor_j1.setValue(t_now)
+        self._cursor_j2.setValue(t_now)
+
+    def clear(self) -> None:
+        """Reset to an empty state (called on simulation reset)."""
+        self._result = None
+        if not _HAS_PYQTGRAPH:
+            return
+        for curve in (*self._curves_j1.values(), *self._curves_j2.values()):
+            curve.setData([], [])
+        self._cursor_j1.setValue(0.0)
+        self._cursor_j2.setValue(0.0)

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/torque_preview_widget.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/torque_preview_widget.py
@@ -1,0 +1,95 @@
+"""
+Torque preview widget for polynomial joint torques.
+"""
+
+from typing import Iterable, List, Tuple
+
+import numpy as np
+from PyQt6.QtCore import Qt, QRectF
+from PyQt6.QtGui import QPainter, QPen, QColor, QFont
+from PyQt6.QtWidgets import QWidget
+
+
+class TorquePreviewWidget(QWidget):
+    """Plot polynomial torque profiles for one or more joints."""
+
+    COLOR_BG = QColor(26, 26, 36)
+    COLOR_GRID = QColor(50, 50, 65)
+    COLOR_TEXT = QColor(180, 180, 200)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setMinimumHeight(140)
+        self._profiles: List[Tuple[str, List[float], QColor]] = []
+        self._t_end = 2.0
+
+    def set_duration(self, t_end: float) -> None:
+        self._t_end = max(0.1, float(t_end))
+        self.update()
+
+    def set_profiles(self, profiles: Iterable[Tuple[str, List[float], QColor]]) -> None:
+        self._profiles = [(name, list(coeffs), color) for name, coeffs, color in profiles]
+        self.update()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.fillRect(self.rect(), self.COLOR_BG)
+
+        rect = self.rect().adjusted(10, 10, -10, -24)
+        self._draw_grid(painter, rect)
+
+        if not self._profiles:
+            painter.setPen(self.COLOR_TEXT)
+            painter.setFont(QFont("Sans", 9))
+            painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter, "Torque preview")
+            painter.end()
+            return
+
+        t = np.linspace(0.0, self._t_end, 120)
+        series = []
+        for name, coeffs, _ in self._profiles:
+            if len(coeffs) == 0:
+                series.append((name, np.zeros_like(t)))
+                continue
+            poly = np.array(coeffs[::-1])
+            series.append((name, np.polyval(poly, t)))
+
+        all_vals = np.concatenate([s[1] for s in series]) if series else np.array([0.0])
+        v_min = float(np.min(all_vals))
+        v_max = float(np.max(all_vals))
+        if abs(v_max - v_min) < 1e-6:
+            v_min -= 1.0
+            v_max += 1.0
+
+        for (name, values), (_, _, color) in zip(series, self._profiles):
+            pen = QPen(color, 2)
+            painter.setPen(pen)
+            points = []
+            for i, val in enumerate(values):
+                x = rect.left() + (t[i] / self._t_end) * rect.width()
+                y = rect.bottom() - (val - v_min) / (v_max - v_min) * rect.height()
+                points.append((x, y))
+            for i in range(1, len(points)):
+                painter.drawLine(points[i - 1][0], points[i - 1][1], points[i][0], points[i][1])
+
+        self._draw_legend(painter, rect)
+        painter.end()
+
+    def _draw_grid(self, painter: QPainter, rect: QRectF) -> None:
+        painter.setPen(QPen(self.COLOR_GRID, 1, Qt.PenStyle.DotLine))
+        for i in range(5):
+            y = rect.top() + i * rect.height() / 4
+            painter.drawLine(rect.left(), y, rect.right(), y)
+        for i in range(5):
+            x = rect.left() + i * rect.width() / 4
+            painter.drawLine(x, rect.top(), x, rect.bottom())
+
+    def _draw_legend(self, painter: QPainter, rect: QRectF) -> None:
+        painter.setFont(QFont("Sans", 8))
+        x = rect.left()
+        y = rect.bottom() + 14
+        for name, _, color in self._profiles:
+            painter.setPen(color)
+            painter.drawText(int(x), int(y), name)
+            x += 70

--- a/src/pendulum_simulator/src/double_pendulum_golf/physics.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/physics.py
@@ -1,0 +1,434 @@
+"""
+Double pendulum physics using Lagrangian formulation with relative coordinates.
+
+Coordinate convention:
+    q1 (theta1): Absolute angle of segment 1 from downward vertical,
+                 positive counterclockwise.
+    q2 (phi):    Angle of segment 2 relative to segment 1,
+                 positive counterclockwise.
+
+    When q1=0 and q2=0, both segments hang straight down (equilibrium).
+
+All segments modeled as uniform rods with mass concentrated at the tip
+(point-mass approximation) for clarity. Extend to distributed mass by
+replacing L with l_c and adding rotational inertia terms.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PendulumParams:
+    """Immutable physical parameters for the double pendulum.
+
+    Contract:
+        - All lengths and masses must be strictly positive.
+        - Gravity must be non-negative.
+        - Damping coefficients b1, b2 must be non-negative  (N·m·s/rad).
+        - Coulomb friction mu1, mu2 must be non-negative  (N·m peak magnitude).
+    """
+    m1: float   # mass of segment 1 (kg)
+    m2: float   # mass of segment 2 (kg)
+    L1: float   # length of segment 1 (m)
+    L2: float   # length of segment 2 (m)
+    g: float = 9.81   # gravitational acceleration (m/s^2)
+    # --- Dissipative parameters (default 0 = no losses) ---
+    b1: float = 0.0   # viscous damping at joint 1 (N·m·s/rad)
+    b2: float = 0.0   # viscous damping at joint 2 (N·m·s/rad)
+    mu1: float = 0.0  # Coulomb friction at joint 1 (N·m, constant magnitude)
+    mu2: float = 0.0  # Coulomb friction at joint 2 (N·m, constant magnitude)
+
+    def __post_init__(self):
+        assert self.m1 > 0, f"m1 must be positive, got {self.m1}"
+        assert self.m2 > 0, f"m2 must be positive, got {self.m2}"
+        assert self.L1 > 0, f"L1 must be positive, got {self.L1}"
+        assert self.L2 > 0, f"L2 must be positive, got {self.L2}"
+        assert self.g >= 0, f"g must be non-negative, got {self.g}"
+        assert self.b1 >= 0, f"b1 must be non-negative, got {self.b1}"
+        assert self.b2 >= 0, f"b2 must be non-negative, got {self.b2}"
+        assert self.mu1 >= 0, f"mu1 must be non-negative, got {self.mu1}"
+        assert self.mu2 >= 0, f"mu2 must be non-negative, got {self.mu2}"
+
+
+# Type alias: state vector [theta1, phi, dtheta1, dphi]
+State = np.ndarray  # shape (4,)
+
+# Torque function signature: (t) -> (tau1, tau2)
+TorqueFunc = Callable[[float], Tuple[float, float]]
+
+
+# ---------------------------------------------------------------------------
+# Mass matrix and its components
+# ---------------------------------------------------------------------------
+
+def mass_matrix(phi: float, params: PendulumParams) -> np.ndarray:
+    """Compute the 2x2 mass (inertia) matrix M(q).
+
+    Preconditions:
+        - phi is a finite float.
+    Postconditions:
+        - Returns a 2x2 symmetric positive-definite matrix.
+        - M[0,1] == M[1,0]  (symmetry).
+        - M[1,1] > 0  (positive diagonal).
+
+    Parameters
+    ----------
+    phi : float
+        Relative angle of segment 2 w.r.t. segment 1 (rad).
+    params : PendulumParams
+
+    Returns
+    -------
+    M : np.ndarray, shape (2, 2)
+    """
+    assert np.isfinite(phi), f"phi must be finite, got {phi}"
+    m1, m2, L1, L2 = params.m1, params.m2, params.L1, params.L2
+    cos_phi = np.cos(phi)
+
+    M11 = (m1 + m2) * L1**2 + m2 * L2**2 + 2.0 * m2 * L1 * L2 * cos_phi
+    M12 = m2 * L2**2 + m2 * L1 * L2 * cos_phi
+    M22 = m2 * L2**2
+
+    M = np.array([[M11, M12],
+                   [M12, M22]])
+
+    # Postcondition: symmetry
+    assert np.isclose(M[0, 1], M[1, 0]), "Mass matrix must be symmetric"
+    return M
+
+
+def mass_matrix_components(phi: float, params: PendulumParams) -> dict:
+    """Return individual diagonal and off-diagonal terms with physical labels.
+
+    This is the key decomposition: diagonal terms are 'self-coupling'
+    (each joint's torque acting on its own acceleration) and off-diagonal
+    terms are 'cross-coupling' (how one joint's torque accelerates the other).
+
+    Parameters
+    ----------
+    phi : float
+        Relative angle of segment 2 (rad).
+    params : PendulumParams
+
+    Returns
+    -------
+    dict with keys: 'M11', 'M12', 'M21', 'M22', 'M_full'
+    """
+    M = mass_matrix(phi, params)
+    return {
+        "M11": M[0, 0],
+        "M12": M[0, 1],
+        "M21": M[1, 0],
+        "M22": M[1, 1],
+        "M_full": M,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coriolis and centrifugal terms
+# ---------------------------------------------------------------------------
+
+def coriolis_vector(phi: float, dtheta1: float, dphi: float,
+                    params: PendulumParams) -> np.ndarray:
+    """Compute the Coriolis/centrifugal force vector C(q, qdot) * qdot.
+
+    This vector captures velocity-dependent forces: centrifugal effects
+    from rotation and Coriolis coupling between the two angular velocities.
+
+    Preconditions:
+        - All inputs are finite floats.
+
+    Parameters
+    ----------
+    phi : float
+        Relative angle (rad).
+    dtheta1 : float
+        Angular velocity of segment 1 (rad/s).
+    dphi : float
+        Relative angular velocity of segment 2 (rad/s).
+    params : PendulumParams
+
+    Returns
+    -------
+    C_qdot : np.ndarray, shape (2,)
+    """
+    assert all(np.isfinite(v) for v in [phi, dtheta1, dphi]), \
+        "All velocity inputs must be finite"
+    m2, L1, L2 = params.m2, params.L1, params.L2
+    h = -m2 * L1 * L2 * np.sin(phi)
+
+    c1 = h * (2.0 * dtheta1 * dphi + dphi**2)
+    c2 = -h * dtheta1**2
+
+    return np.array([c1, c2])
+
+
+# ---------------------------------------------------------------------------
+# Gravity vector
+# ---------------------------------------------------------------------------
+
+def gravity_vector(theta1: float, phi: float,
+                   params: PendulumParams) -> np.ndarray:
+    """Compute the gravitational torque vector G(q).
+
+    Derived from potential energy V = -m1*g*L1*cos(theta1)
+                                      - m2*g*(L1*cos(theta1) + L2*cos(theta1+phi))
+
+    G_i = dV/dq_i
+
+    Parameters
+    ----------
+    theta1 : float
+        Absolute angle of segment 1 (rad).
+    phi : float
+        Relative angle of segment 2 (rad).
+    params : PendulumParams
+
+    Returns
+    -------
+    G : np.ndarray, shape (2,)
+    """
+    m1, m2, L1, L2, g = params.m1, params.m2, params.L1, params.L2, params.g
+    abs_angle2 = theta1 + phi
+
+    G1 = (m1 + m2) * g * L1 * np.sin(theta1) + m2 * g * L2 * np.sin(abs_angle2)
+    G2 = m2 * g * L2 * np.sin(abs_angle2)
+
+    return np.array([G1, G2])
+
+
+# ---------------------------------------------------------------------------
+# Friction and damping
+# ---------------------------------------------------------------------------
+
+def friction_torque_vector(
+    dtheta1: float, dphi: float, params: PendulumParams
+) -> np.ndarray:
+    """Compute the total dissipative torque vector at the joints.
+
+    Combines viscous (linear) damping and Coulomb (constant) friction.
+    Both always oppose the direction of motion.
+
+    Model:
+        tau_friction_i = -b_i * qdot_i - mu_i * sign(qdot_i)
+
+    The sign() function is zero when the joint is stationary, so Coulomb
+    friction correctly does not apply a torque at rest.
+
+    Preconditions:
+        - dtheta1 and dphi are finite.
+    Postconditions:
+        - Returns shape (2,), both values finite.
+        - Each component has opposite sign to the corresponding velocity
+          (or is zero if both b_i and mu_i are zero).
+
+    Parameters
+    ----------
+    dtheta1 : float
+        Angular velocity of segment 1 (rad/s).
+    dphi : float
+        Relative angular velocity of segment 2 (rad/s).
+    params : PendulumParams
+
+    Returns
+    -------
+    tau_f : np.ndarray, shape (2,)  [N·m]
+    """
+    assert np.isfinite(dtheta1), f"dtheta1 must be finite, got {dtheta1}"
+    assert np.isfinite(dphi), f"dphi must be finite, got {dphi}"
+
+    tau_f1 = -params.b1 * dtheta1 - params.mu1 * np.sign(dtheta1)
+    tau_f2 = -params.b2 * dphi - params.mu2 * np.sign(dphi)
+
+    return np.array([tau_f1, tau_f2])
+
+
+# ---------------------------------------------------------------------------
+# Equations of motion
+# ---------------------------------------------------------------------------
+
+def equations_of_motion(state: State, t: float, params: PendulumParams,
+                        torque_func: TorqueFunc) -> State:
+    """Compute the state derivative: dx/dt = f(x, t).
+
+    State vector x = [theta1, phi, dtheta1, dphi].
+
+    Full equations of motion:
+
+        M(q) * qddot = tau_drive(t) + tau_friction(qdot) - C(q,qdot)*qdot - G(q)
+
+    where:
+        tau_drive   = user-supplied driving torques (polynomial functions of t)
+        tau_friction = dissipative joint torques (viscous damping + Coulomb friction)
+                       These are NOT part of torque_func — they are computed from
+                       current velocity so they can be tracked separately for the
+                       total applied torque analysis.
+
+    Preconditions:
+        - state has shape (4,) with all finite values.
+        - torque_func returns a 2-tuple of finite floats.
+    Postconditions:
+        - Returns shape (4,) with all finite values.
+
+    Parameters
+    ----------
+    state : np.ndarray, shape (4,)
+    t : float
+    params : PendulumParams
+    torque_func : callable (t) -> (tau1, tau2)  — driving torques only
+
+    Returns
+    -------
+    state_dot : np.ndarray, shape (4,)
+    """
+    assert state.shape == (4,), f"State must have shape (4,), got {state.shape}"
+    assert all(np.isfinite(state)), f"State values must be finite: {state}"
+
+    theta1, phi, dtheta1, dphi = state
+
+    M = mass_matrix(phi, params)
+    C = coriolis_vector(phi, dtheta1, dphi, params)
+    G = gravity_vector(theta1, phi, params)
+
+    tau1, tau2 = torque_func(t)
+    tau_drive = np.array([tau1, tau2])
+    tau_friction = friction_torque_vector(dtheta1, dphi, params)
+
+    # Solve: M * qddot = tau_drive + tau_friction - C - G
+    rhs = tau_drive + tau_friction - C - G
+    qddot = np.linalg.solve(M, rhs)
+
+    state_dot = np.array([dtheta1, dphi, qddot[0], qddot[1]])
+
+    assert all(np.isfinite(state_dot)), \
+        f"State derivative has non-finite values: {state_dot}"
+    return state_dot
+
+
+# ---------------------------------------------------------------------------
+# Forward kinematics (for visualization)
+# ---------------------------------------------------------------------------
+
+def forward_kinematics(theta1: float, phi: float,
+                       params: PendulumParams) -> dict:
+    """Compute joint and tip positions in the world frame.
+
+    Origin is at the shoulder (fixed pivot).
+    x-axis points right, y-axis points up.
+
+    Parameters
+    ----------
+    theta1 : float
+        Absolute angle of segment 1 from downward vertical (rad).
+    phi : float
+        Relative angle of segment 2 (rad).
+    params : PendulumParams
+
+    Returns
+    -------
+    dict with 'shoulder', 'wrist', 'tip' as (x, y) tuples.
+    """
+    L1, L2 = params.L1, params.L2
+    abs_angle2 = theta1 + phi
+
+    # Segment 1 endpoint (wrist / elbow joint)
+    wx = L1 * np.sin(theta1)
+    wy = -L1 * np.cos(theta1)
+
+    # Segment 2 endpoint (club tip)
+    tx = wx + L2 * np.sin(abs_angle2)
+    ty = wy - L2 * np.cos(abs_angle2)
+
+    return {
+        "shoulder": (0.0, 0.0),
+        "wrist": (wx, wy),
+        "tip": (tx, ty),
+    }
+
+
+def linear_accelerations(state: State, qddot: np.ndarray,
+                         params: PendulumParams) -> dict:
+    """Compute linear accelerations of joints in world coordinates.
+
+    Returns
+    -------
+    dict with keys: 'wrist', 'tip' as (ax, ay) tuples.
+    """
+    assert state.shape == (4,), f"State must have shape (4,), got {state.shape}"
+    assert qddot.shape == (2,), f"qddot must have shape (2,), got {qddot.shape}"
+    theta1, phi, dtheta1, dphi = state
+    ddtheta1, ddphi = qddot
+
+    L1, L2 = params.L1, params.L2
+    abs_angle2 = theta1 + phi
+    dabs2 = dtheta1 + dphi
+    ddabs2 = ddtheta1 + ddphi
+
+    ax_w = L1 * (-np.sin(theta1) * dtheta1**2 + np.cos(theta1) * ddtheta1)
+    ay_w = L1 * (np.cos(theta1) * dtheta1**2 + np.sin(theta1) * ddtheta1)
+
+    ax_t = ax_w + L2 * (-np.sin(abs_angle2) * dabs2**2 + np.cos(abs_angle2) * ddabs2)
+    ay_t = ay_w + L2 * (np.cos(abs_angle2) * dabs2**2 + np.sin(abs_angle2) * ddabs2)
+
+    return {
+        "wrist": (ax_w, ay_w),
+        "tip": (ax_t, ay_t),
+    }
+
+
+def net_joint_forces(state: State, qddot: np.ndarray,
+                     params: PendulumParams) -> dict:
+    """Compute net joint forces (proximal on distal) in world coordinates.
+
+    Returns
+    -------
+    dict with keys: 'shoulder', 'wrist' as (fx, fy) tuples.
+    """
+    acc = linear_accelerations(state, qddot, params)
+    g_vec = np.array([0.0, -params.g])
+
+    m1, m2 = params.m1, params.m2
+    a_w = np.array(acc["wrist"])
+    a_t = np.array(acc["tip"])
+
+    f_wrist = m2 * a_t - m2 * g_vec
+    f_shoulder = (m1 * a_w + m2 * a_t) - (m1 + m2) * g_vec
+
+    return {
+        "shoulder": (float(f_shoulder[0]), float(f_shoulder[1])),
+        "wrist": (float(f_wrist[0]), float(f_wrist[1])),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Energy calculations (for verification / display)
+# ---------------------------------------------------------------------------
+
+def kinetic_energy(state: State, params: PendulumParams) -> float:
+    """Compute total kinetic energy T = 0.5 * qdot^T M qdot."""
+    _, phi, dtheta1, dphi = state
+    M = mass_matrix(phi, params)
+    qdot = np.array([dtheta1, dphi])
+    return 0.5 * qdot @ M @ qdot
+
+
+def potential_energy(state: State, params: PendulumParams) -> float:
+    """Compute gravitational potential energy (zero at shoulder height)."""
+    theta1, phi = state[0], state[1]
+    m1, m2, L1, L2, g = params.m1, params.m2, params.L1, params.L2, params.g
+    abs_angle2 = theta1 + phi
+
+    V = -(m1 + m2) * g * L1 * np.cos(theta1) - m2 * g * L2 * np.cos(abs_angle2)
+    return V
+
+
+def total_energy(state: State, params: PendulumParams) -> float:
+    """Total mechanical energy E = T + V."""
+    return kinetic_energy(state, params) + potential_energy(state, params)

--- a/src/pendulum_simulator/src/double_pendulum_golf/physics_triple.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/physics_triple.py
@@ -1,0 +1,450 @@
+"""
+Triple pendulum physics using Lagrangian formulation with relative coordinates.
+
+Coordinate convention:
+    q1 (theta1): Absolute angle of segment 1 from downward vertical,
+                 positive counterclockwise.
+    q2 (phi1):   Angle of segment 2 relative to segment 1,
+                 positive counterclockwise.
+    q3 (phi2):   Angle of segment 3 relative to segment 2,
+                 positive counterclockwise.
+
+All segments modeled as uniform rods with mass concentrated at the tip
+(point-mass approximation).
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class TriplePendulumParams:
+    """Immutable physical parameters for the triple pendulum.
+
+    Contract:
+        - All lengths and masses must be strictly positive.
+        - Gravity must be non-negative.
+    """
+    m1: float   # mass of segment 1 (kg)
+    m2: float   # mass of segment 2 (kg)
+    m3: float   # mass of segment 3 (kg)
+    L1: float   # length of segment 1 (m)
+    L2: float   # length of segment 2 (m)
+    L3: float   # length of segment 3 (m)
+    g: float = 9.81  # gravitational acceleration (m/s^2)
+
+    def __post_init__(self):
+        assert self.m1 > 0, f"m1 must be positive, got {self.m1}"
+        assert self.m2 > 0, f"m2 must be positive, got {self.m2}"
+        assert self.m3 > 0, f"m3 must be positive, got {self.m3}"
+        assert self.L1 > 0, f"L1 must be positive, got {self.L1}"
+        assert self.L2 > 0, f"L2 must be positive, got {self.L2}"
+        assert self.L3 > 0, f"L3 must be positive, got {self.L3}"
+        assert self.g >= 0, f"g must be non-negative, got {self.g}"
+
+
+# Type alias: state vector [theta1, phi1, phi2, dtheta1, dphi1, dphi2]
+State = np.ndarray  # shape (6,)
+
+# Torque function signature: (t) -> (tau1, tau2, tau3)
+TorqueFunc = Callable[[float], Tuple[float, float, float]]
+
+
+# ---------------------------------------------------------------------------
+# Mass matrix and its components
+# ---------------------------------------------------------------------------
+
+def mass_matrix(phi1: float, phi2: float, params: TriplePendulumParams) -> np.ndarray:
+    """Compute the 3x3 mass (inertia) matrix M(q).
+
+    Preconditions:
+        - phi1 and phi2 are finite floats.
+    Postconditions:
+        - Returns a 3x3 symmetric positive-definite matrix.
+        - M[i,j] == M[j,i]  (symmetry).
+        - All eigenvalues > 0  (positive definiteness).
+
+    Parameters
+    ----------
+    phi1 : float
+        Relative angle of segment 2 w.r.t. segment 1 (rad).
+    phi2 : float
+        Relative angle of segment 3 w.r.t. segment 2 (rad).
+    params : TriplePendulumParams
+
+    Returns
+    -------
+    M : np.ndarray, shape (3, 3)
+    """
+    assert np.isfinite(phi1), f"phi1 must be finite, got {phi1}"
+    assert np.isfinite(phi2), f"phi2 must be finite, got {phi2}"
+    
+    m1, m2, m3 = params.m1, params.m2, params.m3
+    L1, L2, L3 = params.L1, params.L2, params.L3
+    
+    c1 = np.cos(phi1)
+    c2 = np.cos(phi2)
+    c12 = np.cos(phi1 + phi2)
+    
+    # M11: inertia of segment 1 + contributions from 2 and 3
+    M11 = ((m1 + m2 + m3) * L1**2 + 
+           (m2 + m3) * L2**2 + 
+           m3 * L3**2 +
+           2.0 * (m2 + m3) * L1 * L2 * c1 +
+           2.0 * m3 * L1 * L3 * c12)
+    
+    # M12: coupling between segments 1 and 2
+    M12 = ((m2 + m3) * L2**2 + 
+           m3 * L3**2 +
+           m3 * L1 * L3 * np.cos(phi2) +
+           (m2 + m3) * L1 * L2 * c1)
+    
+    # M13: coupling between segments 1 and 3
+    M13 = m3 * L3**2 + m3 * L1 * L3 * c12
+    
+    # M22: self-coupling of segment 2
+    M22 = (m2 + m3) * L2**2 + m3 * L3**2 + 2.0 * m3 * L2 * L3 * c2
+    
+    # M23: coupling between segments 2 and 3
+    M23 = m3 * L3**2 + m3 * L2 * L3 * c2
+    
+    # M33: self-coupling of segment 3
+    M33 = m3 * L3**2
+    
+    M = np.array([
+        [M11, M12, M13],
+        [M12, M22, M23],
+        [M13, M23, M33],
+    ])
+    
+    # Postcondition: symmetry
+    for i in range(3):
+        for j in range(3):
+            assert np.isclose(M[i, j], M[j, i]), f"Mass matrix not symmetric at [{i},{j}]"
+    
+    return M
+
+
+def mass_matrix_components(phi1: float, phi2: float,
+                           params: TriplePendulumParams) -> dict:
+    """Return individual mass matrix terms with labels.
+
+    Returns
+    -------
+    dict with keys M11..M33 and M_full.
+    """
+    M = mass_matrix(phi1, phi2, params)
+    return {
+        "M11": M[0, 0], "M12": M[0, 1], "M13": M[0, 2],
+        "M21": M[1, 0], "M22": M[1, 1], "M23": M[1, 2],
+        "M31": M[2, 0], "M32": M[2, 1], "M33": M[2, 2],
+        "M_full": M,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Coriolis and centrifugal terms
+# ---------------------------------------------------------------------------
+
+def coriolis_vector(phi1: float, phi2: float,
+                    dtheta1: float, dphi1: float, dphi2: float,
+                    params: TriplePendulumParams) -> np.ndarray:
+    """Compute the Coriolis/centrifugal force vector C(q, qdot).
+
+    This captures velocity-dependent forces.
+
+    Preconditions:
+        - All inputs are finite floats.
+
+    Parameters
+    ----------
+    phi1 : float
+        Relative angle of segment 2 (rad).
+    phi2 : float
+        Relative angle of segment 3 (rad).
+    dtheta1 : float
+        Angular velocity of segment 1 (rad/s).
+    dphi1 : float
+        Relative angular velocity of segment 2 (rad/s).
+    dphi2 : float
+        Relative angular velocity of segment 3 (rad/s).
+    params : TriplePendulumParams
+
+    Returns
+    -------
+    C_qdot : np.ndarray, shape (3,)
+    """
+    assert all(np.isfinite(v) for v in [phi1, phi2, dtheta1, dphi1, dphi2]), \
+        "All inputs must be finite"
+    
+    m2, m3 = params.m2, params.m3
+    L1, L2, L3 = params.L1, params.L2, params.L3
+    
+    s1 = np.sin(phi1)
+    s2 = np.sin(phi2)
+    s12 = np.sin(phi1 + phi2)
+    
+    # Coupling terms
+    h12 = -m2 * L1 * L2 * s1 - m3 * L1 * L2 * s1
+    h13 = -m3 * L1 * L3 * s12
+    h23 = -m3 * L2 * L3 * s2
+    
+    # Centrifugal and Coriolis terms
+    c1 = h12 * (dtheta1 + dphi1) * dphi1 + h13 * (dtheta1 + dphi1 + dphi2) * dphi2
+    c2 = -h12 * dtheta1**2 + h23 * (dtheta1 + dphi1 + dphi2) * dphi2 - h23 * (dtheta1 + dphi1) * dphi2
+    c3 = -h13 * dtheta1**2 - h23 * (dtheta1 + dphi1)**2
+    
+    return np.array([c1, c2, c3])
+
+
+# ---------------------------------------------------------------------------
+# Gravity vector
+# ---------------------------------------------------------------------------
+
+def gravity_vector(theta1: float, phi1: float, phi2: float,
+                   params: TriplePendulumParams) -> np.ndarray:
+    """Compute the gravitational torque vector G(q).
+
+    Derived from potential energy.
+
+    Parameters
+    ----------
+    theta1 : float
+        Absolute angle of segment 1 (rad).
+    phi1 : float
+        Relative angle of segment 2 (rad).
+    phi2 : float
+        Relative angle of segment 3 (rad).
+    params : TriplePendulumParams
+
+    Returns
+    -------
+    G : np.ndarray, shape (3,)
+    """
+    m1, m2, m3 = params.m1, params.m2, params.m3
+    L1, L2, L3 = params.L1, params.L2, params.L3
+    g = params.g
+    
+    abs_angle2 = theta1 + phi1
+    abs_angle3 = theta1 + phi1 + phi2
+    
+    G1 = ((m1 + m2 + m3) * g * L1 * np.sin(theta1) +
+          (m2 + m3) * g * L2 * np.sin(abs_angle2) +
+          m3 * g * L3 * np.sin(abs_angle3))
+    
+    G2 = ((m2 + m3) * g * L2 * np.sin(abs_angle2) +
+          m3 * g * L3 * np.sin(abs_angle3))
+    
+    G3 = m3 * g * L3 * np.sin(abs_angle3)
+    
+    return np.array([G1, G2, G3])
+
+
+# ---------------------------------------------------------------------------
+# Equations of motion
+# ---------------------------------------------------------------------------
+
+def equations_of_motion(state: State, t: float, params: TriplePendulumParams,
+                        torque_func: TorqueFunc) -> State:
+    """Compute the state derivative: dx/dt = f(x, t).
+
+    State vector x = [theta1, phi1, phi2, dtheta1, dphi1, dphi2].
+
+    M(q) * qddot = tau - C(q,qdot) - G(q)
+
+    Preconditions:
+        - state has shape (6,) with all finite values.
+        - torque_func returns a 3-tuple of finite floats.
+    Postconditions:
+        - Returns shape (6,) with all finite values.
+
+    Parameters
+    ----------
+    state : np.ndarray, shape (6,)
+    t : float
+    params : TriplePendulumParams
+    torque_func : callable (t) -> (tau1, tau2, tau3)
+
+    Returns
+    -------
+    state_dot : np.ndarray, shape (6,)
+    """
+    assert state.shape == (6,), f"State must have shape (6,), got {state.shape}"
+    assert all(np.isfinite(state)), f"State values must be finite: {state}"
+    
+    theta1, phi1, phi2, dtheta1, dphi1, dphi2 = state
+    
+    M = mass_matrix(phi1, phi2, params)
+    C = coriolis_vector(phi1, phi2, dtheta1, dphi1, dphi2, params)
+    G = gravity_vector(theta1, phi1, phi2, params)
+    
+    tau1, tau2, tau3 = torque_func(t)
+    tau = np.array([tau1, tau2, tau3])
+    
+    # Solve: M * qddot = tau - C - G
+    rhs = tau - C - G
+    qddot = np.linalg.solve(M, rhs)
+    
+    state_dot = np.array([dtheta1, dphi1, dphi2, qddot[0], qddot[1], qddot[2]])
+    
+    assert all(np.isfinite(state_dot)), \
+        f"State derivative has non-finite values: {state_dot}"
+    return state_dot
+
+
+# ---------------------------------------------------------------------------
+# Forward kinematics (for visualization)
+# ---------------------------------------------------------------------------
+
+def forward_kinematics(theta1: float, phi1: float, phi2: float,
+                       params: TriplePendulumParams) -> dict:
+    """Compute joint and tip positions in the world frame.
+
+    Origin is at the shoulder (fixed pivot).
+    x-axis points right, y-axis points up.
+
+    Parameters
+    ----------
+    theta1 : float
+        Absolute angle of segment 1 from downward vertical (rad).
+    phi1 : float
+        Relative angle of segment 2 (rad).
+    phi2 : float
+        Relative angle of segment 3 (rad).
+    params : TriplePendulumParams
+
+    Returns
+    -------
+    dict with 'shoulder', 'wrist1', 'wrist2', 'tip' as (x, y) tuples.
+    """
+    L1, L2, L3 = params.L1, params.L2, params.L3
+    
+    abs_angle2 = theta1 + phi1
+    abs_angle3 = theta1 + phi1 + phi2
+    
+    # Segment 1 endpoint (wrist1 / first joint)
+    w1x = L1 * np.sin(theta1)
+    w1y = -L1 * np.cos(theta1)
+    
+    # Segment 2 endpoint (wrist2 / second joint)
+    w2x = w1x + L2 * np.sin(abs_angle2)
+    w2y = w1y - L2 * np.cos(abs_angle2)
+    
+    # Segment 3 endpoint (tip)
+    tx = w2x + L3 * np.sin(abs_angle3)
+    ty = w2y - L3 * np.cos(abs_angle3)
+    
+    return {
+        "shoulder": (0.0, 0.0),
+        "wrist1": (w1x, w1y),
+        "wrist2": (w2x, w2y),
+        "tip": (tx, ty),
+    }
+
+
+def linear_accelerations(state: State, qddot: np.ndarray,
+                         params: TriplePendulumParams) -> dict:
+    """Compute linear accelerations of joints in world coordinates.
+
+    Returns
+    -------
+    dict with keys: 'wrist1', 'wrist2', 'tip' as (ax, ay) tuples.
+    """
+    assert state.shape == (6,), f"State must have shape (6,), got {state.shape}"
+    assert qddot.shape == (3,), f"qddot must have shape (3,), got {qddot.shape}"
+
+    theta1, phi1, phi2, dtheta1, dphi1, dphi2 = state
+    ddtheta1, ddphi1, ddphi2 = qddot
+
+    L1, L2, L3 = params.L1, params.L2, params.L3
+    abs_angle2 = theta1 + phi1
+    abs_angle3 = theta1 + phi1 + phi2
+
+    dabs2 = dtheta1 + dphi1
+    ddabs2 = ddtheta1 + ddphi1
+    dabs3 = dtheta1 + dphi1 + dphi2
+    ddabs3 = ddtheta1 + ddphi1 + ddphi2
+
+    ax_w1 = L1 * (-np.sin(theta1) * dtheta1**2 + np.cos(theta1) * ddtheta1)
+    ay_w1 = L1 * (np.cos(theta1) * dtheta1**2 + np.sin(theta1) * ddtheta1)
+
+    ax_w2 = ax_w1 + L2 * (-np.sin(abs_angle2) * dabs2**2 + np.cos(abs_angle2) * ddabs2)
+    ay_w2 = ay_w1 + L2 * (np.cos(abs_angle2) * dabs2**2 + np.sin(abs_angle2) * ddabs2)
+
+    ax_t = ax_w2 + L3 * (-np.sin(abs_angle3) * dabs3**2 + np.cos(abs_angle3) * ddabs3)
+    ay_t = ay_w2 + L3 * (np.cos(abs_angle3) * dabs3**2 + np.sin(abs_angle3) * ddabs3)
+
+    return {
+        "wrist1": (ax_w1, ay_w1),
+        "wrist2": (ax_w2, ay_w2),
+        "tip": (ax_t, ay_t),
+    }
+
+
+def net_joint_forces(state: State, qddot: np.ndarray,
+                     params: TriplePendulumParams) -> dict:
+    """Compute net joint forces (proximal on distal) in world coordinates.
+
+    Returns
+    -------
+    dict with keys: 'shoulder', 'wrist1', 'wrist2' as (fx, fy) tuples.
+    """
+    acc = linear_accelerations(state, qddot, params)
+    g_vec = np.array([0.0, -params.g])
+
+    m1, m2, m3 = params.m1, params.m2, params.m3
+    a_w1 = np.array(acc["wrist1"])
+    a_w2 = np.array(acc["wrist2"])
+    a_t = np.array(acc["tip"])
+
+    f_wrist2 = m3 * a_t - m3 * g_vec
+    f_wrist1 = (m2 * a_w2 + m3 * a_t) - (m2 + m3) * g_vec
+    f_shoulder = (m1 * a_w1 + m2 * a_w2 + m3 * a_t) - (m1 + m2 + m3) * g_vec
+
+    return {
+        "shoulder": (float(f_shoulder[0]), float(f_shoulder[1])),
+        "wrist1": (float(f_wrist1[0]), float(f_wrist1[1])),
+        "wrist2": (float(f_wrist2[0]), float(f_wrist2[1])),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Energy calculations
+# ---------------------------------------------------------------------------
+
+def kinetic_energy(state: State, params: TriplePendulumParams) -> float:
+    """Compute total kinetic energy T = 0.5 * qdot^T M qdot."""
+    theta1, phi1, phi2, dtheta1, dphi1, dphi2 = state
+    M = mass_matrix(phi1, phi2, params)
+    qdot = np.array([dtheta1, dphi1, dphi2])
+    return 0.5 * qdot @ M @ qdot
+
+
+def potential_energy(state: State, params: TriplePendulumParams) -> float:
+    """Compute total potential energy."""
+    theta1, phi1, phi2, _, _, _ = state
+    
+    m1, m2, m3 = params.m1, params.m2, params.m3
+    L1, L2, L3 = params.L1, params.L2, params.L3
+    g = params.g
+    
+    abs_angle2 = theta1 + phi1
+    abs_angle3 = theta1 + phi1 + phi2
+    
+    # Taking the shoulder as reference (zero potential energy)
+    V = (-m1 * g * L1 * np.cos(theta1) -
+         m2 * g * (L1 * np.cos(theta1) + L2 * np.cos(abs_angle2)) -
+         m3 * g * (L1 * np.cos(theta1) + L2 * np.cos(abs_angle2) + L3 * np.cos(abs_angle3)))
+    
+    return V
+
+
+def total_energy(state: State, params: TriplePendulumParams) -> float:
+    """Compute total energy E = T + V."""
+    return kinetic_energy(state, params) + potential_energy(state, params)

--- a/src/pendulum_simulator/src/double_pendulum_golf/simulation.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/simulation.py
@@ -1,0 +1,277 @@
+"""
+Simulation engine for the driven double pendulum.
+
+Integrates the equations of motion using scipy's solve_ivp and
+stores results in a structured SimulationResult for easy access
+by the GUI and analysis code.
+"""
+
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Tuple
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+from .physics import (
+    PendulumParams,
+    State,
+    TorqueFunc,
+    coriolis_vector,
+    equations_of_motion,
+    forward_kinematics,
+    friction_torque_vector,
+    gravity_vector,
+    kinetic_energy,
+    net_joint_forces,
+    mass_matrix,
+    mass_matrix_components,
+    potential_energy,
+    total_energy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Polynomial torque builder
+# ---------------------------------------------------------------------------
+
+def make_polynomial_torque(
+    coeffs_shoulder: list[float],
+    coeffs_wrist: list[float],
+) -> TorqueFunc:
+    """Create a torque function from polynomial coefficients.
+
+    tau(t) = c0 + c1*t + c2*t^2 + ...
+
+    Preconditions:
+        - Each coefficient list has at least one element.
+    Postconditions:
+        - Returned function produces finite values for finite t.
+
+    Parameters
+    ----------
+    coeffs_shoulder : list of float
+        Polynomial coefficients [c0, c1, c2, ...] for shoulder torque.
+    coeffs_wrist : list of float
+        Polynomial coefficients [c0, c1, c2, ...] for wrist torque.
+
+    Returns
+    -------
+    torque_func : callable (t) -> (tau1, tau2)
+    """
+    assert len(coeffs_shoulder) >= 1, "Need at least one coefficient for shoulder"
+    assert len(coeffs_wrist) >= 1, "Need at least one coefficient for wrist"
+
+    # numpy polyval expects highest-degree first, so reverse
+    p_shoulder = np.array(coeffs_shoulder[::-1])
+    p_wrist = np.array(coeffs_wrist[::-1])
+
+    def torque_func(t: float) -> Tuple[float, float]:
+        tau1 = float(np.polyval(p_shoulder, t))
+        tau2 = float(np.polyval(p_wrist, t))
+        return tau1, tau2
+
+    return torque_func
+
+
+# ---------------------------------------------------------------------------
+# Simulation result container
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SimulationResult:
+    """Stores the complete trajectory and derived quantities.
+
+    Attributes
+    ----------
+    t : np.ndarray, shape (N,)
+        Time points.
+    states : np.ndarray, shape (N, 4)
+        State vectors [theta1, phi, dtheta1, dphi] at each time.
+    params : PendulumParams
+        Physical parameters used.
+    torque_func : TorqueFunc
+        Torque function used.
+    """
+    t: np.ndarray
+    states: np.ndarray
+    params: PendulumParams
+    torque_func: TorqueFunc
+
+    # Lazily computed caches
+    _mass_matrices: Optional[np.ndarray] = field(default=None, repr=False)
+    _positions: Optional[list] = field(default=None, repr=False)
+
+    @property
+    def n_steps(self) -> int:
+        return len(self.t)
+
+    @property
+    def theta1(self) -> np.ndarray:
+        return self.states[:, 0]
+
+    @property
+    def phi(self) -> np.ndarray:
+        return self.states[:, 1]
+
+    @property
+    def dtheta1(self) -> np.ndarray:
+        return self.states[:, 2]
+
+    @property
+    def dphi(self) -> np.ndarray:
+        return self.states[:, 3]
+
+    def mass_matrix_at(self, idx: int) -> dict:
+        """Get mass matrix components at time index idx."""
+        assert 0 <= idx < self.n_steps, f"Index {idx} out of range [0, {self.n_steps})"
+        return mass_matrix_components(self.states[idx, 1], self.params)
+
+    def positions_at(self, idx: int) -> dict:
+        """Get joint positions at time index idx."""
+        assert 0 <= idx < self.n_steps
+        return forward_kinematics(
+            self.states[idx, 0], self.states[idx, 1], self.params
+        )
+
+    def torques_at(self, idx: int) -> Tuple[float, float]:
+        """Get applied torques at time index idx."""
+        assert 0 <= idx < self.n_steps
+        return self.torque_func(self.t[idx])
+
+    def accelerations_at(self, idx: int) -> np.ndarray:
+        """Get angular accelerations [ddtheta1, ddphi] at time index idx."""
+        assert 0 <= idx < self.n_steps
+        state_dot = equations_of_motion(
+            self.states[idx], self.t[idx], self.params, self.torque_func
+        )
+        return state_dot[2:]
+
+    def joint_forces_at(self, idx: int) -> dict:
+        """Get net joint forces (proximal on distal) at time index idx."""
+        assert 0 <= idx < self.n_steps
+        qddot = self.accelerations_at(idx)
+        return net_joint_forces(self.states[idx], qddot, self.params)
+
+    def energy_at(self, idx: int) -> dict:
+        """Get energy components at time index idx."""
+        state = self.states[idx]
+        return {
+            "kinetic": kinetic_energy(state, self.params),
+            "potential": potential_energy(state, self.params),
+            "total": total_energy(state, self.params),
+        }
+
+    def coriolis_at(self, idx: int) -> np.ndarray:
+        """Get Coriolis/centrifugal vector at time index idx."""
+        assert 0 <= idx < self.n_steps
+        s = self.states[idx]
+        return coriolis_vector(s[1], s[2], s[3], self.params)
+
+    def gravity_at(self, idx: int) -> np.ndarray:
+        """Get gravity vector at time index idx."""
+        assert 0 <= idx < self.n_steps
+        s = self.states[idx]
+        return gravity_vector(s[0], s[1], self.params)
+
+    def friction_torques_at(self, idx: int) -> np.ndarray:
+        """Get dissipative friction torque vector [tau_f1, tau_f2] at time idx.
+
+        These are the damping + Coulomb friction torques computed from the
+        joint velocities at this timestep. They are NOT part of the driving
+        torque_func and represent energy removed from the system.
+
+        Returns
+        -------
+        np.ndarray, shape (2,)  [N\u00b7m]   (negative = opposing motion)
+        """
+        assert 0 <= idx < self.n_steps
+        s = self.states[idx]
+        return friction_torque_vector(s[2], s[3], self.params)
+
+    def total_torques_at(self, idx: int) -> np.ndarray:
+        """Get total applied torque [tau_total_1, tau_total_2] at time idx.
+
+        Total = driving torque (from torque_func) + friction torque.
+        This is the net torque that actually enters the equations of motion.
+
+        Returns
+        -------
+        np.ndarray, shape (2,)  [N\u00b7m]
+        """
+        assert 0 <= idx < self.n_steps
+        tau_drive = np.array(self.torque_func(self.t[idx]))
+        tau_friction = self.friction_torques_at(idx)
+        return tau_drive + tau_friction
+
+
+# ---------------------------------------------------------------------------
+# Simulation runner
+# ---------------------------------------------------------------------------
+
+def run_simulation(
+    params: PendulumParams,
+    initial_state: State,
+    t_end: float,
+    torque_func: TorqueFunc,
+    dt: float = 0.005,
+    method: str = "RK45",
+) -> SimulationResult:
+    """Integrate the double pendulum equations of motion.
+
+    Preconditions:
+        - initial_state has shape (4,) with finite values.
+        - t_end > 0.
+        - dt > 0 and dt < t_end.
+    Postconditions:
+        - Result contains at least 2 time points.
+        - All state values in result are finite (if integration succeeded).
+
+    Parameters
+    ----------
+    params : PendulumParams
+    initial_state : np.ndarray, shape (4,)
+    t_end : float
+        Simulation duration (s).
+    torque_func : callable
+    dt : float
+        Output time step (s). Integration uses adaptive stepping internally.
+    method : str
+        scipy integrator method.
+
+    Returns
+    -------
+    SimulationResult
+    """
+    assert initial_state.shape == (4,), f"Initial state shape must be (4,), got {initial_state.shape}"
+    assert all(np.isfinite(initial_state)), "Initial state must be finite"
+    assert t_end > 0, f"t_end must be positive, got {t_end}"
+    assert 0 < dt < t_end, f"dt must be in (0, t_end), got {dt}"
+
+    t_eval = np.arange(0.0, t_end, dt)
+
+    def ode_rhs(t, y):
+        return equations_of_motion(y, t, params, torque_func)
+
+    sol = solve_ivp(
+        ode_rhs,
+        t_span=(0.0, t_end),
+        y0=initial_state,
+        t_eval=t_eval,
+        method=method,
+        rtol=1e-8,
+        atol=1e-10,
+        max_step=dt,
+    )
+
+    if not sol.success:
+        raise RuntimeError(f"Integration failed: {sol.message}")
+
+    result = SimulationResult(
+        t=sol.t,
+        states=sol.y.T,  # transpose to (N, 4)
+        params=params,
+        torque_func=torque_func,
+    )
+
+    assert result.n_steps >= 2, "Simulation must produce at least 2 time points"
+    return result

--- a/src/pendulum_simulator/src/double_pendulum_golf/simulation_triple.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/simulation_triple.py
@@ -1,0 +1,168 @@
+"""
+Simulation engine for the driven triple pendulum.
+
+Integrates the equations of motion using scipy's solve_ivp and
+stores results in a structured TripleSimulationResult for easy access
+by the GUI and analysis code.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+from .physics_triple import (
+    TriplePendulumParams,
+    State,
+    TorqueFunc,
+    coriolis_vector,
+    equations_of_motion,
+    forward_kinematics,
+    gravity_vector,
+    kinetic_energy,
+    mass_matrix_components,
+    net_joint_forces,
+    potential_energy,
+    total_energy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Polynomial torque builder
+# ---------------------------------------------------------------------------
+
+def make_polynomial_torque(
+    coeffs_shoulder: list[float],
+    coeffs_elbow: list[float],
+    coeffs_wrist: list[float],
+) -> TorqueFunc:
+    """Create a torque function from polynomial coefficients.
+
+    tau(t) = c0 + c1*t + c2*t^2 + ...
+    """
+    assert len(coeffs_shoulder) >= 1, "Need at least one coefficient for shoulder"
+    assert len(coeffs_elbow) >= 1, "Need at least one coefficient for elbow"
+    assert len(coeffs_wrist) >= 1, "Need at least one coefficient for wrist"
+
+    p_shoulder = np.array(coeffs_shoulder[::-1])
+    p_elbow = np.array(coeffs_elbow[::-1])
+    p_wrist = np.array(coeffs_wrist[::-1])
+
+    def torque_func(t: float) -> Tuple[float, float, float]:
+        tau1 = float(np.polyval(p_shoulder, t))
+        tau2 = float(np.polyval(p_elbow, t))
+        tau3 = float(np.polyval(p_wrist, t))
+        return tau1, tau2, tau3
+
+    return torque_func
+
+
+# ---------------------------------------------------------------------------
+# Simulation result container
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TripleSimulationResult:
+    """Stores the complete trajectory and derived quantities."""
+
+    t: np.ndarray
+    states: np.ndarray
+    params: TriplePendulumParams
+    torque_func: TorqueFunc
+
+    @property
+    def n_steps(self) -> int:
+        return len(self.t)
+
+    def mass_matrix_at(self, idx: int) -> dict:
+        assert 0 <= idx < self.n_steps, f"Index {idx} out of range [0, {self.n_steps})"
+        s = self.states[idx]
+        return mass_matrix_components(s[1], s[2], self.params)
+
+    def positions_at(self, idx: int) -> dict:
+        assert 0 <= idx < self.n_steps
+        s = self.states[idx]
+        return forward_kinematics(s[0], s[1], s[2], self.params)
+
+    def torques_at(self, idx: int) -> Tuple[float, float, float]:
+        assert 0 <= idx < self.n_steps
+        return self.torque_func(self.t[idx])
+
+    def accelerations_at(self, idx: int) -> np.ndarray:
+        assert 0 <= idx < self.n_steps
+        state_dot = equations_of_motion(
+            self.states[idx], self.t[idx], self.params, self.torque_func
+        )
+        return state_dot[3:]
+
+    def joint_forces_at(self, idx: int) -> dict:
+        assert 0 <= idx < self.n_steps
+        qddot = self.accelerations_at(idx)
+        return net_joint_forces(self.states[idx], qddot, self.params)
+
+    def coriolis_at(self, idx: int) -> np.ndarray:
+        assert 0 <= idx < self.n_steps
+        s = self.states[idx]
+        return coriolis_vector(s[1], s[2], s[3], s[4], s[5], self.params)
+
+    def gravity_at(self, idx: int) -> np.ndarray:
+        assert 0 <= idx < self.n_steps
+        s = self.states[idx]
+        return gravity_vector(s[0], s[1], s[2], self.params)
+
+    def energy_at(self, idx: int) -> dict:
+        state = self.states[idx]
+        return {
+            "kinetic": kinetic_energy(state, self.params),
+            "potential": potential_energy(state, self.params),
+            "total": total_energy(state, self.params),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Simulation runner
+# ---------------------------------------------------------------------------
+
+def run_simulation(
+    params: TriplePendulumParams,
+    initial_state: State,
+    t_end: float,
+    torque_func: TorqueFunc,
+    dt: float = 0.005,
+    method: str = "RK45",
+) -> TripleSimulationResult:
+    """Integrate the triple pendulum equations of motion."""
+    assert initial_state.shape == (6,), f"Initial state shape must be (6,), got {initial_state.shape}"
+    assert all(np.isfinite(initial_state)), "Initial state must be finite"
+    assert t_end > 0, f"t_end must be positive, got {t_end}"
+    assert 0 < dt < t_end, f"dt must be in (0, t_end), got {dt}"
+
+    t_eval = np.arange(0.0, t_end, dt)
+
+    def ode_rhs(t, y):
+        return equations_of_motion(y, t, params, torque_func)
+
+    sol = solve_ivp(
+        ode_rhs,
+        t_span=(0.0, t_end),
+        y0=initial_state,
+        t_eval=t_eval,
+        method=method,
+        rtol=1e-8,
+        atol=1e-10,
+        max_step=dt,
+    )
+
+    if not sol.success:
+        raise RuntimeError(f"Integration failed: {sol.message}")
+
+    result = TripleSimulationResult(
+        t=sol.t,
+        states=sol.y.T,
+        params=params,
+        torque_func=torque_func,
+    )
+
+    assert result.n_steps >= 2, "Simulation must produce at least 2 time points"
+    return result

--- a/src/pendulum_simulator/test_sim.py
+++ b/src/pendulum_simulator/test_sim.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Quick test to see if simulation runs without GUI."""
+
+import numpy as np
+from src.double_pendulum_golf.physics import PendulumParams
+from src.double_pendulum_golf.simulation import make_polynomial_torque, run_simulation
+
+# Default preset params
+params = PendulumParams(
+    m1=5.0, m2=0.5,
+    L1=0.6, L2=1.0,
+)
+
+initial_state = np.array([
+    np.radians(120.0),  # theta1
+    np.radians(-90.0),  # phi
+    0.0,                # dtheta1
+    0.0,                # dphi
+])
+
+torque_func = make_polynomial_torque(
+    [-25, 10],  # shoulder
+    [0],        # wrist
+)
+
+print("Running simulation...")
+try:
+    result = run_simulation(
+        params=params,
+        initial_state=initial_state,
+        t_end=2.0,
+        torque_func=torque_func,
+        dt=0.005,
+    )
+    print(f"✓ Simulation succeeded!")
+    print(f"  Steps: {result.n_steps}")
+    print(f"  Time range: {result.t[0]:.3f} to {result.t[-1]:.3f} s")
+    print(f"  Initial state: {result.states[0]}")
+    print(f"  Final state: {result.states[-1]}")
+except Exception as e:
+    print(f"✗ Simulation failed: {e}")
+    import traceback
+    traceback.print_exc()

--- a/src/pendulum_simulator/tests/__init__.py
+++ b/src/pendulum_simulator/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for double_pendulum_golf."""

--- a/src/pendulum_simulator/tests/conftest.py
+++ b/src/pendulum_simulator/tests/conftest.py
@@ -1,0 +1,42 @@
+"""Shared pytest fixtures for the test suite."""
+
+import numpy as np
+import pytest
+
+from double_pendulum_golf.physics import PendulumParams
+
+
+@pytest.fixture
+def default_params():
+    """Standard test parameters: golf-like arm + club."""
+    return PendulumParams(m1=5.0, m2=0.5, L1=0.6, L2=1.0)
+
+
+@pytest.fixture
+def equal_params():
+    """Equal-mass, equal-length pendulum for symmetry tests."""
+    return PendulumParams(m1=1.0, m2=1.0, L1=1.0, L2=1.0)
+
+
+@pytest.fixture
+def aligned_state():
+    """Both segments straight down, positive velocities."""
+    return np.array([0.0, 0.0, 2.0, 1.0])
+
+
+@pytest.fixture
+def cocked_state():
+    """Arm back, club cocked (golf backswing position)."""
+    return np.array([np.radians(120), np.radians(-90), 0.0, 0.0])
+
+
+@pytest.fixture
+def zero_torque():
+    """No applied torques."""
+    return lambda t: (0.0, 0.0)
+
+
+@pytest.fixture
+def constant_shoulder_torque():
+    """Constant shoulder torque, zero wrist."""
+    return lambda t: (-25.0, 0.0)

--- a/src/pendulum_simulator/tests/test_friction.py
+++ b/src/pendulum_simulator/tests/test_friction.py
@@ -1,0 +1,282 @@
+"""
+Tests for damping and Coulomb friction in the double pendulum physics.
+
+Following TDD / DbC pattern established in the codebase.
+"""
+
+import numpy as np
+import pytest
+
+from double_pendulum_golf.physics import (
+    PendulumParams,
+    equations_of_motion,
+    friction_torque_vector,
+)
+from double_pendulum_golf.simulation import (
+    SimulationResult,
+    make_polynomial_torque,
+    run_simulation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def base_params() -> PendulumParams:
+    return PendulumParams(m1=5.0, m2=0.5, L1=0.6, L2=1.0)
+
+
+@pytest.fixture
+def damped_params() -> PendulumParams:
+    """Params with moderate viscous damping at both joints."""
+    return PendulumParams(m1=5.0, m2=0.5, L1=0.6, L2=1.0, b1=0.5, b2=0.2)
+
+
+@pytest.fixture
+def frictional_params() -> PendulumParams:
+    """Params with Coulomb friction only (no viscous damping)."""
+    return PendulumParams(m1=5.0, m2=0.5, L1=0.6, L2=1.0, mu1=0.1, mu2=0.05)
+
+
+@pytest.fixture
+def combined_params() -> PendulumParams:
+    """Params with both viscous damping and Coulomb friction."""
+    return PendulumParams(
+        m1=5.0, m2=0.5, L1=0.6, L2=1.0,
+        b1=0.3, b2=0.1, mu1=0.05, mu2=0.02,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PendulumParams contract tests
+# ---------------------------------------------------------------------------
+
+class TestPendulumParamsContracts:
+    """Verify new DbC constraints on damping/friction parameters."""
+
+    def test_default_no_dissipation(self, base_params: PendulumParams) -> None:
+        assert base_params.b1 == 0.0
+        assert base_params.b2 == 0.0
+        assert base_params.mu1 == 0.0
+        assert base_params.mu2 == 0.0
+
+    def test_valid_damping(self) -> None:
+        p = PendulumParams(m1=1.0, m2=1.0, L1=1.0, L2=1.0, b1=0.5, b2=1.0)
+        assert p.b1 == 0.5
+        assert p.b2 == 1.0
+
+    def test_valid_coulomb(self) -> None:
+        p = PendulumParams(m1=1.0, m2=1.0, L1=1.0, L2=1.0, mu1=0.1, mu2=0.2)
+        assert p.mu1 == 0.1
+        assert p.mu2 == 0.2
+
+    def test_negative_b1_rejected(self) -> None:
+        with pytest.raises(AssertionError, match="b1 must be non-negative"):
+            PendulumParams(m1=1.0, m2=1.0, L1=1.0, L2=1.0, b1=-0.1)
+
+    def test_negative_b2_rejected(self) -> None:
+        with pytest.raises(AssertionError, match="b2 must be non-negative"):
+            PendulumParams(m1=1.0, m2=1.0, L1=1.0, L2=1.0, b2=-0.1)
+
+    def test_negative_mu1_rejected(self) -> None:
+        with pytest.raises(AssertionError, match="mu1 must be non-negative"):
+            PendulumParams(m1=1.0, m2=1.0, L1=1.0, L2=1.0, mu1=-0.01)
+
+    def test_negative_mu2_rejected(self) -> None:
+        with pytest.raises(AssertionError, match="mu2 must be non-negative"):
+            PendulumParams(m1=1.0, m2=1.0, L1=1.0, L2=1.0, mu2=-0.01)
+
+
+# ---------------------------------------------------------------------------
+# friction_torque_vector tests
+# ---------------------------------------------------------------------------
+
+class TestFrictionTorqueVector:
+    """Unit tests for the friction torque computation."""
+
+    def test_zero_dissipation_gives_zero(self, base_params: PendulumParams) -> None:
+        tf = friction_torque_vector(dtheta1=2.0, dphi=-1.0, params=base_params)
+        assert tf.shape == (2,)
+        assert np.allclose(tf, [0.0, 0.0])
+
+    def test_viscous_opposes_velocity(self, damped_params: PendulumParams) -> None:
+        """Viscous friction must oppose motion (same sign as -velocity)."""
+        dtheta1, dphi = 3.0, -2.0
+        tf = friction_torque_vector(dtheta1, dphi, damped_params)
+        # Joint 1: positive velocity → negative friction
+        assert tf[0] < 0.0, "Friction at joint 1 must oppose positive velocity"
+        # Joint 2: negative velocity → positive friction
+        assert tf[1] > 0.0, "Friction at joint 2 must oppose negative velocity"
+
+    def test_viscous_magnitude_linear(self, damped_params: PendulumParams) -> None:
+        """Viscous torque magnitude = b * |qdot|."""
+        dtheta1 = 2.0
+        tf = friction_torque_vector(dtheta1=dtheta1, dphi=0.0, params=damped_params)
+        expected_tau_f1 = -damped_params.b1 * dtheta1
+        assert np.isclose(tf[0], expected_tau_f1)
+
+    def test_coulomb_has_constant_magnitude(
+        self, frictional_params: PendulumParams
+    ) -> None:
+        """Coulomb friction magnitude is mu regardless of velocity magnitude."""
+        for speed in [0.1, 1.0, 10.0, 100.0]:
+            tf = friction_torque_vector(dtheta1=speed, dphi=speed, params=frictional_params)
+            assert np.isclose(abs(tf[0]), frictional_params.mu1), \
+                f"Expected |tau_f1|={frictional_params.mu1}, got {abs(tf[0])} at speed={speed}"
+
+    def test_coulomb_zero_at_rest(self, frictional_params: PendulumParams) -> None:
+        """np.sign(0) == 0, so Coulomb friction is zero when stationary."""
+        tf = friction_torque_vector(dtheta1=0.0, dphi=0.0, params=frictional_params)
+        assert np.allclose(tf, [0.0, 0.0])
+
+    def test_combined_friction_superposition(
+        self, combined_params: PendulumParams
+    ) -> None:
+        """Combined damping+friction = viscous + Coulomb separately."""
+        dtheta1, dphi = 1.5, -0.8
+        tf = friction_torque_vector(dtheta1, dphi, combined_params)
+
+        expected_1 = (
+            -combined_params.b1 * dtheta1
+            - combined_params.mu1 * np.sign(dtheta1)
+        )
+        expected_2 = (
+            -combined_params.b2 * dphi
+            - combined_params.mu2 * np.sign(dphi)
+        )
+        assert np.isclose(tf[0], expected_1)
+        assert np.isclose(tf[1], expected_2)
+
+    def test_output_shape_and_finiteness(
+        self, combined_params: PendulumParams
+    ) -> None:
+        tf = friction_torque_vector(dtheta1=5.0, dphi=3.0, params=combined_params)
+        assert tf.shape == (2,)
+        assert all(np.isfinite(tf))
+
+
+# ---------------------------------------------------------------------------
+# EOM integration tests with dissipation
+# ---------------------------------------------------------------------------
+
+class TestEquationsOfMotionWithDissipation:
+    """Verify that EOM correctly incorporates friction into dynamics."""
+
+    def test_undamped_conserves_energy_approximately(
+        self, base_params: PendulumParams
+    ) -> None:
+        """Without dissipation, total energy should be nearly conserved."""
+        from double_pendulum_golf.physics import total_energy
+
+        state0 = np.array([np.pi / 4, 0.0, 0.0, 0.0])
+        torque_func = make_polynomial_torque([0.0], [0.0])
+
+        result = run_simulation(
+            params=base_params,
+            initial_state=state0,
+            t_end=2.0,
+            torque_func=torque_func,
+            dt=0.001,
+        )
+
+        e_start = total_energy(result.states[0], base_params)
+        e_end = total_energy(result.states[-1], base_params)
+        # Allow ~1% drift from numerical integration
+        assert abs(e_end - e_start) / max(abs(e_start), 1e-9) < 0.01, \
+            f"Energy drift too large: {e_start:.4f} → {e_end:.4f}"
+
+    def test_damped_pendulum_loses_energy(
+        self, damped_params: PendulumParams
+    ) -> None:
+        """With viscous damping, total energy must decrease over time."""
+        from double_pendulum_golf.physics import total_energy
+
+        state0 = np.array([np.pi / 4, 0.0, 0.0, 0.0])
+        torque_func = make_polynomial_torque([0.0], [0.0])
+
+        result = run_simulation(
+            params=damped_params,
+            initial_state=state0,
+            t_end=3.0,
+            torque_func=torque_func,
+            dt=0.005,
+        )
+
+        e_start = total_energy(result.states[0], damped_params)
+        e_end = total_energy(result.states[-1], damped_params)
+        assert e_end < e_start, \
+            f"Damped pendulum energy should decrease: {e_start:.4f} → {e_end:.4f}"
+
+    def test_friction_does_not_blow_up(
+        self, combined_params: PendulumParams
+    ) -> None:
+        """Simulation with both friction types must remain numerically stable."""
+        state0 = np.array([np.radians(120), np.radians(-90), 0.0, 0.0])
+        torque_func = make_polynomial_torque([-25.0, 10.0], [0.0])
+
+        result = run_simulation(
+            params=combined_params,
+            initial_state=state0,
+            t_end=2.0,
+            torque_func=torque_func,
+            dt=0.005,
+        )
+
+        assert result.n_steps >= 2
+        assert all(np.isfinite(result.states.flatten())), \
+            "Simulation with combined friction/damping produced non-finite states"
+
+
+# ---------------------------------------------------------------------------
+# SimulationResult friction accessor tests
+# ---------------------------------------------------------------------------
+
+class TestSimulationResultFrictionAccessors:
+    """Verify friction_torques_at and total_torques_at methods."""
+
+    @pytest.fixture
+    def friction_result(
+        self, combined_params: PendulumParams
+    ) -> SimulationResult:
+        state0 = np.array([np.radians(90), 0.0, 0.5, 0.0])
+        torque_func = make_polynomial_torque([5.0], [0.0])
+        return run_simulation(
+            params=combined_params,
+            initial_state=state0,
+            t_end=1.0,
+            torque_func=torque_func,
+            dt=0.005,
+        )
+
+    def test_friction_torques_shape(
+        self, friction_result: SimulationResult
+    ) -> None:
+        tf = friction_result.friction_torques_at(0)
+        assert tf.shape == (2,)
+
+    def test_total_torques_equals_drive_plus_friction(
+        self, friction_result: SimulationResult
+    ) -> None:
+        idx = friction_result.n_steps // 2
+        drive = np.array(friction_result.torques_at(idx))
+        friction = friction_result.friction_torques_at(idx)
+        total = friction_result.total_torques_at(idx)
+        assert np.allclose(total, drive + friction)
+
+    def test_no_dissipation_zero_friction_torques(
+        self, base_params: PendulumParams
+    ) -> None:
+        state0 = np.array([np.radians(45), 0.0, 1.0, 0.0])
+        result = run_simulation(
+            params=base_params,
+            initial_state=state0,
+            t_end=0.5,
+            torque_func=make_polynomial_torque([0.0], [0.0]),
+            dt=0.005,
+        )
+        for i in range(0, result.n_steps, 20):
+            tf = result.friction_torques_at(i)
+            assert np.allclose(tf, [0.0, 0.0]), \
+                f"Expected zero friction torques at step {i}, got {tf}"

--- a/src/pendulum_simulator/tests/test_physics.py
+++ b/src/pendulum_simulator/tests/test_physics.py
@@ -1,0 +1,265 @@
+"""Tests for the physics module.
+
+Organized by property being tested, following TDD principles:
+each test was conceptualized before the implementation to verify
+a specific physical or mathematical property.
+"""
+
+import numpy as np
+import pytest
+
+from double_pendulum_golf.physics import (
+    PendulumParams,
+    coriolis_vector,
+    equations_of_motion,
+    forward_kinematics,
+    gravity_vector,
+    kinetic_energy,
+    mass_matrix,
+    mass_matrix_components,
+    net_joint_forces,
+    potential_energy,
+    total_energy,
+)
+
+
+# ======================================================================
+# Mass matrix properties
+# ======================================================================
+
+class TestMassMatrixSymmetry:
+    """The mass matrix must be symmetric: M12 == M21."""
+
+    def test_symmetric_at_zero(self, default_params):
+        M = mass_matrix(0.0, default_params)
+        assert np.isclose(M[0, 1], M[1, 0])
+
+    def test_symmetric_at_arbitrary_angle(self, default_params):
+        for phi in np.linspace(-np.pi, np.pi, 20):
+            M = mass_matrix(phi, default_params)
+            assert np.isclose(M[0, 1], M[1, 0]), f"Not symmetric at phi={phi}"
+
+
+class TestMassMatrixPositiveDefinite:
+    """The mass matrix must be positive definite (all eigenvalues > 0)."""
+
+    def test_positive_definite_at_various_angles(self, default_params):
+        for phi in np.linspace(-np.pi, np.pi, 50):
+            M = mass_matrix(phi, default_params)
+            eigenvalues = np.linalg.eigvalsh(M)
+            assert all(ev > 0 for ev in eigenvalues), \
+                f"Not positive definite at phi={phi}: eigenvalues={eigenvalues}"
+
+
+class TestMassMatrixCouplingMaximum:
+    """Off-diagonal coupling |M12| should be maximized when segments are aligned (phi=0)."""
+
+    def test_coupling_maximized_at_alignment(self, default_params):
+        M12_at_zero = abs(mass_matrix(0.0, default_params)[0, 1])
+        for phi in np.linspace(0.1, np.pi, 30):
+            M12 = abs(mass_matrix(phi, default_params)[0, 1])
+            assert M12 <= M12_at_zero + 1e-10, \
+                f"|M12| at phi={phi:.2f} ({M12:.4f}) exceeds value at phi=0 ({M12_at_zero:.4f})"
+
+
+class TestMassMatrixDiagonalConstant:
+    """M22 (club's self-inertia) should be constant — it doesn't depend on phi."""
+
+    def test_m22_independent_of_phi(self, default_params):
+        M22_ref = mass_matrix(0.0, default_params)[1, 1]
+        for phi in np.linspace(-np.pi, np.pi, 30):
+            M22 = mass_matrix(phi, default_params)[1, 1]
+            assert np.isclose(M22, M22_ref), \
+                f"M22 changed at phi={phi}: {M22} vs {M22_ref}"
+
+    def test_m22_equals_expected(self, default_params):
+        """M22 = m2 * L2^2 for point mass at tip."""
+        expected = default_params.m2 * default_params.L2 ** 2
+        M22 = mass_matrix(0.0, default_params)[1, 1]
+        assert np.isclose(M22, expected)
+
+
+class TestMassMatrixKnownValues:
+    """Verify mass matrix against hand-computed values for simple case."""
+
+    def test_aligned_equal_segments(self, equal_params):
+        """When m1=m2=1, L1=L2=1, phi=0:
+        M11 = 2*1 + 1 + 2*1 = 5
+        M12 = 1 + 1 = 2
+        M22 = 1
+        """
+        M = mass_matrix(0.0, equal_params)
+        assert np.isclose(M[0, 0], 5.0)
+        assert np.isclose(M[0, 1], 2.0)
+        assert np.isclose(M[1, 1], 1.0)
+
+    def test_perpendicular_equal_segments(self, equal_params):
+        """phi=pi/2 -> cos(phi)=0:
+        M11 = 2 + 1 + 0 = 3
+        M12 = 1 + 0 = 1
+        M22 = 1
+        """
+        M = mass_matrix(np.pi / 2, equal_params)
+        assert np.isclose(M[0, 0], 3.0)
+        assert np.isclose(M[0, 1], 1.0)
+        assert np.isclose(M[1, 1], 1.0)
+
+
+# ======================================================================
+# Coriolis / centrifugal
+# ======================================================================
+
+class TestCoriolisVector:
+    """Tests for the Coriolis/centrifugal force computation."""
+
+    def test_zero_velocity_gives_zero_coriolis(self, default_params):
+        """No velocity => no velocity-dependent forces."""
+        C = coriolis_vector(0.5, 0.0, 0.0, default_params)
+        assert np.allclose(C, [0.0, 0.0])
+
+    def test_zero_at_alignment_with_only_theta1_velocity(self, default_params):
+        """When phi=0 (sin(phi)=0), Coriolis vanishes regardless of velocities."""
+        C = coriolis_vector(0.0, 5.0, 3.0, default_params)
+        assert np.allclose(C, [0.0, 0.0], atol=1e-14)
+
+    def test_antisymmetric_in_phi(self, default_params):
+        """C(-phi, ...) has opposite sign since sin(-phi) = -sin(phi)."""
+        phi = 0.7
+        C_pos = coriolis_vector(phi, 2.0, 1.0, default_params)
+        C_neg = coriolis_vector(-phi, 2.0, 1.0, default_params)
+        assert np.allclose(C_pos, -C_neg, atol=1e-14)
+
+
+# ======================================================================
+# Gravity vector
+# ======================================================================
+
+class TestGravityVector:
+    """Tests for gravitational torques."""
+
+    def test_zero_at_equilibrium(self, default_params):
+        """When hanging straight down (theta1=0, phi=0), gravity torque is zero."""
+        G = gravity_vector(0.0, 0.0, default_params)
+        assert np.allclose(G, [0.0, 0.0], atol=1e-14)
+
+    def test_nonzero_when_displaced(self, default_params):
+        """Any displacement from vertical should produce restoring torques."""
+        G = gravity_vector(0.5, 0.0, default_params)
+        assert not np.allclose(G, [0.0, 0.0])
+
+
+# ======================================================================
+# Equations of motion
+# ======================================================================
+
+class TestEquationsOfMotion:
+    """Tests for the complete EOM."""
+
+    def test_equilibrium_at_bottom(self, default_params, zero_torque):
+        """At vertical with zero velocity and zero torque, acceleration is zero."""
+        state = np.array([0.0, 0.0, 0.0, 0.0])
+        sdot = equations_of_motion(state, 0.0, default_params, zero_torque)
+        # Velocities are zero, accelerations should be zero at equilibrium
+        assert np.allclose(sdot, [0.0, 0.0, 0.0, 0.0], atol=1e-12)
+
+    def test_state_shape(self, default_params, zero_torque, aligned_state):
+        sdot = equations_of_motion(aligned_state, 0.0, default_params, zero_torque)
+        assert sdot.shape == (4,)
+
+    def test_velocity_passthrough(self, default_params, zero_torque, aligned_state):
+        """First two components of state_dot should equal the velocities."""
+        sdot = equations_of_motion(aligned_state, 0.0, default_params, zero_torque)
+        assert np.isclose(sdot[0], aligned_state[2])
+        assert np.isclose(sdot[1], aligned_state[3])
+
+
+# ======================================================================
+# Forward kinematics
+# ======================================================================
+
+class TestForwardKinematics:
+    """Tests for Cartesian position computation."""
+
+    def test_straight_down(self, default_params):
+        """theta1=0, phi=0 -> wrist at (0, -L1), tip at (0, -(L1+L2))."""
+        pos = forward_kinematics(0.0, 0.0, default_params)
+        assert np.isclose(pos["shoulder"][0], 0.0)
+        assert np.isclose(pos["shoulder"][1], 0.0)
+        assert np.isclose(pos["wrist"][0], 0.0)
+        assert np.isclose(pos["wrist"][1], -default_params.L1)
+        assert np.isclose(pos["tip"][0], 0.0)
+        assert np.isclose(pos["tip"][1], -(default_params.L1 + default_params.L2))
+
+    def test_arm_horizontal_club_straight(self, default_params):
+        """theta1=pi/2, phi=0 -> arm points right, club continues right."""
+        pos = forward_kinematics(np.pi / 2, 0.0, default_params)
+        L1, L2 = default_params.L1, default_params.L2
+        assert np.isclose(pos["wrist"][0], L1, atol=1e-10)
+        assert np.isclose(pos["wrist"][1], 0.0, atol=1e-10)
+        assert np.isclose(pos["tip"][0], L1 + L2, atol=1e-10)
+        assert np.isclose(pos["tip"][1], 0.0, atol=1e-10)
+
+
+# ======================================================================
+# Energy
+# ======================================================================
+
+class TestEnergy:
+    """Tests for energy computations."""
+
+    def test_zero_kinetic_at_rest(self, default_params):
+        state = np.array([0.5, 0.3, 0.0, 0.0])
+        assert np.isclose(kinetic_energy(state, default_params), 0.0)
+
+    def test_positive_kinetic_when_moving(self, default_params, aligned_state):
+        T = kinetic_energy(aligned_state, default_params)
+        assert T > 0
+
+    def test_potential_minimum_at_bottom(self, default_params):
+        """Potential energy is minimized when both segments hang down."""
+        V_bottom = potential_energy(np.array([0, 0, 0, 0]), default_params)
+        V_displaced = potential_energy(np.array([0.5, 0.3, 0, 0]), default_params)
+        assert V_bottom < V_displaced
+
+
+# ======================================================================
+# Net joint forces
+# ======================================================================
+
+class TestNetJointForces:
+    """Net joint forces should balance gravity at rest."""
+
+    def test_forces_at_rest(self, default_params):
+        state = np.array([0.0, 0.0, 0.0, 0.0])
+        qddot = np.array([0.0, 0.0])
+        forces = net_joint_forces(state, qddot, default_params)
+
+        m1, m2, g = default_params.m1, default_params.m2, default_params.g
+        assert np.isclose(forces["wrist"][0], 0.0)
+        assert np.isclose(forces["wrist"][1], m2 * g)
+        assert np.isclose(forces["shoulder"][0], 0.0)
+        assert np.isclose(forces["shoulder"][1], (m1 + m2) * g)
+
+
+# ======================================================================
+# Design by Contract: precondition violations
+# ======================================================================
+
+class TestDbCViolations:
+    """Verify that precondition violations raise AssertionError."""
+
+    def test_negative_mass_rejected(self):
+        with pytest.raises(AssertionError):
+            PendulumParams(m1=-1, m2=1, L1=1, L2=1)
+
+    def test_zero_length_rejected(self):
+        with pytest.raises(AssertionError):
+            PendulumParams(m1=1, m2=1, L1=0, L2=1)
+
+    def test_nan_phi_rejected(self, default_params):
+        with pytest.raises(AssertionError):
+            mass_matrix(float('nan'), default_params)
+
+    def test_wrong_state_shape_rejected(self, default_params, zero_torque):
+        with pytest.raises(AssertionError):
+            equations_of_motion(np.array([0, 0, 0]), 0.0, default_params, zero_torque)

--- a/src/pendulum_simulator/tests/test_physics_triple.py
+++ b/src/pendulum_simulator/tests/test_physics_triple.py
@@ -1,0 +1,223 @@
+"""Tests for the triple pendulum physics module using TDD.
+
+Organized by property being tested, following TDD principles.
+Each test verifies a specific physical or mathematical property.
+"""
+
+import numpy as np
+import pytest
+
+from double_pendulum_golf.physics_triple import (
+    TriplePendulumParams,
+    mass_matrix as mass_matrix_triple,
+    coriolis_vector as coriolis_vector_triple,
+    gravity_vector as gravity_vector_triple,
+    equations_of_motion as equations_of_motion_triple,
+    forward_kinematics as forward_kinematics_triple,
+    net_joint_forces as net_joint_forces_triple,
+)
+
+
+@pytest.fixture
+def triple_params():
+    """Default parameters for triple pendulum."""
+    return TriplePendulumParams(
+        m1=5.0, m2=0.5, m3=0.2,
+        L1=0.6, L2=0.6, L3=0.6,
+    )
+
+
+@pytest.fixture
+def triple_torque_func():
+    """Simple constant torque function."""
+    def torque(t):
+        return (0.0, 0.0, 0.0)
+    return torque
+
+
+class TestTripleMassMatrixSymmetry:
+    """The 3x3 mass matrix must be symmetric."""
+
+    def test_symmetric_at_zero(self, triple_params):
+        phi1, phi2 = 0.0, 0.0
+        M = mass_matrix_triple(phi1, phi2, triple_params)
+        assert M.shape == (3, 3)
+        # Check symmetry: M[i,j] == M[j,i]
+        for i in range(3):
+            for j in range(3):
+                assert np.isclose(M[i, j], M[j, i]), \
+                    f"M[{i},{j}] != M[{j},{i}]"
+
+    def test_symmetric_at_arbitrary_angles(self, triple_params):
+        for phi1 in np.linspace(-np.pi, np.pi, 10):
+            for phi2 in np.linspace(-np.pi, np.pi, 10):
+                M = mass_matrix_triple(phi1, phi2, triple_params)
+                for i in range(3):
+                    for j in range(3):
+                        assert np.isclose(M[i, j], M[j, i]), \
+                            f"Not symmetric at phi1={phi1}, phi2={phi2}"
+
+
+class TestTripleMassMatrixPositiveDefinite:
+    """The 3x3 mass matrix must be positive definite."""
+
+    def test_positive_definite_at_various_angles(self, triple_params):
+        test_angles = list(np.linspace(-np.pi, np.pi, 15))
+        for phi1 in test_angles:
+            for phi2 in test_angles:
+                M = mass_matrix_triple(phi1, phi2, triple_params)
+                eigenvalues = np.linalg.eigvalsh(M)
+                assert all(ev > 0 for ev in eigenvalues), \
+                    f"Not positive definite at phi1={phi1}, phi2={phi2}"
+
+
+class TestTripleCoriolisZeroAtRest:
+    """Coriolis/centrifugal vector should be zero when velocities are zero."""
+
+    def test_zero_at_rest(self, triple_params):
+        phi1, phi2 = 0.5, -0.3
+        dtheta1, dphi1, dphi2 = 0.0, 0.0, 0.0
+        C = coriolis_vector_triple(phi1, phi2, dtheta1, dphi1, dphi2, triple_params)
+        assert C.shape == (3,)
+        assert np.allclose(C, 0.0, atol=1e-12)
+
+
+class TestTripleGravityVectorDirection:
+    """Gravity should pull the system downward."""
+
+    def test_gravity_points_downward_at_rest(self, triple_params):
+        # At theta1 = 0 (straight down), gravity should be zero
+        theta1, phi1, phi2 = 0.0, 0.0, 0.0
+        G = gravity_vector_triple(theta1, phi1, phi2, triple_params)
+        assert G.shape == (3,)
+        # At equilibrium (all pointing down), gravity torques should be zero
+        assert np.allclose(G, 0.0, atol=1e-12)
+
+    def test_gravity_restores_from_lifted_position(self, triple_params):
+        # When lifted (theta1 = pi/2, pointing to the side),
+        # gravity should create restoring torque
+        theta1, phi1, phi2 = np.pi / 2, 0.0, 0.0
+        G = gravity_vector_triple(theta1, phi1, phi2, triple_params)
+        assert not np.allclose(G, 0.0)
+
+
+class TestTripleForwardKinematics:
+    """Forward kinematics should give correct positions."""
+
+    def test_all_hanging_down(self, triple_params):
+        theta1, phi1, phi2 = 0.0, 0.0, 0.0
+        pos = forward_kinematics_triple(theta1, phi1, phi2, triple_params)
+        
+        # Check keys
+        assert set(pos.keys()) == {"shoulder", "wrist1", "wrist2", "tip"}
+        
+        # Shoulder at origin
+        assert np.allclose(pos["shoulder"], (0.0, 0.0))
+        
+        # When straight down, positions should be at negative y
+        assert pos["wrist1"][0] == 0.0  # x = 0
+        assert pos["wrist1"][1] < 0  # y < 0
+        
+        assert pos["tip"][0] == 0.0
+        assert pos["tip"][1] < 0
+
+    def test_all_horizontal(self, triple_params):
+        theta1 = np.pi / 2
+        phi1, phi2 = 0.0, 0.0
+        pos = forward_kinematics_triple(theta1, phi1, phi2, triple_params)
+        
+        # Wrist1 should be at (L1, 0)
+        L1 = triple_params.L1
+        assert np.isclose(pos["wrist1"][0], L1)
+        assert np.isclose(pos["wrist1"][1], 0.0, atol=1e-12)
+
+
+class TestTripleEquationsOfMotion:
+    """Equations of motion should produce valid accelerations."""
+
+    def test_eom_produces_valid_state_derivative(self, triple_params, triple_torque_func):
+        # State: [theta1, phi1, phi2, dtheta1, dphi1, dphi2]
+        state = np.array([0.1, 0.05, -0.05, 0.0, 0.0, 0.0])
+        state_dot = equations_of_motion_triple(state, 0.0, triple_params, triple_torque_func)
+        
+        assert state_dot.shape == (6,)
+        assert all(np.isfinite(state_dot)), f"Invalid values: {state_dot}"
+
+    def test_eom_at_rest_at_equilibrium(self, triple_params, triple_torque_func):
+        # At equilibrium with zero velocity, acceleration should be zero
+        state = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        state_dot = equations_of_motion_triple(state, 0.0, triple_params, triple_torque_func)
+        
+        # Velocities should match input (first 3 elements should be all zeros)
+        assert np.isclose(state_dot[0], 0.0)  # dtheta1
+        assert np.isclose(state_dot[1], 0.0)  # dphi1
+        assert np.isclose(state_dot[2], 0.0)  # dphi2
+        # Accelerations should be small (near zero at equilibrium)
+        assert np.allclose(state_dot[3:], 0.0, atol=1e-10)
+
+
+class TestTripleParameterValidation:
+    """Parameters must satisfy constraints."""
+
+    def test_negative_mass_rejected(self):
+        with pytest.raises(AssertionError):
+            TriplePendulumParams(m1=-1.0, m2=0.5, m3=0.2, L1=0.6, L2=0.6, L3=0.6)
+
+    def test_negative_length_rejected(self):
+        with pytest.raises(AssertionError):
+            TriplePendulumParams(m1=1.0, m2=0.5, m3=0.2, L1=-0.6, L2=0.6, L3=0.6)
+
+    def test_zero_mass_rejected(self):
+        with pytest.raises(AssertionError):
+            TriplePendulumParams(m1=1.0, m2=0.0, m3=0.2, L1=0.6, L2=0.6, L3=0.6)
+
+
+class TestTripleMassMatrixDependenceOnAngles:
+    """Mass matrix should depend on the coupling angles."""
+
+    def test_mass_matrix_different_at_different_angles(self, triple_params):
+        M1 = mass_matrix_triple(0.0, 0.0, triple_params)
+        M2 = mass_matrix_triple(np.pi/4, 0.0, triple_params)
+        
+        # They should be different
+        assert not np.allclose(M1, M2)
+
+
+class TestTripleCoriolisNonlinearCoupling:
+    """Coriolis vector should show nonlinear dependence on velocities."""
+
+    def test_coriolis_scales_with_velocity_squared(self, triple_params):
+        phi1, phi2 = 0.5, -0.3
+        
+        dtheta1_small = 0.1
+        C_small = coriolis_vector_triple(phi1, phi2, dtheta1_small, 0.1, 0.1, triple_params)
+        
+        dtheta1_large = 0.2  # 2x larger
+        C_large = coriolis_vector_triple(phi1, phi2, dtheta1_large, 0.1, 0.1, triple_params)
+        
+        # The change should not be linear (quadratic in velocity)
+        ratio = np.linalg.norm(C_large) / np.linalg.norm(C_small)
+        # ratio should be approximately 4x (since velocity is 2x)
+        assert ratio > 2 and ratio < 8, f"Unexpected scaling: {ratio}"
+
+
+class TestTripleNetJointForces:
+    """Net joint forces should balance gravity at rest."""
+
+    def test_forces_at_rest(self, triple_params):
+        state = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+        qddot = np.array([0.0, 0.0, 0.0])
+        forces = net_joint_forces_triple(state, qddot, triple_params)
+
+        m1, m2, m3, g = (
+            triple_params.m1,
+            triple_params.m2,
+            triple_params.m3,
+            triple_params.g,
+        )
+        assert np.isclose(forces["wrist2"][0], 0.0)
+        assert np.isclose(forces["wrist2"][1], m3 * g)
+        assert np.isclose(forces["wrist1"][0], 0.0)
+        assert np.isclose(forces["wrist1"][1], (m2 + m3) * g)
+        assert np.isclose(forces["shoulder"][0], 0.0)
+        assert np.isclose(forces["shoulder"][1], (m1 + m2 + m3) * g)

--- a/src/pendulum_simulator/tests/test_simulation.py
+++ b/src/pendulum_simulator/tests/test_simulation.py
@@ -1,0 +1,147 @@
+"""Tests for the simulation module.
+
+Focuses on integration accuracy, energy conservation (for
+undriven systems), and correct handling of polynomial torques.
+"""
+
+import numpy as np
+import pytest
+
+from double_pendulum_golf.physics import PendulumParams, total_energy
+from double_pendulum_golf.simulation import (
+    SimulationResult,
+    make_polynomial_torque,
+    run_simulation,
+)
+
+
+# ======================================================================
+# Polynomial torque builder
+# ======================================================================
+
+class TestPolynomialTorque:
+    """Verify polynomial torque function construction."""
+
+    def test_constant_torque(self):
+        func = make_polynomial_torque([5.0], [0.0])
+        assert func(0.0) == (5.0, 0.0)
+        assert func(10.0) == (5.0, 0.0)
+
+    def test_linear_torque(self):
+        # tau(t) = 2 + 3*t
+        func = make_polynomial_torque([2.0, 3.0], [0.0])
+        tau1, tau2 = func(1.0)
+        assert np.isclose(tau1, 5.0)  # 2 + 3*1
+        assert np.isclose(tau2, 0.0)
+
+    def test_quadratic_torque(self):
+        # tau(t) = 1 + 0*t + 2*t^2  =>  tau(3) = 1 + 18 = 19
+        func = make_polynomial_torque([1.0, 0.0, 2.0], [0.0])
+        tau1, _ = func(3.0)
+        assert np.isclose(tau1, 19.0)
+
+    def test_empty_coefficients_rejected(self):
+        with pytest.raises(AssertionError):
+            make_polynomial_torque([], [1.0])
+
+
+# ======================================================================
+# Simulation execution
+# ======================================================================
+
+class TestSimulationBasics:
+    """Basic simulation sanity checks."""
+
+    def test_produces_result(self, default_params, zero_torque, aligned_state):
+        result = run_simulation(
+            default_params, aligned_state, t_end=0.5,
+            torque_func=zero_torque, dt=0.01,
+        )
+        assert isinstance(result, SimulationResult)
+        assert result.n_steps > 10
+
+    def test_initial_state_preserved(self, default_params, zero_torque, cocked_state):
+        result = run_simulation(
+            default_params, cocked_state, t_end=0.1,
+            torque_func=zero_torque, dt=0.01,
+        )
+        assert np.allclose(result.states[0], cocked_state, atol=1e-6)
+
+    def test_time_monotonically_increases(self, default_params, zero_torque, aligned_state):
+        result = run_simulation(
+            default_params, aligned_state, t_end=1.0,
+            torque_func=zero_torque, dt=0.01,
+        )
+        assert all(np.diff(result.t) > 0)
+
+
+class TestEnergyConservation:
+    """For an undriven system (zero torque), total energy must be conserved."""
+
+    def test_energy_conserved_free_pendulum(self, equal_params, zero_torque):
+        """Energy drift should be < 0.1% over 2 seconds."""
+        state0 = np.array([np.radians(45), np.radians(30), 0.0, 0.0])
+        result = run_simulation(
+            equal_params, state0, t_end=2.0,
+            torque_func=zero_torque, dt=0.005,
+        )
+        E0 = total_energy(result.states[0], equal_params)
+        energies = np.array([
+            total_energy(result.states[i], equal_params)
+            for i in range(result.n_steps)
+        ])
+        max_drift = np.max(np.abs(energies - E0))
+        relative_drift = max_drift / abs(E0) if abs(E0) > 1e-10 else max_drift
+        assert relative_drift < 1e-3, \
+            f"Energy drift {relative_drift:.2e} exceeds 0.1% threshold"
+
+
+class TestSimulationAccessors:
+    """Test the SimulationResult data access methods."""
+
+    def test_mass_matrix_at(self, default_params, zero_torque, aligned_state):
+        result = run_simulation(
+            default_params, aligned_state, t_end=0.1,
+            torque_func=zero_torque, dt=0.01,
+        )
+        mc = result.mass_matrix_at(0)
+        assert "M11" in mc
+        assert "M12" in mc
+        assert "M22" in mc
+        assert mc["M12"] == mc["M21"]  # symmetry
+
+    def test_positions_at(self, default_params, zero_torque, aligned_state):
+        result = run_simulation(
+            default_params, aligned_state, t_end=0.1,
+            torque_func=zero_torque, dt=0.01,
+        )
+        pos = result.positions_at(0)
+        assert "shoulder" in pos
+        assert "wrist" in pos
+        assert "tip" in pos
+
+    def test_out_of_range_index_rejected(self, default_params, zero_torque, aligned_state):
+        result = run_simulation(
+            default_params, aligned_state, t_end=0.1,
+            torque_func=zero_torque, dt=0.01,
+        )
+        with pytest.raises(AssertionError):
+            result.mass_matrix_at(result.n_steps + 10)
+
+
+class TestSimulationDbC:
+    """Contract violations for simulation inputs."""
+
+    def test_negative_duration_rejected(self, default_params, zero_torque, aligned_state):
+        with pytest.raises(AssertionError):
+            run_simulation(
+                default_params, aligned_state, t_end=-1.0,
+                torque_func=zero_torque,
+            )
+
+    def test_wrong_state_shape_rejected(self, default_params, zero_torque):
+        with pytest.raises(AssertionError):
+            run_simulation(
+                default_params, np.array([0, 0]), t_end=1.0,
+                torque_func=zero_torque,
+            )

--- a/src/pendulum_simulator/tests/test_simulation_triple.py
+++ b/src/pendulum_simulator/tests/test_simulation_triple.py
@@ -1,0 +1,71 @@
+"""Tests for the triple pendulum simulation module."""
+
+import numpy as np
+import pytest
+
+from double_pendulum_golf.physics_triple import TriplePendulumParams, total_energy
+from double_pendulum_golf.simulation_triple import (
+    TripleSimulationResult,
+    make_polynomial_torque,
+    run_simulation,
+)
+
+
+@pytest.fixture
+def triple_params():
+    return TriplePendulumParams(m1=5.0, m2=0.5, m3=0.2, L1=0.6, L2=0.6, L3=0.6)
+
+
+@pytest.fixture
+def zero_torque():
+    return lambda t: (0.0, 0.0, 0.0)
+
+
+@pytest.fixture
+def aligned_state():
+    return np.array([0.0, 0.0, 0.0, 1.0, 0.5, 0.2])
+
+
+class TestTriplePolynomialTorque:
+    def test_constant_torque(self):
+        func = make_polynomial_torque([5.0], [0.0], [1.0])
+        assert func(0.0) == (5.0, 0.0, 1.0)
+        assert func(2.0) == (5.0, 0.0, 1.0)
+
+    def test_empty_coefficients_rejected(self):
+        with pytest.raises(AssertionError):
+            make_polynomial_torque([], [1.0], [0.0])
+
+
+class TestTripleSimulationBasics:
+    def test_produces_result(self, triple_params, zero_torque, aligned_state):
+        result = run_simulation(
+            triple_params, aligned_state, t_end=0.5, torque_func=zero_torque, dt=0.01
+        )
+        assert isinstance(result, TripleSimulationResult)
+        assert result.n_steps > 10
+
+    def test_initial_state_preserved(self, triple_params, zero_torque, aligned_state):
+        result = run_simulation(
+            triple_params, aligned_state, t_end=0.1, torque_func=zero_torque, dt=0.01
+        )
+        assert np.allclose(result.states[0], aligned_state, atol=1e-6)
+
+    def test_time_monotonically_increases(self, triple_params, zero_torque, aligned_state):
+        result = run_simulation(
+            triple_params, aligned_state, t_end=1.0, torque_func=zero_torque, dt=0.01
+        )
+        assert all(np.diff(result.t) > 0)
+
+
+class TestTripleEnergyConservation:
+    def test_energy_conserved_free_pendulum(self, triple_params, zero_torque):
+        state0 = np.array([np.radians(45), np.radians(30), np.radians(-15), 0.0, 0.0, 0.0])
+        result = run_simulation(
+            triple_params, state0, t_end=1.0, torque_func=zero_torque, dt=0.005
+        )
+        E0 = total_energy(result.states[0], triple_params)
+        energies = np.array([total_energy(s, triple_params) for s in result.states])
+        max_drift = np.max(np.abs(energies - E0))
+        relative_drift = max_drift / abs(E0) if abs(E0) > 1e-10 else max_drift
+        assert relative_drift < 1e-3


### PR DESCRIPTION
Adds the double pendulum golf swing simulator (double_pendulum_golf package) to src/pendulum_simulator/.

**Physics additions:**
- PendulumParams gains b1, b2 (viscous damping) and mu1, mu2 (Coulomb friction)
- friction_torque_vector(): tau_f = -b*qdot - mu*sign(qdot)  
- EOM: M*qddot = tau_drive + tau_friction - C*qdot - G
- Friction is separate from driving torques for independent tracking

**New GUI widget: TorqueHistoryWidget**
- Post-simulation plot of driving / friction / total torque vs time (both joints)
- Animated time cursor; pyqtgraph optional with text fallback

**Controls & CSV export**
- ControlsWidget: Dissipation group for b1, b2, mu1, mu2
- CSV: tau_drive_1/2, tau_friction_1/2, tau_total_1/2 + forces

**Tests: 59 pass (26 new in test_friction.py)**