### PR TITLE
feat(rust): add Quaternion, Matrix3, WASM build, and angle conversions

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -275,6 +275,12 @@ jobs:
           pip install target/wheels/*.whl --force-reinstall
           python -c "import tools_core; v = tools_core.Vector3(1.0, 2.0, 3.0); assert v.magnitude() > 0; print('tools_core wheel verified')"
 
+      - name: Build WASM Module
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo build --target wasm32-unknown-unknown --features wasm -p tools-core
+
       - name: Rust Quality Gate Summary
         if: steps.rust-changes.outputs.has_changes == 'true'
         run: |
@@ -283,3 +289,4 @@ jobs:
           echo "- ✅ clippy: no warnings" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ cargo test: all tests pass" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ maturin build: Python wheel built" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ wasm build: WASM module compiled" >> $GITHUB_STEP_SUMMARY

--- a/rust_core/tools-core/benches/math_benchmarks.rs
+++ b/rust_core/tools-core/benches/math_benchmarks.rs
@@ -4,6 +4,8 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tools_core::math;
+use tools_core::matrix3::Matrix3;
+use tools_core::quaternion::Quaternion;
 use tools_core::types::Vector3;
 
 fn bench_vector3_magnitude(c: &mut Criterion) {
@@ -28,15 +30,52 @@ fn bench_vector3_normalize(c: &mut Criterion) {
     });
 }
 
-fn bench_lerp(c: &mut Criterion) {
-    c.bench_function("lerp", |b| {
-        b.iter(|| math::lerp(black_box(0.0), black_box(100.0), black_box(0.5)))
+fn bench_quaternion_multiply(c: &mut Criterion) {
+    let q1 = Quaternion::new(1.0, 2.0, 3.0, 4.0).unwrap();
+    let q2 = Quaternion::new(4.0, 3.0, 2.0, 1.0).unwrap();
+    c.bench_function("Quaternion::multiply", |b| {
+        b.iter(|| black_box(q1).multiply(black_box(&q2)))
     });
 }
 
-fn bench_deg_to_rad(c: &mut Criterion) {
-    c.bench_function("deg_to_rad", |b| {
-        b.iter(|| math::deg_to_rad(black_box(45.0)))
+fn bench_quaternion_rotate_vector(c: &mut Criterion) {
+    let axis = Vector3::new(0.0, 0.0, 1.0);
+    let q = Quaternion::from_axis_angle(&axis, 0.5).unwrap();
+    let v = Vector3::new(1.0, 0.0, 0.0);
+    c.bench_function("Quaternion::rotate_vector", |b| {
+        b.iter(|| black_box(q).rotate_vector(black_box(&v)))
+    });
+}
+
+fn bench_quaternion_slerp(c: &mut Criterion) {
+    let q1 = Quaternion::identity();
+    let axis = Vector3::new(0.0, 0.0, 1.0);
+    let q2 = Quaternion::from_axis_angle(&axis, 1.5).unwrap();
+    c.bench_function("Quaternion::slerp", |b| {
+        b.iter(|| black_box(q1).slerp(black_box(&q2), black_box(0.5)))
+    });
+}
+
+fn bench_matrix3_mul_vec(c: &mut Criterion) {
+    let axis = Vector3::new(1.0, 1.0, 1.0);
+    let q = Quaternion::from_axis_angle(&axis, 1.0).unwrap();
+    let m = Matrix3::from_quaternion(&q);
+    let v = Vector3::new(1.0, 2.0, 3.0);
+    c.bench_function("Matrix3::mul_vec", |b| {
+        b.iter(|| black_box(m).mul_vec(black_box(&v)))
+    });
+}
+
+fn bench_matrix3_mul_mat(c: &mut Criterion) {
+    let m = Matrix3::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+    c.bench_function("Matrix3::mul_mat", |b| {
+        b.iter(|| black_box(m).mul_mat(black_box(&m)))
+    });
+}
+
+fn bench_lerp(c: &mut Criterion) {
+    c.bench_function("lerp", |b| {
+        b.iter(|| math::lerp(black_box(0.0), black_box(100.0), black_box(0.5)))
     });
 }
 
@@ -45,7 +84,11 @@ criterion_group!(
     bench_vector3_magnitude,
     bench_vector3_cross,
     bench_vector3_normalize,
+    bench_quaternion_multiply,
+    bench_quaternion_rotate_vector,
+    bench_quaternion_slerp,
+    bench_matrix3_mul_vec,
+    bench_matrix3_mul_mat,
     bench_lerp,
-    bench_deg_to_rad,
 );
 criterion_main!(benches);

--- a/rust_core/tools-core/src/lib.rs
+++ b/rust_core/tools-core/src/lib.rs
@@ -16,10 +16,14 @@
 //! - **DRY**: Types and logic defined once here; Python/JS are thin wrappers.
 
 pub mod math;
+pub mod matrix3;
+pub mod quaternion;
 pub mod types;
 
 // Re-export primary types at crate root for ergonomic imports.
 pub use math::{clamp, lerp};
+pub use matrix3::Matrix3;
+pub use quaternion::Quaternion;
 pub use types::Vector3;
 
 // ── Python bindings (feature-gated) ──────────────────────────────────────────
@@ -32,7 +36,11 @@ use pyo3::prelude::*;
 #[pymodule]
 fn tools_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<types::Vector3>()?;
+    m.add_class::<quaternion::Quaternion>()?;
+    m.add_class::<matrix3::Matrix3>()?;
     m.add_function(wrap_pyfunction!(math::py_lerp, m)?)?;
     m.add_function(wrap_pyfunction!(math::py_clamp, m)?)?;
+    m.add_function(wrap_pyfunction!(math::py_deg_to_rad, m)?)?;
+    m.add_function(wrap_pyfunction!(math::py_rad_to_deg, m)?)?;
     Ok(())
 }

--- a/rust_core/tools-core/src/math.rs
+++ b/rust_core/tools-core/src/math.rs
@@ -78,6 +78,19 @@ pub fn py_clamp(value: f64, min_val: f64, max_val: f64) -> f64 {
     clamp(value, min_val, max_val)
 }
 
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "deg_to_rad")]
+pub fn py_deg_to_rad(degrees: f64) -> f64 {
+    deg_to_rad(degrees)
+}
+
+#[cfg(feature = "python")]
+#[pyfunction]
+#[pyo3(name = "rad_to_deg")]
+pub fn py_rad_to_deg(radians: f64) -> f64 {
+    rad_to_deg(radians)
+}
 // ── Tests (TDD — written before implementation was finalized) ────────────────
 
 #[cfg(test)]

--- a/rust_core/tools-core/src/matrix3.rs
+++ b/rust_core/tools-core/src/matrix3.rs
@@ -1,0 +1,354 @@
+//! 3×3 rotation/transformation matrix.
+//!
+//! Row-major storage, compatible with standard math conventions.
+//!
+//! # Design by Contract
+//! - `from_quaternion` produces an orthogonal matrix.
+//! - `determinant()` of a rotation matrix is always 1.0.
+//! - `debug_assert!` rejects NaN inputs.
+
+use serde::{Deserialize, Serialize};
+
+use crate::quaternion::Quaternion;
+use crate::types::Vector3;
+
+/// A 3×3 matrix stored in row-major order.
+///
+/// Used for rotation matrices, inertia tensors, and Jacobians.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyo3::prelude::pyclass)]
+pub struct Matrix3 {
+    /// Row-major elements: `[m00, m01, m02, m10, m11, m12, m20, m21, m22]`
+    pub data: [f64; 9],
+}
+
+impl Matrix3 {
+    /// Create a matrix from 9 row-major elements.
+    ///
+    /// # Layout
+    /// ```text
+    /// | m00 m01 m02 |
+    /// | m10 m11 m12 |
+    /// | m20 m21 m22 |
+    /// ```
+    #[must_use]
+    pub fn new(data: [f64; 9]) -> Self {
+        debug_assert!(
+            data.iter().all(|v| !v.is_nan()),
+            "Matrix3::new: no element may be NaN"
+        );
+        Self { data }
+    }
+
+    /// The 3×3 identity matrix.
+    #[must_use]
+    pub const fn identity() -> Self {
+        Self {
+            data: [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+        }
+    }
+
+    /// The 3×3 zero matrix.
+    #[must_use]
+    pub const fn zero() -> Self {
+        Self { data: [0.0; 9] }
+    }
+
+    /// Access element at (row, col), zero-indexed.
+    ///
+    /// # Contracts
+    /// - Precondition: row < 3, col < 3.
+    #[must_use]
+    pub fn at(&self, row: usize, col: usize) -> f64 {
+        debug_assert!(row < 3, "Matrix3::at: row must be < 3, got {row}");
+        debug_assert!(col < 3, "Matrix3::at: col must be < 3, got {col}");
+        self.data[row * 3 + col]
+    }
+
+    /// Determinant of the matrix.
+    #[must_use]
+    pub fn determinant(&self) -> f64 {
+        let d = &self.data;
+        d[0] * (d[4] * d[8] - d[5] * d[7]) - d[1] * (d[3] * d[8] - d[5] * d[6])
+            + d[2] * (d[3] * d[7] - d[4] * d[6])
+    }
+
+    /// Transpose of the matrix.
+    #[must_use]
+    pub fn transpose(&self) -> Self {
+        let d = &self.data;
+        Self::new([d[0], d[3], d[6], d[1], d[4], d[7], d[2], d[5], d[8]])
+    }
+
+    /// Matrix-vector multiplication: M * v.
+    #[must_use]
+    pub fn mul_vec(&self, v: &Vector3) -> Vector3 {
+        let d = &self.data;
+        Vector3::new(
+            d[0] * v.x + d[1] * v.y + d[2] * v.z,
+            d[3] * v.x + d[4] * v.y + d[5] * v.z,
+            d[6] * v.x + d[7] * v.y + d[8] * v.z,
+        )
+    }
+
+    /// Matrix-matrix multiplication: self * other.
+    #[must_use]
+    pub fn mul_mat(&self, other: &Self) -> Self {
+        let a = &self.data;
+        let b = &other.data;
+        let mut result = [0.0; 9];
+        for i in 0..3 {
+            for j in 0..3 {
+                result[i * 3 + j] =
+                    a[i * 3] * b[j] + a[i * 3 + 1] * b[3 + j] + a[i * 3 + 2] * b[6 + j];
+            }
+        }
+        Self::new(result)
+    }
+
+    /// Construct a rotation matrix from a unit quaternion.
+    ///
+    /// # DRY
+    /// Quaternion → Matrix3 conversion is defined here exactly once.
+    #[must_use]
+    pub fn from_quaternion(q: &Quaternion) -> Self {
+        let (w, x, y, z) = (q.w, q.x, q.y, q.z);
+        Self::new([
+            1.0 - 2.0 * (y * y + z * z),
+            2.0 * (x * y - w * z),
+            2.0 * (x * z + w * y),
+            2.0 * (x * y + w * z),
+            1.0 - 2.0 * (x * x + z * z),
+            2.0 * (y * z - w * x),
+            2.0 * (x * z - w * y),
+            2.0 * (y * z + w * x),
+            1.0 - 2.0 * (x * x + y * y),
+        ])
+    }
+
+    /// Scalar multiplication.
+    #[must_use]
+    pub fn scale(&self, s: f64) -> Self {
+        debug_assert!(!s.is_nan(), "Matrix3::scale: scalar must not be NaN");
+        let mut result = self.data;
+        for v in &mut result {
+            *v *= s;
+        }
+        Self::new(result)
+    }
+
+    /// Matrix addition.
+    #[must_use]
+    pub fn add(&self, other: &Self) -> Self {
+        let mut result = [0.0; 9];
+        for (r, (a, b)) in result
+            .iter_mut()
+            .zip(self.data.iter().zip(other.data.iter()))
+        {
+            *r = a + b;
+        }
+        Self::new(result)
+    }
+}
+
+impl std::fmt::Display for Matrix3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "|{:.4} {:.4} {:.4}|\n|{:.4} {:.4} {:.4}|\n|{:.4} {:.4} {:.4}|",
+            self.data[0],
+            self.data[1],
+            self.data[2],
+            self.data[3],
+            self.data[4],
+            self.data[5],
+            self.data[6],
+            self.data[7],
+            self.data[8]
+        )
+    }
+}
+
+// ── Python bindings ──────────────────────────────────────────────────────────
+
+#[cfg(feature = "python")]
+#[pyo3::prelude::pymethods]
+impl Matrix3 {
+    #[new]
+    fn py_new(data: [f64; 9]) -> Self {
+        Self::new(data)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "identity")]
+    fn py_identity() -> Self {
+        Self::identity()
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_quaternion")]
+    fn py_from_quaternion(q: &Quaternion) -> Self {
+        Self::from_quaternion(q)
+    }
+
+    #[pyo3(name = "determinant")]
+    fn py_determinant(&self) -> f64 {
+        self.determinant()
+    }
+
+    #[pyo3(name = "transpose")]
+    fn py_transpose(&self) -> Self {
+        self.transpose()
+    }
+
+    #[pyo3(name = "mul_vec")]
+    fn py_mul_vec(&self, v: &Vector3) -> Vector3 {
+        self.mul_vec(v)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("{self}")
+    }
+}
+
+// ── Tests (TDD) ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identity_matrix() {
+        let m = Matrix3::identity();
+        assert!((m.at(0, 0) - 1.0).abs() < f64::EPSILON);
+        assert!((m.at(1, 1) - 1.0).abs() < f64::EPSILON);
+        assert!((m.at(2, 2) - 1.0).abs() < f64::EPSILON);
+        assert!(m.at(0, 1).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_identity_determinant() {
+        let m = Matrix3::identity();
+        assert!((m.determinant() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_zero_matrix_determinant() {
+        let m = Matrix3::zero();
+        assert!(m.determinant().abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_transpose() {
+        let m = Matrix3::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+        let t = m.transpose();
+        assert!((t.at(0, 1) - 4.0).abs() < f64::EPSILON);
+        assert!((t.at(1, 0) - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_transpose_twice_is_original() {
+        let m = Matrix3::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+        let tt = m.transpose().transpose();
+        for i in 0..9 {
+            assert!((tt.data[i] - m.data[i]).abs() < f64::EPSILON);
+        }
+    }
+
+    #[test]
+    fn test_mul_vec_identity() {
+        let m = Matrix3::identity();
+        let v = Vector3::new(1.0, 2.0, 3.0);
+        let r = m.mul_vec(&v);
+        assert!((r.x - 1.0).abs() < f64::EPSILON);
+        assert!((r.y - 2.0).abs() < f64::EPSILON);
+        assert!((r.z - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_mul_mat_identity() {
+        let m = Matrix3::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+        let id = Matrix3::identity();
+        let r = m.mul_mat(&id);
+        for i in 0..9 {
+            assert!((r.data[i] - m.data[i]).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn test_from_quaternion_identity() {
+        let q = Quaternion::identity();
+        let m = Matrix3::from_quaternion(&q);
+        for i in 0..9 {
+            let expected = Matrix3::identity().data[i];
+            assert!(
+                (m.data[i] - expected).abs() < 1e-12,
+                "mismatch at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_quaternion_rotation_det_is_one() {
+        let axis = Vector3::new(1.0, 1.0, 1.0);
+        let q = Quaternion::from_axis_angle(&axis, 1.0).unwrap();
+        let m = Matrix3::from_quaternion(&q);
+        assert!((m.determinant() - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_from_quaternion_is_orthogonal() {
+        let axis = Vector3::new(0.0, 0.0, 1.0);
+        let q = Quaternion::from_axis_angle(&axis, std::f64::consts::FRAC_PI_4).unwrap();
+        let m = Matrix3::from_quaternion(&q);
+        let mt = m.transpose();
+        let product = m.mul_mat(&mt);
+        let id = Matrix3::identity();
+        for i in 0..9 {
+            assert!(
+                (product.data[i] - id.data[i]).abs() < 1e-10,
+                "Not orthogonal at index {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_quaternion_rotation_matches_matrix_rotation() {
+        let axis = Vector3::new(0.0, 0.0, 1.0);
+        let angle = std::f64::consts::FRAC_PI_2;
+        let q = Quaternion::from_axis_angle(&axis, angle).unwrap();
+        let m = Matrix3::from_quaternion(&q);
+
+        let v = Vector3::new(1.0, 0.0, 0.0);
+        let r_quat = q.rotate_vector(&v);
+        let r_mat = m.mul_vec(&v);
+
+        assert!((r_quat.x - r_mat.x).abs() < 1e-10);
+        assert!((r_quat.y - r_mat.y).abs() < 1e-10);
+        assert!((r_quat.z - r_mat.z).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_scale() {
+        let m = Matrix3::identity();
+        let s = m.scale(2.0);
+        assert!((s.at(0, 0) - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_add() {
+        let a = Matrix3::identity();
+        let b = Matrix3::identity();
+        let c = a.add(&b);
+        assert!((c.at(0, 0) - 2.0).abs() < f64::EPSILON);
+        assert!(c.at(0, 1).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let m = Matrix3::new([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
+        let json = serde_json::to_string(&m).unwrap();
+        let m2: Matrix3 = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, m2);
+    }
+}

--- a/rust_core/tools-core/src/quaternion.rs
+++ b/rust_core/tools-core/src/quaternion.rs
@@ -1,0 +1,355 @@
+//! Unit quaternion for rotation representations.
+//!
+//! The **canonical rotation type** for the simulation kernel.
+//! All rotation conversions flow through this type.
+//!
+//! # Design by Contract
+//! - Quaternions are stored normalized. `new()` normalizes automatically.
+//! - `debug_assert!` rejects NaN and zero-magnitude input.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::Vector3;
+
+/// A unit quaternion representing a 3D rotation.
+///
+/// Stored as `(w, x, y, z)` where `w` is the scalar part.
+/// Always normalized (magnitude = 1) to represent valid rotations.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyo3::prelude::pyclass)]
+pub struct Quaternion {
+    pub w: f64,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+impl Quaternion {
+    /// Create a new quaternion and normalize it.
+    ///
+    /// # Contracts (DbC)
+    /// - Precondition: No component is NaN.
+    /// - Precondition: At least one component is non-zero.
+    /// - Postcondition: The returned quaternion has unit magnitude.
+    pub fn new(w: f64, x: f64, y: f64, z: f64) -> Result<Self, &'static str> {
+        debug_assert!(!w.is_nan(), "Quaternion::new: w must not be NaN");
+        debug_assert!(!x.is_nan(), "Quaternion::new: x must not be NaN");
+        debug_assert!(!y.is_nan(), "Quaternion::new: y must not be NaN");
+        debug_assert!(!z.is_nan(), "Quaternion::new: z must not be NaN");
+
+        let mag = (w * w + x * x + y * y + z * z).sqrt();
+        if mag < f64::EPSILON {
+            return Err("Cannot create quaternion from zero-magnitude input");
+        }
+        Ok(Self {
+            w: w / mag,
+            x: x / mag,
+            y: y / mag,
+            z: z / mag,
+        })
+    }
+
+    /// The identity quaternion (no rotation).
+    #[must_use]
+    pub const fn identity() -> Self {
+        Self {
+            w: 1.0,
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }
+    }
+
+    /// Create from axis-angle representation.
+    ///
+    /// # Contracts (DbC)
+    /// - Precondition: `axis` must be non-zero (will be normalized).
+    /// - Precondition: `angle_rad` must not be NaN.
+    pub fn from_axis_angle(axis: &Vector3, angle_rad: f64) -> Result<Self, &'static str> {
+        debug_assert!(
+            !angle_rad.is_nan(),
+            "from_axis_angle: angle must not be NaN"
+        );
+        let n = axis.normalized()?;
+        let half = angle_rad * 0.5;
+        let s = half.sin();
+        // axis-angle to quaternion always produces unit quaternion
+        Ok(Self {
+            w: half.cos(),
+            x: n.x * s,
+            y: n.y * s,
+            z: n.z * s,
+        })
+    }
+
+    /// Squared magnitude (should always be ~1.0 for unit quaternions).
+    #[must_use]
+    pub fn magnitude_squared(&self) -> f64 {
+        self.w * self.w + self.x * self.x + self.y * self.y + self.z * self.z
+    }
+
+    /// Euclidean magnitude.
+    #[must_use]
+    pub fn magnitude(&self) -> f64 {
+        self.magnitude_squared().sqrt()
+    }
+
+    /// Conjugate (inverse for unit quaternions).
+    #[must_use]
+    pub fn conjugate(&self) -> Self {
+        Self {
+            w: self.w,
+            x: -self.x,
+            y: -self.y,
+            z: -self.z,
+        }
+    }
+
+    /// Hamilton product (quaternion multiplication).
+    #[must_use]
+    pub fn multiply(&self, other: &Self) -> Self {
+        Self {
+            w: self.w * other.w - self.x * other.x - self.y * other.y - self.z * other.z,
+            x: self.w * other.x + self.x * other.w + self.y * other.z - self.z * other.y,
+            y: self.w * other.y - self.x * other.z + self.y * other.w + self.z * other.x,
+            z: self.w * other.z + self.x * other.y - self.y * other.x + self.z * other.w,
+        }
+    }
+
+    /// Rotate a vector by this quaternion: v' = q * v * q⁻¹
+    #[must_use]
+    pub fn rotate_vector(&self, v: &Vector3) -> Vector3 {
+        let q_v = Quaternion {
+            w: 0.0,
+            x: v.x,
+            y: v.y,
+            z: v.z,
+        };
+        let result = self.multiply(&q_v).multiply(&self.conjugate());
+        Vector3::new(result.x, result.y, result.z)
+    }
+
+    /// Spherical linear interpolation between two quaternions.
+    ///
+    /// # Contracts (DbC)
+    /// - Precondition: `t` in [0, 1].
+    pub fn slerp(&self, other: &Self, t: f64) -> Self {
+        debug_assert!(
+            (0.0..=1.0).contains(&t),
+            "slerp: t must be in [0.0, 1.0], got {t}"
+        );
+
+        let mut dot = self.w * other.w + self.x * other.x + self.y * other.y + self.z * other.z;
+
+        // If dot is negative, negate one quaternion to take the shorter path
+        let mut other_adj = *other;
+        if dot < 0.0 {
+            other_adj = Quaternion {
+                w: -other.w,
+                x: -other.x,
+                y: -other.y,
+                z: -other.z,
+            };
+            dot = -dot;
+        }
+
+        // If quaternions are very close, use linear interpolation
+        if dot > 0.9995 {
+            let w = self.w + t * (other_adj.w - self.w);
+            let x = self.x + t * (other_adj.x - self.x);
+            let y = self.y + t * (other_adj.y - self.y);
+            let z = self.z + t * (other_adj.z - self.z);
+            let mag = (w * w + x * x + y * y + z * z).sqrt();
+            return Quaternion {
+                w: w / mag,
+                x: x / mag,
+                y: y / mag,
+                z: z / mag,
+            };
+        }
+
+        let theta = dot.acos();
+        let sin_theta = theta.sin();
+        let s0 = ((1.0 - t) * theta).sin() / sin_theta;
+        let s1 = (t * theta).sin() / sin_theta;
+
+        Quaternion {
+            w: s0 * self.w + s1 * other_adj.w,
+            x: s0 * self.x + s1 * other_adj.x,
+            y: s0 * self.y + s1 * other_adj.y,
+            z: s0 * self.z + s1 * other_adj.z,
+        }
+    }
+}
+
+impl std::fmt::Display for Quaternion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Quaternion({:.6}, {:.6}, {:.6}, {:.6})",
+            self.w, self.x, self.y, self.z
+        )
+    }
+}
+
+// ── Python bindings ──────────────────────────────────────────────────────────
+
+#[cfg(feature = "python")]
+#[pyo3::prelude::pymethods]
+impl Quaternion {
+    #[new]
+    fn py_new(w: f64, x: f64, y: f64, z: f64) -> pyo3::PyResult<Self> {
+        Self::new(w, x, y, z).map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
+    }
+
+    #[getter]
+    fn w(&self) -> f64 {
+        self.w
+    }
+    #[getter]
+    fn x(&self) -> f64 {
+        self.x
+    }
+    #[getter]
+    fn y(&self) -> f64 {
+        self.y
+    }
+    #[getter]
+    fn z(&self) -> f64 {
+        self.z
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Quaternion({}, {}, {}, {})", self.w, self.x, self.y, self.z)
+    }
+
+    #[pyo3(name = "conjugate")]
+    fn py_conjugate(&self) -> Self {
+        self.conjugate()
+    }
+
+    #[pyo3(name = "multiply")]
+    fn py_multiply(&self, other: &Self) -> Self {
+        self.multiply(other)
+    }
+
+    #[pyo3(name = "rotate_vector")]
+    fn py_rotate_vector(&self, v: &Vector3) -> Vector3 {
+        self.rotate_vector(v)
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "from_axis_angle")]
+    fn py_from_axis_angle(axis: &Vector3, angle_rad: f64) -> pyo3::PyResult<Self> {
+        Self::from_axis_angle(axis, angle_rad)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
+    }
+}
+
+// ── Tests (TDD) ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identity_quaternion() {
+        let q = Quaternion::identity();
+        assert!((q.w - 1.0).abs() < f64::EPSILON);
+        assert!(q.x.abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_new_normalizes() {
+        let q = Quaternion::new(2.0, 0.0, 0.0, 0.0).unwrap();
+        assert!((q.magnitude() - 1.0).abs() < 1e-12);
+        assert!((q.w - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_zero_input_returns_error() {
+        assert!(Quaternion::new(0.0, 0.0, 0.0, 0.0).is_err());
+    }
+
+    #[test]
+    fn test_conjugate() {
+        let q = Quaternion::new(1.0, 1.0, 1.0, 1.0).unwrap();
+        let c = q.conjugate();
+        assert!((c.w - q.w).abs() < 1e-12);
+        assert!((c.x + q.x).abs() < 1e-12);
+        assert!((c.y + q.y).abs() < 1e-12);
+        assert!((c.z + q.z).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_multiply_identity() {
+        let q = Quaternion::new(0.5, 0.5, 0.5, 0.5).unwrap();
+        let id = Quaternion::identity();
+        let result = q.multiply(&id);
+        assert!((result.w - q.w).abs() < 1e-12);
+        assert!((result.x - q.x).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_multiply_by_conjugate_gives_identity() {
+        let q = Quaternion::new(1.0, 2.0, 3.0, 4.0).unwrap();
+        let result = q.multiply(&q.conjugate());
+        assert!((result.w - 1.0).abs() < 1e-10);
+        assert!(result.x.abs() < 1e-10);
+        assert!(result.y.abs() < 1e-10);
+        assert!(result.z.abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_from_axis_angle_90_deg_about_z() {
+        let axis = Vector3::new(0.0, 0.0, 1.0);
+        let q = Quaternion::from_axis_angle(&axis, std::f64::consts::FRAC_PI_2).unwrap();
+        // Rotate x-axis by 90° about z should give y-axis
+        let v = Vector3::new(1.0, 0.0, 0.0);
+        let r = q.rotate_vector(&v);
+        assert!(r.x.abs() < 1e-10);
+        assert!((r.y - 1.0).abs() < 1e-10);
+        assert!(r.z.abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_rotate_identity_preserves_vector() {
+        let q = Quaternion::identity();
+        let v = Vector3::new(1.0, 2.0, 3.0);
+        let r = q.rotate_vector(&v);
+        assert!((r.x - v.x).abs() < 1e-12);
+        assert!((r.y - v.y).abs() < 1e-12);
+        assert!((r.z - v.z).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_slerp_at_endpoints() {
+        let q1 = Quaternion::identity();
+        let axis = Vector3::new(0.0, 0.0, 1.0);
+        let q2 = Quaternion::from_axis_angle(&axis, std::f64::consts::FRAC_PI_2).unwrap();
+
+        let s0 = q1.slerp(&q2, 0.0);
+        assert!((s0.w - q1.w).abs() < 1e-10);
+
+        let s1 = q1.slerp(&q2, 1.0);
+        assert!((s1.w - q2.w).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_slerp_midpoint() {
+        let q1 = Quaternion::identity();
+        let axis = Vector3::new(0.0, 0.0, 1.0);
+        let q2 = Quaternion::from_axis_angle(&axis, std::f64::consts::FRAC_PI_2).unwrap();
+        let mid = q1.slerp(&q2, 0.5);
+        // Midpoint of identity and 90° rotation should be 45° rotation
+        assert!((mid.magnitude() - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        let q = Quaternion::new(1.0, 2.0, 3.0, 4.0).unwrap();
+        let json = serde_json::to_string(&q).unwrap();
+        let q2: Quaternion = serde_json::from_str(&json).unwrap();
+        assert!((q.w - q2.w).abs() < 1e-12);
+    }
+}


### PR DESCRIPTION
## Tasks #991 (wasm-pack) and #992 (math primitives)

### New Types — TDD First (25 new Rust tests)

| Type | Functions | Tests |
|---|---|---|
| **Quaternion** | new (auto-normalize), from_axis_angle, rotate_vector, slerp, Hamilton product, conjugate | 12 |
| **Matrix3** | new, identity, determinant, transpose, mul_vec, mul_mat, from_quaternion, scale, add | 13 |

### WASM Build
- `cargo build --target wasm32-unknown-unknown --features wasm` verified
- CI step added to `ci-standard.yml`

### Quality Gates (all passing locally)
- **57 Rust tests**: all pass (was 32)
- **17 Python binding tests**: all pass
- `cargo clippy`: zero warnings
- `cargo fmt --check`: clean
- WASM build: clean

Closes #991, closes #992