### PR TITLE
fix(ci): guard Rust quality gate behind Cargo.toml check

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -224,9 +224,14 @@ jobs:
           fi
 
           if [ -n "$RUST_FILES" ]; then
-            echo "has_changes=true" >> "$GITHUB_OUTPUT"
-            echo "Changed Rust files:"
-            echo "$RUST_FILES"
+            if [ -f "Cargo.toml" ]; then
+              echo "has_changes=true" >> "$GITHUB_OUTPUT"
+              echo "Changed Rust files:"
+              echo "$RUST_FILES"
+            else
+              echo "has_changes=false" >> "$GITHUB_OUTPUT"
+              echo "Rust files changed but no Cargo.toml found — skipping quality gate."
+            fi
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No Rust changes detected — skipping Rust quality gate."


### PR DESCRIPTION
Prevents rust-quality-gate from failing when rust-toolchain.toml exists but no Cargo workspace is initialized yet. Applied identically across all 4 flagship repos (DRY CI fix).