### PR TITLE
feat(rust): add ball flight benchmarks (Phase 1)

### DIFF
--- a/rust_core/tools-core/benches/math_benchmarks.rs
+++ b/rust_core/tools-core/benches/math_benchmarks.rs
@@ -3,6 +3,10 @@
 //! Run with: `cargo bench`
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use tools_core::ball_flight::{
+    self, analyze_trajectory, apply_spin_decay, calculate_accel_core, simulate_trajectory,
+    BallProperties, EnvironmentalConditions, LaunchConditions,
+};
 use tools_core::math;
 use tools_core::matrix3::Matrix3;
 use tools_core::quaternion::Quaternion;
@@ -79,6 +83,79 @@ fn bench_lerp(c: &mut Criterion) {
     });
 }
 
+// ── Ball Flight Physics Benchmarks ──────────────────────────────────────────
+
+fn bench_accel_core(c: &mut Criterion) {
+    let rel_vel = Vector3::new(68.0, 14.0, 0.0);
+    let gravity = Vector3::new(0.0, -ball_flight::GRAVITY, 0.0);
+    let coeffs = (0.21, 0.05, 0.02, 0.0, 0.38, 0.0);
+    let spin_axis = Vector3::new(0.0, 0.0, 1.0);
+    c.bench_function("calculate_accel_core", |b| {
+        b.iter(|| {
+            calculate_accel_core(
+                black_box(&rel_vel),
+                black_box(69.4),
+                black_box(&gravity),
+                black_box(0.021335),
+                black_box(19.1),
+                black_box(&coeffs),
+                black_box(261.8),
+                black_box(&spin_axis),
+            )
+        })
+    });
+}
+
+fn bench_spin_decay(c: &mut Criterion) {
+    c.bench_function("apply_spin_decay", |b| {
+        b.iter(|| apply_spin_decay(black_box(261.8), black_box(0.08), black_box(0.01)))
+    });
+}
+
+fn bench_simulate_trajectory(c: &mut Criterion) {
+    let ball = BallProperties::default();
+    let env = EnvironmentalConditions::default();
+    let launch = LaunchConditions::default();
+    c.bench_function("simulate_trajectory (dt=0.01)", |b| {
+        b.iter(|| {
+            simulate_trajectory(
+                black_box(&ball),
+                black_box(&env),
+                black_box(&launch),
+                10.0,
+                0.01,
+            )
+        })
+    });
+}
+
+fn bench_simulate_trajectory_fine(c: &mut Criterion) {
+    let ball = BallProperties::default();
+    let env = EnvironmentalConditions::default();
+    let launch = LaunchConditions::default();
+    c.bench_function("simulate_trajectory (dt=0.001)", |b| {
+        b.iter(|| {
+            simulate_trajectory(
+                black_box(&ball),
+                black_box(&env),
+                black_box(&launch),
+                10.0,
+                0.001,
+            )
+        })
+    });
+}
+
+fn bench_analyze_trajectory(c: &mut Criterion) {
+    let ball = BallProperties::default();
+    let env = EnvironmentalConditions::default();
+    let launch = LaunchConditions::default();
+    let traj = simulate_trajectory(&ball, &env, &launch, 10.0, 0.01);
+    c.bench_function("analyze_trajectory", |b| {
+        b.iter(|| analyze_trajectory(black_box(&traj)))
+    });
+}
+
 criterion_group!(
     benches,
     bench_vector3_magnitude,
@@ -90,5 +167,10 @@ criterion_group!(
     bench_matrix3_mul_vec,
     bench_matrix3_mul_mat,
     bench_lerp,
+    bench_accel_core,
+    bench_spin_decay,
+    bench_simulate_trajectory,
+    bench_simulate_trajectory_fine,
+    bench_analyze_trajectory,
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Phase 1 Continuation: Performance Benchmarks

Adds 5 Criterion benchmarks for ball flight physics:
- `calculate_accel_core` — single force calculation
- `apply_spin_decay` — spin decay step
- `simulate_trajectory (dt=0.01)` — standard resolution sim
- `simulate_trajectory (dt=0.001)` — high resolution sim
- `analyze_trajectory` — trajectory analysis

Total: 14 benchmarks covering all Rust simulation primitives.

All 71 tests passing. Clippy and fmt clean.