### PR TITLE
feat(ci): upgrade WASM build to wasm-pack with NPM verification

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -280,11 +280,23 @@ jobs:
           pip install target/wheels/*.whl --force-reinstall
           python -c "import tools_core; v = tools_core.Vector3(1.0, 2.0, 3.0); assert v.magnitude() > 0; print('tools_core wheel verified')"
 
-      - name: Build WASM Module
+      - name: Build WASM Module (wasm-pack)
         if: steps.rust-changes.outputs.has_changes == 'true'
         run: |
           rustup target add wasm32-unknown-unknown
-          cargo build --target wasm32-unknown-unknown --features wasm -p tools-core
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          cd rust_core/tools-core
+          wasm-pack build --target web --features wasm --no-default-features
+          echo "wasm-pack build completed"
+          ls pkg/
+
+      - name: Verify WASM Module
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: |
+          # Verify the WASM package was produced with expected files
+          test -f rust_core/tools-core/pkg/tools_core_bg.wasm && echo "✅ WASM binary exists"
+          test -f rust_core/tools-core/pkg/package.json && echo "✅ package.json exists"
+          test -f rust_core/tools-core/pkg/tools_core.js && echo "✅ JS glue exists"
 
       - name: Rust Quality Gate Summary
         if: steps.rust-changes.outputs.has_changes == 'true'
@@ -294,4 +306,4 @@ jobs:
           echo "- ✅ clippy: no warnings" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ cargo test: all tests pass" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ maturin build: Python wheel built" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ wasm build: WASM module compiled" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ wasm-pack build: WASM + NPM package produced" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Upgrades the Rust quality gate WASM step from basic cargo build to full wasm-pack build.

## Changes
- Install wasm-pack and build with --target web for browser-ready output
- Verify WASM binary, JS glue, and package.json are produced
- NPM package is now ready for consumption by downstream React UIs

Ref: #985