### PR TITLE
fix: publish-artifacts.yml environment schema (closes #1014)

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -85,7 +85,8 @@ jobs:
     if: >-
       github.event_name == 'release' ||
       (github.event_name == 'workflow_dispatch' && inputs.dry_run == 'false')
-    environment: pypi  # Requires PyPI trusted publishing configured
+    environment:
+      name: pypi  # GitHub environment with PyPI trusted publishing configured
     steps:
       - name: Download Wheel
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Use object form for GitHub environment reference to satisfy YAML schema validation. The secrets warnings are informational (linter cannot verify external secret names).