### PR TITLE
fix: add #[must_use] to remaining tools-core public functions

### DIFF
--- a/rust_core/tools-core/src/ball_flight.rs
+++ b/rust_core/tools-core/src/ball_flight.rs
@@ -418,6 +418,7 @@ pub fn apply_spin_decay(omega: f64, decay_rate: f64, dt: f64) -> f64 {
 ///
 /// # Returns
 /// A vector of `TrajectoryPoint` values.
+#[must_use]
 pub fn simulate_trajectory(
     ball: &BallProperties,
     env: &EnvironmentalConditions,

--- a/rust_core/tools-core/src/quaternion.rs
+++ b/rust_core/tools-core/src/quaternion.rs
@@ -134,6 +134,7 @@ impl Quaternion {
     ///
     /// # Contracts (DbC)
     /// - Precondition: `t` in [0, 1].
+    #[must_use]
     pub fn slerp(&self, other: &Self, t: f64) -> Self {
         debug_assert!(
             (0.0..=1.0).contains(&t),


### PR DESCRIPTION
Adds #[must_use] to the last 2 public functions missing it:
- simulate_trajectory() in ball_flight.rs
- Quaternion::slerp() in quaternion.rs

These functions return computed values that should not be discarded.