### PR TITLE
docs: add PyO3 text_signature and docstrings for Python help() (closes #1019)

### DIFF
--- a/rust_core/tools-core/src/types.rs
+++ b/rust_core/tools-core/src/types.rs
@@ -160,67 +160,68 @@ impl std::ops::Mul<Vector3> for f64 {
 #[cfg(feature = "python")]
 #[pyo3::prelude::pymethods]
 impl Vector3 {
-    /// Python constructor: ``Vector3(x, y, z)``
+    /// Create a 3D vector with components (x, y, z).
     #[new]
+    #[pyo3(text_signature = "(x, y, z)")]
     fn py_new(x: f64, y: f64, z: f64) -> Self {
         Self::new(x, y, z)
     }
 
-    /// X component accessor.
+    /// X component of the vector.
     #[getter]
     fn x(&self) -> f64 {
         self.x
     }
 
-    /// Y component accessor.
+    /// Y component of the vector.
     #[getter]
     fn y(&self) -> f64 {
         self.y
     }
 
-    /// Z component accessor.
+    /// Z component of the vector.
     #[getter]
     fn z(&self) -> f64 {
         self.z
     }
 
-    /// Python repr: ``Vector3(1.0, 2.0, 3.0)``
     fn __repr__(&self) -> String {
         format!("Vector3({}, {}, {})", self.x, self.y, self.z)
     }
 
-    /// Python str: ``(1.000000, 2.000000, 3.000000)``
     fn __str__(&self) -> String {
         format!("{self}")
     }
 
-    /// Expose magnitude to Python.
-    #[pyo3(name = "magnitude")]
+    /// Return the Euclidean magnitude (length) of the vector.
+    #[pyo3(name = "magnitude", text_signature = "($self)")]
     fn py_magnitude(&self) -> f64 {
         self.magnitude()
     }
 
-    /// Expose dot product to Python.
-    #[pyo3(name = "dot")]
+    /// Compute the dot product with another Vector3.
+    #[pyo3(name = "dot", text_signature = "($self, other)")]
     fn py_dot(&self, other: &Self) -> f64 {
         self.dot(other)
     }
 
-    /// Expose cross product to Python.
-    #[pyo3(name = "cross")]
+    /// Compute the cross product with another Vector3.
+    #[pyo3(name = "cross", text_signature = "($self, other)")]
     fn py_cross(&self, other: &Self) -> Self {
         self.cross(other)
     }
 
-    /// Expose normalization to Python (raises ValueError on zero vector).
-    #[pyo3(name = "normalized")]
+    /// Return a unit vector in the same direction.
+    ///
+    /// Raises ValueError if the vector has zero magnitude.
+    #[pyo3(name = "normalized", text_signature = "($self)")]
     fn py_normalized(&self) -> pyo3::PyResult<Self> {
         self.normalized()
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
     }
 
-    /// Expose scale to Python.
-    #[pyo3(name = "scale")]
+    /// Return a new vector scaled by the given factor.
+    #[pyo3(name = "scale", text_signature = "($self, s)")]
     fn py_scale(&self, s: f64) -> Self {
         self.scale(s)
     }


### PR DESCRIPTION
## Summary
From Fleet Rust Review 2026-03-08 §10 P2-9.

Adds #[pyo3(text_signature)] to all Python-exposed Vector3 methods. This enables:
- Proper python help(Vector3) output
- IDE autocompletion with correct signatures
- Descriptive docstrings instead of generic expose comments

83 tests pass.