### PR TITLE
feat: add R_GAS and GRAVITY constants to tools-core (closes #1030)

### DIFF
--- a/rust_core/tools-core/src/lib.rs
+++ b/rust_core/tools-core/src/lib.rs
@@ -22,7 +22,7 @@ pub mod quaternion;
 pub mod types;
 
 // Re-export primary types at crate root for ergonomic imports.
-pub use math::{clamp, lerp};
+pub use math::{clamp, lerp, GRAVITY, R_GAS};
 pub use matrix3::Matrix3;
 pub use quaternion::Quaternion;
 pub use types::Vector3;

--- a/rust_core/tools-core/src/math.rs
+++ b/rust_core/tools-core/src/math.rs
@@ -9,6 +9,13 @@
 //!
 //! # DRY
 //! - Python and WASM wrappers call these functions directly.
+//! - Physical constants are defined here once; downstream crates import them.
+
+/// Universal gas constant [J/(mol·K)] — CODATA 2018 recommended value.
+pub const R_GAS: f64 = 8.31446;
+
+/// Standard gravitational acceleration [m/s²].
+pub const GRAVITY: f64 = 9.80665;
 
 /// Linear interpolation between `a` and `b` by factor `t`.
 ///


### PR DESCRIPTION
P0-DRY fix. Adds canonical physical constants to tools_core::math:
- R_GAS = 8.31446 J/(mol·K) (CODATA 2018)
- GRAVITY = 9.80665 m/s²

Re-exported at crate root for ergonomic imports. Downstream crates (thermo-solver, upstream-physics) should use these instead of local definitions.