### PR TITLE
feat: add text_signature to Quaternion and ball_flight bindings (closes #1031)

### DIFF
--- a/rust_core/tools-core/src/ball_flight.rs
+++ b/rust_core/tools-core/src/ball_flight.rs
@@ -547,7 +547,9 @@ pub fn analyze_trajectory(trajectory: &[TrajectoryPoint]) -> TrajectoryAnalysis 
 #[cfg(feature = "python")]
 #[pyo3::prelude::pymethods]
 impl BallProperties {
+    /// Create default golf ball properties.
     #[new]
+    #[pyo3(text_signature = "()")]
     fn py_new() -> Self {
         Self::default()
     }
@@ -563,8 +565,12 @@ impl BallProperties {
 #[cfg(feature = "python")]
 #[pyo3::prelude::pymethods]
 impl LaunchConditions {
+    /// Create launch conditions for a golf shot.
     #[new]
     #[pyo3(signature = (velocity=70.0, launch_angle=12.0, azimuth_angle=0.0, spin_rate=2500.0))]
+    #[pyo3(
+        text_signature = "(velocity=70.0, launch_angle=12.0, azimuth_angle=0.0, spin_rate=2500.0)"
+    )]
     fn py_new(velocity: f64, launch_angle: f64, azimuth_angle: f64, spin_rate: f64) -> Self {
         Self {
             velocity,
@@ -586,7 +592,9 @@ impl LaunchConditions {
 #[cfg(feature = "python")]
 #[pyo3::prelude::pymethods]
 impl EnvironmentalConditions {
+    /// Create default environmental conditions (sea level, 15°C, no wind).
     #[new]
+    #[pyo3(text_signature = "()")]
     fn py_new() -> Self {
         Self::default()
     }

--- a/rust_core/tools-core/src/quaternion.rs
+++ b/rust_core/tools-core/src/quaternion.rs
@@ -199,23 +199,29 @@ impl std::fmt::Display for Quaternion {
 #[cfg(feature = "python")]
 #[pyo3::prelude::pymethods]
 impl Quaternion {
+    /// Create a new unit quaternion (automatically normalized).
     #[new]
+    #[pyo3(text_signature = "(w, x, y, z)")]
     fn py_new(w: f64, x: f64, y: f64, z: f64) -> pyo3::PyResult<Self> {
         Self::new(w, x, y, z).map_err(|e| pyo3::exceptions::PyValueError::new_err(e))
     }
 
+    /// Scalar component.
     #[getter]
     fn w(&self) -> f64 {
         self.w
     }
+    /// X imaginary component.
     #[getter]
     fn x(&self) -> f64 {
         self.x
     }
+    /// Y imaginary component.
     #[getter]
     fn y(&self) -> f64 {
         self.y
     }
+    /// Z imaginary component.
     #[getter]
     fn z(&self) -> f64 {
         self.z
@@ -225,23 +231,27 @@ impl Quaternion {
         format!("Quaternion({}, {}, {}, {})", self.w, self.x, self.y, self.z)
     }
 
-    #[pyo3(name = "conjugate")]
+    /// Return the conjugate (inverse for unit quaternions).
+    #[pyo3(name = "conjugate", text_signature = "($self)")]
     fn py_conjugate(&self) -> Self {
         self.conjugate()
     }
 
-    #[pyo3(name = "multiply")]
+    /// Hamilton product (quaternion multiplication).
+    #[pyo3(name = "multiply", text_signature = "($self, other)")]
     fn py_multiply(&self, other: &Self) -> Self {
         self.multiply(other)
     }
 
-    #[pyo3(name = "rotate_vector")]
+    /// Rotate a 3D vector by this quaternion: v' = q * v * q⁻¹.
+    #[pyo3(name = "rotate_vector", text_signature = "($self, v)")]
     fn py_rotate_vector(&self, v: &Vector3) -> Vector3 {
         self.rotate_vector(v)
     }
 
+    /// Create a quaternion from axis-angle representation.
     #[staticmethod]
-    #[pyo3(name = "from_axis_angle")]
+    #[pyo3(name = "from_axis_angle", text_signature = "(axis, angle_rad)")]
     fn py_from_axis_angle(axis: &Vector3, angle_rad: f64) -> pyo3::PyResult<Self> {
         Self::from_axis_angle(axis, angle_rad)
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(e))


### PR DESCRIPTION
DRY consistency: extends text_signature coverage from Vector3-only to Quaternion (5 methods), BallProperties, LaunchConditions, and EnvironmentalConditions.

Improves Python help() output and IDE autocompletion for all simulation kernel types.