### PR TITLE
Add standalone Signal Toolkit launcher with Polynomial Generator

### DIFF
--- a/launch_signal_toolkit.py
+++ b/launch_signal_toolkit.py
@@ -200,7 +200,9 @@ class SignalToolkitLauncher(QMainWindow):
         self.poly_gen.polynomial_generated.connect(self._on_poly_generated)
 
         self._build_menus()
-        self.statusBar().showMessage("Ready")
+        sb = self.statusBar()
+        if sb is not None:
+            sb.showMessage("Ready")
 
     # ------------------------------------------------------------------
     # Signal routing
@@ -225,9 +227,9 @@ class SignalToolkitLauncher(QMainWindow):
         signal.name = f"Polynomial ({joint_name})"
         self.toolkit.load_external_signal(signal)
 
-        self.statusBar().showMessage(
-            f"Polynomial ({joint_name}) sent to Signal Toolkit", 5000
-        )
+        sb = self.statusBar()
+        if sb is not None:
+            sb.showMessage(f"Polynomial ({joint_name}) sent to Signal Toolkit", 5000)
 
     # ------------------------------------------------------------------
     # Menu bar
@@ -236,6 +238,7 @@ class SignalToolkitLauncher(QMainWindow):
     def _build_menus(self) -> None:
         """Create the application menu bar."""
         menubar = self.menuBar()
+        assert menubar is not None
 
         # --- File ---
         file_menu = QMenu("&File", self)


### PR DESCRIPTION
## Summary

Adds a new standalone launcher application (`launch_signal_toolkit.py`) that provides an integrated two-tab GUI combining the Polynomial Generator and Signal Toolkit. This enables users to visually design polynomial functions in the first tab and immediately forward them to the Signal Toolkit for analysis and inspection without requiring the full UpstreamDrift application context.

**Key features:**
- **Tab 1: Polynomial Generator** — Visual polynomial curve design interface
- **Tab 2: Signal Toolkit** — Signal analysis, filtering, and fitting tools
- **Signal routing** — Polynomial coefficients generated in Tab 1 are automatically converted to signals and loaded into Tab 2 for immediate inspection
- **Unified dark theme** — Consistent styling across both widgets via a comprehensive stylesheet
- **Menu bar** — Quick navigation between tabs (Ctrl+1, Ctrl+2) and application controls
- **Standalone operation** — Uses shared components from `src/shared/python/signal_toolkit` without modification, safe to run alongside other projects

The launcher uses the existing `PolynomialGeneratorWidget` and `SignalToolkitWidget` components with `use_builtin_theme=False` to apply a unified dark stylesheet at the window level, ensuring consistent visual appearance.

## AI Changes

N/A — This is a new file addition.

## Checklist

- [x] Reproducible: Launcher can be executed with `python launch_signal_toolkit.py`
- [x] No tests required: Standalone GUI application; manual testing via launcher execution
- [x] No large binaries added
- [x] No environment files modified (uses existing signal_toolkit package)
- [x] No secrets added

https://claude.ai/code/session_0168V8eLQ84Kfhs9NXyFSRKg