### PR TITLE
fix: repair golfer import chain + black formatting + mypy (#1229, #1230, #1231)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -34,6 +34,14 @@ follow_imports = skip
 [mypy-gui_launcher.*]
 follow_imports = skip
 
+# programmatic_pid resolves under both "programmatic_pid" and
+# "src.shared.python.programmatic_pid" due to MYPYPATH overlap.
+[mypy-programmatic_pid]
+follow_imports = skip
+
+[mypy-programmatic_pid.*]
+follow_imports = skip
+
 # Relax mypy strictness for the DWSIM Gasification Model package.
 # This module was migrated from a standalone repo and has not yet been fully
 # annotated.  Disable type-annotation requirements and return-type warnings

--- a/src/pendulum_simulator/src/double_pendulum_golf/constraint_solver.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/constraint_solver.py
@@ -28,18 +28,22 @@ import logging
 import numpy as np
 
 from . import native_backend as _native_backend
+from .golfer_constraints import (
+    analytical_constraint_jacobian as constraint_jacobian,
+    constraint_vector,
+    friction_torque_vector,
+)
+from .golfer_dynamics import (
+    analytical_coriolis as coriolis_matrix,
+    analytical_gravity_vector as gravity_vector,
+    analytical_mass_matrix as mass_matrix,
+)
 from .physics_golfer import (
     N_CONSTRAINTS,
     N_DOF,
     GolferParams,
     State,
     TorqueFunc,
-    constraint_jacobian,
-    constraint_vector,
-    coriolis_matrix,
-    friction_torque_vector,
-    gravity_vector,
-    mass_matrix,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/pendulum_simulator/src/double_pendulum_golf/golfer_constraints.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/golfer_constraints.py
@@ -198,7 +198,11 @@ def linear_accelerations(
 
     Returns dict with keys matching forward_kinematics joint names.
     """
-    if not isinstance(q, np.ndarray) or not isinstance(qdot, np.ndarray) or not isinstance(qddot, np.ndarray):
+    if (
+        not isinstance(q, np.ndarray)
+        or not isinstance(qdot, np.ndarray)
+        or not isinstance(qddot, np.ndarray)
+    ):
         raise TypeError("q, qdot, and qddot must be numpy ndarrays")
     if q.ndim != 1 or q.shape[0] < N_DOF:
         raise ValueError(f"q must be a 1D array of at least {N_DOF} elements")

--- a/src/pendulum_simulator/src/double_pendulum_golf/physics_golfer.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/physics_golfer.py
@@ -194,6 +194,63 @@ N_CONSTRAINTS = 4
 
 
 # Backward compatibility re-exports removed to prevent cyclic import (Issue TDD resolution)
+# Restored via lazy __getattr__ below to avoid circular imports while
+# maintaining API compatibility for existing callers.
+
+# Mapping from old name → (module, actual_name)
+_LAZY_REEXPORTS: dict[str, tuple[str, str]] = {
+    # golfer_kinematics
+    "forward_kinematics": (".golfer_kinematics", "forward_kinematics"),
+    # golfer_constraints
+    "constraint_vector": (".golfer_constraints", "constraint_vector"),
+    "constraint_jacobian": (
+        ".golfer_constraints",
+        "analytical_constraint_jacobian",
+    ),
+    "analytical_constraint_jacobian": (
+        ".golfer_constraints",
+        "analytical_constraint_jacobian",
+    ),
+    "numerical_constraint_jacobian": (
+        ".golfer_constraints",
+        "numerical_constraint_jacobian",
+    ),
+    "friction_torque_vector": (".golfer_constraints", "friction_torque_vector"),
+    "net_joint_forces": (".golfer_constraints", "net_joint_forces"),
+    # golfer_dynamics
+    "mass_matrix": (".golfer_dynamics", "analytical_mass_matrix"),
+    "analytical_mass_matrix": (".golfer_dynamics", "analytical_mass_matrix"),
+    "gravity_vector": (".golfer_dynamics", "analytical_gravity_vector"),
+    "analytical_gravity_vector": (
+        ".golfer_dynamics",
+        "analytical_gravity_vector",
+    ),
+    "coriolis_matrix": (".golfer_dynamics", "analytical_coriolis"),
+    "analytical_coriolis": (".golfer_dynamics", "analytical_coriolis"),
+    "analytical_fk_jacobians": (".golfer_dynamics", "analytical_fk_jacobians"),
+    "kinetic_energy": (".golfer_dynamics", "kinetic_energy"),
+    "potential_energy": (".golfer_dynamics", "potential_energy"),
+    "potential_energy_from_q": (".golfer_dynamics", "potential_energy_from_q"),
+    "total_energy": (".golfer_dynamics", "total_energy"),
+}
+
+
+def __getattr__(name: str) -> object:
+    """Lazy re-export for backward compatibility.
+
+    Defers import of sub-modules until first access, preventing
+    circular import errors while preserving the public API.
+    """
+    if name in _LAZY_REEXPORTS:
+        module_path, attr_name = _LAZY_REEXPORTS[name]
+        import importlib
+
+        mod = importlib.import_module(module_path, package=__package__)
+        value = getattr(mod, attr_name)
+        # Cache in module namespace for subsequent accesses
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get_native_backend_info() -> dict[str, object]:

--- a/src/pendulum_simulator/tests/test_constraint_solver.py
+++ b/src/pendulum_simulator/tests/test_constraint_solver.py
@@ -20,12 +20,14 @@ from double_pendulum_golf.constraint_solver import (
     project_to_constraints,
     project_velocity,
 )
+from double_pendulum_golf.golfer_constraints import (
+    analytical_constraint_jacobian as constraint_jacobian,
+    constraint_vector,
+)
 from double_pendulum_golf.physics_golfer import (
     N_CONSTRAINTS,
     N_DOF,
     GolferParams,
-    constraint_jacobian,
-    constraint_vector,
 )
 
 

--- a/src/pendulum_simulator/tests/test_golfer_constraints.py
+++ b/src/pendulum_simulator/tests/test_golfer_constraints.py
@@ -11,25 +11,43 @@ from double_pendulum_golf.golfer_constraints import (
 )
 from double_pendulum_golf.physics_golfer import GolferParams, N_DOF
 
+
 @pytest.fixture
 def params():
     return GolferParams(
-        m_hub=0.01, m_r_upper=2.0, m_r_fore=1.5, m_l_upper=2.0, m_l_fore=1.5, m_club=0.3,
-        L_hub=0.2, L_r_upper=0.3, L_r_fore=0.3, L_l_upper=0.3, L_l_fore=0.3, L_club=1.0,
-        d_rs=0.1, d_ls=0.1, grip_right=0.2, grip_left=0.3
+        m_hub=0.01,
+        m_r_upper=2.0,
+        m_r_fore=1.5,
+        m_l_upper=2.0,
+        m_l_fore=1.5,
+        m_club=0.3,
+        L_hub=0.2,
+        L_r_upper=0.3,
+        L_r_fore=0.3,
+        L_l_upper=0.3,
+        L_l_fore=0.3,
+        L_club=1.0,
+        d_rs=0.1,
+        d_ls=0.1,
+        grip_right=0.2,
+        grip_left=0.3,
     )
+
 
 @pytest.fixture
 def valid_q():
     return np.zeros(N_DOF)
 
+
 @pytest.fixture
 def valid_qdot():
     return np.zeros(N_DOF)
 
+
 @pytest.fixture
 def valid_qddot():
     return np.zeros(N_DOF)
+
 
 def test_constraint_vector_shape_and_dbc(params, valid_q):
     """Test standard shape output and DbC checks for constraint vector calculation."""
@@ -46,15 +64,17 @@ def test_constraint_vector_shape_and_dbc(params, valid_q):
     with pytest.raises(TypeError):
         constraint_vector(valid_q, "fake_params")  # Wrong params
 
+
 def test_numerical_jacobian_shape_and_dbc(params, valid_q):
     """Test standard shape output and DbC for numerical jacobian."""
     J = numerical_constraint_jacobian(valid_q, params)
     assert J.shape == (4, N_DOF)
-    
+
     with pytest.raises(TypeError):
         numerical_constraint_jacobian("wrong_type", params)
     with pytest.raises(ValueError):
-        numerical_constraint_jacobian(np.ones(N_DOF-1), params)
+        numerical_constraint_jacobian(np.ones(N_DOF - 1), params)
+
 
 def test_analytical_jacobian_shape_and_dbc(params, valid_q):
     """Test standard shape output and DbC for analytical jacobian."""
@@ -64,7 +84,8 @@ def test_analytical_jacobian_shape_and_dbc(params, valid_q):
     with pytest.raises(TypeError):
         analytical_constraint_jacobian("wrong_type", params)
     with pytest.raises(ValueError):
-        analytical_constraint_jacobian(np.ones(N_DOF-1), params)
+        analytical_constraint_jacobian(np.ones(N_DOF - 1), params)
+
 
 def test_analytical_vs_numerical_jacobian(params):
     """TDD check: analytical jacobian closely matches analytical jacobian."""
@@ -75,13 +96,14 @@ def test_analytical_vs_numerical_jacobian(params):
 
     np.testing.assert_allclose(J_num, J_ana, rtol=1e-4, atol=1e-4)
 
+
 def test_linear_accelerations_dbc(params, valid_q, valid_qdot, valid_qddot):
     """Test DbC type enforcement on linear acceleration vectors."""
     acc = linear_accelerations(valid_q, valid_qdot, valid_qddot, params)
     assert isinstance(acc, dict)
-    assert 'rh' in acc
-    assert 'lh' in acc
-    
+    assert "rh" in acc
+    assert "lh" in acc
+
     with pytest.raises(TypeError):
         linear_accelerations(list(valid_q), valid_qdot, valid_qddot, params)
     with pytest.raises(TypeError):
@@ -96,13 +118,13 @@ def test_linear_accelerations_dbc(params, valid_q, valid_qdot, valid_qddot):
     with pytest.raises(ValueError):
         linear_accelerations(valid_q, valid_qdot, np.zeros(2), params)
 
+
 def test_friction_torque_vector_dbc(params, valid_qdot):
     """Test DbC checks for friction torques."""
     tau_f = friction_torque_vector(valid_qdot, params)
     assert tau_f.shape == (N_DOF,)
-    
+
     with pytest.raises(TypeError):
         friction_torque_vector(list(valid_qdot), params)
     with pytest.raises(ValueError):
         friction_torque_vector(np.ones(5), params)
-

--- a/src/pendulum_simulator/tests/test_golfer_dynamics.py
+++ b/src/pendulum_simulator/tests/test_golfer_dynamics.py
@@ -12,21 +12,38 @@ from double_pendulum_golf.golfer_dynamics import (
 )
 from double_pendulum_golf.physics_golfer import GolferParams, N_DOF
 
+
 @pytest.fixture
 def params():
     return GolferParams(
-        m_hub=0.01, m_r_upper=2.0, m_r_fore=1.5, m_l_upper=2.0, m_l_fore=1.5, m_club=0.3,
-        L_hub=0.2, L_r_upper=0.3, L_r_fore=0.3, L_l_upper=0.3, L_l_fore=0.3, L_club=1.0,
-        d_rs=0.1, d_ls=0.1, grip_right=0.2, grip_left=0.3
+        m_hub=0.01,
+        m_r_upper=2.0,
+        m_r_fore=1.5,
+        m_l_upper=2.0,
+        m_l_fore=1.5,
+        m_club=0.3,
+        L_hub=0.2,
+        L_r_upper=0.3,
+        L_r_fore=0.3,
+        L_l_upper=0.3,
+        L_l_fore=0.3,
+        L_club=1.0,
+        d_rs=0.1,
+        d_ls=0.1,
+        grip_right=0.2,
+        grip_left=0.3,
     )
+
 
 @pytest.fixture
 def valid_q():
     return np.zeros(N_DOF)
 
+
 @pytest.fixture
 def valid_qdot():
     return np.zeros(N_DOF)
+
 
 def test_mass_point_positions_dbc(params, valid_q):
     """Test standard shape output and DbC checks for mass points."""
@@ -40,6 +57,7 @@ def test_mass_point_positions_dbc(params, valid_q):
     with pytest.raises(TypeError):
         _mass_point_positions(valid_q, "wrong")
 
+
 def test_potential_energy_from_q_dbc(params, valid_q):
     """Test standard scalar output and DbC checks."""
     pe = potential_energy_from_q(valid_q, params)
@@ -52,17 +70,19 @@ def test_potential_energy_from_q_dbc(params, valid_q):
     with pytest.raises(TypeError):
         potential_energy_from_q(valid_q, None)
 
+
 def test_jacobians_dbc(params, valid_q):
     """Test standard dict output and DbC checks."""
     J = analytical_fk_jacobians(valid_q, params)
     assert isinstance(J, dict)
-    assert 'lh' in J
-    assert J['lh'].shape == (2, N_DOF)
+    assert "lh" in J
+    assert J["lh"].shape == (2, N_DOF)
 
     with pytest.raises(TypeError):
         analytical_fk_jacobians(None, params)
     with pytest.raises(ValueError):
         analytical_fk_jacobians(np.zeros(2), params)
+
 
 def test_mass_matrix_dbc(params, valid_q):
     """Test standard matrix output and DbC checks."""
@@ -73,6 +93,7 @@ def test_mass_matrix_dbc(params, valid_q):
         analytical_mass_matrix(None, params)
     with pytest.raises(ValueError):
         analytical_mass_matrix(np.zeros(2), params)
+
 
 def test_coriolis_dbc(params, valid_q, valid_qdot):
     """Test standard vector output and DbC checks for coriolis."""
@@ -88,6 +109,7 @@ def test_coriolis_dbc(params, valid_q, valid_qdot):
     with pytest.raises(ValueError):
         analytical_coriolis(valid_q, np.zeros(2), params)
 
+
 def test_gravity_vector_dbc(params, valid_q):
     """Test standard vector output and DbC checks for gravity."""
     G = analytical_gravity_vector(valid_q, params)
@@ -97,6 +119,7 @@ def test_gravity_vector_dbc(params, valid_q):
         analytical_gravity_vector(None, params)
     with pytest.raises(ValueError):
         analytical_gravity_vector(np.zeros(2), params)
+
 
 def test_kinetic_energy_dbc(params, valid_q, valid_qdot):
     """Test standard scalar output and DbC checks for kinetic energy."""


### PR DESCRIPTION
## Summary

Fixes the broken golfer module import chain that caused 8 test files (193 tests) to fail to collect.

## Changes

### Critical Fix: Import Chain (#1229)
- **constraint_solver.py** imported , , , etc. from  — but they were removed in a prior refactor
- Fixed to import from actual locations:  and 
- **physics_golfer.py**: Added lazy  re-exports for backward compatibility using deferred  to avoid circular imports

### Black Formatting (#1230)
- Reformatted , , 

### Mypy Fix (#1231)
- Added  for  in  to fix duplicate module path error

## Test Results
- **Before**: 8 test files failed to collect (ImportError)
- **After**: 715+ tests pass, 5 skipped

Closes #1229, #1230, #1231