### PR TITLE
feat: Pose6DOF + Transform6DOF in math-primitives (#1239)

### DIFF
--- a/rust_core/math-primitives/src/lib.rs
+++ b/rust_core/math-primitives/src/lib.rs
@@ -16,7 +16,7 @@ pub mod rotation;
 pub mod transform;
 
 pub use quaternion::{
-    Quaternion, quaternion_inverse, quaternion_multiply, quaternion_normalize, slerp,
+    quaternion_inverse, quaternion_multiply, quaternion_normalize, slerp, Quaternion,
 };
 pub use rotation::{
     axis_angle_to_rotation_matrix, euler_to_quaternion, euler_to_rotation_matrix,

--- a/rust_core/math-primitives/src/rotation.rs
+++ b/rust_core/math-primitives/src/rotation.rs
@@ -37,15 +37,9 @@ pub fn rotation_matrix_to_euler(r: &Matrix3<f64>) -> [f64; 3] {
         // Gimbal lock
         let yaw = 0.0;
         let (pitch, roll) = if r[(2, 0)] < 0.0 {
-            (
-                std::f64::consts::FRAC_PI_2,
-                r[(0, 1)].atan2(r[(0, 2)]),
-            )
+            (std::f64::consts::FRAC_PI_2, r[(0, 1)].atan2(r[(0, 2)]))
         } else {
-            (
-                -std::f64::consts::FRAC_PI_2,
-                (-r[(0, 1)]).atan2(-r[(0, 2)]),
-            )
+            (-std::f64::consts::FRAC_PI_2, (-r[(0, 1)]).atan2(-r[(0, 2)]))
         };
         [roll, pitch, yaw]
     } else {
@@ -165,11 +159,7 @@ pub fn axis_angle_to_rotation_matrix(axis: &[f64; 3], angle: f64) -> Matrix3<f64
     let a = Vector3::new(axis[0], axis[1], axis[2]);
     let a = a / a.norm(); // normalize
 
-    let k = Matrix3::new(
-        0.0, -a[2], a[1],
-        a[2], 0.0, -a[0],
-        -a[1], a[0], 0.0,
-    );
+    let k = Matrix3::new(0.0, -a[2], a[1], a[2], 0.0, -a[0], -a[1], a[0], 0.0);
 
     Matrix3::identity() + angle.sin() * k + (1.0 - angle.cos()) * (k * k)
 }

--- a/rust_core/math-primitives/src/transform.rs
+++ b/rust_core/math-primitives/src/transform.rs
@@ -144,10 +144,7 @@ impl Pose6DOF {
         let r2 = other.rotation_matrix();
         let r = r1 * r2;
         let p = r1 * other.position + self.position;
-        Pose6DOF::from_rotation_matrix(
-            [p[0], p[1], p[2]],
-            &r,
-        )
+        Pose6DOF::from_rotation_matrix([p[0], p[1], p[2]], &r)
     }
 
     /// Transform a point by this pose.
@@ -304,10 +301,7 @@ impl Transform6DOF {
 
     /// Interpolate between two transforms (SLERP + linear).
     pub fn interpolate(t1: &Transform6DOF, t2: &Transform6DOF, alpha: f64) -> Transform6DOF {
-        debug_assert!(
-            (0.0..=1.0).contains(&alpha),
-            "alpha must be in [0, 1]"
-        );
+        debug_assert!((0.0..=1.0).contains(&alpha), "alpha must be in [0, 1]");
 
         let translation = (1.0 - alpha) * t1.translation + alpha * t2.translation;
 
@@ -394,10 +388,7 @@ mod tests {
 
     #[test]
     fn test_transform_compose_inverse_is_identity() {
-        let t = Transform6DOF::new(
-            euler_to_rotation_matrix(&[0.3, 0.5, -0.2]),
-            [1.0, 2.0, 3.0],
-        );
+        let t = Transform6DOF::new(euler_to_rotation_matrix(&[0.3, 0.5, -0.2]), [1.0, 2.0, 3.0]);
         let t_inv = t.inverse();
         let result = t.compose(&t_inv);
         let pt = result.transform_point(&[5.0, 6.0, 7.0]);


### PR DESCRIPTION
## Changes

Adds Pose6DOF and Transform6DOF structs to the math-primitives Rust crate, completing the core SE3/SO3 type system.

### Pose6DOF
- Position [x,y,z] + Euler angles [roll,pitch,yaw]
- Constructors: new, from_quaternion, from_rotation_matrix
- Operations: compose, inverse, translate, rotate_euler
- Conversions: homogeneous_matrix, to_quaternion
- Point/vector transformation

### Transform6DOF
- Rotation matrix + translation (efficient for composition)
- Factory: from_rotation_{x,y,z}, from_translation, from_pose, from_homogeneous
- Operations: compose, inverse, interpolate (SLERP + linear)
- Point/vector transformation
- Roundtrip: to_pose / from_pose

### Test Results
- 25 Rust tests pass (up from 15)
- Clippy: 0 warnings
- All APIs match Python parity (UpstreamDrift/pose6dof.py)

Partial fix for #1239