### PR TITLE
fix(security): bump black to 26.3.1

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -13,7 +13,7 @@ sympy==1.14.0
 pytest==8.4.1
 pytest-cov==7.0.0
 ruff==0.14.10
-black==26.1.0
+black==26.3.1
 mypy==1.13.0
 bandit==1.9.3
 types-PyYAML==6.0.12.20250915

--- a/src/media_processing/video_processor/python/requirements.txt
+++ b/src/media_processing/video_processor/python/requirements.txt
@@ -17,7 +17,7 @@ pytest-mock==3.14.0
 
 # Code quality and formatting
 ruff==0.5.0
-black==24.4.2
+black==26.3.1
 mypy==1.10.0
 pre-commit==4.0.0
 


### PR DESCRIPTION
## Summary\n- bump Black in the shared lockfile to 26.3.1\n- bump Black in the video processor Python requirements to 26.3.1\n- address Dependabot alerts #116 and #117\n\n## Validation\n- verified both manifests now pin black==26.3.1\n