### PR TITLE
refactor(pendulum): DRY — extract _assert_energy_finite and total_torques_at to base

### DIFF
--- a/src/pendulum_simulator/src/double_pendulum_golf/simulation.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/simulation.py
@@ -134,9 +134,7 @@ class SimulationResult(TrajectoryResultMixin):
             "potential": potential_energy(state, self.params),
             "total": total_energy(state, self.params),
         }
-        assert all(
-            np.isfinite(v) for v in result.values()
-        ), f"Non-finite energy at idx={idx}: {result}"
+        self._assert_energy_finite(result, idx)
         return result
 
     def coriolis_at(self, idx: int) -> np.ndarray:

--- a/src/pendulum_simulator/src/double_pendulum_golf/simulation_golfer.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/simulation_golfer.py
@@ -141,9 +141,7 @@ class GolferSimulationResult(TrajectoryResultMixin):
             "potential": potential_energy(state, self.params),
             "total": total_energy(state, self.params),
         }
-        assert all(
-            np.isfinite(v) for v in result.values()
-        ), f"Non-finite energy at idx={idx}: {result}"
+        self._assert_energy_finite(result, idx)
         return result
 
     def friction_torques_at(self, idx: int) -> np.ndarray:
@@ -152,7 +150,11 @@ class GolferSimulationResult(TrajectoryResultMixin):
         return friction_torque_vector(self.qdot_at(idx), self.params)  # type: ignore[no-any-return]
 
     def total_torques_at(self, idx: int) -> np.ndarray:
-        """Total applied torque (drive + friction) at time index."""
+        """Total applied torque (drive + friction) at time index.
+
+        Overrides the base to spread the 7-joint torque_func output over the
+        full N_DOF=8 vector before adding friction.
+        """
         self._check_idx(idx)
         tau_drive = np.zeros(N_DOF)
         tau_drive[:7] = self.torque_func(self.t[idx])

--- a/src/pendulum_simulator/src/double_pendulum_golf/simulation_result_base.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/simulation_result_base.py
@@ -39,6 +39,26 @@ class TrajectoryResultMixin:
     def _check_idx(self, idx: int) -> None:
         assert 0 <= idx < self.n_steps, f"Index {idx} out of range [0, {self.n_steps})"
 
+    @staticmethod
+    def _assert_energy_finite(result: dict, idx: int) -> None:
+        """Shared postcondition: all energy components must be finite."""
+        assert all(
+            np.isfinite(v) for v in result.values()
+        ), f"Non-finite energy at idx={idx}: {result}"
+
+    def total_torques_at(self, idx: int) -> np.ndarray:
+        """Total applied torque (drive + friction) at time index.
+
+        Default implementation: tau_drive + tau_friction.  Subclasses that
+        apply torque clamping (e.g. double-pendulum with TorqueClamp) must
+        override this method.
+        """
+        self._check_idx(idx)
+        torque_func = getattr(self, "torque_func")
+        tau_drive = np.array(torque_func(self.t[idx]))
+        tau_friction: np.ndarray = self.friction_torques_at(idx)  # type: ignore[attr-defined]
+        return np.asarray(tau_drive + tau_friction)
+
     def all_positions(self) -> list[Any]:
         positions_at = getattr(self, "positions_at")
         return [positions_at(i) for i in range(self.n_steps)]

--- a/src/pendulum_simulator/src/double_pendulum_golf/simulation_triple.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/simulation_triple.py
@@ -98,9 +98,7 @@ class TripleSimulationResult(TrajectoryResultMixin):
             "potential": potential_energy(state, self.params),
             "total": total_energy(state, self.params),
         }
-        assert all(
-            np.isfinite(v) for v in result.values()
-        ), f"Non-finite energy at idx={idx}: {result}"
+        self._assert_energy_finite(result, idx)
         return result
 
     def friction_torques_at(self, idx: int) -> np.ndarray:
@@ -113,20 +111,6 @@ class TripleSimulationResult(TrajectoryResultMixin):
         self._check_idx(idx)
         s = self.states[idx]
         return friction_torque_vector(s[3], s[4], s[5], self.params)
-
-    def total_torques_at(self, idx: int) -> np.ndarray:
-        """Get total applied torque at time idx.
-
-        Total = driving torque + friction torque.
-
-        Returns
-        -------
-        np.ndarray, shape (3,)  [N·m]
-        """
-        self._check_idx(idx)
-        tau_drive = np.array(self.torque_func(self.t[idx]))
-        tau_friction = self.friction_torques_at(idx)
-        return np.asarray(tau_drive + tau_friction)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Added `_assert_energy_finite(result, idx)` static helper to `TrajectoryResultMixin` — replaces 3 identical `assert all(np.isfinite(v)...)` blocks in simulation.py, simulation_triple.py, and simulation_golfer.py
- Added default `total_torques_at()` to `TrajectoryResultMixin` for the common `tau_drive + tau_friction` pattern; `TripleSimulationResult` now inherits it, `GolferSimulationResult` overrides it to handle the 7→8 DOF broadcast

## Test plan
- [x] 732 tests pass locally (all tests except `test_no_scroll_widgets.py` which has a pre-existing Qt abort issue)
- [x] ruff check passes on all modified files

Closes #1287