### PR TITLE
feat: wire SwingComparisonDialog into all panel builders (#1285)

### DIFF
--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/panel_builders.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/panel_builders.py
@@ -203,7 +203,6 @@ def build_double_panel(main_window: Any) -> SimulationPanel:
         )
 
     def _double_extract_fn(result: object) -> dict:
-
         res = result  # type: ignore[assignment]
         vels = res.joint_velocities_at(res.n_steps - 1)  # type: ignore[attr-defined]
         tip_v = vels.get("tip", (0.0, 0.0))
@@ -220,6 +219,21 @@ def build_double_panel(main_window: Any) -> SimulationPanel:
             controls.get_params().get("shoulder_coeffs", [0.0]),
             controls.get_params().get("wrist_coeffs", [0.0]),
         ]
+    )
+
+    def _double_preset_coeffs(name: str) -> list[list[float]]:
+        preset = controls.PRESETS.get(name)
+        if preset is None:
+            return [[0.0], [0.0]]
+
+        def _parse(s: str) -> list[float]:
+            return [float(x.strip()) for x in s.split(",") if x.strip()] or [0.0]
+
+        return [_parse(str(preset[4])), _parse(str(preset[5]))]
+
+    perturb.set_preset_source(
+        lambda: list(controls.PRESETS.keys()),
+        _double_preset_coeffs,
     )
     perturb.set_simulation_callbacks(_double_simulate_fn, _double_extract_fn)
     panel.set_perturbation_panel(perturb)
@@ -403,6 +417,22 @@ def build_triple_panel(main_window: Any) -> SimulationPanel:
             controls.get_params().get("elbow_coeffs", [0.0]),
             controls.get_params().get("wrist_coeffs", [0.0]),
         ]
+    )
+
+    def _triple_preset_coeffs(name: str) -> list[list[float]]:
+        preset = controls.PRESETS.get(name)
+        if preset is None:
+            return [[0.0], [0.0], [0.0]]
+
+        def _parse(s: str) -> list[float]:
+            return [float(x.strip()) for x in s.split(",") if x.strip()] or [0.0]
+
+        # Triple PRESETS tuple: indices 6=tau_sh, 7=tau_el, 8=tau_wr
+        return [_parse(str(preset[6])), _parse(str(preset[7])), _parse(str(preset[8]))]
+
+    perturb.set_preset_source(
+        lambda: list(controls.PRESETS.keys()),
+        _triple_preset_coeffs,
     )
     perturb.set_simulation_callbacks(_triple_simulate_fn, _triple_extract_fn)
     panel.set_perturbation_panel(perturb)
@@ -622,6 +652,31 @@ def build_golfer_panel(main_window: Any) -> SimulationPanel:
         return [p.get(k, [0.0]) for k in joint_keys]
 
     perturb.set_coeffs_source(_golfer_coeffs_fn)
+
+    _GOLFER_TAU_KEYS = [
+        "tau_hub",
+        "tau_rs",
+        "tau_re",
+        "tau_rh",
+        "tau_ls",
+        "tau_le",
+        "tau_lh",
+    ]
+
+    def _golfer_preset_coeffs(name: str) -> list[list[float]]:
+        preset = controls.PRESETS.get(name)
+        if preset is None:
+            return [[0.0]] * len(_GOLFER_TAU_KEYS)
+
+        def _parse(s: str) -> list[float]:
+            return [float(x.strip()) for x in s.split(",") if x.strip()] or [0.0]
+
+        return [_parse(str(preset.get(k, "0"))) for k in _GOLFER_TAU_KEYS]
+
+    perturb.set_preset_source(
+        lambda: list(controls.PRESETS.keys()),
+        _golfer_preset_coeffs,
+    )
     perturb.set_simulation_callbacks(_golfer_simulate_fn, _golfer_extract_fn)
     panel.set_perturbation_panel(perturb)
     return panel

--- a/src/pendulum_simulator/tests/test_swing_comparison_dialog.py
+++ b/src/pendulum_simulator/tests/test_swing_comparison_dialog.py
@@ -1,0 +1,183 @@
+"""
+Unit tests for SwingComparisonDialog and PerturbationPanel.set_preset_source().
+
+Uses pytest-qt (QApplication via conftest) with a minimal headless
+environment.  Does NOT run a real simulation — all callbacks are stubs.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PyQt6.QtWidgets import QApplication
+
+    _HAS_QT = True
+except ImportError:
+    _HAS_QT = False
+
+
+pytestmark = pytest.mark.skipif(not _HAS_QT, reason="PyQt6 not available")
+
+
+@pytest.fixture(scope="module")
+def app():
+    """Headless QApplication fixture (shared across module)."""
+    import sys
+
+    existing = QApplication.instance()
+    if existing is not None:
+        yield existing
+        return
+    a = QApplication(sys.argv[:1])
+    yield a
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PRESET_NAMES = ["Preset A", "Preset B", "Preset C"]
+_COEFFS: dict[str, list[list[float]]] = {
+    "Preset A": [[-25.0, 10.0], [0.0]],
+    "Preset B": [[-30.0, 12.0], [0.0]],
+    "Preset C": [[0.0], [0.0]],
+}
+
+
+def _stub_simulate(coeffs):
+    return object()
+
+
+def _stub_extract(result):
+    return {
+        "tip_speed_final": 30.0,
+        "tip_position_final": np.array([0.0, 0.0]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# PerturbationPanel.set_preset_source
+# ---------------------------------------------------------------------------
+
+
+class TestSetPresetSource:
+    @pytest.fixture
+    def panel(self, app):  # noqa: ARG002
+        from double_pendulum_golf.gui.perturbation_panel import PerturbationPanel
+
+        p = PerturbationPanel()
+        p.set_simulation_callbacks(_stub_simulate, _stub_extract)
+        return p
+
+    def test_compare_btn_disabled_without_preset_source(self, panel) -> None:
+        assert not panel._compare_btn.isEnabled()
+
+    def test_compare_btn_enabled_after_set_preset_source(self, panel) -> None:
+        panel.set_preset_source(
+            lambda: _PRESET_NAMES,
+            lambda name: _COEFFS.get(name, [[0.0]]),
+        )
+        assert panel._compare_btn.isEnabled()
+
+    def test_rejects_non_callable_names_fn(self, panel) -> None:
+        with pytest.raises(AssertionError):
+            panel.set_preset_source("not_callable", lambda name: [])  # type: ignore[arg-type]
+
+    def test_rejects_non_callable_coeffs_fn(self, panel) -> None:
+        with pytest.raises(AssertionError):
+            panel.set_preset_source(lambda: [], "not_callable")  # type: ignore[arg-type]
+
+    def test_stores_preset_fns(self, panel) -> None:
+        def names_fn() -> list[str]:
+            return _PRESET_NAMES
+
+        def coeffs_fn(name: str) -> list[list[float]]:
+            return _COEFFS.get(name, [[0.0]])
+
+        panel.set_preset_source(names_fn, coeffs_fn)
+        assert panel._get_preset_names_fn is names_fn
+        assert panel._get_coeffs_for_preset_fn is coeffs_fn
+
+
+# ---------------------------------------------------------------------------
+# SwingComparisonDialog construction
+# ---------------------------------------------------------------------------
+
+
+class TestSwingComparisonDialogConstruction:
+    @pytest.fixture
+    def dialog(self, app):  # noqa: ARG002
+        from double_pendulum_golf.gui.swing_comparison_dialog import (
+            SwingComparisonDialog,
+        )
+
+        return SwingComparisonDialog(
+            preset_names=_PRESET_NAMES,
+            get_coeffs_for_preset=lambda name: _COEFFS.get(name, [[0.0]]),
+            simulate_fn=_stub_simulate,
+            extract_fn=_stub_extract,
+        )
+
+    def test_creates_without_error(self, dialog) -> None:
+        assert dialog is not None
+
+    def test_preset_list_has_all_presets(self, dialog) -> None:
+        assert dialog._preset_list.count() == len(_PRESET_NAMES)
+
+    def test_first_two_presets_selected_by_default(self, dialog) -> None:
+        selected = [
+            dialog._preset_list.item(i).text()
+            for i in range(dialog._preset_list.count())
+            if dialog._preset_list.item(i) and dialog._preset_list.item(i).isSelected()
+        ]
+        assert len(selected) == 2
+        assert selected[0] == _PRESET_NAMES[0]
+        assert selected[1] == _PRESET_NAMES[1]
+
+    def test_run_button_present(self, dialog) -> None:
+        assert dialog._run_btn is not None
+
+    def test_cancel_button_initially_disabled(self, dialog) -> None:
+        assert not dialog._cancel_btn.isEnabled()
+
+    def test_noise_combo_has_three_items(self, dialog) -> None:
+        assert dialog._noise_combo.count() == 3
+
+    def test_trials_spin_default(self, dialog) -> None:
+        assert dialog._trials_spin.value() == 50
+
+    def test_export_button_initially_disabled(self, dialog) -> None:
+        assert not dialog._export_btn.isEnabled()
+
+
+# ---------------------------------------------------------------------------
+# SwingComparisonDialog with fewer than 2 presets
+# ---------------------------------------------------------------------------
+
+
+class TestSwingComparisonDialogSinglePreset:
+    def test_run_button_disabled_with_one_preset(self, app) -> None:  # noqa: ARG002
+        from double_pendulum_golf.gui.swing_comparison_dialog import (
+            SwingComparisonDialog,
+        )
+
+        dlg = SwingComparisonDialog(
+            preset_names=["Only One"],
+            get_coeffs_for_preset=lambda name: [[0.0]],
+            simulate_fn=_stub_simulate,
+            extract_fn=_stub_extract,
+        )
+        # With only 1 preset only 1 can be selected; run needs ≥2 selected
+        # The run button should reflect that fewer than 2 are selected
+        selected_count = sum(
+            1
+            for i in range(dlg._preset_list.count())
+            if dlg._preset_list.item(i) and dlg._preset_list.item(i).isSelected()
+        )
+        assert selected_count < 2


### PR DESCRIPTION
## Summary

- Wire `set_preset_source()` into `build_double_panel`, `build_triple_panel`, and `build_golfer_panel` in `panel_builders.py`
- Each builder now extracts torque coefficient strings from the controls widget's `PRESETS` dict and provides them to `PerturbationPanel.set_preset_source()`, enabling the **Compare** button that opens `SwingComparisonDialog`
- Add `test_swing_comparison_dialog.py` with 12 tests covering construction, preset selection, button states, and `set_preset_source` validation

## Test plan

- [x] `TestSetPresetSource`: compare button disabled/enabled, fn rejection, storage
- [x] `TestSwingComparisonDialogConstruction`: preset count, default selections, button states, noise combo, trials spinner
- [x] `TestSwingComparisonDialogSinglePreset`: edge case with 1 preset

Closes #1285