### PR TITLE
refactor(urdf_builder): extract theme/preview, complete TDD polish

### DIFF
--- a/src/urdf_builder_gui/preview_generator.py
+++ b/src/urdf_builder_gui/preview_generator.py
@@ -1,0 +1,90 @@
+"""Preview text generator — pure-Python, GUI-independent.
+
+Generates human-readable model structure previews from a URDFConfig.
+Extracted from main_window.py for TDD compliance and LoD.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from urdf_builder_gui.anthropometric_model import (
+    HEIGHT_RATIOS,
+    URDFConfig,
+    get_template_segments,
+)
+from urdf_builder_gui.contracts import require
+
+logger = logging.getLogger(__name__)
+
+
+def generate_preview_text(config: URDFConfig) -> str:
+    """Generate a human-readable preview of the model structure.
+
+    **Pre-conditions** (DbC):
+      - ``config.robot_name`` must not be empty.
+      - ``config.height_m`` must be > 0.
+      - ``config.mass_kg`` must be > 0.
+
+    Returns:
+        Multi-line preview string.
+    """
+    require(bool(config.robot_name), "robot_name must not be empty", config.robot_name)
+    require(config.height_m > 0, "height_m must be positive", config.height_m)
+    require(config.mass_kg > 0, "mass_kg must be positive", config.mass_kg)
+
+    logger.info("Generating preview for '%s'", config.robot_name)
+
+    lines: list[str] = [
+        "Model Structure Preview",
+        "=" * 50,
+        f"\nRobot Name: {config.robot_name}",
+        f"Template: {config.template}",
+        "\nBody Parameters:",
+        f"  Height: {config.height_m:.2f} m",
+        f"  Mass: {config.mass_kg:.1f} kg",
+        f"  Gender Factor: {config.gender_factor:.2f}",
+    ]
+
+    # Proportions
+    lines.append("\nSegment Proportions:")
+    for key, value in config.proportions.items():
+        label = key.replace("_", " ").title()
+        lines.append(f"  {label}: {value * 100:.0f}%")
+
+    # Estimated segment sizes — uses shared HEIGHT_RATIOS (DRY)
+    lines.append("\nEstimated Segment Sizes:")
+    segment_labels = {
+        "pelvis": "Pelvis Height",
+        "torso": "Torso Height",
+        "head": "Head Diameter",
+        "thigh": "Thigh Length",
+        "shin": "Shin Length",
+        "upper_arm": "Upper Arm Length",
+        "forearm": "Forearm Length",
+    }
+    for key, label in segment_labels.items():
+        length = config.height_m * HEIGHT_RATIOS[key]
+        lines.append(f"  {label}: {length:.3f} m")
+
+    # Template segments
+    segments = get_template_segments(config.template)
+    lines.append(f"\nTemplate Segments ({len(segments)}):")
+    for seg in segments:
+        lines.append(f"  • {seg}")
+
+    # Options
+    lines.append("\nOptions:")
+    lines.append(f"  Default Geometry: {config.geometry_type}")
+    lines.append(f"  Collision Geometry: {config.collision_geometry}")
+    lines.append(f"  Joint Damping: {config.damping:.2f}")
+    lines.append(f"  Joint Friction: {config.friction:.2f}")
+    lines.append(f"  Inertia Mode: {config.inertia_mode}")
+    lines.append(f"  Density: {config.density:.0f} kg/m³")
+
+    return "\n".join(lines)
+
+
+__all__ = [
+    "generate_preview_text",
+]

--- a/src/urdf_builder_gui/python/urdf_builder_gui/preview_generator.py
+++ b/src/urdf_builder_gui/python/urdf_builder_gui/preview_generator.py
@@ -1,0 +1,90 @@
+"""Preview text generator — pure-Python, GUI-independent.
+
+Generates human-readable model structure previews from a URDFConfig.
+Extracted from main_window.py for TDD compliance and LoD.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from urdf_builder_gui.anthropometric_model import (
+    HEIGHT_RATIOS,
+    URDFConfig,
+    get_template_segments,
+)
+from urdf_builder_gui.contracts import require
+
+logger = logging.getLogger(__name__)
+
+
+def generate_preview_text(config: URDFConfig) -> str:
+    """Generate a human-readable preview of the model structure.
+
+    **Pre-conditions** (DbC):
+      - ``config.robot_name`` must not be empty.
+      - ``config.height_m`` must be > 0.
+      - ``config.mass_kg`` must be > 0.
+
+    Returns:
+        Multi-line preview string.
+    """
+    require(bool(config.robot_name), "robot_name must not be empty", config.robot_name)
+    require(config.height_m > 0, "height_m must be positive", config.height_m)
+    require(config.mass_kg > 0, "mass_kg must be positive", config.mass_kg)
+
+    logger.info("Generating preview for '%s'", config.robot_name)
+
+    lines: list[str] = [
+        "Model Structure Preview",
+        "=" * 50,
+        f"\nRobot Name: {config.robot_name}",
+        f"Template: {config.template}",
+        "\nBody Parameters:",
+        f"  Height: {config.height_m:.2f} m",
+        f"  Mass: {config.mass_kg:.1f} kg",
+        f"  Gender Factor: {config.gender_factor:.2f}",
+    ]
+
+    # Proportions
+    lines.append("\nSegment Proportions:")
+    for key, value in config.proportions.items():
+        label = key.replace("_", " ").title()
+        lines.append(f"  {label}: {value * 100:.0f}%")
+
+    # Estimated segment sizes — uses shared HEIGHT_RATIOS (DRY)
+    lines.append("\nEstimated Segment Sizes:")
+    segment_labels = {
+        "pelvis": "Pelvis Height",
+        "torso": "Torso Height",
+        "head": "Head Diameter",
+        "thigh": "Thigh Length",
+        "shin": "Shin Length",
+        "upper_arm": "Upper Arm Length",
+        "forearm": "Forearm Length",
+    }
+    for key, label in segment_labels.items():
+        length = config.height_m * HEIGHT_RATIOS[key]
+        lines.append(f"  {label}: {length:.3f} m")
+
+    # Template segments
+    segments = get_template_segments(config.template)
+    lines.append(f"\nTemplate Segments ({len(segments)}):")
+    for seg in segments:
+        lines.append(f"  • {seg}")
+
+    # Options
+    lines.append("\nOptions:")
+    lines.append(f"  Default Geometry: {config.geometry_type}")
+    lines.append(f"  Collision Geometry: {config.collision_geometry}")
+    lines.append(f"  Joint Damping: {config.damping:.2f}")
+    lines.append(f"  Joint Friction: {config.friction:.2f}")
+    lines.append(f"  Inertia Mode: {config.inertia_mode}")
+    lines.append(f"  Density: {config.density:.0f} kg/m³")
+
+    return "\n".join(lines)
+
+
+__all__ = [
+    "generate_preview_text",
+]

--- a/src/urdf_builder_gui/python/urdf_builder_gui/theme.py
+++ b/src/urdf_builder_gui/python/urdf_builder_gui/theme.py
@@ -1,0 +1,207 @@
+"""Catppuccin Mocha theme — reusable palette and stylesheet.
+
+Extracted from main_window.py for DRY compliance. This module can be
+shared across multiple GUI tools in the fleet.
+"""
+
+from __future__ import annotations
+
+# ── Catppuccin Mocha Palette ────────────────────────────────────────────
+
+CATPPUCCIN_MOCHA: dict[str, str] = {
+    "rosewater": "#f5e0dc",
+    "flamingo": "#f2cdcd",
+    "pink": "#f5c2e7",
+    "mauve": "#cba6f7",
+    "red": "#f38ba8",
+    "maroon": "#eba0ac",
+    "peach": "#fab387",
+    "yellow": "#f9e2af",
+    "green": "#a6e3a1",
+    "teal": "#94e2d5",
+    "sky": "#89dceb",
+    "sapphire": "#74c7ec",
+    "blue": "#89b4fa",
+    "lavender": "#b4befe",
+    "text": "#cdd6f4",
+    "subtext1": "#bac2de",
+    "subtext0": "#a6adc8",
+    "overlay2": "#9399b2",
+    "overlay1": "#7f849c",
+    "overlay0": "#6c7086",
+    "surface2": "#585b70",
+    "surface1": "#45475a",
+    "surface0": "#313244",
+    "base": "#1e1e2e",
+    "mantle": "#181825",
+    "crust": "#11111b",
+}
+
+
+def build_stylesheet(palette: dict[str, str] | None = None) -> str:
+    """Build a complete Qt stylesheet from a colour palette.
+
+    Args:
+        palette: Colour palette dictionary. Defaults to CATPPUCCIN_MOCHA.
+
+    Returns:
+        A Qt stylesheet string ready for ``setStyleSheet()``.
+    """
+    p = palette or CATPPUCCIN_MOCHA
+    return f"""
+QMainWindow {{
+    background-color: {p["base"]};
+}}
+
+QWidget {{
+    background-color: {p["base"]};
+    color: {p["text"]};
+    font-family: "Segoe UI", "Arial", sans-serif;
+}}
+
+QScrollArea {{
+    border: none;
+    background-color: {p["base"]};
+}}
+
+QTabWidget::pane {{
+    border: 1px solid {p["surface1"]};
+    background-color: {p["mantle"]};
+    border-radius: 4px;
+}}
+
+QTabBar::tab {{
+    background-color: {p["surface0"]};
+    color: {p["subtext1"]};
+    padding: 8px 16px;
+    margin-right: 2px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}}
+
+QTabBar::tab:selected {{
+    background-color: {p["surface1"]};
+    color: {p["blue"]};
+}}
+
+QGroupBox {{
+    background-color: {p["surface0"]};
+    border: 1px solid {p["surface1"]};
+    border-radius: 8px;
+    margin-top: 12px;
+    padding: 12px;
+    font-weight: bold;
+}}
+
+QGroupBox::title {{
+    subcontrol-origin: margin;
+    left: 12px;
+    padding: 0 6px;
+    color: {p["mauve"]};
+}}
+
+QLabel {{
+    color: {p["text"]};
+    background-color: transparent;
+}}
+
+QDoubleSpinBox, QSpinBox {{
+    background-color: {p["surface0"]};
+    color: {p["text"]};
+    border: 1px solid {p["surface2"]};
+    border-radius: 4px;
+    padding: 6px 10px;
+}}
+
+QDoubleSpinBox:focus, QSpinBox:focus {{
+    border: 1px solid {p["blue"]};
+}}
+
+QComboBox {{
+    background-color: {p["surface0"]};
+    color: {p["text"]};
+    border: 1px solid {p["surface2"]};
+    border-radius: 4px;
+    padding: 6px 10px;
+    min-width: 150px;
+}}
+
+QComboBox:hover {{
+    border: 1px solid {p["blue"]};
+}}
+
+QComboBox::drop-down {{
+    border: none;
+    width: 24px;
+}}
+
+QComboBox::down-arrow {{
+    image: none;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid {p["text"]};
+    margin-right: 8px;
+}}
+
+QComboBox QAbstractItemView {{
+    background-color: {p["surface0"]};
+    color: {p["text"]};
+    selection-background-color: {p["surface2"]};
+    border: 1px solid {p["surface1"]};
+}}
+
+QSlider::groove:horizontal {{
+    border: 1px solid {p["surface2"]};
+    height: 8px;
+    background: {p["surface0"]};
+    border-radius: 4px;
+}}
+
+QSlider::handle:horizontal {{
+    background: {p["blue"]};
+    border: 1px solid {p["surface2"]};
+    width: 18px;
+    margin: -5px 0;
+    border-radius: 9px;
+}}
+
+QTextEdit {{
+    background-color: {p["surface0"]};
+    color: {p["text"]};
+    border: 1px solid {p["surface2"]};
+    border-radius: 4px;
+    padding: 8px;
+    font-family: "Consolas", "Courier New", monospace;
+}}
+
+QPushButton {{
+    background-color: {p["blue"]};
+    color: {p["crust"]};
+    border: none;
+    border-radius: 4px;
+    padding: 10px 24px;
+    font-weight: bold;
+}}
+
+QPushButton:hover {{
+    background-color: {p["sapphire"]};
+}}
+
+QPushButton:pressed {{
+    background-color: {p["lavender"]};
+}}
+
+QPushButton#exportBtn {{
+    background-color: {p["green"]};
+}}
+
+QPushButton#exportBtn:hover {{
+    background-color: {p["teal"]};
+}}
+"""
+
+
+__all__ = [
+    "CATPPUCCIN_MOCHA",
+    "build_stylesheet",
+]

--- a/src/urdf_builder_gui/python/urdf_builder_gui/ui/pyqt6/main_window.py
+++ b/src/urdf_builder_gui/python/urdf_builder_gui/ui/pyqt6/main_window.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python3
 """Parametric URDF Builder PyQt6 Main Window.
 
-A PyQt6 GUI for generating parametric URDF models for robotics applications.
+A thin UI shell that delegates all business logic to the extracted modules:
+  - urdf_generator: URDF XML generation & validation
+  - preview_generator: Human-readable model previews
+  - anthropometric_model: Shared constants & config
+  - theme: Reusable palette & stylesheet
 """
 
 from __future__ import annotations
@@ -31,187 +35,11 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-# Catppuccin Mocha color palette
-CATPPUCCIN_MOCHA = {
-    "rosewater": "#f5e0dc",
-    "flamingo": "#f2cdcd",
-    "pink": "#f5c2e7",
-    "mauve": "#cba6f7",
-    "red": "#f38ba8",
-    "maroon": "#eba0ac",
-    "peach": "#fab387",
-    "yellow": "#f9e2af",
-    "green": "#a6e3a1",
-    "teal": "#94e2d5",
-    "sky": "#89dceb",
-    "sapphire": "#74c7ec",
-    "blue": "#89b4fa",
-    "lavender": "#b4befe",
-    "text": "#cdd6f4",
-    "subtext1": "#bac2de",
-    "subtext0": "#a6adc8",
-    "overlay2": "#9399b2",
-    "overlay1": "#7f849c",
-    "overlay0": "#6c7086",
-    "surface2": "#585b70",
-    "surface1": "#45475a",
-    "surface0": "#313244",
-    "base": "#1e1e2e",
-    "mantle": "#181825",
-    "crust": "#11111b",
-}
+from urdf_builder_gui.theme import CATPPUCCIN_MOCHA, build_stylesheet
 
-STYLESHEET = f"""
-QMainWindow {{
-    background-color: {CATPPUCCIN_MOCHA["base"]};
-}}
+logger = logging.getLogger(__name__)
 
-QWidget {{
-    background-color: {CATPPUCCIN_MOCHA["base"]};
-    color: {CATPPUCCIN_MOCHA["text"]};
-    font-family: "Segoe UI", "Arial", sans-serif;
-}}
-
-QScrollArea {{
-    border: none;
-    background-color: {CATPPUCCIN_MOCHA["base"]};
-}}
-
-QTabWidget::pane {{
-    border: 1px solid {CATPPUCCIN_MOCHA["surface1"]};
-    background-color: {CATPPUCCIN_MOCHA["mantle"]};
-    border-radius: 4px;
-}}
-
-QTabBar::tab {{
-    background-color: {CATPPUCCIN_MOCHA["surface0"]};
-    color: {CATPPUCCIN_MOCHA["subtext1"]};
-    padding: 8px 16px;
-    margin-right: 2px;
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-}}
-
-QTabBar::tab:selected {{
-    background-color: {CATPPUCCIN_MOCHA["surface1"]};
-    color: {CATPPUCCIN_MOCHA["blue"]};
-}}
-
-QGroupBox {{
-    background-color: {CATPPUCCIN_MOCHA["surface0"]};
-    border: 1px solid {CATPPUCCIN_MOCHA["surface1"]};
-    border-radius: 8px;
-    margin-top: 12px;
-    padding: 12px;
-    font-weight: bold;
-}}
-
-QGroupBox::title {{
-    subcontrol-origin: margin;
-    left: 12px;
-    padding: 0 6px;
-    color: {CATPPUCCIN_MOCHA["mauve"]};
-}}
-
-QLabel {{
-    color: {CATPPUCCIN_MOCHA["text"]};
-    background-color: transparent;
-}}
-
-QDoubleSpinBox, QSpinBox {{
-    background-color: {CATPPUCCIN_MOCHA["surface0"]};
-    color: {CATPPUCCIN_MOCHA["text"]};
-    border: 1px solid {CATPPUCCIN_MOCHA["surface2"]};
-    border-radius: 4px;
-    padding: 6px 10px;
-}}
-
-QDoubleSpinBox:focus, QSpinBox:focus {{
-    border: 1px solid {CATPPUCCIN_MOCHA["blue"]};
-}}
-
-QComboBox {{
-    background-color: {CATPPUCCIN_MOCHA["surface0"]};
-    color: {CATPPUCCIN_MOCHA["text"]};
-    border: 1px solid {CATPPUCCIN_MOCHA["surface2"]};
-    border-radius: 4px;
-    padding: 6px 10px;
-    min-width: 150px;
-}}
-
-QComboBox:hover {{
-    border: 1px solid {CATPPUCCIN_MOCHA["blue"]};
-}}
-
-QComboBox::drop-down {{
-    border: none;
-    width: 24px;
-}}
-
-QComboBox::down-arrow {{
-    image: none;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-top: 6px solid {CATPPUCCIN_MOCHA["text"]};
-    margin-right: 8px;
-}}
-
-QComboBox QAbstractItemView {{
-    background-color: {CATPPUCCIN_MOCHA["surface0"]};
-    color: {CATPPUCCIN_MOCHA["text"]};
-    selection-background-color: {CATPPUCCIN_MOCHA["surface2"]};
-    border: 1px solid {CATPPUCCIN_MOCHA["surface1"]};
-}}
-
-QSlider::groove:horizontal {{
-    border: 1px solid {CATPPUCCIN_MOCHA["surface2"]};
-    height: 8px;
-    background: {CATPPUCCIN_MOCHA["surface0"]};
-    border-radius: 4px;
-}}
-
-QSlider::handle:horizontal {{
-    background: {CATPPUCCIN_MOCHA["blue"]};
-    border: 1px solid {CATPPUCCIN_MOCHA["surface2"]};
-    width: 18px;
-    margin: -5px 0;
-    border-radius: 9px;
-}}
-
-QTextEdit {{
-    background-color: {CATPPUCCIN_MOCHA["surface0"]};
-    color: {CATPPUCCIN_MOCHA["text"]};
-    border: 1px solid {CATPPUCCIN_MOCHA["surface2"]};
-    border-radius: 4px;
-    padding: 8px;
-    font-family: "Consolas", "Courier New", monospace;
-}}
-
-QPushButton {{
-    background-color: {CATPPUCCIN_MOCHA["blue"]};
-    color: {CATPPUCCIN_MOCHA["crust"]};
-    border: none;
-    border-radius: 4px;
-    padding: 10px 24px;
-    font-weight: bold;
-}}
-
-QPushButton:hover {{
-    background-color: {CATPPUCCIN_MOCHA["sapphire"]};
-}}
-
-QPushButton:pressed {{
-    background-color: {CATPPUCCIN_MOCHA["lavender"]};
-}}
-
-QPushButton#exportBtn {{
-    background-color: {CATPPUCCIN_MOCHA["green"]};
-}}
-
-QPushButton#exportBtn:hover {{
-    background-color: {CATPPUCCIN_MOCHA["teal"]};
-}}
-"""
+STYLESHEET = build_stylesheet()
 
 
 class URDFBuilderWindow(QMainWindow):
@@ -504,6 +332,8 @@ class URDFBuilderWindow(QMainWindow):
 
         return group
 
+    # ── Event handlers ──────────────────────────────────────────────────
+
     def _on_gender_changed(self, value: int) -> None:
         """Update gender label based on slider value."""
         if value < 33:
@@ -517,6 +347,8 @@ class URDFBuilderWindow(QMainWindow):
         """Reset all proportion sliders to defaults."""
         for slider in self.proportion_sliders.values():
             slider.setValue(100)
+
+    # ── LoD gateway ─────────────────────────────────────────────────────
 
     def _get_proportions(self) -> dict[str, float]:
         """Get current proportion factors."""
@@ -548,9 +380,10 @@ class URDFBuilderWindow(QMainWindow):
             proportions=self._get_proportions(),
         )
 
+    # ── Actions (thin shells) ───────────────────────────────────────────
+
     def _generate_urdf(self) -> None:
         """Generate URDF from current parameters."""
-        logger = logging.getLogger(__name__)
         try:
             from urdf_builder_gui.urdf_generator import generate_urdf_xml
 
@@ -564,59 +397,41 @@ class URDFBuilderWindow(QMainWindow):
             self.results_text.setPlainText(f"Generation failed: {exc}")
             self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['red']};")
 
-    # _generate_standalone_urdf removed — replaced by urdf_generator module
-
     def _preview_structure(self) -> None:
-        """Preview the model structure."""
-        name = self.name_input.currentText()
-        height = self.height_input.value()
-        mass = self.mass_input.value()
-        gender = self.gender_slider.value() / 100.0
-        template = self.template_combo.currentText()
-        proportions = self._get_proportions()
+        """Preview model structure via the extracted generator."""
+        try:
+            from urdf_builder_gui.preview_generator import generate_preview_text
 
-        preview = []
-        preview.append("Model Structure Preview")
-        preview.append("=" * 50)
-        preview.append(f"\nRobot Name: {name}")
-        preview.append(f"Template: {template}")
-        preview.append("\nBody Parameters:")
-        preview.append(f"  Height: {height:.2f} m")
-        preview.append(f"  Mass: {mass:.1f} kg")
-        preview.append(f"  Gender Factor: {gender:.2f}")
-
-        preview.append("\nSegment Proportions:")
-        for key, value in proportions.items():
-            label = key.replace("_", " ").title()
-            preview.append(f"  {label}: {value * 100:.0f}%")
-
-        preview.append("\nEstimated Segment Sizes:")
-        preview.append(f"  Pelvis Height: {height * 0.078:.3f} m")
-        preview.append(f"  Torso Height: {height * 0.278:.3f} m")
-        preview.append(f"  Head Diameter: {height * 0.139:.3f} m")
-        preview.append(f"  Thigh Length: {height * 0.245:.3f} m")
-        preview.append(f"  Shin Length: {height * 0.246:.3f} m")
-        preview.append(f"  Upper Arm Length: {height * 0.186:.3f} m")
-        preview.append(f"  Forearm Length: {height * 0.146:.3f} m")
-
-        preview.append("\nOptions:")
-        preview.append(f"  Default Geometry: {self.geometry_combo.currentText()}")
-        preview.append(f"  Joint Damping: {self.damping_input.value():.2f}")
-        preview.append(f"  Joint Friction: {self.friction_input.value():.2f}")
-        preview.append(f"  Inertia Mode: {self.inertia_mode_combo.currentText()}")
-        preview.append(f"  Density: {self.density_input.value():.0f} kg/m³")
-
-        self.results_text.setPlainText("\n".join(preview))
-        self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['text']};")
+            config = self._get_config()
+            preview = generate_preview_text(config)
+            self.results_text.setPlainText(preview)
+            self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['text']};")
+        except Exception as exc:
+            logger.error("Preview generation failed: %s", exc)
+            self.results_text.setPlainText(f"Preview failed: {exc}")
+            self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['red']};")
 
     def _export_urdf(self) -> None:
-        """Export URDF to file."""
+        """Export URDF to file with structural validation."""
         content = self.results_text.toPlainText()
+
+        # Must have generated URDF first
         if not content or not content.strip().startswith("<?xml"):
             self.results_text.setPlainText(
                 "Please generate URDF first before exporting."
             )
             self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['yellow']};")
+            return
+
+        # Validate before writing
+        from urdf_builder_gui.urdf_generator import validate_urdf_structure
+
+        is_valid, errors = validate_urdf_structure(content)
+        if not is_valid:
+            msg = "URDF validation failed:\n" + "\n".join(f"  • {e}" for e in errors)
+            self.results_text.setPlainText(msg)
+            self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['red']};")
+            logger.warning("Export blocked: URDF validation failed: %s", errors)
             return
 
         file_path, _ = QFileDialog.getSaveFileName(
@@ -632,7 +447,9 @@ class URDFBuilderWindow(QMainWindow):
                     f.write(content)
                 self.results_text.append(f"\n\nExported to: {file_path}")
                 self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['green']};")
+                logger.info("URDF exported to %s", file_path)
             except OSError as e:
+                logger.error("Export failed: %s", e)
                 self.results_text.append(f"\n\nExport failed: {e}")
                 self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['red']};")
 

--- a/src/urdf_builder_gui/tests/test_urdf_builder_gui.py
+++ b/src/urdf_builder_gui/tests/test_urdf_builder_gui.py
@@ -5,6 +5,9 @@ Tests cover:
     segment dimensions, template definitions, DbC contract enforcement.
   - urdf_generator: generate_urdf_xml, validate_urdf_structure, template
     dispatch, config propagation, XML validity.
+  - preview_generator: generate_preview_text, DbC, content validation.
+  - theme: build_stylesheet, palette structure.
+  - contracts: require/ensure, PreconditionError/PostconditionError.
 
 Replaces the old mock-heavy tests with real functional tests.
 """
@@ -18,6 +21,7 @@ import pytest
 from urdf_builder_gui.anthropometric_model import (
     HEIGHT_RATIOS,
     MASS_RATIOS,
+    TEMPLATE_SEGMENTS,
     URDFConfig,
     compute_box_inertia,
     compute_cylinder_inertia,
@@ -27,11 +31,91 @@ from urdf_builder_gui.anthropometric_model import (
     get_template_segments,
     interpolate_gender_factor,
 )
-from urdf_builder_gui.contracts import PreconditionError
+from urdf_builder_gui.contracts import (
+    PostconditionError,
+    PreconditionError,
+    ensure,
+    require,
+)
+from urdf_builder_gui.preview_generator import generate_preview_text
+from urdf_builder_gui.theme import CATPPUCCIN_MOCHA, build_stylesheet
 from urdf_builder_gui.urdf_generator import (
     generate_urdf_xml,
     validate_urdf_structure,
 )
+
+# ═══════════════════════════════════════════════════════════════════════
+# Contracts Tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestContracts:
+    """Tests for the local DbC contracts module."""
+
+    def test_require_passes_on_true(self) -> None:
+        require(True, "should not fail")
+
+    def test_require_raises_on_false(self) -> None:
+        with pytest.raises(PreconditionError, match="bad input"):
+            require(False, "bad input")
+
+    def test_require_includes_args(self) -> None:
+        with pytest.raises(PreconditionError, match="42"):
+            require(False, "value is wrong", 42)
+
+    def test_ensure_passes_on_true(self) -> None:
+        ensure(True, "should not fail")
+
+    def test_ensure_raises_on_false(self) -> None:
+        with pytest.raises(PostconditionError, match="output invalid"):
+            ensure(False, "output invalid")
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Theme Tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestTheme:
+    """Tests for the shared theme module."""
+
+    def test_palette_has_required_keys(self) -> None:
+        """Palette must have all core keys used by the GUI."""
+        required = {"base", "text", "blue", "green", "red", "yellow", "surface0"}
+        assert required.issubset(set(CATPPUCCIN_MOCHA.keys()))
+
+    def test_palette_values_are_hex_colours(self) -> None:
+        for key, val in CATPPUCCIN_MOCHA.items():
+            assert val.startswith("#"), f"{key} is not a hex colour"
+            assert len(val) == 7, f"{key} must be #RRGGBB"
+
+    def test_build_stylesheet_returns_string(self) -> None:
+        ss = build_stylesheet()
+        assert isinstance(ss, str)
+        assert "QMainWindow" in ss
+        assert "QPushButton" in ss
+
+    def test_build_stylesheet_with_custom_palette(self) -> None:
+        custom = {**CATPPUCCIN_MOCHA, "base": "#000000"}
+        ss = build_stylesheet(custom)
+        assert "#000000" in ss
+
+    def test_build_stylesheet_contains_all_widgets(self) -> None:
+        ss = build_stylesheet()
+        widgets = [
+            "QMainWindow",
+            "QWidget",
+            "QTabWidget",
+            "QGroupBox",
+            "QLabel",
+            "QComboBox",
+            "QSlider",
+            "QTextEdit",
+            "QPushButton",
+        ]
+        for w in widgets:
+            assert w in ss, f"Stylesheet missing {w}"
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # Anthropometric Model Tests
@@ -77,6 +161,12 @@ class TestMassRatios:
     def test_all_ratios_positive(self) -> None:
         for key, val in MASS_RATIOS.items():
             assert val > 0, f"Mass ratio for {key} must be positive"
+
+    def test_torso_equals_lumbar_plus_thorax(self) -> None:
+        """Combined torso entry must match lumbar + thorax."""
+        assert MASS_RATIOS["torso"] == pytest.approx(
+            MASS_RATIOS["lumbar"] + MASS_RATIOS["thorax"]
+        )
 
 
 class TestComputeSegmentLength:
@@ -211,6 +301,38 @@ class TestTemplateSegments:
         with pytest.raises((PreconditionError, AssertionError)):
             get_template_segments("Nonexistent Template")
 
+    def test_all_templates_have_pelvis(self) -> None:
+        """Every template must have the pelvis root segment."""
+        for name, segs in TEMPLATE_SEGMENTS.items():
+            assert "pelvis" in segs, f"Template '{name}' missing pelvis"
+
+    def test_templates_produce_unique_segments(self) -> None:
+        """Each template should produce a unique set of segments."""
+        segment_sets = [frozenset(s) for s in TEMPLATE_SEGMENTS.values()]
+        assert len(segment_sets) == len(set(segment_sets))
+
+
+class TestURDFConfig:
+    """Tests for URDFConfig dataclass."""
+
+    def test_defaults(self) -> None:
+        cfg = URDFConfig()
+        assert cfg.robot_name == "humanoid"
+        assert cfg.height_m == 1.75
+        assert cfg.mass_kg == 70.0
+        assert cfg.gender_factor == 0.5
+
+    def test_proportions_default_all_one(self) -> None:
+        cfg = URDFConfig()
+        for key, val in cfg.proportions.items():
+            assert val == 1.0, f"Proportion '{key}' should default to 1.0"
+
+    def test_frozen(self) -> None:
+        """URDFConfig should be immutable."""
+        cfg = URDFConfig()
+        with pytest.raises(AttributeError):
+            cfg.robot_name = "changed"  # type: ignore[misc]
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # URDF Generator Tests
@@ -264,6 +386,18 @@ class TestGenerateURDF:
         assert 'damping="5.00"' in xml
         assert 'friction="2.00"' in xml
 
+    def test_collision_geometry_none_omits_collision(self) -> None:
+        """When collision_geometry='None', no collision elements."""
+        config = URDFConfig(collision_geometry="None")
+        xml = generate_urdf_xml(config)
+        assert "<collision>" not in xml
+
+    def test_collision_geometry_default_includes_collision(self) -> None:
+        """Default collision_geometry includes collision elements."""
+        config = URDFConfig()
+        xml = generate_urdf_xml(config)
+        assert "<collision>" in xml
+
     def test_invalid_robot_name_raises(self) -> None:
         """Invalid XML names should be rejected."""
         with pytest.raises((PreconditionError, AssertionError)):
@@ -276,6 +410,22 @@ class TestGenerateURDF:
     def test_zero_height_raises(self) -> None:
         with pytest.raises((PreconditionError, AssertionError)):
             generate_urdf_xml(URDFConfig(height_m=0.0))
+
+    def test_all_templates_produce_valid_urdf(self) -> None:
+        """Every template should produce valid URDF."""
+        for template_name in TEMPLATE_SEGMENTS:
+            config = URDFConfig(template=template_name)
+            xml = generate_urdf_xml(config)
+            is_valid, errors = validate_urdf_structure(xml)
+            assert is_valid, f"Template '{template_name}' invalid: {errors}"
+
+    def test_proportions_affect_output(self) -> None:
+        """Different proportions should produce different dimensions."""
+        cfg1 = URDFConfig(proportions={"torso_length": 1.0, "arm_length": 1.0})
+        cfg2 = URDFConfig(proportions={"torso_length": 1.5, "arm_length": 1.0})
+        xml1 = generate_urdf_xml(cfg1)
+        xml2 = generate_urdf_xml(cfg2)
+        assert xml1 != xml2
 
 
 class TestValidateURDF:
@@ -306,3 +456,74 @@ class TestValidateURDF:
         is_valid, errors = validate_urdf_structure(xml)
         assert not is_valid
         assert any("duplicate" in e.lower() for e in errors)
+
+    def test_unknown_joint_reference(self) -> None:
+        xml = """<?xml version="1.0"?>
+<robot name="test">
+  <link name="a"/>
+  <joint name="j1" type="fixed">
+    <parent link="nonexistent"/>
+    <child link="a"/>
+  </joint>
+</robot>"""
+        is_valid, errors = validate_urdf_structure(xml)
+        assert not is_valid
+        assert any("unknown" in e.lower() for e in errors)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Preview Generator Tests
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestPreviewGenerator:
+    """Tests for generate_preview_text."""
+
+    def test_contains_robot_name(self) -> None:
+        config = URDFConfig(robot_name="test_bot")
+        text = generate_preview_text(config)
+        assert "test_bot" in text
+
+    def test_contains_body_parameters(self) -> None:
+        config = URDFConfig(height_m=1.80, mass_kg=80.0)
+        text = generate_preview_text(config)
+        assert "1.80" in text
+        assert "80.0" in text
+
+    def test_contains_template_name(self) -> None:
+        config = URDFConfig(template="Upper Body Only")
+        text = generate_preview_text(config)
+        assert "Upper Body Only" in text
+
+    def test_contains_segment_sizes(self) -> None:
+        """Preview should list estimated segment sizes."""
+        text = generate_preview_text(URDFConfig())
+        assert "Torso Height" in text
+        assert "Thigh Length" in text
+
+    def test_contains_template_segments(self) -> None:
+        """Preview should list the segments in the template."""
+        text = generate_preview_text(URDFConfig(template="Custom"))
+        assert "pelvis" in text
+        assert "torso" in text
+
+    def test_contains_options(self) -> None:
+        config = URDFConfig(damping=3.0, friction=1.5)
+        text = generate_preview_text(config)
+        assert "3.00" in text
+        assert "1.50" in text
+
+    def test_uses_shared_height_ratios(self) -> None:
+        """Segment sizes should use HEIGHT_RATIOS, not hardcoded values."""
+        config = URDFConfig(height_m=2.0)
+        text = generate_preview_text(config)
+        expected_torso = 2.0 * HEIGHT_RATIOS["torso"]
+        assert f"{expected_torso:.3f}" in text
+
+    def test_empty_name_raises(self) -> None:
+        with pytest.raises((PreconditionError, AssertionError)):
+            generate_preview_text(URDFConfig(robot_name=""))
+
+    def test_zero_height_raises(self) -> None:
+        with pytest.raises((PreconditionError, AssertionError)):
+            generate_preview_text(URDFConfig(height_m=0.0))

--- a/src/urdf_builder_gui/theme.py
+++ b/src/urdf_builder_gui/theme.py
@@ -1,0 +1,207 @@
+"""Catppuccin Mocha theme — reusable palette and stylesheet.
+
+Extracted from main_window.py for DRY compliance. This module can be
+shared across multiple GUI tools in the fleet.
+"""
+
+from __future__ import annotations
+
+# ── Catppuccin Mocha Palette ────────────────────────────────────────────
+
+CATPPUCCIN_MOCHA: dict[str, str] = {
+    "rosewater": "#f5e0dc",
+    "flamingo": "#f2cdcd",
+    "pink": "#f5c2e7",
+    "mauve": "#cba6f7",
+    "red": "#f38ba8",
+    "maroon": "#eba0ac",
+    "peach": "#fab387",
+    "yellow": "#f9e2af",
+    "green": "#a6e3a1",
+    "teal": "#94e2d5",
+    "sky": "#89dceb",
+    "sapphire": "#74c7ec",
+    "blue": "#89b4fa",
+    "lavender": "#b4befe",
+    "text": "#cdd6f4",
+    "subtext1": "#bac2de",
+    "subtext0": "#a6adc8",
+    "overlay2": "#9399b2",
+    "overlay1": "#7f849c",
+    "overlay0": "#6c7086",
+    "surface2": "#585b70",
+    "surface1": "#45475a",
+    "surface0": "#313244",
+    "base": "#1e1e2e",
+    "mantle": "#181825",
+    "crust": "#11111b",
+}
+
+
+def build_stylesheet(palette: dict[str, str] | None = None) -> str:
+    """Build a complete Qt stylesheet from a colour palette.
+
+    Args:
+        palette: Colour palette dictionary. Defaults to CATPPUCCIN_MOCHA.
+
+    Returns:
+        A Qt stylesheet string ready for ``setStyleSheet()``.
+    """
+    p = palette or CATPPUCCIN_MOCHA
+    return f"""
+QMainWindow {{
+    background-color: {p["base"]};
+}}
+
+QWidget {{
+    background-color: {p["base"]};
+    color: {p["text"]};
+    font-family: "Segoe UI", "Arial", sans-serif;
+}}
+
+QScrollArea {{
+    border: none;
+    background-color: {p["base"]};
+}}
+
+QTabWidget::pane {{
+    border: 1px solid {p["surface1"]};
+    background-color: {p["mantle"]};
+    border-radius: 4px;
+}}
+
+QTabBar::tab {{
+    background-color: {p["surface0"]};
+    color: {p["subtext1"]};
+    padding: 8px 16px;
+    margin-right: 2px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+}}
+
+QTabBar::tab:selected {{
+    background-color: {p["surface1"]};
+    color: {p["blue"]};
+}}
+
+QGroupBox {{
+    background-color: {p["surface0"]};
+    border: 1px solid {p["surface1"]};
+    border-radius: 8px;
+    margin-top: 12px;
+    padding: 12px;
+    font-weight: bold;
+}}
+
+QGroupBox::title {{
+    subcontrol-origin: margin;
+    left: 12px;
+    padding: 0 6px;
+    color: {p["mauve"]};
+}}
+
+QLabel {{
+    color: {p["text"]};
+    background-color: transparent;
+}}
+
+QDoubleSpinBox, QSpinBox {{
+    background-color: {p["surface0"]};
+    color: {p["text"]};
+    border: 1px solid {p["surface2"]};
+    border-radius: 4px;
+    padding: 6px 10px;
+}}
+
+QDoubleSpinBox:focus, QSpinBox:focus {{
+    border: 1px solid {p["blue"]};
+}}
+
+QComboBox {{
+    background-color: {p["surface0"]};
+    color: {p["text"]};
+    border: 1px solid {p["surface2"]};
+    border-radius: 4px;
+    padding: 6px 10px;
+    min-width: 150px;
+}}
+
+QComboBox:hover {{
+    border: 1px solid {p["blue"]};
+}}
+
+QComboBox::drop-down {{
+    border: none;
+    width: 24px;
+}}
+
+QComboBox::down-arrow {{
+    image: none;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid {p["text"]};
+    margin-right: 8px;
+}}
+
+QComboBox QAbstractItemView {{
+    background-color: {p["surface0"]};
+    color: {p["text"]};
+    selection-background-color: {p["surface2"]};
+    border: 1px solid {p["surface1"]};
+}}
+
+QSlider::groove:horizontal {{
+    border: 1px solid {p["surface2"]};
+    height: 8px;
+    background: {p["surface0"]};
+    border-radius: 4px;
+}}
+
+QSlider::handle:horizontal {{
+    background: {p["blue"]};
+    border: 1px solid {p["surface2"]};
+    width: 18px;
+    margin: -5px 0;
+    border-radius: 9px;
+}}
+
+QTextEdit {{
+    background-color: {p["surface0"]};
+    color: {p["text"]};
+    border: 1px solid {p["surface2"]};
+    border-radius: 4px;
+    padding: 8px;
+    font-family: "Consolas", "Courier New", monospace;
+}}
+
+QPushButton {{
+    background-color: {p["blue"]};
+    color: {p["crust"]};
+    border: none;
+    border-radius: 4px;
+    padding: 10px 24px;
+    font-weight: bold;
+}}
+
+QPushButton:hover {{
+    background-color: {p["sapphire"]};
+}}
+
+QPushButton:pressed {{
+    background-color: {p["lavender"]};
+}}
+
+QPushButton#exportBtn {{
+    background-color: {p["green"]};
+}}
+
+QPushButton#exportBtn:hover {{
+    background-color: {p["teal"]};
+}}
+"""
+
+
+__all__ = [
+    "CATPPUCCIN_MOCHA",
+    "build_stylesheet",
+]


### PR DESCRIPTION
Wave 2 of URDF Builder quality remediation.

## New Modules
- **theme.py**: Reusable Catppuccin Mocha palette + stylesheet builder (fleet-shareable)
- **preview_generator.py**: Pure-Python preview text generation with DbC contracts

## Key Changes
- **main_window.py**: Reduced to thin UI shell (~480 lines, down from 733)
  - All business logic extracted (DRY, Orthogonality)
  - Preview uses shared HEIGHT_RATIOS instead of hardcoded magic numbers
  - Export validates URDF structure before writing to file
  - All actions log through fleet-standard logging module
  - Law of Demeter enforced via _get_config() gateway

## Test Coverage
- **67 tests passing** (up from 37 in Wave 1)
- New test classes: TestContracts, TestTheme, TestPreviewGenerator, TestURDFConfig
- Cross-module integration tests (all templates produce valid URDF)

## Principle Compliance
| Principle | Wave 1 | Wave 2 |
|-----------|--------|--------|
| DRY | 8/10 | 9/10 |
| Orthogonality | 8/10 | 9/10 |
| DbC | 8/10 | 9/10 |
| LoD | 7/10 | 9/10 |
| TDD | 8/10 | 9/10 |
| Reusability | 8/10 | 9/10 |