### PR TITLE
fix: correctness — electrode z-position, tick-hiding, temperature mode (#1415-#1418)

### DIFF
--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_controls.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_controls.py
@@ -102,7 +102,6 @@ class ControlsMixin:
                 "Default colors",
                 "Current intensity",
                 "Power dissipation",
-                "Temperature gradient",
             ]
         )
         self.color_mode_combo.setCurrentText("Current intensity")

--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_results_charts.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_results_charts.py
@@ -19,7 +19,6 @@ logger = logging.getLogger(__name__)
 
 _COLOR_MODE_CURRENT = "Current intensity"
 _COLOR_MODE_POWER = "Power dissipation"
-_COLOR_MODE_TEMPERATURE = "Temperature gradient"
 
 
 class ResultsAndChartsMixin:
@@ -162,8 +161,6 @@ class ResultsAndChartsMixin:
             value = self._get_path_current(path_type, phase_index)
         elif color_mode == _COLOR_MODE_POWER:
             value = self._get_path_power(path_type, phase_index)
-        elif color_mode == _COLOR_MODE_TEMPERATURE:
-            value = self._get_path_temperature(path_type, phase_index)
         else:
             return "lightblue"
 
@@ -253,14 +250,6 @@ class ResultsAndChartsMixin:
             return float(current**2 * resistance)
         return 0.0
 
-    def _get_path_temperature(self, _path_type: str, _phase_index: int) -> float:
-        """Return bath temperature as path temperature baseline.
-
-        A physics-based thermal rise model is not yet implemented.
-        Issue #1359: the old ``power * 0.001`` formula had no physical basis.
-        """
-        return float(self.bath_temp_input.value())
-
     def _calculate_color_scale_bounds(self, color_mode: str) -> tuple[float, float]:
         """Calculate min/max values for color scaling"""
         values = []
@@ -271,8 +260,6 @@ class ResultsAndChartsMixin:
                     values.append(self._get_path_current(path_type, phase_idx))
                 elif color_mode == _COLOR_MODE_POWER:
                     values.append(self._get_path_power(path_type, phase_idx))
-                elif color_mode == _COLOR_MODE_TEMPERATURE:
-                    values.append(self._get_path_temperature(path_type, phase_idx))
 
         if values:
             return min(values), max(values)
@@ -286,8 +273,6 @@ class ResultsAndChartsMixin:
             cmap = colormaps.get_cmap("coolwarm")
         elif color_mode == _COLOR_MODE_POWER:
             cmap = colormaps.get_cmap("hot")
-        elif color_mode == _COLOR_MODE_TEMPERATURE:
-            cmap = colormaps.get_cmap("plasma")
         else:
             cmap = colormaps.get_cmap("viridis")  # Default
 

--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_visual_controls.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_visual_controls.py
@@ -137,7 +137,6 @@ class VisualControlsMixin:
                 "Default colors",
                 "Current intensity",
                 "Power dissipation",
-                "Temperature gradient",
             ]
         )
         self.color_mode_combo.setCurrentText("Current intensity")

--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_visualization.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_visualization.py
@@ -231,8 +231,6 @@ class VisualizationMixin:
             value = self._get_path_current(path_type, phase_index)
         elif color_mode == "Power dissipation":
             value = self._get_path_power(path_type, phase_index)
-        elif color_mode == "Temperature gradient":
-            value = self._get_path_temperature(path_type, phase_index)
         else:
             return "lightblue"
 
@@ -341,8 +339,6 @@ class VisualizationMixin:
                     values.append(self._get_path_current(path_type, phase_idx))
                 elif color_mode == "Power dissipation":
                     values.append(self._get_path_power(path_type, phase_idx))
-                elif color_mode == "Temperature gradient":
-                    values.append(self._get_path_temperature(path_type, phase_idx))
 
         if values:
             return min(values), max(values)
@@ -356,8 +352,6 @@ class VisualizationMixin:
             cmap = colormaps.get_cmap("coolwarm")  # Blue to red
         elif color_mode == "Power dissipation":
             cmap = colormaps.get_cmap("hot")  # Black to red to yellow to white
-        elif color_mode == "Temperature gradient":
-            cmap = colormaps.get_cmap("plasma")  # Purple to pink to yellow
         else:
             cmap = colormaps.get_cmap("viridis")  # Default
 

--- a/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_visualization_update.py
+++ b/src/electrode_advisor/python/electrode_advisor/ui/pyqt6/main_window_visualization_update.py
@@ -333,15 +333,22 @@ class VisualizationUpdateMixin:
                 self.electrode_ax.set_ylabel("")
                 if hasattr(self.electrode_ax, "set_zlabel"):
                     self.electrode_ax.set_zlabel("")
-        if hasattr(self, "electrode_ax") and self.electrode_ax:
-            self.electrode_ax.tick_params(
-                axis="x", which="both", bottom=False, top=False, labelbottom=False
-            )
-            self.electrode_ax.tick_params(
-                axis="y", which="both", left=False, right=False, labelleft=False
-            )
-            if hasattr(self.electrode_ax, "zaxis"):
-                self.electrode_ax.zaxis.set_tick_params(labelleft=False)
+                self.electrode_ax.tick_params(
+                    axis="x",
+                    which="both",
+                    bottom=False,
+                    top=False,
+                    labelbottom=False,
+                )
+                self.electrode_ax.tick_params(
+                    axis="y",
+                    which="both",
+                    left=False,
+                    right=False,
+                    labelleft=False,
+                )
+                if hasattr(self.electrode_ax, "zaxis"):
+                    self.electrode_ax.zaxis.set_tick_params(labelleft=False)
 
         if self.electrode_ax is not None:
             self.electrode_ax.set_title("")

--- a/src/electrode_advisor/python/electrode_advisor/utils/visualization.py
+++ b/src/electrode_advisor/python/electrode_advisor/utils/visualization.py
@@ -362,7 +362,7 @@ class ElectrodeVisualization(ElectrodeLayersMixin):
 
         for i, (depth, angle) in enumerate(zip(depths, angles, strict=False)):
             angle_rad = np.radians(angle)
-            electrode_z = metal_height + glass_height / 2
+            electrode_z = metal_height + glass_height - depth
 
             x_start = (bath_radius + extension_length) * np.cos(angle_rad)
             y_start = (bath_radius + extension_length) * np.sin(angle_rad)

--- a/src/electrode_advisor/tests/test_electrode_advisor_contracts.py
+++ b/src/electrode_advisor/tests/test_electrode_advisor_contracts.py
@@ -1250,3 +1250,72 @@ class TestDryElimination:
             pytest.skip("Drawing file not found")
         line_count = len(drawing_path.read_text().splitlines())
         assert line_count < 150, f"DrawingMixin should be <150 lines, got {line_count}"
+
+
+# ── Batch 3: Correctness fixes tests ────────────────────────────────────────
+
+
+class TestCorrectnessFixes:
+    """Tests for Batch 3 correctness fixes (#1415-#1418)."""
+
+    def test_electrode_z_uses_depth(self) -> None:
+        """#1415: draw_3d_electrodes must use depth in z-position formula."""
+        try:
+            from electrode_advisor.utils.visualization import ElectrodeVisualization
+        except ImportError:
+            pytest.skip("ElectrodeVisualization not importable")
+        import inspect
+
+        src = inspect.getsource(ElectrodeVisualization.draw_3d_electrodes)
+        uses_depth = "glass_height - depth" in src
+        assert uses_depth, "z must use glass_height - depth"
+
+    def test_tick_hiding_not_unconditional(self) -> None:
+        """#1416: tick-hiding must be inside else branch, not unconditional."""
+        try:
+            from electrode_advisor.ui.pyqt6.main_window_visualization_update import (
+                VisualizationUpdateMixin,
+            )
+        except ImportError:
+            pytest.skip("VisualizationUpdateMixin not importable")
+        import inspect
+
+        src = inspect.getsource(VisualizationUpdateMixin._configure_viz_axis_labels)
+        # The old bug had an unconditional block after the if/else that always
+        # hid ticks. After the fix, labelbottom=False should only appear once
+        # (in the else branch), not twice.
+        count = src.count("labelbottom=False")
+        assert count == 1, f"labelbottom=False once, got {count}"
+
+    def test_temperature_gradient_removed_from_results(self) -> None:
+        """#1417: _COLOR_MODE_TEMPERATURE must be removed from results_charts."""
+        try:
+            from electrode_advisor.ui.pyqt6 import main_window_results_charts as mod
+        except ImportError:
+            pytest.skip("main_window_results_charts not importable")
+        has_temp = hasattr(mod, "_COLOR_MODE_TEMPERATURE")
+        assert not has_temp, "Temperature gradient constant must be removed"
+
+    def test_temperature_gradient_not_in_visual_controls(self) -> None:
+        """#1417: Temperature gradient must not be in color mode combo items."""
+        try:
+            from electrode_advisor.ui.pyqt6 import main_window_visual_controls as mod
+        except ImportError:
+            pytest.skip("main_window_visual_controls not importable")
+        import inspect
+
+        src = inspect.getsource(mod)
+        has_temp = "Temperature gradient" in src
+        assert not has_temp, "Temperature gradient must be removed from combo"
+
+    def test_visualization_constructor_takes_config(self) -> None:
+        """#1418: ElectrodeVisualization constructor must accept config param."""
+        try:
+            from electrode_advisor.utils.visualization import ElectrodeVisualization
+        except ImportError:
+            pytest.skip("ElectrodeVisualization not importable")
+        import inspect
+
+        sig = inspect.signature(ElectrodeVisualization.__init__)
+        has_config = "config" in sig.parameters
+        assert has_config, "constructor must accept config parameter"


### PR DESCRIPTION
## Summary
- **C1 (#1415)**: Fix electrode z-position formula from `glass_height / 2` to `glass_height - depth` so deeper electrodes sit at correct vertical position
- **C2 (#1416)**: Move unconditional tick-hiding block into else branch so axis labels show when checkbox is checked
- **C3 (#1417)**: Remove non-functional "Temperature gradient" color mode from combo boxes and all dead code (`_COLOR_MODE_TEMPERATURE`, `_get_path_temperature`)
- **C4 (#1418)**: Already fixed in Batch 1 (constructor accepts config)

Closes #1415, closes #1416, closes #1417, closes #1418.

## Test plan
- [x] 5 new tests in `TestCorrectnessFixes` verify all fixes
- [x] All 53 existing tests pass
- [x] `ruff check` and `ruff format` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)