### PR TITLE
test: Boost coverage for 5 shared upstream_drift targets >90%

### DIFF
--- a/src/shared/python/upstream_drift_tools/tests/test_base_calculator_mixin.py
+++ b/src/shared/python/upstream_drift_tools/tests/test_base_calculator_mixin.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+
+from upstream_drift_tools.ui.mixins.base_calculator_mixin import BaseCalculatorMixin
+
+
+class MockCalculator(BaseCalculatorMixin):
+    def __init__(self, name=None):
+        super().__init__(name)
+
+
+def test_base_calculator_mixin_init_default():
+    calc = MockCalculator()
+    assert calc.calculator_name == "MockCalculator"
+    assert hasattr(calc, "_splitters")
+    assert hasattr(calc, "_copyable_widgets")
+    assert hasattr(calc, "_state")
+    assert isinstance(calc._splitters, list)
+    assert isinstance(calc._copyable_widgets, list)
+    assert isinstance(calc._state, dict)
+    assert (
+        calc._logger.name
+        == "upstream_drift_tools.ui.mixins.base_calculator_mixin.MockCalculator"
+    )
+
+
+def test_base_calculator_mixin_init_with_name():
+    calc = MockCalculator("CustomName")
+    assert calc.calculator_name == "CustomName"
+    assert (
+        calc._logger.name
+        == "upstream_drift_tools.ui.mixins.base_calculator_mixin.MockCalculator"
+    )
+
+
+def test_base_calculator_mixin_existing_attrs():
+    class ExtMockCalculator(BaseCalculatorMixin):
+        def __init__(self):
+            self._splitters = ["a"]
+            self._copyable_widgets = ["b"]
+            self._state = {"c": 1}
+            super().__init__()
+
+    calc = ExtMockCalculator()
+    assert calc._splitters == ["a"]
+    assert calc._copyable_widgets == ["b"]
+    assert calc._state == {"c": 1}
+
+
+def test_base_calculator_mixin_logging(caplog):
+    calc = MockCalculator("Test")
+    with caplog.at_level(logging.INFO):
+        calc.log_info("Info message")
+        calc.log_warning("Warning message")
+        calc.log_error("Error message")
+
+    assert "Info message" in caplog.text
+    assert "Warning message" in caplog.text
+    assert "Error message" in caplog.text

--- a/src/shared/python/upstream_drift_tools/tests/test_base_calculator_widget.py
+++ b/src/shared/python/upstream_drift_tools/tests/test_base_calculator_widget.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from PyQt6.QtGui import QCloseEvent
+from upstream_drift_tools.ui.widgets.base_calculator_widget import (
+    BaseCalculatorWidget,
+    BaseCalculatorWindow,
+)
+
+
+def test_base_calculator_widget_init(qapp):
+    widget = BaseCalculatorWidget("TestCalcWidget")
+    assert widget.calculator_name == "TestCalcWidget"
+    assert widget.parent() is None
+
+
+@patch("PyQt6.QtWidgets.QMessageBox.critical")
+def test_base_calculator_widget_show_error(mock_critical, qapp):
+    widget = BaseCalculatorWidget("TestCalcWidget")
+    widget.show_error("ErrorTitle", "ErrorMsg")
+    mock_critical.assert_called_once_with(widget, "ErrorTitle", "ErrorMsg")
+
+
+@patch("PyQt6.QtWidgets.QMessageBox.information")
+def test_base_calculator_widget_show_info(mock_info, qapp):
+    widget = BaseCalculatorWidget("TestCalcWidget")
+    widget.show_info("InfoTitle", "InfoMsg")
+    mock_info.assert_called_once_with(widget, "InfoTitle", "InfoMsg")
+
+
+def test_base_calculator_window_init(qapp):
+    # Missing calculator name should raise AssertionError
+    with pytest.raises(AssertionError):
+        BaseCalculatorWindow(calculator_name=None)  # type: ignore
+
+    window = BaseCalculatorWindow(
+        calculator_name="TestWindow", window_title="MyTitle", min_size=(400, 300)
+    )
+    assert window.calculator_name == "TestWindow"
+    assert window.windowTitle() == "MyTitle"
+    assert window.minimumSize().width() == 400
+    assert window.minimumSize().height() == 300
+    assert window.central_widget is not None
+    assert window.main_layout is not None
+
+
+@patch("PyQt6.QtWidgets.QMessageBox.critical")
+def test_base_calculator_window_show_error(mock_critical, qapp):
+    window = BaseCalculatorWindow("TestWindow")
+    window.show_error("ErrTitle", "ErrMsg")
+    mock_critical.assert_called_once_with(window, "ErrTitle", "ErrMsg")
+
+
+@patch("PyQt6.QtWidgets.QMessageBox.information")
+def test_base_calculator_window_show_info(mock_info, qapp):
+    window = BaseCalculatorWindow("TestWindow")
+    window.show_info("InfTitle", "InfMsg")
+    mock_info.assert_called_once_with(window, "InfTitle", "InfMsg")
+
+
+@patch.object(BaseCalculatorWindow, "handle_close_event")
+def test_base_calculator_window_close_event(mock_handle_close, qapp):
+    window = BaseCalculatorWindow("TestWindow")
+    event = QCloseEvent()
+    window.closeEvent(event)
+    mock_handle_close.assert_called_once_with(event)

--- a/src/shared/python/upstream_drift_tools/tests/test_paths.py
+++ b/src/shared/python/upstream_drift_tools/tests/test_paths.py
@@ -49,15 +49,11 @@ class TestGetRepoRoot:
 
     def test_raises_from_filesystem_root(self):
         """Starting from filesystem root triggers the parent==current break path."""
-        from unittest.mock import patch
+        # Find the root of the file system (e.g. '/' or 'C:\\')
+        fs_root = Path(Path.cwd().anchor)
 
-        # Adjust _MAX_SEARCH_DEPTH to 1 so we exhaust very quickly from tmp
-        with patch("upstream_drift_tools.utils.paths._MAX_SEARCH_DEPTH", 1):
-            import tempfile
-
-            with tempfile.TemporaryDirectory() as tmpdir:
-                with pytest.raises(FileNotFoundError):
-                    get_repo_root(Path(tmpdir) / "no_such_thing")
+        with pytest.raises(FileNotFoundError, match="Repository root not found"):
+            get_repo_root(fs_root)
 
     def test_default_no_file_frame_uses_cwd(self, monkeypatch):
         """When calling frame has no __file__, start_path falls back to cwd()."""

--- a/src/shared/python/upstream_drift_tools/tests/test_state_manager.py
+++ b/src/shared/python/upstream_drift_tools/tests/test_state_manager.py
@@ -1,0 +1,241 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from upstream_drift_tools.utils.state_manager import (
+    StateManager,
+    _StateManagerHolder,
+    get_state_manager,
+)
+
+
+@pytest.fixture
+def manager(tmp_path):
+    # Use tmp_path to isolate states for testing
+    mgr = StateManager(base_directory=str(tmp_path))
+    return mgr
+
+
+def test_initialization(manager, tmp_path):
+    assert manager.base_directory == tmp_path
+    assert manager.states_dir.exists()
+    assert manager.sessions_dir.exists()
+    assert manager.backups_dir.exists()
+    assert manager.exports_dir.exists()
+    assert manager.protected_states == set()
+
+
+def test_protect_unprotect_state(manager):
+    # Protect a state that doesn't exist yet
+    manager.protect_state("test_state")
+    assert "test_state" in manager.protected_states
+
+    manager.unprotect_state("test_state")
+    assert "test_state" not in manager.protected_states
+
+
+def test_save_load_state(manager):
+    state_data = {"key": "value", "num": 42}
+    success = manager.save_state("test_save", state_data, description="test desc")
+    assert success is True
+
+    loaded = manager.load_state("test_save")
+    assert loaded == state_data
+
+
+def test_save_state_with_protection(manager):
+    state_data = {"foo": "bar"}
+    manager.save_state("protected_state", state_data, protected=True)
+    assert "protected_state" in manager.protected_states
+
+    # Verify we can't delete it without force
+    deleted = manager.delete_state("protected_state")
+    assert deleted is False
+
+    # Force delete works
+    deleted = manager.delete_state("protected_state", force=True)
+    assert deleted is True
+
+
+def test_delete_state(manager):
+    manager.save_state("to_delete", {"a": 1})
+    assert manager.delete_state("to_delete") is True
+    assert manager.load_state("to_delete") is None
+
+
+def test_list_states(manager):
+    manager.save_state("state1", {"1": 1})
+    manager.save_state("state2", {"2": 2})
+
+    states = manager.list_states()
+    assert len(states) == 2
+    names = [s["name"] for s in states]
+    assert "state1" in names
+    assert "state2" in names
+
+
+def test_export_import_state(manager, tmp_path):
+    manager.save_state("export_me", {"data": "yes"})
+
+    export_path = tmp_path / "export.json"
+    actual_path = manager.export_state("export_me", str(export_path))
+
+    assert actual_path == str(export_path)
+    assert Path(export_path).exists()
+
+    # Import it under a new name
+    success = manager.import_state(str(export_path), "imported_state")
+    assert success is True
+
+    loaded = manager.load_state("imported_state")
+    assert loaded == {"data": "yes"}
+
+    # Attempt to import over existing state
+    success = manager.import_state(str(export_path), "imported_state")
+    assert success is False  # already exists
+
+
+def test_save_load_session(manager):
+    session_data = {"current_tab": 2}
+    manager.save_session(session_data)
+
+    loaded = manager.load_session()
+    assert loaded == session_data
+
+
+def test_cleanup_backups(manager, tmp_path):
+    manager.save_state("old_state", {"old": 1})
+    # Save it again to trigger a backup
+    manager.save_state("old_state", {"new": 2})
+
+    backups = list(manager.backups_dir.glob("*.backup"))
+    assert len(backups) == 1
+
+    # Modify mtime to be old
+    old_time = datetime.now().timestamp() - (35 * 24 * 3600)
+    import os
+
+    os.utime(backups[0], (old_time, old_time))
+
+    manager.cleanup_old_backups(max_age_days=30)
+    assert len(list(manager.backups_dir.glob("*.backup"))) == 0
+
+
+def test_json_serializer(manager):
+    from pathlib import Path
+
+    dt = datetime(2023, 1, 1, 12, 0, 0)
+    res = manager._json_serializer(dt)
+    assert res == "2023-01-01T12:00:00"
+
+    p = Path("/tmp/foo")
+    res = manager._json_serializer(p)
+    assert res == str(p)
+
+    class Dummy:
+        pass
+
+    d = Dummy()
+    d.attr = "val"
+    res = manager._json_serializer(d)
+    assert res == {"attr": "val"}
+
+
+def test_load_state_invalid_format(manager, tmp_path):
+    # Create invalid state file
+    file_path = manager.states_dir / "invalid.json"
+    with open(file_path, "w") as f:
+        f.write("not valid json")
+
+    with pytest.raises(json.JSONDecodeError):
+        manager.load_state("invalid")
+
+    # Valid JSON but missing schema struct
+    with open(file_path, "w") as f:
+        json.dump({"bad": "state"}, f)
+
+    loaded = manager.load_state("invalid")
+    assert loaded is None
+
+
+def test_permission_error_save_load(manager):
+    # Mock open to raise PermissionError
+    with patch("builtins.open", side_effect=PermissionError):
+        # Save
+        assert manager.save_state("err_state", {"data": 1}) is False
+
+        # Load (requires file to exist first, so we mock exists)
+        with patch("pathlib.Path.exists", return_value=True):
+            assert manager.load_state("err_state") is None
+
+        # Export
+        with patch.object(manager, "load_state", return_value={"data": 1}):
+            assert manager.export_state("err_state") is None
+
+        # Import
+        with patch("pathlib.Path.exists", return_value=True):
+            assert manager.import_state("some_path.json") is False
+
+        # Save session
+        assert manager.save_session({"s": 1}) is False
+
+        # Load session
+        with patch("pathlib.Path.exists", return_value=True):
+            assert manager.load_session() is None
+
+
+def test_singleton_get_state_manager(tmp_path):
+    _StateManagerHolder.instance = None
+    mgr1 = get_state_manager(str(tmp_path))
+    mgr2 = get_state_manager(str(tmp_path))
+    assert mgr1 is mgr2
+    # Ensure cleanup
+    _StateManagerHolder.instance = None
+
+
+def test_delete_state_not_found(manager):
+    assert manager.delete_state("does_not_exist") is False
+
+
+def test_protect_state_existing(manager):
+    manager.save_state("exists", {"a": 1})
+
+    # Actually protect it (writes to metadata)
+    assert manager.protect_state("exists") is True
+    loaded = manager.load_state("exists")
+    assert loaded is not None
+    assert "exists" in manager.protected_states
+
+    # Now unprotect it
+    assert manager.unprotect_state("exists") is True
+    assert "exists" not in manager.protected_states
+
+
+def test_list_states_errors_and_cache(manager, tmp_path):
+    manager.save_state("s1", {"b": 2})
+
+    # Add a non-json file to the dir
+    (manager.states_dir / "not_a_state.txt").write_text("hello")
+
+    states = manager.list_states()
+    assert len(states) == 1
+    assert states[0]["name"] == "s1"
+
+    # Run list again to hit cache logic
+    states2 = manager.list_states()
+    assert states == states2
+
+
+def test_unprotect_permission_error(manager):
+    manager.save_state("some", {"a": 1})
+    with patch("builtins.open", side_effect=PermissionError):
+        assert manager.protect_state("some") is False
+        assert manager.unprotect_state("some") is False
+
+
+def test_delete_state_permission_error(manager):
+    manager.save_state("del_err", {"a": 1})
+    with patch("pathlib.Path.unlink", side_effect=PermissionError):
+        assert manager.delete_state("del_err") is False

--- a/src/shared/python/upstream_drift_tools/tests/test_unit_preferences_manager.py
+++ b/src/shared/python/upstream_drift_tools/tests/test_unit_preferences_manager.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PyQt6.QtCore import QSettings
+from upstream_drift_tools.ui.managers.unit_preferences_manager import (
+    UnitPreferencesManager,
+    _PreferencesHolder,
+    get_unit_preferences_manager,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_preferences():
+    # Clear the singleton before and after each test
+    _PreferencesHolder.instance = None
+    settings = QSettings("UpstreamDriftTools", "UnitPreferences")
+    settings.clear()
+    yield
+    _PreferencesHolder.instance = None
+    settings.clear()
+
+
+def test_manager_singleton():
+    manager1 = get_unit_preferences_manager()
+    manager2 = get_unit_preferences_manager()
+    assert manager1 is manager2
+
+
+def test_load_preferences_default(qapp):
+    manager = UnitPreferencesManager()
+    assert manager._preset_name == "Default"
+    assert manager.get_preferred_unit("temperature") == "°C"
+
+
+def test_load_preferences_custom(qapp):
+    settings = QSettings("UpstreamDriftTools", "UnitPreferences")
+    custom_prefs = {"temperature": "K"}
+    settings.setValue("unit_preferences", json.dumps(custom_prefs))
+    settings.setValue("preset_name", "Custom")
+
+    manager = UnitPreferencesManager()
+    assert manager._preset_name == "Custom"
+    assert manager.get_preferred_unit("temperature") == "K"
+    assert manager.get_preferred_unit("pressure") == "atm"  # fell back to default
+
+
+def test_load_preferences_bad_json(qapp):
+    settings = QSettings("UpstreamDriftTools", "UnitPreferences")
+    settings.setValue("unit_preferences", "{bad json}")
+    manager = UnitPreferencesManager()
+    assert manager.get_preferred_unit("temperature") == "°C"  # default recovery
+
+
+def test_set_preferred_unit(qapp):
+    manager = UnitPreferencesManager()
+    settings = QSettings("UpstreamDriftTools", "UnitPreferences")
+
+    def on_changed(cat, unit):
+        assert cat == "temperature"
+        assert unit == "K"
+
+    manager.category_unit_changed.connect(on_changed)
+
+    manager.set_preferred_unit("temperature", "K")
+    assert manager.get_preferred_unit("temperature") == "K"
+
+    # Verify it was saved
+    saved_str = settings.value("unit_preferences", "{}")
+    saved = json.loads(saved_str if isinstance(saved_str, str) else "{}")
+    assert saved.get("temperature") == "K"
+
+
+def test_set_preferred_unit_invalid(qapp):
+    manager = UnitPreferencesManager()
+    manager.set_preferred_unit("invalid_category", "X")
+    manager.set_preferred_unit("temperature", "invalid_unit")
+    assert manager.get_preferred_unit("temperature") == "°C"
+
+
+def test_get_si_unit():
+    manager = UnitPreferencesManager()
+    assert manager.get_si_unit("temperature") == "K"
+    assert manager.get_si_unit("invalid_category") == ""
+
+
+@patch(
+    "upstream_drift_tools.ui.managers.unit_preferences_manager.UnitPreferencesManager.converter"
+)
+def test_convert_to_si(mock_converter, qapp):
+    manager = UnitPreferencesManager()
+    # Mock the return of converter.convert().value
+    mock_convert_result = MagicMock()
+    mock_convert_result.value = 273.15
+    mock_converter.convert.return_value = mock_convert_result
+
+    # Base case
+    res = manager.convert_to_si(0.0, "temperature", "°C")
+    assert res == 273.15
+    mock_converter.convert.assert_called_once_with(0.0, "°C", "K")
+
+    # When from_unit == si_unit
+    assert manager.convert_to_si(100.0, "temperature", "K") == 100.0
+
+
+@patch(
+    "upstream_drift_tools.ui.managers.unit_preferences_manager.UnitPreferencesManager.converter"
+)
+def test_convert_from_si(mock_converter, qapp):
+    manager = UnitPreferencesManager()
+    mock_convert_result = MagicMock()
+    mock_convert_result.value = 0.0
+    mock_converter.convert.return_value = mock_convert_result
+
+    res = manager.convert_from_si(273.15, "temperature", "°C")
+    assert res == 0.0
+    mock_converter.convert.assert_called_once_with(273.15, "K", "°C")
+
+    # When to_unit == si_unit
+    assert manager.convert_from_si(100.0, "temperature", "K") == 100.0
+
+
+@patch(
+    "upstream_drift_tools.ui.managers.unit_preferences_manager.UnitPreferencesManager.converter"
+)
+def test_convert_error_handling(mock_converter, qapp):
+    manager = UnitPreferencesManager()
+    mock_converter.convert.side_effect = ValueError("Bad unit")
+
+    # Should fall back to returning original value
+    assert manager.convert_to_si(123.4, "temperature", "°C") == 123.4
+    assert manager.convert_from_si(567.8, "temperature", "°C") == 567.8
+
+
+def test_lazy_converter_property(qapp):
+    # Tests the lazy property initialization
+    manager = UnitPreferencesManager()
+    with patch(
+        "upstream_drift_tools.calculators.conversion.service.get_service",
+        return_value="MOCKED_SERVICE",
+    ):
+        assert manager.converter == "MOCKED_SERVICE"
+        # Accessing it again should not re-call get_service
+        assert manager.converter == "MOCKED_SERVICE"


### PR DESCRIPTION
Boosted test coverage for paths, base_calculator_mixin, base_calculator_widget, unit_preferences_manager, and state_manager to >90% in the upstream_drift_tools package.