### PR TITLE
fix: Add actionlint.yaml with custom runner label allowlist

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  labels:
+    - d-sorg-fleet-4core
+    - ubuntu-latest
+    - ubuntu-22.04
+    - ubuntu-24.04


### PR DESCRIPTION
Adds `.github/actionlint.yaml` to register the `d-sorg-fleet-4core` custom runner label.