### PR TITLE
Fix heavy integration workflow inputs

### DIFF
--- a/.github/workflows/heavy-tests-opt-in.yml
+++ b/.github/workflows/heavy-tests-opt-in.yml
@@ -9,4 +9,5 @@ jobs:
   run-heavy-tests:
     uses: D-sorganization/Repository_Management/.github/workflows/reusable-heavy-tests.yml@main
     with:
+      repo_name: 'Tools'
       test_path: 'tests/heavy_integration/'


### PR DESCRIPTION
## Summary
- pass the required epo_name input to the reusable heavy-tests workflow
- keep the existing heavy integration test path unchanged
- restore a valid workflow_call contract so opt-in heavy runs can execute

Closes #1578
