### PR TITLE
fix: repair stale src.tools.* imports in test files (14% to 29% coverage)

### DIFF
--- a/tests/test_launch_utils.py
+++ b/tests/test_launch_utils.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.shared.python.contracts import PreconditionError
-from src.tools.launch_utils import (
+from tools.launch_utils import (
     LaunchError,
     PlatformError,
     SecurityError,
@@ -222,7 +222,7 @@ class TestLaunchToolDispatch:
         with pytest.raises((PreconditionError, ValueError, TypeError)):
             launch_tool("not-a-dict", tmp_path)  # type: ignore[arg-type]
 
-    @patch("src.tools.launch_utils.launch_python_tool")
+    @patch("tools.launch_utils.launch_python_tool")
     def test_dispatches_to_launch_python_tool(
         self, mock_launch: MagicMock, tmp_path: Path
     ) -> None:

--- a/tests/tools/test_config_loader.py
+++ b/tests/tools/test_config_loader.py
@@ -2,7 +2,7 @@
 
 import json
 
-from src.tools.config_loader import load_tools_config, validate_tools_config
+from tools.config_loader import load_tools_config, validate_tools_config
 
 
 def test_validate_tools_config(tmp_path):

--- a/tests/tools/test_dependency_utils.py
+++ b/tests/tools/test_dependency_utils.py
@@ -3,7 +3,7 @@
 import sys
 from unittest.mock import MagicMock, patch
 
-from src.tools.dependency_utils import check_dependencies, install_packages
+from tools.dependency_utils import check_dependencies, install_packages
 
 
 def test_check_dependencies_all_present():

--- a/tests/tools/test_icon_utils.py
+++ b/tests/tools/test_icon_utils.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from src.shared.python.contracts import PreconditionError
-from src.tools.icon_utils import (
+from tools.icon_utils import (
     ICO_SIZES,
     check_pil_installed,
     convert_png_to_ico,

--- a/tests/tools/test_launch_utils.py
+++ b/tests/tools/test_launch_utils.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.shared.python.contracts import PreconditionError
-from src.tools.launch_utils import (
+from tools.launch_utils import (
     LaunchError,
     PlatformError,
     SecurityError,

--- a/tests/tools/test_matlab_quality_utils.py
+++ b/tests/tools/test_matlab_quality_utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from src.shared.python.contracts import PreconditionError
-from src.tools.matlab_quality_utils import MATLABQualityChecker
+from tools.matlab_quality_utils import MATLABQualityChecker
 
 # ─── __init__ DbC ──────────────────────────────────────────────
 

--- a/tests/tools/test_quality_utils.py
+++ b/tests/tools/test_quality_utils.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from src.shared.python.contracts import PreconditionError
-from src.tools.quality_utils import (
+from tools.quality_utils import (
     check_ast_issues,
     check_banned_patterns,
     check_file,

--- a/tests/tools/test_scientific_auditor.py
+++ b/tests/tools/test_scientific_auditor.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from src.shared.python.contracts import PreconditionError
-from src.tools.scientific_auditor import ScienceAuditor, audit_directory, audit_file
+from tools.scientific_auditor import ScienceAuditor, audit_directory, audit_file
 
 # ─── ScienceAuditor.visit_BinOp ────────────────────────────────
 

--- a/tests/tools/test_ui_utils.py
+++ b/tests/tools/test_ui_utils.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.shared.python.contracts import PreconditionError
-from src.tools.ui_utils import find_icon, set_qt_icon, set_tk_icon
+from tools.ui_utils import find_icon, set_qt_icon, set_tk_icon
 
 # ─── find_icon ─────────────────────────────────────────────────
 
 
-@patch("src.tools.ui_utils.get_repo_root")
+@patch("tools.ui_utils.get_repo_root")
 @patch("pathlib.Path.exists")
 def test_find_icon_success(mock_exists, mock_root, tmp_path):
     mock_root.return_value = tmp_path
@@ -22,7 +22,7 @@ def test_find_icon_success(mock_exists, mock_root, tmp_path):
     assert str(icon_path) == str(tmp_path / "test.ico")
 
 
-@patch("src.tools.ui_utils.get_repo_root")
+@patch("tools.ui_utils.get_repo_root")
 @patch("pathlib.Path.exists")
 def test_find_icon_failure(mock_exists, mock_root, tmp_path):
     mock_root.return_value = tmp_path
@@ -51,7 +51,7 @@ def test_find_icon_dbc_non_string():
 # ─── set_tk_icon ───────────────────────────────────────────────
 
 
-@patch("src.tools.ui_utils.find_icon")
+@patch("tools.ui_utils.find_icon")
 def test_set_tk_icon_success(mock_find):
     mock_find.return_value = Path("fake.ico")
     mock_root = MagicMock()
@@ -60,7 +60,7 @@ def test_set_tk_icon_success(mock_find):
     mock_root.iconbitmap.assert_called_once_with("fake.ico")
 
 
-@patch("src.tools.ui_utils.find_icon")
+@patch("tools.ui_utils.find_icon")
 def test_set_tk_icon_no_icon(mock_find):
     mock_find.return_value = None
     mock_root = MagicMock()
@@ -69,7 +69,7 @@ def test_set_tk_icon_no_icon(mock_find):
     mock_root.iconbitmap.assert_not_called()
 
 
-@patch("src.tools.ui_utils.find_icon")
+@patch("tools.ui_utils.find_icon")
 def test_set_tk_icon_os_error(mock_find):
     """iconbitmap raising OSError returns False gracefully."""
     mock_find.return_value = Path("fake.ico")
@@ -79,7 +79,7 @@ def test_set_tk_icon_os_error(mock_find):
     assert success is False
 
 
-@patch("src.tools.ui_utils.find_icon")
+@patch("tools.ui_utils.find_icon")
 def test_set_tk_icon_runtime_error(mock_find):
     """iconbitmap raising RuntimeError returns False gracefully."""
     mock_find.return_value = Path("fake.ico")
@@ -92,7 +92,7 @@ def test_set_tk_icon_runtime_error(mock_find):
 # ─── set_qt_icon ───────────────────────────────────────────────
 
 
-@patch("src.tools.ui_utils.find_icon")
+@patch("tools.ui_utils.find_icon")
 def test_set_qt_icon_no_icon(mock_find):
     mock_find.return_value = None
     success = set_qt_icon(MagicMock(), "fake.ico")
@@ -100,7 +100,7 @@ def test_set_qt_icon_no_icon(mock_find):
 
 
 @patch("builtins.__import__")
-@patch("src.tools.ui_utils.find_icon")
+@patch("tools.ui_utils.find_icon")
 def test_set_qt_icon_import_error(mock_find, mock_import):
     mock_find.return_value = Path("fake.ico")
 
@@ -115,7 +115,7 @@ def test_set_qt_icon_import_error(mock_find, mock_import):
     assert success is False
 
 
-@patch("src.tools.ui_utils.find_icon")
+@patch("tools.ui_utils.find_icon")
 def test_set_qt_icon_success_with_mock(mock_find):
     """If PyQt6 is available, icon should be set successfully."""
     mock_find.return_value = Path("fake.ico")


### PR DESCRIPTION
## Summary

9 test files had stale import paths using  instead of the correct  (matching the  pythonpath configuration). This caused collection errors in all 9 files, silently excluding their test coverage from CI.

## Changes
- Fixed  →  in:
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
- Fixed  → 

## Impact
| Before | After |
|--------|-------|
| 10 collection errors | 0 errors |
| ~14% coverage | ~29% coverage |
| N/A | 176 tests pass |