### PR TITLE
chore: remove hardcoded agent Co-authored-by trailers from Jules workflow files (#1572)

### DIFF
--- a/.github/workflows/Jules-Assessment-AutoFix.yml
+++ b/.github/workflows/Jules-Assessment-AutoFix.yml
@@ -328,9 +328,7 @@ jobs:
           Fixes applied:${FIX_SUMMARY:-"\n- Various improvements"}
 
           Assessment Score: ${{ needs.run-assessments.outputs.assessment_score }}/10
-          Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
           git push -u origin "$BRANCH_NAME"
 

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -339,9 +339,7 @@ jobs:
             git config user.name "Jules Assessment Remediator"
             git config user.email "jules-bot@github-actions"
             git add .
-            git commit -m "style: apply automated formatting
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+            git commit -m "style: apply automated formatting"
             git push origin "$BRANCH_NAME"
           fi
 

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -330,9 +330,7 @@ jobs:
           Iteration: $iteration of $MAX_ITERATIONS
           Tools:$CHANGES_MADE
 
-          CI verification loop will check if more fixes are needed.
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          CI verification loop will check if more fixes are needed."
 
                 git push origin "$BRANCH"
                 echo "✅ Pushed repair iteration $iteration"

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -194,9 +194,7 @@ jobs:
           if ! git diff --staged --quiet; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git commit -m "fix: code quality improvements
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+            git commit -m "fix: code quality improvements"
             git push -u origin "$BRANCH_NAME"
 
             if [ "$REUSING_PR" = "true" ] && [ -n "$EXISTING_PR_NUM" ]; then

--- a/.github/workflows/Jules-Comment-Processor.yml
+++ b/.github/workflows/Jules-Comment-Processor.yml
@@ -303,8 +303,6 @@ jobs:
           Processed ${{ steps.analyze.outputs.dedup_count }} comments across ${{ steps.analyze.outputs.pr_count }} PRs.
 
           PRs addressed: #${{ steps.analyze.outputs.prs }}
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           EOF
           )"
 

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -412,9 +412,7 @@ jobs:
 
             git commit -m "$MSG
 
-          Automated update by Jules Critics Comments Writer.
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          Automated update by Jules Critics Comments Writer."
 
             git push origin "$BRANCH_NAME"
 

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -208,9 +208,7 @@ jobs:
 
           git add -A
           if ! git diff --staged --quiet; then
-            git commit -m "fix: resolve priority issues
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+            git commit -m "fix: resolve priority issues"
             git push origin "$BRANCH_NAME"
 
             if [ "$REUSING_PR" = "true" ] && [ -n "$EXISTING_PR_NUM" ]; then

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -401,9 +401,7 @@ jobs:
 
             git commit -m "$MSG
 
-          Automated update by Jules Layman's Terms Writer.
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          Automated update by Jules Layman's Terms Writer."
 
             git push origin "$BRANCH_NAME"
 

--- a/.github/workflows/Jules-PR-AutoFix.yml
+++ b/.github/workflows/Jules-PR-AutoFix.yml
@@ -277,9 +277,7 @@ jobs:
           Tools used:$CHANGES_MADE
 
           This commit was created by Jules PR AutoFix workflow.
-          CI verification loop will check if more fixes are needed.
-
-          Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          CI verification loop will check if more fixes are needed."
 
               # Push changes
               git push origin "$BRANCH"

--- a/docs/assessments/README.md
+++ b/docs/assessments/README.md
@@ -192,6 +192,7 @@ This document defines the comprehensive 16-point assessment framework (A-O + Hig
 _See individual Assessment_Prompt_X.md files for detailed prompts._
 | 4.2 | 2026-03 | Executed Completist Audit (Mar 15) |
 | 4.3 | 2026-03 | Archived 16 non-standard assessment files to archive/; added pragmatic_programmer/ directory |
+| 4.4 | 2026-03 | Removed hardcoded agent Co-authored-by trailers from Jules workflow files (#1572) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes hardcoded `Co-authored-by: github-actions[bot]` trailer lines from the git commit message strings embedded in 9 Jules workflow YAML files
- These were attribution trailers in the workflow YAML body (not in git commit messages), which triggered issue #1572
- Updates `docs/assessments/README.md` version history to 4.4

## Files Changed (9 workflow files + 1 docs file)
- `.github/workflows/Jules-Assessment-AutoFix.yml`
- `.github/workflows/Jules-Assessment-Remediator.yml`
- `.github/workflows/Jules-Auto-Repair.yml`
- `.github/workflows/Jules-Code-Quality-Fixer.yml`
- `.github/workflows/Jules-Comment-Processor.yml`
- `.github/workflows/Jules-Critics-Comments.yml`
- `.github/workflows/Jules-Issue-Resolver.yml`
- `.github/workflows/Jules-Laymans-Terms-Writer.yml`
- `.github/workflows/Jules-PR-AutoFix.yml`

## Test plan
- [ ] Verify CI passes (docs/YAML-only change, no logic modified)
- [ ] Confirm `grep -rl "Co-authored-by" .github/workflows/` returns no results

Closes #1572

🤖 Generated with [Claude Code](https://claude.com/claude-code)