### PR TITLE
test: ratchet coverage thresholds to meaningful levels (#1600)

### DIFF
--- a/config/coverage_baseline.json
+++ b/config/coverage_baseline.json
@@ -1,6 +1,6 @@
 {
-  "total_percent": 0.63,
+  "total_percent": 31.37,
   "package_percent": {
-    "src/shared/python/notes": 49.75
+    "src/shared/python/notes": 55.77
   }
 }

--- a/config/coverage_policy.json
+++ b/config/coverage_policy.json
@@ -1,6 +1,6 @@
 {
-  "minimum_total_percent": 0.6,
-  "max_total_drop_percent": 0.1,
+  "minimum_total_percent": 28.0,
+  "max_total_drop_percent": 2.0,
   "tracked_packages": {
     "src/shared/python/notes": 49.0
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 35
+fail_under = 40
 show_missing = true
 skip_empty = true
 exclude_lines = [


### PR DESCRIPTION
## Summary

- Raises `coverage_policy.json` `minimum_total_percent` from 0.6% → 28% (was essentially zero, now enforces real floor)
- Updates `max_total_drop_percent` 0.1 → 2.0 (creates a real regression guard without false positives)
- Updates `coverage_baseline.json` to actual CI measurement (31.37% from smoke tests)
- Raises `pyproject.toml` `fail_under` 35 → 40 for local full-suite runs

The CI runs smoke tests (3 files) and measures ~31.37% coverage. The 28% floor prevents catastrophic regressions while not causing flaky failures from normal variance.

Closes #1600

## Test plan

- [x] Coverage policy values are consistent with current CI measurements
- [ ] CI tests job passes (Coverage Policy Gate should pass with 31.37 >= 28.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)