### PR TITLE
ci: expand required core test suite from 3-file smoke to 9-file cross-module slice (#1577)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -178,16 +178,33 @@ jobs:
 
       - name: Run Tests with Coverage (Python ${{ matrix.python-version }})
         run: |
-          smoke_tests=(
+          # Core required test suite — always runs regardless of which files changed.
+          # Covers: utilities, shared-library contracts, architecture boundaries,
+          # rotation math, process calculator constants, and manifest generation.
+          # Expanded from 3-file smoke set to representative cross-module slice (issue #1577).
+          core_tests=(
+            # Utility + error handling (original smoke tests)
             "tests/test_path_helpers.py"
             "tests/test_error_handling.py"
+            # Notes storage (original smoke test)
             "tests/shared/python/notes/test_storage.py"
+            # Shared-library contracts and security primitives
+            "tests/shared/python/test_contracts.py"
+            "tests/shared/python/test_safe_eval.py"
+            # Architecture layer boundary enforcement
+            "tests/architecture/test_layer_boundaries.py"
+            # Core rotation math (shared library used across many tools)
+            "tests/rotation_converter/test_rotation_core.py"
+            # Process calculator constants (always fast, catches unit regressions)
+            "tests/shared/python/process_calculators/test_constants.py"
+            # Tools manifest integrity
+            "tests/scripts/test_generate_tools_json.py"
           )
           if [ -s changed_test_files.txt ]; then
             mapfile -t changed_test_files < changed_test_files.txt
-            pytest "${changed_test_files[@]}" "${smoke_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=0
+            pytest "${changed_test_files[@]}" "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=0
           else
-            pytest "${smoke_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=0
+            pytest "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=0
           fi
 
       - name: Coverage Policy Gate


### PR DESCRIPTION
## Summary

Expands the always-required test suite in CI Standard from 3 smoke tests to 9 representative tests covering different key areas of the codebase.

## Before → After

**Before** (3 files, smoke-only):
- `tests/test_path_helpers.py`
- `tests/test_error_handling.py`
- `tests/shared/python/notes/test_storage.py`

**After** (9 files, cross-module representative slice):
| Test file | Area |
|-----------|------|
| `tests/test_path_helpers.py` | Utilities (existing) |
| `tests/test_error_handling.py` | Error handling (existing) |
| `tests/shared/python/notes/test_storage.py` | Notes storage (existing) |
| `tests/shared/python/test_contracts.py` | Shared lib Design-by-Contract |
| `tests/shared/python/test_safe_eval.py` | Security primitives |
| `tests/architecture/test_layer_boundaries.py` | Architecture layer enforcement |
| `tests/rotation_converter/test_rotation_core.py` | Core rotation math library |
| `tests/shared/python/process_calculators/test_constants.py` | Physical constants / units |
| `tests/scripts/test_generate_tools_json.py` | Tools manifest integrity |

## Why these tests

- **Contracts + architecture**: Catch regressions in shared library contract enforcement and layer boundary violations
- **Safe eval + security**: Ensure security primitives don't regress silently
- **Rotation core**: Shared math library used across many tools — regressions affect many surfaces
- **Process constants**: Physical constants with units; regressions cause silent numerical bugs
- **Tools manifest**: Ensures tool discovery doesn't break when GUI registration changes

## Test plan

- [ ] CI passes on this PR
- [ ] All 9 core test files pass individually

Closes #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)