### PR TITLE
fix(GH1648): resolve relative import regression in cors.py

### DIFF
--- a/src/shared/python/cors.py
+++ b/src/shared/python/cors.py
@@ -20,7 +20,10 @@ from typing import Any
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .contracts import require
+try:
+    from .contracts import require
+except ImportError:
+    from contracts import require  # type: ignore[no-redef]
 
 # Default local-development origins used when CORS_ORIGINS env var is unset.
 DEFAULT_ORIGINS: list[str] = [


### PR DESCRIPTION
Fixes #1648. Relative import in cors.py broke 30 test files. Changed to try/except for both package and direct import contexts.