### PR TITLE
fix(GH1651): replace MD5 weak hash with SHA-256 in text_editor.py

### DIFF
--- a/src/shared/python/model_generation/editor/text_editor.py
+++ b/src/shared/python/model_generation/editor/text_editor.py
@@ -793,7 +793,7 @@ class URDFTextEditor(TextEditorDiffMixin):
     def _add_to_history(self, description: str) -> None:
         """Add current content to history."""
         assert description is not None, "description must be provided"
-        checksum = hashlib.md5(self._content.encode()).hexdigest()
+        checksum = hashlib.sha256(self._content.encode()).hexdigest()
 
         version = EditorVersion(
             content=self._content,


### PR DESCRIPTION
Fixes #1651. text_editor.py:796 was using hashlib.md5() to compute version history checksums. Replaced with hashlib.sha256() which is equally efficient for this non-security change-detection purpose and passes security scanners without false positives.