### PR TITLE
fix: standardize contracts module import paths to bare sys.path style

### DIFF
--- a/src/data_processing/data_processor/python/data_processor/contracts.py
+++ b/src/data_processing/data_processor/python/data_processor/contracts.py
@@ -1,6 +1,6 @@
 """Design by Contract (DbC) adapter for the data_processor package.
 
-Re-exports the fleet-standard contract primitives from ``src.shared.python.contracts``
+Re-exports the fleet-standard contract primitives from ``contracts``
 with a transparent fallback so the module works both as part of the Tools monorepo
 (editable install) and as a standalone installation.
 
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 # Try the fleet-shared contracts module first (monorepo editable install)
 try:
-    from src.shared.python.contracts import (  # type: ignore[import]
+    from contracts import (  # type: ignore[import]
         ContractLevel,
         ContractViolationError,
         InvariantError,

--- a/src/shared/python/signal_toolkit/polynomial_generator.py
+++ b/src/shared/python/signal_toolkit/polynomial_generator.py
@@ -24,7 +24,7 @@ from PyQt6 import QtCore, QtWidgets
 
 # Configure logging - use standard logging for standalone operation
 try:
-    from src.shared.python.logging_config import configure_gui_logging, get_logger
+    from logging_config import configure_gui_logging, get_logger
 
     configure_gui_logging()
     logger = get_logger(__name__)

--- a/src/steam_engine_calculator/python/steam_engine_calculator/api.py
+++ b/src/steam_engine_calculator/python/steam_engine_calculator/api.py
@@ -15,14 +15,13 @@ from __future__ import annotations
 import logging
 from enum import Enum
 
+from cors import add_cors_middleware
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 from upstream_drift_tools.calculators.thermo.steam_engine import (
     SteamCalculationEngine,
     SteamProperties,
 )
-
-from shared.python.cors import add_cors_middleware
 
 logger = logging.getLogger(__name__)
 

--- a/tests/shared/python/gui_launcher/test_registry.py
+++ b/tests/shared/python/gui_launcher/test_registry.py
@@ -305,14 +305,13 @@ class TestGUIRegistryContracts:
 
     def test_auto_discover_non_list(self) -> None:
         from contracts import PreconditionError
-
-        from src.shared.python.gui_launcher.registry import auto_discover_guis
+        from gui_launcher.registry import auto_discover_guis
 
         with pytest.raises(PreconditionError):
             auto_discover_guis("/not/a/list")  # type: ignore[arg-type]
 
     def test_auto_discover_empty_list_returns_zero(self) -> None:
-        from src.shared.python.gui_launcher.registry import auto_discover_guis
+        from gui_launcher.registry import auto_discover_guis
 
         count = auto_discover_guis([])
         assert count == 0

--- a/tests/shared/python/test_cors.py
+++ b/tests/shared/python/test_cors.py
@@ -10,10 +10,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from contracts import PreconditionError
+from cors import DEFAULT_ORIGINS, add_cors_middleware
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-
-from src.shared.python.cors import DEFAULT_ORIGINS, add_cors_middleware
 
 _PreconditionError = PreconditionError
 


### PR DESCRIPTION
## Summary

Closes #1700

- Replaces `from src.shared.python.contracts import ...` with `from contracts import ...` in `data_processor/contracts.py`
- Replaces `from src.shared.python.cors import ...` with `from cors import ...` in `tests/shared/python/test_cors.py`
- Replaces `from src.shared.python.gui_launcher.registry import ...` with `from gui_launcher.registry import ...` in `tests/shared/python/gui_launcher/test_registry.py`
- Replaces `from src.shared.python.logging_config import ...` with `from logging_config import ...` in `signal_toolkit/polynomial_generator.py`
- Replaces `from shared.python.cors import ...` with `from cors import ...` in `steam_engine_calculator/api.py`

All changed imports now use the canonical bare form that resolves through the `sys.path` entries configured in `pytest.ini` (`src/shared/python` is listed as a `pythonpath` root). The absolute-path style (`from src.shared.python.X`) would break in a packaged install (`pip install ud-tools`) and was inconsistent with the 33-file majority already using bare imports.

## Test plan

- [ ] `ruff check .` passes (verified locally — 0 errors)
- [ ] `ruff format --check .` passes (verified locally — 1059 files already formatted)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)