### PR TITLE
fix(folder_tool): resolve 5 test failures — Pillow compat + ctypes.windll patching

### DIFF
--- a/src/folder_tool/folder_tool_ui.py
+++ b/src/folder_tool/folder_tool_ui.py
@@ -69,6 +69,9 @@ class UICreationMixin:
         try:
             from PIL import Image, ImageTk
 
+            # Pillow 9.1+ uses Image.Resampling.LANCZOS; older versions use Image.LANCZOS
+            _lanczos = getattr(Image, "Resampling", Image).LANCZOS
+
             # Load the ICO file which now has multiple sizes
             image = Image.open(ico_path)
 
@@ -80,7 +83,7 @@ class UICreationMixin:
                     # Try to get exact size from ICO, or resize
                     resized = image.resize(
                         (size, size),
-                        Image.Resampling.LANCZOS,
+                        _lanczos,
                     )
                     if resized.mode != "RGBA":
                         resized = resized.convert("RGBA")
@@ -106,6 +109,9 @@ class UICreationMixin:
         if Path(png_path).exists():
             from PIL import Image, ImageTk
 
+            # Pillow 9.1+ uses Image.Resampling.LANCZOS; older versions use Image.LANCZOS
+            _lanczos = getattr(Image, "Resampling", Image).LANCZOS
+
             try:
                 raw_image = Image.open(png_path)
                 if raw_image.mode != "RGBA":
@@ -115,7 +121,7 @@ class UICreationMixin:
 
                 photos = []
                 for size in ICON_SIZES:
-                    resized = image.resize((size, size), Image.Resampling.LANCZOS)
+                    resized = image.resize((size, size), _lanczos)
                     photo = ImageTk.PhotoImage(resized)
                     photos.append(photo)
 

--- a/tests/folder_tool/test_folder_tool_ui.py
+++ b/tests/folder_tool/test_folder_tool_ui.py
@@ -77,19 +77,18 @@ class TestUICreationMixin:
             app._setup_application_icon()
 
     def test_set_windows_app_id_success(self, app):
+        mock_windll = MagicMock()
         with patch("sys.platform", "win32"):
-            with patch(
-                "ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID"
-            ) as mock_set:
+            with patch("ctypes.windll", mock_windll, create=True):
                 app._set_windows_app_id()
-                mock_set.assert_called_once()
+                mock_windll.shell32.SetCurrentProcessExplicitAppUserModelID.assert_called_once()
 
     def test_set_windows_app_id_error(self, app):
+        mock_windll = MagicMock()
+        set_id = mock_windll.shell32.SetCurrentProcessExplicitAppUserModelID
+        set_id.side_effect = TypeError("mock error")
         with patch("sys.platform", "win32"):
-            with patch(
-                "ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID",
-                side_effect=TypeError("mock error"),
-            ):
+            with patch("ctypes.windll", mock_windll, create=True):
                 app._set_windows_app_id()
 
     def test_load_ico_icon_success(self, app):


### PR DESCRIPTION
## Summary

- **Pillow backward-compat**: `Image.Resampling.LANCZOS` was introduced in Pillow 9.1; the CI environment has 9.0.1 which only has `Image.LANCZOS`. Added `getattr(Image, "Resampling", Image).LANCZOS` shim in both `_load_ico_icon` and `_load_png_fallback` so source runs on any supported Pillow version.
- **ctypes.windll cross-platform patching**: `patch("ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID")` raises `ModuleNotFoundError` on Linux because `windll` does not exist as a real attribute. Switched to `patch("ctypes.windll", mock_windll, create=True)` which injects the mock without touching the real ctypes namespace.
- **Import sort fix**: `model_generation/__init__.py` had an unsorted import block (I001) after new lazy-import lines were added in the staging pull; auto-fixed with `ruff check --fix`.

Closes #1688

## Test plan

- [ ] `python3 -m pytest tests/folder_tool/test_folder_tool_ui.py` — 22/22 pass
- [ ] `python3 -m pytest --tb=short -q` — 4394 passed, 0 failed
- [ ] `python3 -m ruff check .` — no violations
- [ ] `python3 -m ruff format --check .` — no diffs
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)