### PR TITLE
fix: Security annotation for xml.etree import

### DIFF
--- a/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/urdf_generator.py
@@ -13,7 +13,7 @@ and does not depend on other Golf Modeling Suite modules.
 from __future__ import annotations
 
 import logging
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # nosec B405 — creation only (Element, SubElement, tostring); no parsing
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any


### PR DESCRIPTION
## Summary
- Add nosec B405 annotation to the one remaining xml.etree import without annotation
- The import in urdf_generator.py is used for XML creation only (Element, SubElement, tostring), not parsing
- All 7 xml.etree usages in the repo are now properly annotated or use defusedxml for parsing

Closes #1787

## Test plan
- [x] Verified import is creation-only (no parse/fromstring/iterparse calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)