### PR TITLE
fix(#1862): unify contracts API between Tools and Tools_Private

### DIFF
--- a/src/shared/python/contracts.py
+++ b/src/shared/python/contracts.py
@@ -255,11 +255,13 @@ def precondition(
     assert condition is not None, "condition must be provided"
 
     def decorator(func: F) -> F:
-        if DBC_LEVEL == ContractLevel.OFF:
+        if _ContractState.level == ContractLevel.OFF:
             return func
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if _ContractState.level == ContractLevel.OFF:
+                return func(*args, **kwargs)
             try:
                 result = _evaluate_precondition(condition, func, args, kwargs)
             except (TypeError, ValueError) as exc:
@@ -288,12 +290,14 @@ def postcondition(
     assert condition is not None, "condition must be provided"
 
     def decorator(func: F) -> F:
-        if DBC_LEVEL == ContractLevel.OFF:
+        if _ContractState.level == ContractLevel.OFF:
             return func
 
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             result = func(*args, **kwargs)
+            if _ContractState.level == ContractLevel.OFF:
+                return result
 
             try:
                 check = condition(result)
@@ -429,7 +433,7 @@ def class_invariant(
     assert condition is not None, "condition must be provided"
 
     def class_decorator(cls: type) -> type:
-        if DBC_LEVEL == ContractLevel.OFF:
+        if _ContractState.level == ContractLevel.OFF:
             return cls
 
         # Wrap __init__
@@ -471,13 +475,14 @@ class ContractChecker:
 
     def verify_invariants(self) -> bool:
         """Verify all class invariants hold."""
-        if DBC_LEVEL == ContractLevel.OFF:
+        level = _ContractState.level
+        if level == ContractLevel.OFF:
             return True
 
         for condition_fn, message in self._get_invariants():
             try:
                 if not condition_fn():
-                    if DBC_LEVEL == ContractLevel.ENFORCE:
+                    if level == ContractLevel.ENFORCE:
                         raise InvariantError(f"{self.__class__.__name__}: {message}")
                     else:
                         logger.warning(
@@ -488,7 +493,7 @@ class ContractChecker:
             except InvariantError:
                 raise
             except (RuntimeError, TypeError, ValueError) as exc:
-                if DBC_LEVEL == ContractLevel.ENFORCE:
+                if level == ContractLevel.ENFORCE:
                     raise InvariantError(
                         f"{self.__class__.__name__}: "
                         f"Failed to evaluate invariant: {exc}"
@@ -499,7 +504,7 @@ class ContractChecker:
 
 def invariant_checked(func: F) -> F:
     """Decorator to check class invariants after method execution."""
-    if DBC_LEVEL == ContractLevel.OFF:
+    if _ContractState.level == ContractLevel.OFF:
         return func
 
     @functools.wraps(func)
@@ -566,7 +571,7 @@ def require_positive(value: float, name: str = "value") -> None:
     Raises:
         PreconditionError: If *value* ``<= 0``.
     """
-    if not CONTRACTS_ENABLED:
+    if _ContractState.level == ContractLevel.OFF:
         return
     if value <= 0:
         raise PreconditionError(f"{name} must be positive (got {value})")
@@ -580,7 +585,7 @@ def require_finite(array: Any, name: str = "array") -> None:
     """
     import numpy as np
 
-    if not CONTRACTS_ENABLED:
+    if _ContractState.level == ContractLevel.OFF:
         return
     if not np.all(np.isfinite(array)):
         raise PreconditionError(f"{name} contains NaN or Inf values")
@@ -594,7 +599,7 @@ def require_unit_vector(vector: Any, name: str = "vector", tol: float = 1e-6) ->
     """
     import numpy as np
 
-    if not CONTRACTS_ENABLED:
+    if _ContractState.level == ContractLevel.OFF:
         return
     norm = np.linalg.norm(vector)
     if abs(norm - 1.0) > tol:
@@ -607,7 +612,7 @@ def ensure_valid_result(result: Any) -> None:
     Raises:
         PostconditionError: If ``result.is_valid`` is falsy.
     """
-    if not CONTRACTS_ENABLED:
+    if _ContractState.level == ContractLevel.OFF:
         return
     if not result.is_valid:
         errors = "; ".join(result.get_error_messages())

--- a/src/urdf_builder_gui/python/urdf_builder_gui/contracts.py
+++ b/src/urdf_builder_gui/python/urdf_builder_gui/contracts.py
@@ -1,64 +1,22 @@
-"""Lightweight Design by Contract support for urdf_builder_gui.
+"""Design by Contract support for urdf_builder_gui.
 
-Provides require() and ensure() for precondition and postcondition
-enforcement without depending on the data_processor package.
+Re-exports from the canonical contracts implementation at
+``src/shared/python/contracts.py``.  The shared module provides the
+full API (imperative + decorator styles) and tri-state enforcement.
 """
 
 from __future__ import annotations
 
-import os
-from typing import Any
-
-
-class PreconditionError(ValueError):
-    """Raised when a precondition is violated."""
-
-
-class PostconditionError(ValueError):
-    """Raised when a postcondition is violated."""
-
-
-# DBC_LEVEL controls enforcement: "enforce" (default), "warn", "disabled"
-_DBC_LEVEL = os.environ.get("DBC_LEVEL", "enforce")
-
-
-def require(condition: bool, message: str, *args: Any) -> None:
-    """Assert a precondition.
-
-    Args:
-        condition: The boolean condition that must be true.
-        message: Error message if violated.
-        *args: Additional context values to include in the error.
-    """
-    if _DBC_LEVEL == "disabled":
-        return
-    if not condition:
-        detail = f"{message}"
-        if args:
-            detail += f" (got: {', '.join(str(a) for a in args)})"
-        raise PreconditionError(detail)
-
-
-def ensure(condition: bool, message: str, *args: Any) -> None:
-    """Assert a postcondition.
-
-    Args:
-        condition: The boolean condition that must be true.
-        message: Error message if violated.
-        *args: Additional context values.
-    """
-    if _DBC_LEVEL == "disabled":
-        return
-    if not condition:
-        detail = f"{message}"
-        if args:
-            detail += f" (got: {', '.join(str(a) for a in args)})"
-        raise PostconditionError(detail)
-
+from contracts import (  # noqa: F401
+    PostconditionError,
+    PreconditionError,
+    ensure,
+    require,
+)
 
 __all__ = [
-    "PreconditionError",
     "PostconditionError",
+    "PreconditionError",
     "ensure",
     "require",
 ]


### PR DESCRIPTION
## Summary

- **Fixed namespace double-import bug** in `src/shared/python/contracts.py`: all internal reads now use `_ContractState.level` instead of the module-level `DBC_LEVEL` / `CONTRACTS_ENABLED` aliases, which could become stale when `set_contract_level()` updates `_ContractState` but multiple module copies exist due to namespace package imports.
- **Replaced standalone `urdf_builder_gui/contracts.py`** with a thin re-export from the canonical shared contracts module, eliminating a duplicate implementation with a slightly different API.
- Decorator wrappers (`precondition`, `postcondition`, `class_invariant`, `invariant_checked`) and convenience validators (`require_positive`, `require_finite`, `require_unit_vector`, `ensure_valid_result`) now all consistently read from the single source of truth (`_ContractState.level`).

Closes #1862

## Test plan

- [x] All 110 contract tests pass (`tests/unit/test_contracts.py`, `tests/shared/python/test_contracts.py`, `src/shared/python/tests/test_contracts_shared.py`)
- [x] `urdf_builder_gui` contract tests pass (5/5) with re-exported API
- [x] `ruff check` and `ruff format --check` clean
- [x] Pre-commit and pre-push hooks pass (including mypy, bandit, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)