### PR TITLE
test: bridge pendulum discovery into pytest tests

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.8                                      |
+| **Spec Version**        | 1.1.9                                      |
 | **Last Spec Update**    | 2026-04-05                                 |
 
 ## 2. Purpose & Mission
@@ -463,6 +463,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-05 | 1.1.6   | Optimize DataChart point extraction loop to explicitly map selected properties instead of using an object spread on the entire row in `src/data_processing/data_processor/web/src/components/DataChart.tsx`.                                                                                                                                                                                                                                           |
 | 2026-04-05 | 1.1.7   | Improve HelpPanel accessibility by adding ARIA expanded states and control links to accordion toggles, and adding explicit focus-visible rings for keyboard users.                                                                                                                                                                                                                                                                                     |
 | 2026-04-05 | 1.1.8   | Optimize PlotView WebGL rendering to use Float64Array and bypass map array creation overhead.                                                                                                                                                                                                                                                                                                                                                          |
+| 2026-04-05 | 1.1.9   | Bridge the embedded `src/pendulum_simulator/tests` suite into the top-level `tests/` tree so standard `pytest tests/` collection includes pendulum coverage without double-collecting the same files during root-level pytest runs.                                                                                                                                                                                                                 |
 
 ---
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,40 @@
+"""Repository-level pytest hooks for cross-tree test discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent
+PENDULUM_TESTS_DIR = REPO_ROOT / "src" / "pendulum_simulator" / "tests"
+
+
+def _path_is_within(candidate: Path, parent: Path) -> bool:
+    """Return whether ``candidate`` is inside ``parent``."""
+    try:
+        candidate.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
+    """Avoid double-collecting the embedded pendulum suite from ``src/``.
+
+    The suite is bridged into ``tests/pendulum_simulator`` so that
+    ``pytest tests/`` includes it. If a developer explicitly targets the
+    embedded directory, preserve the direct path-based behavior.
+    """
+    candidate = Path(collection_path)
+    if not _path_is_within(candidate, PENDULUM_TESTS_DIR):
+        return None
+
+    explicit_targets = [
+        (config.rootpath / arg).resolve()
+        for arg in config.args
+        if arg and not arg.startswith("-")
+    ]
+    if any(_path_is_within(target, PENDULUM_TESTS_DIR) for target in explicit_targets):
+        return None
+    return True

--- a/tests/pendulum_simulator/conftest.py
+++ b/tests/pendulum_simulator/conftest.py
@@ -1,0 +1,31 @@
+"""Bridge embedded pendulum tests into the top-level test tree."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+EMBEDDED_TESTS_DIR = (
+    Path(__file__).resolve().parents[2] / "src" / "pendulum_simulator" / "tests"
+)
+BRIDGE_FILE_NAME = "test_embedded_suite.py"
+
+
+class EmbeddedPendulumSuite(pytest.File):
+    """Collect the legacy embedded pendulum tests through ``tests/``."""
+
+    def collect(self) -> list[pytest.Module]:
+        return [
+            pytest.Module.from_parent(self, path=test_file)
+            for test_file in sorted(EMBEDDED_TESTS_DIR.glob("test_*.py"))
+        ]
+
+
+def pytest_collect_file(
+    file_path: Path, parent: pytest.Collector
+) -> EmbeddedPendulumSuite | None:
+    """Route the placeholder bridge file to the embedded suite collector."""
+    if file_path.name != BRIDGE_FILE_NAME:
+        return None
+    return EmbeddedPendulumSuite.from_parent(parent, path=file_path)

--- a/tests/pendulum_simulator/test_embedded_suite.py
+++ b/tests/pendulum_simulator/test_embedded_suite.py
@@ -1,0 +1,1 @@
+"""Placeholder collected by ``tests/pendulum_simulator/conftest.py``."""

--- a/tests/test_pendulum_discovery.py
+++ b/tests/test_pendulum_discovery.py
@@ -1,0 +1,55 @@
+"""Regression tests for the pendulum pytest discovery bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from _pytest.config import Config
+
+from conftest import PENDULUM_TESTS_DIR, pytest_ignore_collect
+from tests.pendulum_simulator.conftest import BRIDGE_FILE_NAME, EMBEDDED_TESTS_DIR
+
+
+def test_embedded_pendulum_suite_contains_expected_regression_target() -> None:
+    """The bridge should point at the real embedded pendulum test suite."""
+    discovered = {path.name for path in EMBEDDED_TESTS_DIR.glob("test_*.py")}
+
+    assert "test_constants.py" in discovered
+    assert len(discovered) >= 90
+
+
+def test_bridge_placeholder_exists_under_top_level_tests() -> None:
+    """Top-level pytest discovery should have a stable pendulum entrypoint."""
+    bridge_file = (
+        Path(__file__).resolve().parent / "pendulum_simulator" / BRIDGE_FILE_NAME
+    )
+
+    assert bridge_file.is_file()
+
+
+def test_root_pytest_ignores_direct_pendulum_collection_by_default() -> None:
+    """Default root-level pytest runs should not double-collect pendulum tests."""
+    config = cast(
+        Config,
+        SimpleNamespace(rootpath=Path(__file__).resolve().parents[1], args=[]),
+    )
+    candidate = PENDULUM_TESTS_DIR / "test_constants.py"
+
+    assert pytest_ignore_collect(candidate, config) is True
+
+
+def test_root_pytest_keeps_explicit_pendulum_paths() -> None:
+    """Explicit pendulum test invocations should still work unchanged."""
+    repo_root = Path(__file__).resolve().parents[1]
+    config = cast(
+        Config,
+        SimpleNamespace(
+            rootpath=repo_root,
+            args=["src/pendulum_simulator/tests/test_constants.py"],
+        ),
+    )
+    candidate = PENDULUM_TESTS_DIR / "test_constants.py"
+
+    assert pytest_ignore_collect(candidate, config) is None


### PR DESCRIPTION
## Summary
- bridge the embedded pendulum test suite into the top-level 	ests/ tree
- prevent default root pytest runs from double-collecting src/pendulum_simulator/tests
- add a regression test for the new discovery bridge and update SPEC.md

## Validation
- python -m ruff check conftest.py tests/test_pendulum_discovery.py tests/pendulum_simulator/conftest.py tests/pendulum_simulator/test_embedded_suite.py
- python -m black --check conftest.py tests/test_pendulum_discovery.py tests/pendulum_simulator/conftest.py tests/pendulum_simulator/test_embedded_suite.py
- python -m mypy conftest.py tests/test_pendulum_discovery.py tests/pendulum_simulator/conftest.py
- python -m pytest tests/test_pendulum_discovery.py -q -n 0

Closes #1932