### PR TITLE
fix: standardize vessel drafter require_positive order

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.9                                      |
+| **Spec Version**        | 1.1.10                                     |
 | **Last Spec Update**    | 2026-04-05                                 |
 
 ## 2. Purpose & Mission
@@ -464,6 +464,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-05 | 1.1.7   | Improve HelpPanel accessibility by adding ARIA expanded states and control links to accordion toggles, and adding explicit focus-visible rings for keyboard users.                                                                                                                                                                                                                                                                                     |
 | 2026-04-05 | 1.1.8   | Optimize PlotView WebGL rendering to use Float64Array and bypass map array creation overhead.                                                                                                                                                                                                                                                                                                                                                          |
 | 2026-04-05 | 1.1.9   | Bridge the embedded `src/pendulum_simulator/tests` suite into the top-level `tests/` tree so standard `pytest tests/` collection includes pendulum coverage without double-collecting the same files during root-level pytest runs.                                                                                                                                                                                                                 |
+| 2026-04-05 | 1.1.10  | Standardize vessel drafter `require_positive` usage onto the fleet-wide `(value, name)` argument order while keeping guarded support for the legacy local order and adding regression tests for the signature normalization.                                                                                                                                                                                                                         |
 
 ---
 

--- a/src/vessel_drafter/python/vessel_drafter/contracts.py
+++ b/src/vessel_drafter/python/vessel_drafter/contracts.py
@@ -28,6 +28,8 @@ try:
         PreconditionError,
         ensure,
         require,
+    )
+    from contracts import (
         require_positive as _shared_require_positive,
     )
 except ImportError:
@@ -42,17 +44,17 @@ except ImportError:
                 detail += f" (got: {value!r})"
             super().__init__(detail)
 
-    def require(condition: bool, message: str, value: Any = None) -> None:  # type: ignore[misc]
+    def require(condition: bool, message: str, value: Any = None) -> None:
         """Assert a pre-condition (standard bool-style API)."""
         if not condition:
             raise PreconditionError(message, value)
 
-    def ensure(condition: bool, message: str, value: Any = None) -> None:  # type: ignore[misc]
+    def ensure(condition: bool, message: str, value: Any = None) -> None:
         """Assert a post-condition (standard bool-style API)."""
         if not condition:
             raise ValueError(f"[DbC post-condition] {message}")
 
-    def _shared_require_positive(value: float, name: str = "value") -> None:  # type: ignore[misc]
+    def _shared_require_positive(value: float, name: str = "value") -> None:
         """Require that *value* is strictly positive."""
         if value <= 0:
             raise PreconditionError(f"{name} must be positive (got {value})")

--- a/src/vessel_drafter/python/vessel_drafter/contracts.py
+++ b/src/vessel_drafter/python/vessel_drafter/contracts.py
@@ -1,12 +1,13 @@
 """Design by Contract helpers for the vessel_drafter package.
 
 Re-exports the fleet-standard contract primitives from the shared
-``contracts`` module (``src/shared/python/contracts.py``).  Domain-specific
+``contracts`` module (``src/shared/python/contracts.py``). Domain-specific
 helpers (``require_nonnegative``, ``require_fraction``, etc.) are kept here
 as thin wrappers around ``require()``.
 
 Signature fix (closes #1930): ``require_positive(value, name)`` now matches
-the canonical signature in ``src/shared/python/contracts.py``.
+the canonical signature in ``src/shared/python/contracts.py`` while still
+accepting the legacy local ``(name, value)`` order during migration.
 
 De-duplicated per https://github.com/D-sorganization/Tools/issues/1926.
 """
@@ -15,6 +16,7 @@ from __future__ import annotations
 
 import logging
 from math import isfinite
+from numbers import Real
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -26,7 +28,7 @@ try:
         PreconditionError,
         ensure,
         require,
-        require_positive,
+        require_positive as _shared_require_positive,
     )
 except ImportError:
     # ── Standalone fallback ────────────────────────────────────────────────
@@ -50,10 +52,45 @@ except ImportError:
         if not condition:
             raise ValueError(f"[DbC post-condition] {message}")
 
-    def require_positive(value: float, name: str = "value") -> None:  # type: ignore[misc]
+    def _shared_require_positive(value: float, name: str = "value") -> None:  # type: ignore[misc]
         """Require that *value* is strictly positive."""
         if value <= 0:
             raise PreconditionError(f"{name} must be positive (got {value})")
+
+
+def _normalize_value_and_name(
+    first: object,
+    second: object,
+    *,
+    function_name: str,
+) -> tuple[float, str]:
+    """Normalize either ``(value, name)`` or legacy ``(name, value)`` pairs."""
+    if isinstance(first, str):
+        if not isinstance(second, Real):
+            raise TypeError(
+                f"{function_name} expects (value, name) or legacy (name, value); "
+                f"got {type(first).__name__}, {type(second).__name__}"
+            )
+        return float(second), first
+    if isinstance(second, str):
+        if not isinstance(first, Real):
+            raise TypeError(
+                f"{function_name} expects (value, name) or legacy (name, value); "
+                f"got {type(first).__name__}, {type(second).__name__}"
+            )
+        return float(first), second
+    raise TypeError(
+        f"{function_name} expects (value, name) or legacy (name, value); "
+        f"got {type(first).__name__}, {type(second).__name__}"
+    )
+
+
+def require_positive(value: float | str, name: str | float = "value") -> None:
+    """Require a strictly positive numeric value."""
+    normalized_value, normalized_name = _normalize_value_and_name(
+        value, name, function_name="require_positive"
+    )
+    _shared_require_positive(normalized_value, normalized_name)
 
 
 # ── Domain-specific wrapper helpers ──────────────────────────────────────
@@ -134,15 +171,13 @@ def require_finite(name: str, value: float) -> None:
 
 
 __all__ = [
-    # Shared primitives
     "PreconditionError",
     "ensure",
     "require",
-    "require_positive",
-    # Domain-specific (name, value) wrappers
     "require_finite",
     "require_fraction",
     "require_integer_at_least",
     "require_less_or_equal",
     "require_nonnegative",
+    "require_positive",
 ]

--- a/tests/vessel_drafter/test_contracts.py
+++ b/tests/vessel_drafter/test_contracts.py
@@ -1,0 +1,46 @@
+"""Regression tests for vessel drafter contract helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _enable_vessel_drafter_imports(monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    monkeypatch.syspath_prepend(str(repo_root / "src" / "vessel_drafter" / "python"))
+
+
+def test_require_positive_accepts_shared_argument_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper should accept the fleet-standard ``(value, name)`` order."""
+    _enable_vessel_drafter_imports(monkeypatch)
+
+    from vessel_drafter.contracts import require_positive
+
+    require_positive(1.0, "diameter_in")
+
+
+def test_require_positive_preserves_legacy_argument_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing vessel drafter call sites should keep working during migration."""
+    _enable_vessel_drafter_imports(monkeypatch)
+
+    from vessel_drafter.contracts import require_positive
+
+    require_positive("diameter_in", 1.0)
+
+
+def test_require_positive_rejects_non_numeric_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bad argument pairs should fail explicitly instead of comparing strings."""
+    _enable_vessel_drafter_imports(monkeypatch)
+
+    from vessel_drafter.contracts import require_positive
+
+    with pytest.raises(TypeError, match="expects"):
+        require_positive("diameter_in", "not-a-number")


### PR DESCRIPTION
## Summary
- standardize vessel drafter equire_positive around the fleet-wide (value, name) order
- keep guarded compatibility for the legacy local (name, value) call form
- update vessel drafter model call sites and add regression tests for the signature normalization

## Validation
- python -m pytest tests/vessel_drafter/test_contracts.py -q -n 0
- python -m ruff check src/vessel_drafter/python/vessel_drafter/contracts.py src/vessel_drafter/python/vessel_drafter/models/vessel_drafter.py src/vessel_drafter/python/vessel_drafter/models/vessel_materials.py tests/vessel_drafter/test_contracts.py
- python -m mypy src/vessel_drafter/python/vessel_drafter/contracts.py src/vessel_drafter/python/vessel_drafter/models/vessel_drafter.py src/vessel_drafter/python/vessel_drafter/models/vessel_materials.py tests/vessel_drafter/test_contracts.py
- python -m black --check src/vessel_drafter/python/vessel_drafter/contracts.py src/vessel_drafter/python/vessel_drafter/models/vessel_drafter.py src/vessel_drafter/python/vessel_drafter/models/vessel_materials.py tests/vessel_drafter/test_contracts.py

Closes #1930