### PR TITLE
refactor: deduplicate analysis tab surface evaluators

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.10                                     |
+| **Spec Version**        | 1.1.11                                     |
 | **Last Spec Update**    | 2026-04-05                                 |
 
 ## 2. Purpose & Mission
@@ -465,6 +465,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-05 | 1.1.8   | Optimize PlotView WebGL rendering to use Float64Array and bypass map array creation overhead.                                                                                                                                                                                                                                                                                                                                                          |
 | 2026-04-05 | 1.1.9   | Bridge the embedded `src/pendulum_simulator/tests` suite into the top-level `tests/` tree so standard `pytest tests/` collection includes pendulum coverage without double-collecting the same files during root-level pytest runs.                                                                                                                                                                                                                 |
 | 2026-04-05 | 1.1.10  | Standardize vessel drafter `require_positive` usage onto the fleet-wide `(value, name)` argument order while keeping guarded support for the legacy local order and adding regression tests for the signature normalization.                                                                                                                                                                                                                         |
+| 2026-04-05 | 1.1.11  | Deduplicate repeated scalar surface evaluator closures in `analysis_tab.py` by routing matrix and transformed-value cases through shared helper builders, with regression coverage for the new helper paths.                                                                                                                                                                                                                                          |
 
 ---
 

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/analysis_tab.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/analysis_tab.py
@@ -395,8 +395,10 @@ class AnalysisTab:
             raise ValueError("x_key must be provided")
         x_vals = np.linspace(x_range[0], x_range[1], n_pts)
         y_vals = np.linspace(y_range[0], y_range[1], n_pts)
+        X: np.ndarray
+        Y: np.ndarray
         X, Y = np.meshgrid(x_vals, y_vals)
-        Z = np.zeros_like(X)
+        Z: np.ndarray = np.zeros_like(X)
 
         # Compute Z values via the appropriate physics function
         evaluator = self._get_surface_evaluator(z_key)
@@ -462,28 +464,22 @@ class AnalysisTab:
         )
 
         if z_key == "mass_matrix_det":
-
-            def _eval(angles: dict) -> float:
-                M = mass_matrix(angles.get("phi", 0.0), params)
-                return float(np.linalg.det(M))
-
-            return _eval
+            return self._matrix_metric_evaluator(
+                lambda angles: mass_matrix(angles.get("phi", 0.0), params),
+                np.linalg.det,
+            )
         if z_key == "mass_matrix_cond":
-
-            def _eval(angles: dict) -> float:
-                M = mass_matrix(angles.get("phi", 0.0), params)
-                return float(np.linalg.cond(M))
-
-            return _eval
+            return self._matrix_metric_evaluator(
+                lambda angles: mass_matrix(angles.get("phi", 0.0), params),
+                np.linalg.cond,
+            )
         if z_key == "potential_energy":
-
-            def _eval(angles: dict) -> float:
-                state = np.array(
+            return self._transformed_scalar_evaluator(
+                lambda angles: np.array(
                     [angles.get("theta1", 0.0), angles.get("phi", 0.0), 0.0, 0.0]
-                )
-                return potential_energy(state, params)
-
-            return _eval
+                ),
+                lambda state: potential_energy(state, params),
+            )
         if z_key == "manipulability":
             return self._numerical_manipulability(
                 lambda a: forward_kinematics(a["theta1"], a["phi"], params),
@@ -517,23 +513,22 @@ class AnalysisTab:
         )
 
         if z_key == "mass_matrix_det":
-
-            def _eval(angles: dict) -> float:
-                M = triple_mm(angles.get("phi1", 0.0), angles.get("phi2", 0.0), params)
-                return float(np.linalg.det(M))
-
-            return _eval
+            return self._matrix_metric_evaluator(
+                lambda angles: triple_mm(
+                    angles.get("phi1", 0.0), angles.get("phi2", 0.0), params
+                ),
+                np.linalg.det,
+            )
         if z_key == "mass_matrix_cond":
-
-            def _eval(angles: dict) -> float:
-                M = triple_mm(angles.get("phi1", 0.0), angles.get("phi2", 0.0), params)
-                return float(np.linalg.cond(M))
-
-            return _eval
+            return self._matrix_metric_evaluator(
+                lambda angles: triple_mm(
+                    angles.get("phi1", 0.0), angles.get("phi2", 0.0), params
+                ),
+                np.linalg.cond,
+            )
         if z_key == "potential_energy":
-
-            def _eval(angles: dict) -> float:
-                state = np.array(
+            return self._transformed_scalar_evaluator(
+                lambda angles: np.array(
                     [
                         angles.get("theta1", 0.0),
                         angles.get("phi1", 0.0),
@@ -542,10 +537,9 @@ class AnalysisTab:
                         0.0,
                         0.0,
                     ]
-                )
-                return triple_pe(state, params)
-
-            return _eval
+                ),
+                lambda state: triple_pe(state, params),
+            )
         if z_key == "manipulability":
             return self._numerical_manipulability(
                 lambda a: triple_fk(
@@ -587,28 +581,20 @@ class AnalysisTab:
         )
 
         if z_key == "mass_matrix_det":
-
-            def _eval(angles: dict) -> float:
-                q = self._golfer_q_from_angles(angles)
-                M = golfer_mm(q, params)
-                return float(np.linalg.det(M))
-
-            return _eval
+            return self._q_scalar_evaluator(
+                self._golfer_q_from_angles,
+                lambda q: np.linalg.det(golfer_mm(q, params)),
+            )
         if z_key == "mass_matrix_cond":
-
-            def _eval(angles: dict) -> float:
-                q = self._golfer_q_from_angles(angles)
-                M = golfer_mm(q, params)
-                return float(np.linalg.cond(M))
-
-            return _eval
+            return self._q_scalar_evaluator(
+                self._golfer_q_from_angles,
+                lambda q: np.linalg.cond(golfer_mm(q, params)),
+            )
         if z_key == "potential_energy":
-
-            def _eval(angles: dict) -> float:
-                q = self._golfer_q_from_angles(angles)
-                return potential_energy_from_q(q, params)
-
-            return _eval
+            return self._q_scalar_evaluator(
+                self._golfer_q_from_angles,
+                lambda q: potential_energy_from_q(q, params),
+            )
         if z_key == "manipulability":
             try:
                 from ..golfer_dynamics import analytical_fk_jacobians
@@ -635,6 +621,33 @@ class AnalysisTab:
         except AttributeError:
             pass
         return default_factory()
+
+    @staticmethod
+    def _matrix_metric_evaluator(matrix_builder: Any, metric: Any) -> Any:
+        """Return an evaluator that applies a scalar metric to a matrix."""
+
+        def _eval(angles: dict) -> float:
+            return float(metric(matrix_builder(angles)))
+
+        return _eval
+
+    @staticmethod
+    def _transformed_scalar_evaluator(value_builder: Any, scalar_fn: Any) -> Any:
+        """Return an evaluator that transforms angles before a scalar call."""
+
+        def _eval(angles: dict) -> float:
+            return float(scalar_fn(value_builder(angles)))
+
+        return _eval
+
+    @staticmethod
+    def _q_scalar_evaluator(q_builder: Any, scalar_fn: Any) -> Any:
+        """Return an evaluator that computes a q vector before a scalar call."""
+
+        def _eval(angles: dict) -> float:
+            return float(scalar_fn(q_builder(angles)))
+
+        return _eval
 
     @staticmethod
     def _golfer_q_from_angles(angles: dict) -> np.ndarray:
@@ -713,7 +726,7 @@ class AnalysisTab:
         ax.zaxis.pane.fill = False  # type: ignore[attr-defined]
 
         # Mask NaN for cleaner rendering
-        Z_masked = np.ma.array(Z, mask=~np.isfinite(Z))
+        Z_masked: np.ma.MaskedArray[Any] = np.ma.array(Z, mask=~np.isfinite(Z))
 
         ax.plot_surface(  # type: ignore[attr-defined]
             X,

--- a/src/pendulum_simulator/tests/test_analysis_tab.py
+++ b/src/pendulum_simulator/tests/test_analysis_tab.py
@@ -150,6 +150,28 @@ def test_analysis_tab_evaluators(qapp) -> Any:
         assert isinstance(mani_eval3({"theta1": 0.0}), float)
 
 
+def test_analysis_tab_shared_evaluator_helpers(qapp) -> Any:
+    tab = AnalysisTab()
+
+    matrix_eval = tab._matrix_metric_evaluator(
+        lambda angles: np.array([[angles["x"], 0.0], [0.0, 2.0]]),
+        np.linalg.det,
+    )
+    assert matrix_eval({"x": 3.0}) == 6.0
+
+    transformed_eval = tab._transformed_scalar_evaluator(
+        lambda angles: np.array([angles["x"], angles["y"]]),
+        np.sum,
+    )
+    assert transformed_eval({"x": 1.5, "y": 2.5}) == 4.0
+
+    q_eval = tab._q_scalar_evaluator(
+        lambda angles: np.array([angles["x"], angles["y"]]),
+        np.linalg.norm,
+    )
+    assert q_eval({"x": 3.0, "y": 4.0}) == 5.0
+
+
 def test_analysis_tab_plot_2d_errors(qapp, monkeypatch) -> Any:
     tab = AnalysisTab()
     tab.set_result(MagicMock(), "double")


### PR DESCRIPTION
## Summary
- deduplicate repeated scalar surface evaluator closures in nalysis_tab.py
- route matrix and transformed-value cases through shared helper builders
- add regression coverage for the shared evaluator helpers and update SPEC.md

## Validation
- python -m ruff check src/pendulum_simulator/src/double_pendulum_golf/gui/analysis_tab.py src/pendulum_simulator/tests/test_analysis_tab.py
- python -m black --check src/pendulum_simulator/src/double_pendulum_golf/gui/analysis_tab.py src/pendulum_simulator/tests/test_analysis_tab.py
- python -m mypy --follow-imports skip src/pendulum_simulator/src/double_pendulum_golf/gui/analysis_tab.py
- python -m pytest src/pendulum_simulator/tests/test_analysis_tab.py -q -n 0 *(fails locally during collection because installed 
umba rejects installed 
umpy 2.4 on Python 3.13 before tests run)*

Closes #1942