### PR TITLE
refactor: stop simulation panel reaching into optimizer internals

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.12                                     |
+| **Spec Version**        | 1.1.13                                     |
 | **Last Spec Update**    | 2026-04-05                                 |
 
 ## 2. Purpose & Mission
@@ -467,6 +467,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-05 | 1.1.10  | Standardize vessel drafter `require_positive` usage onto the fleet-wide `(value, name)` argument order while keeping guarded support for the legacy local order and adding regression tests for the signature normalization.                                                                                                                                                                                                                         |
 | 2026-04-05 | 1.1.11  | Deduplicate repeated scalar surface evaluator closures in `analysis_tab.py` by routing matrix and transformed-value cases through shared helper builders, with regression coverage for the new helper paths.                                                                                                                                                                                                                                          |
 | 2026-04-05 | 1.1.12  | Expand the embedded-suite discovery policy so root-level pytest ignores bridged `src/` suites by default while `pytest tests/` includes both pendulum and solar-system embedded tests through top-level bridge directories.                                                                                                                                                                                                                          |
+| 2026-04-05 | 1.1.13  | Move pendulum optimizer objective-refresh wiring behind a public `OptimizationWidget` API so `SimulationPanel` no longer reaches through private optimizer button and log internals before optimization runs.                                                                                                                                                                                                                                         |
 
 ---
 

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/optimization_widget.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/optimization_widget.py
@@ -473,6 +473,8 @@ class OptimizationWidget(QWidget):
         self._model_name = model_name
         self._n_torque_params = n_torque_params
         self._objective_fn: Callable | None = None
+        self._params_getter: Callable[[], dict[str, Any]] | None = None
+        self._objective_builder: Callable[[dict[str, Any]], Callable] | None = None
         self._result: dict | None = None
         self._last_best_coeffs: np.ndarray | None = None
         self._convergence_history: list[float] = []
@@ -638,9 +640,40 @@ class OptimizationWidget(QWidget):
         """
         self._objective_fn = fn
 
+    def bind_objective_builder(
+        self,
+        params_getter: Callable[[], dict[str, Any]],
+        objective_builder: Callable[[dict[str, Any]], Callable],
+    ) -> None:
+        """Bind callables that rebuild the objective from current UI params."""
+        self._params_getter = params_getter
+        self._objective_builder = objective_builder
+
+    def append_status_message(self, message: str) -> None:
+        """Append a status message to the optimizer log."""
+        if not (message is not None):
+            raise ValueError("message must be provided")
+        self._log.append(message)
+
+    def _refresh_bound_objective(self) -> bool:
+        """Refresh the objective function from bound UI providers when present."""
+        if self._params_getter is None or self._objective_builder is None:
+            return True
+        try:
+            params = self._params_getter()
+            self.set_objective_function(self._objective_builder(params))
+        except (ValueError, AssertionError) as exc:
+            self.append_status_message(f"⚠ Cannot build objective: {exc}")
+            return False
+        return True
+
     def _on_run(self) -> None:
+        if not self._refresh_bound_objective():
+            return
         if self._objective_fn is None:
-            self._log.append("⚠ No objective function set. Run a simulation first.")
+            self.append_status_message(
+                "⚠ No objective function set. Run a simulation first."
+            )
             return
 
         n_params = self._n_torque_params * self._spin_degree.value()
@@ -654,17 +687,19 @@ class OptimizationWidget(QWidget):
         if self._chk_warm.isChecked() and self._last_best_coeffs is not None:
             if len(self._last_best_coeffs) == n_params:
                 warm_start = self._last_best_coeffs.copy()
-                self._log.append("🔄 Warm-starting from previous best solution")
+                self.append_status_message(
+                    "🔄 Warm-starting from previous best solution"
+                )
 
         self._log.clear()
-        self._log.append(f"Starting {method} optimization...")
-        self._log.append(
+        self.append_status_message(f"Starting {method} optimization...")
+        self.append_status_message(
             f"  Params: {n_params}, Generations: {n_iters}, Pop: {pop_size}"
         )
         if _HAS_NATIVE_BATCH and self._chk_native.isChecked():
-            self._log.append("  Backend: 🦀 Rust parallel (rayon)")
+            self.append_status_message("  Backend: 🦀 Rust parallel (rayon)")
         else:
-            self._log.append("  Backend: 🐍 Python sequential")
+            self.append_status_message("  Backend: 🐍 Python sequential")
         self._progress.setValue(0)
         self._convergence_history.clear()
         self._btn_run.setEnabled(False)
@@ -730,18 +765,22 @@ class OptimizationWidget(QWidget):
             self._last_best_coeffs = np.array(coeffs).copy()
 
         self._lbl_status.setText(f"{'✓' if success else '⚠'} Speed: {speed:.4f} m/s")
-        self._log.append(f"\n{'✓' if success else '⚠'} {method} optimization complete:")
-        self._log.append(f"  Max speed: {speed:.4f} m/s")
-        self._log.append(f"  Status: {msg}")
+        self.append_status_message(
+            f"\n{'✓' if success else '⚠'} {method} optimization complete:"
+        )
+        self.append_status_message(f"  Max speed: {speed:.4f} m/s")
+        self.append_status_message(f"  Status: {msg}")
 
         # Convergence summary
         if self._convergence_history:
             n_gens = len(self._convergence_history)
             best = min(self._convergence_history)
-            self._log.append(f"  Generations: {n_gens}, Best loss: {best:.6f}")
+            self.append_status_message(
+                f"  Generations: {n_gens}, Best loss: {best:.6f}"
+            )
 
         if coeffs is not None:
-            self._log.append(
+            self.append_status_message(
                 f"  Coefficients: {np.array2string(np.asarray(coeffs), precision=4)}"
             )
 
@@ -754,10 +793,12 @@ class OptimizationWidget(QWidget):
         self._btn_cancel.setEnabled(False)
         self._progress.setValue(0)
         self._lbl_status.setText("⚠ Error")
-        self._log.append(f"\n⚠ Optimization error: {msg}")
+        self.append_status_message(f"\n⚠ Optimization error: {msg}")
         logger.error("Optimization error: %s", msg)
 
     def _on_apply(self) -> None:
         if self._result is not None:
             self.optimized_coefficients.emit(self._result)
-            self._log.append("\n✓ Applied optimized coefficients to controls.")
+            self.append_status_message(
+                "\n✓ Applied optimized coefficients to controls."
+            )

--- a/src/pendulum_simulator/src/double_pendulum_golf/gui/simulation_panel.py
+++ b/src/pendulum_simulator/src/double_pendulum_golf/gui/simulation_panel.py
@@ -293,23 +293,7 @@ class SimulationPanel(QWidget):
             _obj_builder = self.objective_builder  # capture for closure
             if not (callable(_obj_builder)):
                 raise ValueError("objective_builder must be callable")
-
-            # Before each optimizer run, rebuild the objective with current params
-            orig_on_run = opt._on_run
-
-            def _patched_on_run() -> None:
-                """Build objective from current UI params, then run optimizer."""
-                try:
-                    p = self.controls.get_params()
-                    obj_fn = _obj_builder(p)
-                    opt.set_objective_function(obj_fn)
-                except (ValueError, AssertionError) as e:
-                    opt._log.append(f"⚠ Cannot build objective: {e}")
-                    return
-                orig_on_run()
-
-            opt._btn_run.clicked.disconnect()
-            opt._btn_run.clicked.connect(_patched_on_run)
+            opt.bind_objective_builder(self.controls.get_params, _obj_builder)
 
             # Wire apply back to controls (set torque coefficients)
             opt.optimized_coefficients.connect(self._apply_optimized_coefficients)

--- a/src/pendulum_simulator/tests/test_optimization_widget.py
+++ b/src/pendulum_simulator/tests/test_optimization_widget.py
@@ -180,3 +180,27 @@ def test_optimization_widget_ui(mock_start, qapp) -> Any:
     # Clean up what happens when cancel is pressed
     # the worker internally receives cancel
     assert w._worker._cancelled is True
+
+
+def test_optimization_widget_bound_objective_builder(qapp) -> Any:
+    w = OptimizationWidget("Test Model", 2)
+    params_getter = MagicMock(return_value={"gain": 3.0})
+    objective_builder = MagicMock(return_value=dummy_objective)
+
+    w.bind_objective_builder(params_getter, objective_builder)
+    assert w._refresh_bound_objective() is True
+
+    params_getter.assert_called_once()
+    objective_builder.assert_called_once_with({"gain": 3.0})
+    assert w._objective_fn is dummy_objective
+
+
+def test_optimization_widget_bound_objective_builder_error(qapp) -> Any:
+    w = OptimizationWidget("Test Model", 2)
+    params_getter = MagicMock(side_effect=ValueError("bad params"))
+    objective_builder = MagicMock()
+
+    w.bind_objective_builder(params_getter, objective_builder)
+
+    assert w._refresh_bound_objective() is False
+    assert "Cannot build objective" in w._log.toPlainText()

--- a/src/pendulum_simulator/tests/test_simulation_panel.py
+++ b/src/pendulum_simulator/tests/test_simulation_panel.py
@@ -109,10 +109,8 @@ def mock_sim_kwargs() -> Any:
 
         def __init__(self):
             super().__init__()
-            self._btn_run = MagicMock()
-            self._log = MagicMock()
+            self.bind_objective_builder = MagicMock()
             self.set_objective_function = MagicMock()
-            self._on_run = MagicMock()
 
     opt = MockOpt()
 
@@ -381,16 +379,13 @@ def test_apply_optimized_coefficients(qapp, mock_sim_kwargs) -> Any:
 def test_patched_on_run_optimizer(qapp, mock_sim_kwargs) -> Any:
     panel = SimulationPanel(**mock_sim_kwargs)
 
-    # Access the patched on run method to cover lines 294-301
-    panel.optimizer._btn_run.clicked.emit()
+    panel.optimizer.bind_objective_builder.assert_called_once()
+    params_getter, objective_builder = panel.optimizer.bind_objective_builder.call_args[
+        0
+    ]
 
-    # Test ValueError
-    panel.controls.get_params = MagicMock(side_effect=ValueError("test val"))
-    panel.optimizer._btn_run.clicked.emit()
-
-    # Test AssertionError
-    panel.controls.get_params = MagicMock(side_effect=AssertionError("test err"))
-    panel.optimizer._btn_run.clicked.emit()
+    assert params_getter is panel.controls.get_params
+    assert objective_builder is panel.objective_builder
 
 
 def test_sim_worker() -> Any:


### PR DESCRIPTION
## Summary
- add a public objective-binding API on OptimizationWidget
- move pre-run objective refresh and error logging behind the widget boundary
- update pendulum widget and panel tests and bump SPEC.md

## Validation
- python -m ruff check src/pendulum_simulator/src/double_pendulum_golf/gui/optimization_widget.py src/pendulum_simulator/src/double_pendulum_golf/gui/simulation_panel.py src/pendulum_simulator/tests/test_optimization_widget.py src/pendulum_simulator/tests/test_simulation_panel.py
- python -m black --check src/pendulum_simulator/src/double_pendulum_golf/gui/optimization_widget.py src/pendulum_simulator/src/double_pendulum_golf/gui/simulation_panel.py src/pendulum_simulator/tests/test_optimization_widget.py src/pendulum_simulator/tests/test_simulation_panel.py
- python -m mypy --follow-imports skip src/pendulum_simulator/src/double_pendulum_golf/gui/optimization_widget.py src/pendulum_simulator/src/double_pendulum_golf/gui/simulation_panel.py
- python -m pytest src/pendulum_simulator/tests/test_optimization_widget.py -q -n 0
- python -m pytest src/pendulum_simulator/tests/test_simulation_panel.py -q -n 0 *(blocked locally: importing simulation_panel.py fails because this workstation's PyQt6 QtSvg DLL load is broken before tests run)*

Closes #1935