### PR TITLE
🎨 Palette: Add keyboard focus indicators to ToolsPanel

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -25,11 +25,10 @@
 | **GitHub URL**          | `https://github.com/D-sorganization/Tools` |
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
-<<<<<<< HEAD
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.19                                     |
-| **Last Spec Update**    | 2026-04-06                                 |
+| **Spec Version**        | 1.1.20                                     |
+| **Last Spec Update**    | 2026-04-07                                 |
 
 ## 2. Purpose & Mission
 
@@ -445,7 +444,6 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 ## 12. Change Log
 
-<<<<<<< HEAD
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | 2026-03-28 | 1.0.0   | Initial specification                                                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -478,6 +476,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-06 | 1.1.17 | Optimize Polynomial Regression Matrix Construction in AnalyticsSuite using single-pass loops. |
 | 2026-04-06 | 1.1.18 | Refactored `applyFilter` inside `useDataProcessor.ts` to pre-allocate buffers and run the mapping in a single loop. |
 | 2026-04-06 | 1.1.19 | Split `pressure_drop_interface.py` into facade-oriented `pressure_drop_api`, `pressure_drop_validation`, `pressure_drop_reference`, and `pressure_drop_results` modules while preserving the public interface and extending regression coverage for the pressure-drop calculator. |
+| 2026-04-07 | 1.1.20 | Added explicit `focus-visible` keyboard focus indicators to the Video Processor web `ToolsPanel` buttons, color controls, slider, and destructive action buttons so keyboard navigation remains visible throughout the drawing workflow. |
 
 ---
 

--- a/src/media_processing/video_processor/apps/web/components/tools/ToolsPanel.tsx
+++ b/src/media_processing/video_processor/apps/web/components/tools/ToolsPanel.tsx
@@ -61,7 +61,7 @@ const ToolsPanel = memo(function ToolsPanel({
               onClick={() => !disabled && onToolChange(tool.id)}
               disabled={disabled}
               className={`
-                px-3 py-2 text-sm font-medium rounded-md transition-colors
+                px-3 py-2 text-sm font-medium rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
                 ${
                   currentTool === tool.id
                     ? 'bg-blue-600 text-white'
@@ -88,7 +88,7 @@ const ToolsPanel = memo(function ToolsPanel({
               onClick={() => !disabled && onColorChange(color)}
               disabled={disabled}
               className={`
-                w-full h-10 rounded-md border-2 transition-all
+                w-full h-10 rounded-md border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500
                 ${
                   currentColor === color
                     ? 'border-gray-900 ring-2 ring-offset-2 ring-blue-500'
@@ -108,7 +108,7 @@ const ToolsPanel = memo(function ToolsPanel({
           value={currentColor}
           onChange={(e) => !disabled && onColorChange(e.target.value)}
           disabled={disabled}
-          className="mt-2 w-full h-10 rounded-md border border-gray-300 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+          className="mt-2 w-full h-10 rounded-md border border-gray-300 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-label="Custom color picker"
         />
       </div>
@@ -126,7 +126,7 @@ const ToolsPanel = memo(function ToolsPanel({
             !disabled && onStrokeWidthChange(parseInt(e.target.value))
           }
           disabled={disabled}
-          className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           aria-labelledby="stroke-width-label"
         />
       </div>
@@ -135,14 +135,14 @@ const ToolsPanel = memo(function ToolsPanel({
         <button
           onClick={onDeleteSelected}
           disabled={disabled || currentTool !== 'select'}
-          className="w-full px-4 py-2 text-sm font-medium text-red-700 bg-red-50 rounded-md hover:bg-red-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="w-full px-4 py-2 text-sm font-medium text-red-700 bg-red-50 rounded-md hover:bg-red-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >
           Delete Selected
         </button>
         <button
           onClick={onClear}
           disabled={disabled}
-          className="w-full px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="w-full px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >
           Clear All
         </button>


### PR DESCRIPTION
### 💡 What:
Added visual focus indicators (`focus-visible:ring-2`) to all interactive elements (buttons, custom color pickers, range sliders) in the `ToolsPanel` component of the Video Analyzer.

### 🎯 Why:
To ensure the interface is fully keyboard-navigable. Previously, elements in the ToolsPanel lacked visible states when focused via the keyboard, creating a frustrating experience for users relying on keyboard navigation or screen readers.

### 📸 Before/After:
Before: Tabbing through the tools panel gave no indication of which element was focused.
After: Interactive elements now display a distinct blue focus ring when navigated to via the keyboard.

### ♿ Accessibility:
*   Significantly improved keyboard navigation by adding explicit `focus-visible` styles to elements.
*   Ensured adherence to WCAG guidelines regarding clear visual indicators of focus.
*   Used standard existing Tailwind CSS variables (blue ring) to maintain consistency with the rest of the application.

---
*PR created automatically by Jules for task [5742274354512197370](https://jules.google.com/task/5742274354512197370) started by @dieterolson*