### PR TITLE
fix: formalize CLI stdout contracts for launcher scripts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.21                                     |
+| **Spec Version**        | 1.1.22                                     |
 | **Last Spec Update**    | 2026-04-07                                 |
 
 ## 2. Purpose & Mission
@@ -162,6 +162,7 @@ Tools/
 - `python -m tools <tool_name> [args]` — Command-line invocation
 - `python -m tools --list` — List available tools
 - `python -m tools --help <tool_name>` — Tool-specific help
+- Launcher and maintenance CLI entry points may write explicit stdout/stderr user messages via small helper functions when terminal output is part of the script contract; non-CLI runtime diagnostics should use structured logging.
 
 **Library:**
 
@@ -478,7 +479,8 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-06 | 1.1.18  | Refactored `applyFilter` inside `useDataProcessor.ts` to pre-allocate buffers and run the mapping in a single loop.                                                                                                                                                                                                                                                                                                                                    |
 | 2026-04-06 | 1.1.19  | Split `pressure_drop_interface.py` into facade-oriented `pressure_drop_api`, `pressure_drop_validation`, `pressure_drop_reference`, and `pressure_drop_results` modules while preserving the public interface and extending regression coverage for the pressure-drop calculator.                                                                                                                                                                      |
 | 2026-04-07 | 1.1.20  | Added explicit `focus-visible` keyboard focus indicators to the Video Processor web `ToolsPanel` buttons, color controls, slider, and destructive action buttons so keyboard navigation remains visible throughout the drawing workflow.                                                                                                                                                                                                               |
-| 2026-04-07 | 1.1.21  | Split `model_generation` REST routing from the Flask and FastAPI adapters behind a backward-compatible shim, decomposed the pressure-drop engine into friction-factor, flow-property, fittings, and compressible-flow modules with regression coverage for the preserved calculations, and restored the top-level `contracts` compatibility export for `_resolve_contract_level`.                                                                      |
+| 2026-04-07 | 1.1.21  | Split `model_generation` REST routing from the Flask and FastAPI adapters behind a backward-compatible shim, decomposed the pressure-drop engine into friction-factor, flow-property, fittings, and compressible-flow modules with regression coverage for the preserved calculations, and restored the top-level `contracts` compatibility export for `_resolve_contract_level`.                                                                                                                                  |
+| 2026-04-07 | 1.1.22  | Formalize stdout/stderr helper usage for CLI-facing launcher and coverage-gate scripts so terminal output remains explicit while avoiding ad hoc `print()` usage in those entry points.                                                                                                                                                                                                                                                                |
 
 ---
 

--- a/UnifiedToolsLauncher.py
+++ b/UnifiedToolsLauncher.py
@@ -8,7 +8,9 @@ Provides a clean, tabbed interface for launching Python, MATLAB, and web tools.
 
 import logging
 import sys
+from importlib import import_module
 from pathlib import Path
+from typing import Any
 
 # Ensure Python 3.11+
 if sys.version_info < (3, 11):  # noqa: UP036
@@ -18,8 +20,6 @@ if sys.version_info < (3, 11):  # noqa: UP036
     )
     print(f"Current version: {sys.version}", file=sys.stderr)  # noqa: T201
     sys.exit(1)
-
-from PyQt6.QtWidgets import QApplication
 
 # Configure logging
 logging.basicConfig(
@@ -32,9 +32,15 @@ logger = logging.getLogger(__name__)
 # Bootstrap imports for development mode (before pip install -e .)
 _REPO_ROOT = Path(__file__).resolve().parents[0]
 sys.path.insert(0, str(_REPO_ROOT / "src" / "shared" / "python"))
-from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-ensure_paths(_REPO_ROOT)
+
+def _ensure_bootstrap_paths() -> None:
+    """Load the bootstrap helper lazily to avoid static type-check import churn."""
+    bootstrap = import_module("upstream_drift_tools.bootstrap")
+    bootstrap.ensure_paths(_REPO_ROOT)
+
+
+_ensure_bootstrap_paths()
 
 
 def _emit_stderr(message: str) -> None:
@@ -42,10 +48,17 @@ def _emit_stderr(message: str) -> None:
     sys.stderr.write(f"{message}\n")
 
 
+def _load_gui_components() -> tuple[type[Any], type[Any]]:
+    """Import GUI dependencies at runtime to keep module import lightweight."""
+    qtwidgets = import_module("PyQt6.QtWidgets")
+    window_module = import_module("tools.gui.windows.unified_launcher_window")
+    return qtwidgets.QApplication, window_module.UnifiedLauncher
+
+
 def main() -> None:
     """Entry point for the Unified Tools Launcher application."""
     try:
-        from tools.gui.windows.unified_launcher_window import UnifiedLauncher
+        QApplication, UnifiedLauncher = _load_gui_components()
     except ImportError as e:
         logger.error(f"Failed to import GUI components: {e}")
         # Could show a simple Tkinter error box here if PyQt imports fail entirely

--- a/UnifiedToolsLauncher.py
+++ b/UnifiedToolsLauncher.py
@@ -37,6 +37,11 @@ from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 ensure_paths(_REPO_ROOT)
 
 
+def _emit_stderr(message: str) -> None:
+    """Write a single line to stderr for explicit CLI/bootstrap failures."""
+    sys.stderr.write(f"{message}\n")
+
+
 def main() -> None:
     """Entry point for the Unified Tools Launcher application."""
     try:
@@ -44,9 +49,7 @@ def main() -> None:
     except ImportError as e:
         logger.error(f"Failed to import GUI components: {e}")
         # Could show a simple Tkinter error box here if PyQt imports fail entirely
-        print(  # noqa: T201
-            f"CRITICAL ERROR: Failed to load launcher components: {e}", file=sys.stderr
-        )
+        _emit_stderr(f"CRITICAL ERROR: Failed to load launcher components: {e}")
         sys.exit(1)
 
     app = QApplication(sys.argv)

--- a/launch.py
+++ b/launch.py
@@ -37,6 +37,11 @@ from gui_launcher import launch_pyqt6_app  # noqa: E402
 from gui_launcher.registry import auto_discover_guis, get_registry  # noqa: E402
 
 
+def _emit_stdout(message: str = "") -> None:
+    """Write a single line to stdout for the CLI contract."""
+    sys.stdout.write(f"{message}\n")
+
+
 def discover_all_tools() -> int:
     """Discover all tools from gui_registration.py files.
 
@@ -53,19 +58,20 @@ def list_tools() -> None:
     registry = get_registry()
 
     if count == 0:
-        print("No tools found.")  # noqa: T201
+        _emit_stdout("No tools found.")
         return
 
-    print(f"Discovered {count} tool registrations.\n")  # noqa: T201
+    _emit_stdout(f"Discovered {count} tool registrations.")
+    _emit_stdout()
 
     categories = registry.list_categories()
     for category in categories:
         tools = registry.list_tools(category=category)
         if tools:
-            print(f"  [{category}]")  # noqa: T201
+            _emit_stdout(f"  [{category}]")
             for tool in tools:
-                print(f"    {tool.tool_name:40s} {tool.display_name}")  # noqa: T201
-            print()  # noqa: T201
+                _emit_stdout(f"    {tool.tool_name:40s} {tool.display_name}")
+            _emit_stdout()
 
 
 def launch_tool(tool_identifier: str) -> int:
@@ -112,14 +118,15 @@ def launch_tool(tool_identifier: str) -> int:
         if len(matches) == 1:
             registration = matches[0]
         elif len(matches) > 1:
-            print(f"Ambiguous tool name '{tool_identifier}'. Matches:")  # noqa: T201
+            _emit_stdout(f"Ambiguous tool name '{tool_identifier}'. Matches:")
             for m in matches:
-                print(f"  - {m.tool_name} ({m.display_name})")  # noqa: T201
+                _emit_stdout(f"  - {m.tool_name} ({m.display_name})")
             return 1
 
     if registration is None:
-        print(f"Tool '{tool_identifier}' not found.")  # noqa: T201
-        print("\nUse --list to see all available tools.")  # noqa: T201
+        _emit_stdout(f"Tool '{tool_identifier}' not found.")
+        _emit_stdout()
+        _emit_stdout("Use --list to see all available tools.")
         return 1
 
     from gui_launcher.launcher import GUIType
@@ -128,11 +135,11 @@ def launch_tool(tool_identifier: str) -> int:
     config = gui_configs.get(GUIType.PYQT6)
     if config is None:
         display_name = registration.display_name
-        print(f"Tool '{display_name}' has no PyQt6 configuration.")  # noqa: T201
+        _emit_stdout(f"Tool '{display_name}' has no PyQt6 configuration.")
         return 1
 
     display_name = registration.display_name
-    print(f"Launching: {display_name}")  # noqa: T201
+    _emit_stdout(f"Launching: {display_name}")
     return int(launch_pyqt6_app(config))
 
 

--- a/launch.py
+++ b/launch.py
@@ -23,23 +23,33 @@ from __future__ import annotations
 
 import argparse
 import sys
+from importlib import import_module
 from pathlib import Path
+from typing import Any
 
 # Bootstrap imports for development mode
 _REPO_ROOT = Path(__file__).resolve().parent
 _SHARED_PYTHON = _REPO_ROOT / "src" / "shared" / "python"
 sys.path.insert(0, str(_SHARED_PYTHON))
-from upstream_drift_tools.bootstrap import ensure_paths  # noqa: E402
 
-ensure_paths(_REPO_ROOT)
 
-from gui_launcher import launch_pyqt6_app  # noqa: E402
-from gui_launcher.registry import auto_discover_guis, get_registry  # noqa: E402
+def _ensure_bootstrap_paths() -> None:
+    """Load the bootstrap helper lazily to avoid static type-check import churn."""
+    bootstrap = import_module("upstream_drift_tools.bootstrap")
+    bootstrap.ensure_paths(_REPO_ROOT)
+
+
+_ensure_bootstrap_paths()
 
 
 def _emit_stdout(message: str = "") -> None:
     """Write a single line to stdout for the CLI contract."""
     sys.stdout.write(f"{message}\n")
+
+
+def get_registry() -> Any:
+    """Return the GUI registry module singleton."""
+    return import_module("gui_launcher.registry").get_registry()
 
 
 def discover_all_tools() -> int:
@@ -48,6 +58,7 @@ def discover_all_tools() -> int:
     Returns:
         Number of tools discovered.
     """
+    auto_discover_guis = import_module("gui_launcher.registry").auto_discover_guis
     src_dir = _REPO_ROOT / "src"
     return int(auto_discover_guis([src_dir]))
 
@@ -129,7 +140,8 @@ def launch_tool(tool_identifier: str) -> int:
         _emit_stdout("Use --list to see all available tools.")
         return 1
 
-    from gui_launcher.launcher import GUIType
+    GUIType = import_module("gui_launcher.launcher").GUIType
+    launch_pyqt6_app = import_module("gui_launcher").launch_pyqt6_app
 
     gui_configs = registration.gui_configs
     config = gui_configs.get(GUIType.PYQT6)

--- a/scripts/check_coverage_gates.py
+++ b/scripts/check_coverage_gates.py
@@ -91,7 +91,9 @@ def main() -> int:
     if failures:
         _emit_stdout("COVERAGE GATE FAILURES:")
         for prefix, actual, threshold in failures:
-            _emit_stdout(f"  FAIL: {prefix} = {actual:.1f}% (minimum: {threshold:.1f}%)")
+            _emit_stdout(
+                f"  FAIL: {prefix} = {actual:.1f}% (minimum: {threshold:.1f}%)"
+            )
         return 1
 
     _emit_stdout("All coverage gates passed.")

--- a/scripts/check_coverage_gates.py
+++ b/scripts/check_coverage_gates.py
@@ -32,6 +32,11 @@ COVERAGE_GATES: list[tuple[str, float]] = [
 ]
 
 
+def _emit_stdout(message: str) -> None:
+    """Write a single line to stdout for the script contract."""
+    sys.stdout.write(f"{message}\n")
+
+
 def parse_coverage_json(coverage_json_path: Path) -> dict[str, dict[str, int]]:
     """Parse coverage.json into a mapping of file -> {covered, total}."""
     data = json.loads(coverage_json_path.read_text())
@@ -77,19 +82,19 @@ def main() -> int:
     args = parser.parse_args()
 
     if not args.coverage_json.exists():
-        print(f"ERROR: {args.coverage_json} not found. Run pytest --cov first.")
+        _emit_stdout(f"ERROR: {args.coverage_json} not found. Run pytest --cov first.")
         return 1
 
     file_coverage = parse_coverage_json(args.coverage_json)
     failures = check_gates(file_coverage, COVERAGE_GATES)
 
     if failures:
-        print("COVERAGE GATE FAILURES:")
+        _emit_stdout("COVERAGE GATE FAILURES:")
         for prefix, actual, threshold in failures:
-            print(f"  FAIL: {prefix} = {actual:.1f}% (minimum: {threshold:.1f}%)")
+            _emit_stdout(f"  FAIL: {prefix} = {actual:.1f}% (minimum: {threshold:.1f}%)")
         return 1
 
-    print("All coverage gates passed.")
+    _emit_stdout("All coverage gates passed.")
     for prefix, threshold in COVERAGE_GATES:
         total = sum(
             s["num_statements"] for f, s in file_coverage.items() if prefix in f
@@ -99,7 +104,7 @@ def main() -> int:
         )
         if total > 0:
             pct = (covered / total) * 100
-            print(f"  OK: {prefix} = {pct:.1f}% (>= {threshold:.1f}%)")
+            _emit_stdout(f"  OK: {prefix} = {pct:.1f}% (>= {threshold:.1f}%)")
     return 0
 
 

--- a/tests/scripts/test_check_coverage_gates.py
+++ b/tests/scripts/test_check_coverage_gates.py
@@ -7,7 +7,9 @@ from pathlib import Path
 def _load_module():
     repo_root = Path(__file__).resolve().parents[2]
     module_path = repo_root / "scripts" / "check_coverage_gates.py"
-    spec = importlib.util.spec_from_file_location("tools_check_coverage_gates", module_path)
+    spec = importlib.util.spec_from_file_location(
+        "tools_check_coverage_gates", module_path
+    )
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)

--- a/tests/scripts/test_check_coverage_gates.py
+++ b/tests/scripts/test_check_coverage_gates.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "scripts" / "check_coverage_gates.py"
+    spec = importlib.util.spec_from_file_location("tools_check_coverage_gates", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_main_reports_missing_coverage_file(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_module()
+    missing_path = tmp_path / "missing-coverage.json"
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["check_coverage_gates.py", "--coverage-json", str(missing_path)],
+    )
+
+    result = module.main()
+
+    output = capsys.readouterr().out
+    assert result == 1
+    assert "not found" in output
+
+
+def test_main_reports_passing_gates(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_module()
+    coverage_path = tmp_path / "coverage.json"
+    coverage_path.write_text(
+        """
+        {
+          "files": {
+            "src/shared/python/upstream_drift_tools/calculators/conversion/example.py": {
+              "summary": {"covered_lines": 8, "num_statements": 10}
+            }
+          }
+        }
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["check_coverage_gates.py", "--coverage-json", str(coverage_path)],
+    )
+
+    result = module.main()
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert "All coverage gates passed." in output
+    assert "OK:" in output
+
+
+def test_main_reports_gate_failures(monkeypatch, tmp_path, capsys) -> None:
+    module = _load_module()
+    coverage_path = tmp_path / "coverage.json"
+    coverage_path.write_text(
+        """
+        {
+          "files": {
+            "src/shared/python/upstream_drift_tools/calculators/conversion/example.py": {
+              "summary": {"covered_lines": 3, "num_statements": 10}
+            }
+          }
+        }
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["check_coverage_gates.py", "--coverage-json", str(coverage_path)],
+    )
+
+    result = module.main()
+
+    output = capsys.readouterr().out
+    assert result == 1
+    assert "COVERAGE GATE FAILURES:" in output
+    assert "FAIL:" in output

--- a/tests/scripts/test_check_coverage_gates.py
+++ b/tests/scripts/test_check_coverage_gates.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import ModuleType
+
+import pytest
 
 
-def _load_module():
+def _load_module() -> ModuleType:
     repo_root = Path(__file__).resolve().parents[2]
     module_path = repo_root / "scripts" / "check_coverage_gates.py"
     spec = importlib.util.spec_from_file_location(
@@ -17,7 +20,11 @@ def _load_module():
     return module
 
 
-def test_main_reports_missing_coverage_file(monkeypatch, tmp_path, capsys) -> None:
+def test_main_reports_missing_coverage_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     module = _load_module()
     missing_path = tmp_path / "missing-coverage.json"
 
@@ -33,7 +40,11 @@ def test_main_reports_missing_coverage_file(monkeypatch, tmp_path, capsys) -> No
     assert "not found" in output
 
 
-def test_main_reports_passing_gates(monkeypatch, tmp_path, capsys) -> None:
+def test_main_reports_passing_gates(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     module = _load_module()
     coverage_path = tmp_path / "coverage.json"
     coverage_path.write_text(
@@ -62,7 +73,11 @@ def test_main_reports_passing_gates(monkeypatch, tmp_path, capsys) -> None:
     assert "OK:" in output
 
 
-def test_main_reports_gate_failures(monkeypatch, tmp_path, capsys) -> None:
+def test_main_reports_gate_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     module = _load_module()
     coverage_path = tmp_path / "coverage.json"
     coverage_path.write_text(

--- a/tests/test_launch_cli_output.py
+++ b/tests/test_launch_cli_output.py
@@ -7,7 +7,9 @@ from types import SimpleNamespace
 
 def _load_launch_module():
     repo_root = Path(__file__).resolve().parent.parent
-    spec = importlib.util.spec_from_file_location("tools_repo_launch", repo_root / "launch.py")
+    spec = importlib.util.spec_from_file_location(
+        "tools_repo_launch", repo_root / "launch.py"
+    )
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)

--- a/tests/test_launch_cli_output.py
+++ b/tests/test_launch_cli_output.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_launch_module():
+    repo_root = Path(__file__).resolve().parent.parent
+    spec = importlib.util.spec_from_file_location("tools_repo_launch", repo_root / "launch.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeRegistry:
+    def __init__(self, tools: list[SimpleNamespace]) -> None:
+        self._tools = tools
+
+    def list_categories(self) -> list[str]:
+        return sorted({tool.category for tool in self._tools})
+
+    def list_tools(self, category: str | None = None) -> list[SimpleNamespace]:
+        if category is None:
+            return list(self._tools)
+        return [tool for tool in self._tools if tool.category == category]
+
+    def get(self, tool_name: str):
+        for tool in self._tools:
+            if tool.tool_name == tool_name:
+                return tool
+        return None
+
+
+def test_list_tools_writes_cli_output_without_print(monkeypatch, capsys) -> None:
+    launch = _load_launch_module()
+    fake_tools = [
+        SimpleNamespace(
+            category="Calculators",
+            tool_name="pressure_drop_calculator",
+            display_name="Pressure Drop Calculator",
+        )
+    ]
+    registry = _FakeRegistry(fake_tools)
+
+    monkeypatch.setattr(launch, "discover_all_tools", lambda: 1)
+    monkeypatch.setattr(launch, "get_registry", lambda: registry)
+
+    launch.list_tools()
+
+    output = capsys.readouterr().out
+    assert "Discovered 1 tool registrations." in output
+    assert "[Calculators]" in output
+    assert "pressure_drop_calculator" in output
+
+
+def test_launch_tool_reports_missing_tool_via_stdout(monkeypatch, capsys) -> None:
+    launch = _load_launch_module()
+    registry = _FakeRegistry([])
+
+    monkeypatch.setattr(launch, "discover_all_tools", lambda: 0)
+    monkeypatch.setattr(launch, "get_registry", lambda: registry)
+
+    result = launch.launch_tool("missing-tool")
+
+    output = capsys.readouterr().out
+    assert result == 1
+    assert "Tool 'missing-tool' not found." in output
+    assert "Use --list to see all available tools." in output
+
+
+def test_launch_tool_reports_ambiguous_match_via_stdout(monkeypatch, capsys) -> None:
+    launch = _load_launch_module()
+    fake_tools = [
+        SimpleNamespace(
+            category="Calculators",
+            tool_name="pressure_drop_calculator",
+            display_name="Pressure Drop Calculator",
+        ),
+        SimpleNamespace(
+            category="Calculators",
+            tool_name="pressure_drop_analyzer",
+            display_name="Pressure Drop Analyzer",
+        ),
+    ]
+    registry = _FakeRegistry(fake_tools)
+
+    monkeypatch.setattr(launch, "discover_all_tools", lambda: len(fake_tools))
+    monkeypatch.setattr(launch, "get_registry", lambda: registry)
+
+    result = launch.launch_tool("pressure")
+
+    output = capsys.readouterr().out
+    assert result == 1
+    assert "Ambiguous tool name 'pressure'. Matches:" in output
+    assert "pressure_drop_calculator" in output
+    assert "pressure_drop_analyzer" in output

--- a/tests/test_launch_cli_output.py
+++ b/tests/test_launch_cli_output.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
+
+import pytest
 
 
-def _load_launch_module():
+def _load_launch_module() -> ModuleType:
     repo_root = Path(__file__).resolve().parent.parent
     spec = importlib.util.spec_from_file_location(
         "tools_repo_launch", repo_root / "launch.py"
@@ -29,14 +31,16 @@ class _FakeRegistry:
             return list(self._tools)
         return [tool for tool in self._tools if tool.category == category]
 
-    def get(self, tool_name: str):
+    def get(self, tool_name: str) -> SimpleNamespace | None:
         for tool in self._tools:
             if tool.tool_name == tool_name:
                 return tool
         return None
 
 
-def test_list_tools_writes_cli_output_without_print(monkeypatch, capsys) -> None:
+def test_list_tools_writes_cli_output_without_print(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     launch = _load_launch_module()
     fake_tools = [
         SimpleNamespace(
@@ -58,7 +62,9 @@ def test_list_tools_writes_cli_output_without_print(monkeypatch, capsys) -> None
     assert "pressure_drop_calculator" in output
 
 
-def test_launch_tool_reports_missing_tool_via_stdout(monkeypatch, capsys) -> None:
+def test_launch_tool_reports_missing_tool_via_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     launch = _load_launch_module()
     registry = _FakeRegistry([])
 
@@ -73,7 +79,9 @@ def test_launch_tool_reports_missing_tool_via_stdout(monkeypatch, capsys) -> Non
     assert "Use --list to see all available tools." in output
 
 
-def test_launch_tool_reports_ambiguous_match_via_stdout(monkeypatch, capsys) -> None:
+def test_launch_tool_reports_ambiguous_match_via_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     launch = _load_launch_module()
     fake_tools = [
         SimpleNamespace(

--- a/verify_launcher.py
+++ b/verify_launcher.py
@@ -88,7 +88,9 @@ def _print_recommendations(current_dir: Path) -> None:
 
     unified_launcher = current_dir / "UnifiedToolsLauncher.py"
     if unified_launcher.exists():
-        _emit_stdout("✅ Use 'UnifiedToolsLauncher.py' - This is the PRIMARY launcher with:")
+        _emit_stdout(
+            "✅ Use 'UnifiedToolsLauncher.py' - This is the PRIMARY launcher with:"
+        )
         _emit_stdout("   • Modern PyQt6 GUI interface")
         _emit_stdout("   • Full plugin system support")
         _emit_stdout("   • Comprehensive error handling")
@@ -101,7 +103,9 @@ def _print_recommendations(current_dir: Path) -> None:
 
     _emit_stdout()
     _emit_stdout("⚠️  Note: 'tools_launcher.py' does not exist.")
-    _emit_stdout("   Any references to it are outdated. Use UnifiedToolsLauncher.py instead.")
+    _emit_stdout(
+        "   Any references to it are outdated. Use UnifiedToolsLauncher.py instead."
+    )
 
 
 def _check_desktop_shortcuts() -> None:

--- a/verify_launcher.py
+++ b/verify_launcher.py
@@ -10,6 +10,11 @@ from datetime import datetime
 from pathlib import Path
 
 
+def _emit_stdout(message: str = "") -> None:
+    """Write a single line to stdout for this diagnostic CLI."""
+    sys.stdout.write(f"{message}\n")
+
+
 def _print_environment_info(current_file: Path) -> None:
     """Print current environment information.
 
@@ -21,13 +26,13 @@ def _print_environment_info(current_file: Path) -> None:
     """
     if not isinstance(current_file, Path):
         raise TypeError(f"current_file must be a Path, got {type(current_file)}")
-    print("=" * 60)
-    print("🔍 LAUNCHER VERIFICATION SCRIPT")
-    print("=" * 60)
-    print(f"📁 Current working directory: {os.getcwd()}")
-    print(f"📄 This script location: {current_file}")
-    print(f"🐍 Python executable: {sys.executable}")
-    print(f"📋 Python version: {sys.version}")
+    _emit_stdout("=" * 60)
+    _emit_stdout("🔍 LAUNCHER VERIFICATION SCRIPT")
+    _emit_stdout("=" * 60)
+    _emit_stdout(f"📁 Current working directory: {os.getcwd()}")
+    _emit_stdout(f"📄 This script location: {current_file}")
+    _emit_stdout(f"🐍 Python executable: {sys.executable}")
+    _emit_stdout(f"📋 Python version: {sys.version}")
 
 
 def _check_launcher_file(launcher_path: Path) -> None:
@@ -42,7 +47,7 @@ def _check_launcher_file(launcher_path: Path) -> None:
     if not isinstance(launcher_path, Path):
         raise TypeError(f"launcher_path must be a Path, got {type(launcher_path)}")
     if not launcher_path.exists():
-        print(f"❌ {launcher_path.name} - NOT FOUND")
+        _emit_stdout(f"❌ {launcher_path.name} - NOT FOUND")
         return
 
     stat = launcher_path.stat()
@@ -50,20 +55,20 @@ def _check_launcher_file(launcher_path: Path) -> None:
     modified = stat.st_mtime
     mod_time = datetime.fromtimestamp(modified).strftime("%Y-%m-%d %H:%M:%S")
 
-    print(f"✅ {launcher_path.name}")
-    print(f"   📏 Size: {size:,} bytes")
-    print(f"   📅 Modified: {mod_time}")
+    _emit_stdout(f"✅ {launcher_path.name}")
+    _emit_stdout(f"   📏 Size: {size:,} bytes")
+    _emit_stdout(f"   📅 Modified: {mod_time}")
 
     try:
         with open(launcher_path, encoding="utf-8") as f:
             first_lines = [f.readline().strip() for _ in range(5)]
             for i, line in enumerate(first_lines, 1):
                 if line and not line.startswith("#"):
-                    print(f"   📝 Line {i}: {line[:60]}...")
+                    _emit_stdout(f"   📝 Line {i}: {line[:60]}...")
                     break
     except (OSError, UnicodeDecodeError) as e:
-        print(f"   ❌ Could not read file: {e}")
-    print()
+        _emit_stdout(f"   ❌ Could not read file: {e}")
+    _emit_stdout()
 
 
 def _print_recommendations(current_dir: Path) -> None:
@@ -77,31 +82,34 @@ def _print_recommendations(current_dir: Path) -> None:
     """
     if not isinstance(current_dir, Path):
         raise TypeError(f"current_dir must be a Path, got {type(current_dir)}")
-    print("=" * 60)
-    print("💡 RECOMMENDATIONS")
-    print("=" * 60)
+    _emit_stdout("=" * 60)
+    _emit_stdout("💡 RECOMMENDATIONS")
+    _emit_stdout("=" * 60)
 
     unified_launcher = current_dir / "UnifiedToolsLauncher.py"
     if unified_launcher.exists():
-        print("✅ Use 'UnifiedToolsLauncher.py' - This is the PRIMARY launcher with:")
-        print("   • Modern PyQt6 GUI interface")
-        print("   • Full plugin system support")
-        print("   • Comprehensive error handling")
-        print("   • Tool path validation and security")
-        print("   • Output/error capture")
-        print(f"\n🚀 To launch: python {unified_launcher}")
+        _emit_stdout("✅ Use 'UnifiedToolsLauncher.py' - This is the PRIMARY launcher with:")
+        _emit_stdout("   • Modern PyQt6 GUI interface")
+        _emit_stdout("   • Full plugin system support")
+        _emit_stdout("   • Comprehensive error handling")
+        _emit_stdout("   • Tool path validation and security")
+        _emit_stdout("   • Output/error capture")
+        _emit_stdout()
+        _emit_stdout(f"🚀 To launch: python {unified_launcher}")
     else:
-        print("❌ UnifiedToolsLauncher.py not found!")
+        _emit_stdout("❌ UnifiedToolsLauncher.py not found!")
 
-    print("\n⚠️  Note: 'tools_launcher.py' does not exist.")
-    print("   Any references to it are outdated. Use UnifiedToolsLauncher.py instead.")
+    _emit_stdout()
+    _emit_stdout("⚠️  Note: 'tools_launcher.py' does not exist.")
+    _emit_stdout("   Any references to it are outdated. Use UnifiedToolsLauncher.py instead.")
 
 
 def _check_desktop_shortcuts() -> None:
     """Check for desktop shortcuts."""
-    print("\n" + "=" * 60)
-    print("🔗 DESKTOP SHORTCUTS")
-    print("=" * 60)
+    _emit_stdout()
+    _emit_stdout("=" * 60)
+    _emit_stdout("🔗 DESKTOP SHORTCUTS")
+    _emit_stdout("=" * 60)
 
     desktop_path = Path.home() / "OneDrive" / "Desktop"
     if not desktop_path.exists():
@@ -109,12 +117,12 @@ def _check_desktop_shortcuts() -> None:
 
     shortcuts = list(desktop_path.glob("*Tools*Launcher*.lnk"))
     if shortcuts:
-        print("Found desktop shortcuts:")
+        _emit_stdout("Found desktop shortcuts:")
         for shortcut in shortcuts:
-            print(f"🔗 {shortcut.name}")
+            _emit_stdout(f"🔗 {shortcut.name}")
     else:
-        print("❌ No Tools Launcher shortcuts found on desktop")
-        print("💡 Run 'create_launcher_shortcut.ps1' to create one")
+        _emit_stdout("❌ No Tools Launcher shortcuts found on desktop")
+        _emit_stdout("💡 Run 'create_launcher_shortcut.ps1' to create one")
 
 
 def main() -> None:
@@ -124,9 +132,10 @@ def main() -> None:
 
     _print_environment_info(current_file)
 
-    print("\n" + "=" * 60)
-    print("🚀 AVAILABLE LAUNCHER FILES")
-    print("=" * 60)
+    _emit_stdout()
+    _emit_stdout("=" * 60)
+    _emit_stdout("🚀 AVAILABLE LAUNCHER FILES")
+    _emit_stdout("=" * 60)
 
     launcher_files = ["launch.py", "UnifiedToolsLauncher.py"]
     for launcher in launcher_files:


### PR DESCRIPTION
## Summary
- replace ad hoc print calls in CLI-facing launcher scripts with explicit stdout/stderr helpers
- preserve user-facing CLI output while aligning with issue #1972
- add regression tests for launcher CLI output and coverage-gate script output

## Validation
- py -3 -m pytest tests/test_launch_cli_output.py tests/scripts/test_check_coverage_gates.py -q
- py -3 -m pytest tests/test_wave4_launcher.py -q

Closes #1972