### PR TITLE
refactor: split time-series decomposition contracts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.29                                     |
+| **Spec Version**        | 1.1.30                                     |
 | **Last Spec Update**    | 2026-04-07                                 |
 
 ## 2. Purpose & Mission
@@ -487,6 +487,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-07 | 1.1.27  | Optimized `AnalyticsSuite` regression filtering by staging selected x/y series values into `Float64Array` buffers before converting them back to plain arrays for the existing result contract, reducing repeated push-allocation overhead in large regression workloads.                                                                                                                                                                              |
 | 2026-04-07 | 1.1.28  | Optimized `AnalyticsSuite` Pearson correlation by preserving the PR's single-pass accumulation and variance-clamping path while widening the helper to accept pre-allocated `Float64Array` inputs from the newer analytics data flow.                                                                                                                                                                                                                  |
 | 2026-04-07 | 1.1.29  | Decomposed the PSA GUI into focused `ui/` modules while tightening the compatibility export surface to immutable `__all__` tuples in both the facade module and the extracted UI package.                                                                                                                                                                                                                                                              |
+| 2026-04-07 | 1.1.30  | Extracted the public enums/dataclass contracts and low-level helper kernels for `time_series_decomposition` into focused support modules, leaving the main module centered on decomposition orchestration while preserving the existing public import surface through the compatibility facade.                                                                                                                                                      |
 
 ---
 

--- a/src/data_processing/data_processor/python/data_processor/core/time_series_decomposition.py
+++ b/src/data_processing/data_processor/python/data_processor/core/time_series_decomposition.py
@@ -20,145 +20,33 @@ Features:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any
 
 import numpy as np
 from numba import jit
 
+from data_processor.core.time_series_decomposition_contracts import (
+    DecompositionConfig,
+    DecompositionMethod,
+    DecompositionResult,
+    SeasonalityDetectionResult,
+    SeasonalModel,
+    TrendModel,
+)
+from data_processor.core.time_series_decomposition_helpers import (
+    autocorrelation,
+    centered_moving_average,
+    exponential_smooth,
+    extract_stl_seasonal,
+    extrapolate_exponential,
+    find_acf_peaks,
+    hp_filter,
+    lowess_smooth,
+    moving_average,
+    polynomial_trend,
+)
+
 logger = logging.getLogger(__name__)
-
-
-class DecompositionMethod(Enum):
-    """Available decomposition methods."""
-
-    STL = "stl"
-    CLASSICAL_ADDITIVE = "classical_additive"
-    CLASSICAL_MULTIPLICATIVE = "classical_multiplicative"
-    MOVING_AVERAGE = "moving_average"
-    LOWESS = "lowess"
-    HP_FILTER = "hp_filter"  # Hodrick-Prescott filter
-
-
-class SeasonalModel(Enum):
-    """Seasonal model types."""
-
-    ADDITIVE = "additive"
-    MULTIPLICATIVE = "multiplicative"
-
-
-class TrendModel(Enum):
-    """Trend estimation methods."""
-
-    MOVING_AVERAGE = "moving_average"
-    LOWESS = "lowess"
-    POLYNOMIAL = "polynomial"
-    EXPONENTIAL = "exponential"
-    HP_FILTER = "hp_filter"
-
-
-@dataclass
-class DecompositionConfig:
-    """Configuration for time-series decomposition."""
-
-    # General settings
-    method: DecompositionMethod = DecompositionMethod.STL
-    seasonal_model: SeasonalModel = SeasonalModel.ADDITIVE
-
-    # Seasonality settings
-    period: int | None = None  # Auto-detect if None
-    seasonal_deg: int = 1  # Degree of LOESS for seasonal extraction
-    seasonal_jump: int = 1  # LOESS jump for seasonal
-
-    # Trend settings
-    trend_deg: int = 1  # Degree of LOESS for trend extraction
-    trend_jump: int = 1  # LOESS jump for trend
-    low_pass_deg: int = 1  # Degree of LOESS for low-pass filter
-    low_pass_jump: int = 1  # LOESS jump for low-pass
-
-    # Robustness
-    robust: bool = False  # Use robust fitting (iterative re-weighting)
-    robust_iterations: int = 2  # Number of robustness iterations
-
-    # HP filter
-    hp_lambda: float = 1600.0  # Smoothing parameter for HP filter
-
-    # Moving average
-    ma_window: int | None = None  # Window size for moving average
-
-    # Polynomial trend
-    polynomial_degree: int = 2
-
-
-@dataclass
-class DecompositionResult:
-    """Results from time-series decomposition."""
-
-    # Original data
-    observed: np.ndarray
-
-    # Decomposed components
-    trend: np.ndarray
-    seasonal: np.ndarray
-    residual: np.ndarray
-
-    # Method information
-    method: DecompositionMethod
-    seasonal_model: SeasonalModel
-    period: int
-
-    # Quality metrics
-    trend_strength: float = 0.0
-    seasonal_strength: float = 0.0
-    residual_variance: float = 0.0
-
-    # Optional: multiple seasonalities
-    seasonal_components: dict[int, np.ndarray] = field(default_factory=dict)
-
-    # Statistics
-    residual_mean: float = 0.0
-    residual_std: float = 0.0
-    residual_autocorrelation: float = 0.0
-
-    def get_deseasonalized(self) -> np.ndarray:
-        """Get data with seasonal component removed."""
-        if self.seasonal_model == SeasonalModel.ADDITIVE:
-            return self.observed - self.seasonal
-        else:
-            return self.observed / np.where(self.seasonal != 0, self.seasonal, 1.0)
-
-    def get_detrended(self) -> np.ndarray:
-        """Get data with trend removed."""
-        if self.seasonal_model == SeasonalModel.ADDITIVE:
-            return self.observed - self.trend
-        else:
-            return self.observed / np.where(self.trend != 0, self.trend, 1.0)
-
-    def get_seasonally_adjusted(self) -> np.ndarray:
-        """Get seasonally adjusted series (trend + residual)."""
-        if self.seasonal_model == SeasonalModel.ADDITIVE:
-            return self.trend + self.residual
-        else:
-            return self.trend * self.residual
-
-    def reconstruct(self) -> np.ndarray:
-        """Reconstruct original series from components."""
-        if self.seasonal_model == SeasonalModel.ADDITIVE:
-            return self.trend + self.seasonal + self.residual
-        else:
-            return self.trend * self.seasonal * self.residual
-
-
-@dataclass
-class SeasonalityDetectionResult:
-    """Results from seasonality detection."""
-
-    detected_periods: list[int]
-    period_strengths: dict[int, float]
-    dominant_period: int | None
-    is_seasonal: bool
-    autocorrelation_peaks: list[int]
 
 
 class TimeSeriesDecomposer:
@@ -255,10 +143,10 @@ class TimeSeriesDecomposer:
             max_period = min(n // 2, 365)  # Reasonable default
 
         # Calculate autocorrelation
-        acf = self._autocorrelation(data, max_period)
+        acf = autocorrelation(data, max_period)
 
         # Find peaks in ACF
-        peaks = self._find_acf_peaks(acf)
+        peaks = find_acf_peaks(acf)
 
         # Calculate strength for each peak
         period_strengths = {}
@@ -310,23 +198,23 @@ class TimeSeriesDecomposer:
 
         if method == TrendModel.MOVING_AVERAGE:
             window = kwargs.get("window", self.config.ma_window or len(data) // 10)
-            return self._moving_average(data, window)
+            return moving_average(data, window)
 
         elif method == TrendModel.LOWESS:
             frac = kwargs.get("frac", 0.3)
-            return self._lowess_smooth(data, frac)
+            return lowess_smooth(data, frac)
 
         elif method == TrendModel.POLYNOMIAL:
             degree = kwargs.get("degree", self.config.polynomial_degree)
-            return self._polynomial_trend(data, degree)
+            return polynomial_trend(data, degree)
 
         elif method == TrendModel.EXPONENTIAL:
             alpha = kwargs.get("alpha", 0.3)
-            return self._exponential_smooth(data, alpha)
+            return exponential_smooth(data, alpha)
 
         elif method == TrendModel.HP_FILTER:
             lambd = kwargs.get("lambda", self.config.hp_lambda)
-            return self._hp_filter(data, lambd)
+            return hp_filter(data, lambd)
 
         else:
             raise ValueError(f"Unknown trend method: {method}")
@@ -411,7 +299,7 @@ class TimeSeriesDecomposer:
         # Extract each seasonal component
         for period in periods:
             # Extract trend from current residual
-            trend = self._moving_average(residual, period)
+            trend = moving_average(residual, period)
 
             # Detrend
             detrended = residual - trend
@@ -425,7 +313,7 @@ class TimeSeriesDecomposer:
             residual = residual - seasonal
 
         # Final trend extraction
-        trend = self._moving_average(residual, periods[-1])
+        trend = moving_average(residual, periods[-1])
         final_residual = residual - trend
 
         result = DecompositionResult(
@@ -472,7 +360,7 @@ class TimeSeriesDecomposer:
             trend_forecast = np.full(horizon, result.trend[-1])
         else:
             # Exponential extrapolation
-            trend_forecast = self._extrapolate_exponential(result.trend, horizon)
+            trend_forecast = extrapolate_exponential(result.trend, horizon)
 
         # Forecast seasonal (just repeat the pattern)
         period = result.period
@@ -541,7 +429,7 @@ class TimeSeriesDecomposer:
         # Initial trend using moving average
         if not (data is not None):
             raise ValueError("data must be provided")
-        trend = self._moving_average(data, period)
+        trend = moving_average(data, period)
 
         # Iterate for robustness
         iterations = self.config.robust_iterations if self.config.robust else 1
@@ -551,11 +439,11 @@ class TimeSeriesDecomposer:
             detrended = data - trend
 
             # Extract seasonal
-            seasonal = self._extract_stl_seasonal(detrended, period)
+            seasonal = extract_stl_seasonal(detrended, period)
 
             # Calculate new trend from deseasonalized data
             deseasonalized = data - seasonal
-            trend = self._lowess_smooth(deseasonalized, frac=0.3)
+            trend = lowess_smooth(deseasonalized, frac=0.3)
 
         # Calculate residual
         residual = data - trend - seasonal
@@ -582,7 +470,7 @@ class TimeSeriesDecomposer:
         n = len(data)
 
         # Step 1: Calculate trend using centered moving average
-        trend = self._centered_moving_average(data, period)
+        trend = centered_moving_average(data, period)
 
         # Step 2: Detrend
         if model == SeasonalModel.ADDITIVE:
@@ -633,7 +521,7 @@ class TimeSeriesDecomposer:
         # Trend
         if not (data is not None):
             raise ValueError("data must be provided")
-        trend = self._moving_average(data, period)
+        trend = moving_average(data, period)
 
         # Detrend
         detrended = data - trend
@@ -659,7 +547,7 @@ class TimeSeriesDecomposer:
         # Trend using LOWESS
         if not (data is not None):
             raise ValueError("data must be provided")
-        trend = self._lowess_smooth(data, frac=0.3)
+        trend = lowess_smooth(data, frac=0.3)
 
         # Detrend
         detrended = data - trend
@@ -687,7 +575,7 @@ class TimeSeriesDecomposer:
         # Trend using HP filter
         if not (data is not None):
             raise ValueError("data must be provided")
-        trend = self._hp_filter(data, self.config.hp_lambda)
+        trend = hp_filter(data, self.config.hp_lambda)
 
         # Cycle (detrended)
         cycle = data - trend
@@ -707,243 +595,6 @@ class TimeSeriesDecomposer:
             seasonal_model=SeasonalModel.ADDITIVE,
             period=period,
         )
-
-    # Helper methods
-    @jit(nopython=True, fastmath=True)
-    def _moving_average(self, data: np.ndarray, window: int) -> np.ndarray:
-        """Calculate moving average."""
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        if window < 1:
-            window = 1
-        if window > len(data):
-            window = len(data)
-
-        # Use convolution for efficiency
-        kernel = np.ones(window) / window
-        ma = np.convolve(data, kernel, mode="same")
-
-        # Handle edges
-        half = window // 2
-        for i in range(half):
-            ma[i] = np.mean(data[: i + half + 1])
-            ma[-(i + 1)] = np.mean(data[-(i + half + 1) :])
-
-        return ma
-
-    @jit(nopython=True, fastmath=True)
-    def _centered_moving_average(self, data: np.ndarray, period: int) -> np.ndarray:
-        """Calculate centered moving average for classical decomposition."""
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        n = len(data)
-        result = np.full(n, np.nan)
-
-        half = period // 2
-
-        for i in range(half, n - half):
-            if period % 2 == 0:
-                # For even periods, use weighted average
-                result[i] = (
-                    0.5 * data[i - half]
-                    + np.sum(data[i - half + 1 : i + half])
-                    + 0.5 * data[i + half]
-                ) / period
-            else:
-                result[i] = np.mean(data[i - half : i + half + 1])
-
-        # Fill edges with nearest valid values
-        first_valid = half
-        last_valid = n - half - 1
-
-        result[:first_valid] = result[first_valid]
-        result[last_valid + 1 :] = result[last_valid]
-
-        return result
-
-    @jit(nopython=True, fastmath=True)
-    def _lowess_smooth(self, data: np.ndarray, frac: float = 0.3) -> np.ndarray:
-        """LOWESS (Locally Weighted Scatterplot Smoothing)."""
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        n = len(data)
-        x = np.arange(n)
-        result = np.zeros(n)
-
-        # Number of points to use for local regression
-        k = max(int(frac * n), 2)
-
-        for i in range(n):
-            # Calculate distances
-            distances = np.abs(x - x[i])
-
-            # Get k nearest neighbors
-            nearest_idx = np.argsort(distances)[:k]
-
-            # Calculate weights using tricube kernel
-            max_dist = distances[nearest_idx[-1]]
-            if max_dist == 0:
-                max_dist = 1.0
-            u = distances[nearest_idx] / max_dist
-            weights = (1 - u**3) ** 3
-            weights = np.clip(weights, 0, None)
-
-            # Weighted linear regression
-            x_local = x[nearest_idx]
-            y_local = data[nearest_idx]
-
-            # Weighted least squares
-            sum_w = np.sum(weights)
-            if sum_w == 0:
-                result[i] = data[i]
-                continue
-
-            sum_wx = np.sum(weights * x_local)
-            sum_wy = np.sum(weights * y_local)
-            sum_wxx = np.sum(weights * x_local * x_local)
-            sum_wxy = np.sum(weights * x_local * y_local)
-
-            denom = sum_w * sum_wxx - sum_wx * sum_wx
-            if abs(denom) < 1e-10:
-                result[i] = sum_wy / sum_w
-            else:
-                b = (sum_w * sum_wxy - sum_wx * sum_wy) / denom
-                a = (sum_wy - b * sum_wx) / sum_w
-                result[i] = a + b * x[i]
-
-        return result
-
-    def _polynomial_trend(self, data: np.ndarray, degree: int) -> np.ndarray:
-        """Fit polynomial trend."""
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        n = len(data)
-        x = np.arange(n)
-        coeffs = np.polyfit(x, data, degree)
-        return np.polyval(coeffs, x)
-
-    @jit(nopython=True, fastmath=True)
-    def _exponential_smooth(self, data: np.ndarray, alpha: float) -> np.ndarray:
-        """Exponential smoothing."""
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        n = len(data)
-        result = np.zeros(n)
-        result[0] = data[0]
-
-        for i in range(1, n):
-            result[i] = alpha * data[i] + (1 - alpha) * result[i - 1]
-
-        return result
-
-    @jit(nopython=True, fastmath=True)
-    def _hp_filter(self, data: np.ndarray, lambd: float) -> np.ndarray:
-        """Hodrick-Prescott filter implementation."""
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        n = len(data)
-
-        # Construct the penalty matrix
-        # Second difference matrix
-        d2 = np.zeros((n - 2, n))
-        for i in range(n - 2):
-            d2[i, i] = 1
-            d2[i, i + 1] = -2
-            d2[i, i + 2] = 1
-
-        # Solve (I + lambda * D2' * D2) * trend = data
-        penalty = lambd * d2.T @ d2
-        identity = np.eye(n)
-
-        try:
-            trend = np.linalg.solve(identity + penalty, data)
-        except np.linalg.LinAlgError:
-            # Fallback to pseudo-inverse
-            trend = np.linalg.lstsq(identity + penalty, data, rcond=None)[0]
-
-        return trend
-
-    def _extract_stl_seasonal(self, detrended: np.ndarray, period: int) -> np.ndarray:
-        """Extract seasonal component for STL."""
-        if not (detrended is not None):
-            raise ValueError("detrended must be provided")
-        n = len(detrended)
-
-        # Calculate cycle-subseries
-        seasonal_indices = np.zeros(period)
-
-        for i in range(period):
-            subseries = detrended[i::period]
-            # Apply LOWESS to each subseries
-            smoothed = self._lowess_smooth(subseries, frac=0.5)
-            seasonal_indices[i] = np.mean(smoothed)
-
-        # Normalize
-        seasonal_indices -= np.mean(seasonal_indices)
-
-        # Tile to match data length
-        seasonal = np.tile(seasonal_indices, n // period + 1)[:n]
-
-        return seasonal
-
-    @jit(nopython=True, fastmath=True)
-    def _autocorrelation(self, data: np.ndarray, max_lag: int) -> np.ndarray:
-        """Calculate autocorrelation function."""
-        if not (data is not None):
-            raise ValueError("data must be provided")
-        n = len(data)
-        data_centered = data - np.mean(data)
-        var = np.var(data_centered)
-
-        if var == 0:
-            return np.zeros(max_lag + 1)
-
-        acf = np.zeros(max_lag + 1)
-        acf[0] = 1.0
-
-        for lag in range(1, max_lag + 1):
-            acf[lag] = np.sum(data_centered[lag:] * data_centered[:-lag]) / (
-                (n - lag) * var
-            )
-
-        return acf
-
-    @jit(nopython=True, fastmath=True)
-    def _find_acf_peaks(self, acf: np.ndarray) -> list[int]:
-        """Find peaks in autocorrelation function."""
-        if not (acf is not None):
-            raise ValueError("acf must be provided")
-        peaks = []
-        n = len(acf)
-
-        for i in range(2, n - 1):
-            if acf[i] > acf[i - 1] and acf[i] > acf[i + 1] and acf[i] > 0.1:
-                peaks.append(i)
-
-        return peaks
-
-    def _extrapolate_exponential(self, trend: np.ndarray, horizon: int) -> np.ndarray:
-        """Extrapolate trend exponentially."""
-        # Fit exponential to last portion of trend
-        if not (trend is not None):
-            raise ValueError("trend must be provided")
-        n = len(trend)
-        fit_length = min(n, 50)
-
-        x = np.arange(fit_length)
-        y = trend[-fit_length:]
-
-        # Log transform for linear fit
-        y_pos = y - np.min(y) + 1
-        log_y = np.log(y_pos)
-
-        slope, intercept = np.polyfit(x, log_y, 1)
-
-        # Extrapolate
-        future_x = np.arange(fit_length, fit_length + horizon)
-        forecast = np.exp(intercept + slope * future_x) + np.min(y) - 1
-
-        return forecast
 
     def _calculate_metrics(self, result: DecompositionResult) -> DecompositionResult:
         """Calculate quality metrics for decomposition."""
@@ -970,7 +621,7 @@ class TimeSeriesDecomposer:
 
         # Residual autocorrelation (lag 1)
         if len(result.residual) > 1:
-            acf = self._autocorrelation(result.residual, 1)
+            acf = autocorrelation(result.residual, 1)
             result.residual_autocorrelation = float(acf[1]) if len(acf) > 1 else 0.0
 
         return result

--- a/src/data_processing/data_processor/python/data_processor/core/time_series_decomposition_contracts.py
+++ b/src/data_processing/data_processor/python/data_processor/core/time_series_decomposition_contracts.py
@@ -1,0 +1,121 @@
+"""Public contracts for time-series decomposition."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+import numpy as np
+
+
+class DecompositionMethod(Enum):
+    """Available decomposition methods."""
+
+    STL = "stl"
+    CLASSICAL_ADDITIVE = "classical_additive"
+    CLASSICAL_MULTIPLICATIVE = "classical_multiplicative"
+    MOVING_AVERAGE = "moving_average"
+    LOWESS = "lowess"
+    HP_FILTER = "hp_filter"
+
+
+class SeasonalModel(Enum):
+    """Seasonal model types."""
+
+    ADDITIVE = "additive"
+    MULTIPLICATIVE = "multiplicative"
+
+
+class TrendModel(Enum):
+    """Trend estimation methods."""
+
+    MOVING_AVERAGE = "moving_average"
+    LOWESS = "lowess"
+    POLYNOMIAL = "polynomial"
+    EXPONENTIAL = "exponential"
+    HP_FILTER = "hp_filter"
+
+
+@dataclass
+class DecompositionConfig:
+    """Configuration for time-series decomposition."""
+
+    method: DecompositionMethod = DecompositionMethod.STL
+    seasonal_model: SeasonalModel = SeasonalModel.ADDITIVE
+    period: int | None = None
+    seasonal_deg: int = 1
+    seasonal_jump: int = 1
+    trend_deg: int = 1
+    trend_jump: int = 1
+    low_pass_deg: int = 1
+    low_pass_jump: int = 1
+    robust: bool = False
+    robust_iterations: int = 2
+    hp_lambda: float = 1600.0
+    ma_window: int | None = None
+    polynomial_degree: int = 2
+
+
+@dataclass
+class DecompositionResult:
+    """Results from time-series decomposition."""
+
+    observed: np.ndarray
+    trend: np.ndarray
+    seasonal: np.ndarray
+    residual: np.ndarray
+    method: DecompositionMethod
+    seasonal_model: SeasonalModel
+    period: int
+    trend_strength: float = 0.0
+    seasonal_strength: float = 0.0
+    residual_variance: float = 0.0
+    seasonal_components: dict[int, np.ndarray] = field(default_factory=dict)
+    residual_mean: float = 0.0
+    residual_std: float = 0.0
+    residual_autocorrelation: float = 0.0
+
+    def get_deseasonalized(self) -> np.ndarray:
+        """Get data with seasonal component removed."""
+        if self.seasonal_model == SeasonalModel.ADDITIVE:
+            return self.observed - self.seasonal
+        return self.observed / np.where(self.seasonal != 0, self.seasonal, 1.0)
+
+    def get_detrended(self) -> np.ndarray:
+        """Get data with trend removed."""
+        if self.seasonal_model == SeasonalModel.ADDITIVE:
+            return self.observed - self.trend
+        return self.observed / np.where(self.trend != 0, self.trend, 1.0)
+
+    def get_seasonally_adjusted(self) -> np.ndarray:
+        """Get seasonally adjusted series."""
+        if self.seasonal_model == SeasonalModel.ADDITIVE:
+            return self.trend + self.residual
+        return self.trend * self.residual
+
+    def reconstruct(self) -> np.ndarray:
+        """Reconstruct original series from components."""
+        if self.seasonal_model == SeasonalModel.ADDITIVE:
+            return self.trend + self.seasonal + self.residual
+        return self.trend * self.seasonal * self.residual
+
+
+@dataclass
+class SeasonalityDetectionResult:
+    """Results from seasonality detection."""
+
+    detected_periods: list[int]
+    period_strengths: dict[int, float]
+    dominant_period: int | None
+    is_seasonal: bool
+    autocorrelation_peaks: list[int]
+
+
+__all__ = [
+    "DecompositionConfig",
+    "DecompositionMethod",
+    "DecompositionResult",
+    "SeasonalModel",
+    "SeasonalityDetectionResult",
+    "TrendModel",
+]

--- a/src/data_processing/data_processor/python/data_processor/core/time_series_decomposition_helpers.py
+++ b/src/data_processing/data_processor/python/data_processor/core/time_series_decomposition_helpers.py
@@ -1,0 +1,215 @@
+"""Low-level numeric helpers for time-series decomposition."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+from numba import jit
+
+
+@jit(nopython=True, fastmath=True)
+def moving_average(data: np.ndarray, window: int) -> np.ndarray:
+    """Calculate a centered moving average."""
+    if data is None:
+        raise ValueError("data must be provided")
+    if window < 1:
+        window = 1
+    if window > len(data):
+        window = len(data)
+
+    kernel = np.ones(window) / window
+    averaged = np.convolve(data, kernel, mode="same")
+
+    half = window // 2
+    for i in range(half):
+        averaged[i] = np.mean(data[: i + half + 1])
+        averaged[-(i + 1)] = np.mean(data[-(i + half + 1) :])
+
+    return averaged
+
+
+@jit(nopython=True, fastmath=True)
+def centered_moving_average(data: np.ndarray, period: int) -> np.ndarray:
+    """Calculate centered moving average for classical decomposition."""
+    if data is None:
+        raise ValueError("data must be provided")
+    n = len(data)
+    result = np.full(n, np.nan)
+    half = period // 2
+
+    for i in range(half, n - half):
+        if period % 2 == 0:
+            result[i] = (
+                0.5 * data[i - half]
+                + np.sum(data[i - half + 1 : i + half])
+                + 0.5 * data[i + half]
+            ) / period
+        else:
+            result[i] = np.mean(data[i - half : i + half + 1])
+
+    first_valid = half
+    last_valid = n - half - 1
+    result[:first_valid] = result[first_valid]
+    result[last_valid + 1 :] = result[last_valid]
+    return result
+
+
+@jit(nopython=True, fastmath=True)
+def lowess_smooth(data: np.ndarray, frac: float = 0.3) -> np.ndarray:
+    """LOWESS (Locally Weighted Scatterplot Smoothing)."""
+    if data is None:
+        raise ValueError("data must be provided")
+    n = len(data)
+    x = np.arange(n)
+    result = np.zeros(n)
+    neighbors = max(int(frac * n), 2)
+
+    for i in range(n):
+        distances = np.abs(x - x[i])
+        nearest_idx = np.argsort(distances)[:neighbors]
+        max_dist = distances[nearest_idx[-1]]
+        if max_dist == 0:
+            max_dist = 1.0
+        u = distances[nearest_idx] / max_dist
+        weights = (1 - u**3) ** 3
+        weights = np.clip(weights, 0, None)
+
+        x_local = x[nearest_idx]
+        y_local = data[nearest_idx]
+        sum_w = np.sum(weights)
+        if sum_w == 0:
+            result[i] = data[i]
+            continue
+
+        sum_wx = np.sum(weights * x_local)
+        sum_wy = np.sum(weights * y_local)
+        sum_wxx = np.sum(weights * x_local * x_local)
+        sum_wxy = np.sum(weights * x_local * y_local)
+        denom = sum_w * sum_wxx - sum_wx * sum_wx
+        if abs(denom) < 1e-10:
+            result[i] = sum_wy / sum_w
+        else:
+            slope = (sum_w * sum_wxy - sum_wx * sum_wy) / denom
+            intercept = (sum_wy - slope * sum_wx) / sum_w
+            result[i] = intercept + slope * x[i]
+
+    return result
+
+
+def polynomial_trend(data: np.ndarray, degree: int) -> np.ndarray:
+    """Fit a polynomial trend line."""
+    if data is None:
+        raise ValueError("data must be provided")
+    x = np.arange(len(data))
+    coefficients = np.polyfit(x, data, degree)
+    return np.polyval(coefficients, x)
+
+
+@jit(nopython=True, fastmath=True)
+def exponential_smooth(data: np.ndarray, alpha: float) -> np.ndarray:
+    """Apply exponential smoothing."""
+    if data is None:
+        raise ValueError("data must be provided")
+    result = np.zeros(len(data))
+    result[0] = data[0]
+    for i in range(1, len(data)):
+        result[i] = alpha * data[i] + (1 - alpha) * result[i - 1]
+    return result
+
+
+@jit(nopython=True, fastmath=True)
+def hp_filter(data: np.ndarray, lambd: float) -> np.ndarray:
+    """Apply the Hodrick-Prescott filter."""
+    if data is None:
+        raise ValueError("data must be provided")
+    n = len(data)
+    second_difference = np.zeros((n - 2, n))
+    for i in range(n - 2):
+        second_difference[i, i] = 1
+        second_difference[i, i + 1] = -2
+        second_difference[i, i + 2] = 1
+
+    penalty = lambd * second_difference.T @ second_difference
+    identity = np.eye(n)
+    try:
+        return np.linalg.solve(identity + penalty, data)
+    except np.linalg.LinAlgError:
+        return np.linalg.lstsq(identity + penalty, data, rcond=None)[0]
+
+
+def extract_stl_seasonal(
+    detrended: np.ndarray,
+    period: int,
+    smoother: Callable[[np.ndarray, float], np.ndarray] = lowess_smooth,
+) -> np.ndarray:
+    """Extract the STL seasonal component for a detrended series."""
+    if detrended is None:
+        raise ValueError("detrended must be provided")
+    seasonal_indices = np.zeros(period)
+
+    for offset in range(period):
+        subseries = detrended[offset::period]
+        smoothed = smoother(subseries, frac=0.5)
+        seasonal_indices[offset] = np.mean(smoothed)
+
+    seasonal_indices -= np.mean(seasonal_indices)
+    return np.tile(seasonal_indices, len(detrended) // period + 1)[: len(detrended)]
+
+
+@jit(nopython=True, fastmath=True)
+def autocorrelation(data: np.ndarray, max_lag: int) -> np.ndarray:
+    """Calculate the autocorrelation function."""
+    if data is None:
+        raise ValueError("data must be provided")
+    centered = data - np.mean(data)
+    variance = np.var(centered)
+    if variance == 0:
+        return np.zeros(max_lag + 1)
+
+    acf = np.zeros(max_lag + 1)
+    acf[0] = 1.0
+    n = len(data)
+    for lag in range(1, max_lag + 1):
+        acf[lag] = np.sum(centered[lag:] * centered[:-lag]) / ((n - lag) * variance)
+    return acf
+
+
+@jit(nopython=True, fastmath=True)
+def find_acf_peaks(acf: np.ndarray) -> list[int]:
+    """Find dominant peaks in an autocorrelation sequence."""
+    if acf is None:
+        raise ValueError("acf must be provided")
+    peaks = []
+    for i in range(2, len(acf) - 1):
+        if acf[i] > acf[i - 1] and acf[i] > acf[i + 1] and acf[i] > 0.1:
+            peaks.append(i)
+    return peaks
+
+
+def extrapolate_exponential(trend: np.ndarray, horizon: int) -> np.ndarray:
+    """Extrapolate a trend using a log-linear fit over the tail."""
+    if trend is None:
+        raise ValueError("trend must be provided")
+    fit_length = min(len(trend), 50)
+    x = np.arange(fit_length)
+    y = trend[-fit_length:]
+    shifted = y - np.min(y) + 1
+    log_y = np.log(shifted)
+    slope, intercept = np.polyfit(x, log_y, 1)
+    future_x = np.arange(fit_length, fit_length + horizon)
+    return np.exp(intercept + slope * future_x) + np.min(y) - 1
+
+
+__all__ = [
+    "autocorrelation",
+    "centered_moving_average",
+    "exponential_smooth",
+    "extract_stl_seasonal",
+    "extrapolate_exponential",
+    "find_acf_peaks",
+    "hp_filter",
+    "lowess_smooth",
+    "moving_average",
+    "polynomial_trend",
+]

--- a/src/data_processing/data_processor/python/tests/test_advanced_analysis.py
+++ b/src/data_processing/data_processor/python/tests/test_advanced_analysis.py
@@ -278,6 +278,49 @@ class TestOutlierDetection:
 class TestTimeSeriesDecomposition:
     """Tests for time series decomposition module."""
 
+    def test_contracts_module_re_exports_public_types(self) -> None:
+        """Time-series contracts remain importable from a focused support module."""
+        from data_processor.core.time_series_decomposition import (
+            DecompositionConfig,
+            DecompositionMethod,
+            DecompositionResult,
+            SeasonalModel,
+            TrendModel,
+        )
+        from data_processor.core.time_series_decomposition_contracts import (
+            DecompositionConfig as ContractsDecompositionConfig,
+        )
+        from data_processor.core.time_series_decomposition_contracts import (
+            DecompositionMethod as ContractsDecompositionMethod,
+        )
+        from data_processor.core.time_series_decomposition_contracts import (
+            DecompositionResult as ContractsDecompositionResult,
+        )
+        from data_processor.core.time_series_decomposition_contracts import (
+            SeasonalModel as ContractsSeasonalModel,
+        )
+        from data_processor.core.time_series_decomposition_contracts import (
+            TrendModel as ContractsTrendModel,
+        )
+
+        assert ContractsDecompositionConfig is DecompositionConfig
+        assert ContractsDecompositionMethod is DecompositionMethod
+        assert ContractsDecompositionResult is DecompositionResult
+        assert ContractsSeasonalModel is SeasonalModel
+        assert ContractsTrendModel is TrendModel
+
+    def test_helper_module_exposes_moving_average_kernel(self) -> None:
+        """Low-level smoothing helpers remain importable outside the facade."""
+        from data_processor.core.time_series_decomposition_helpers import (
+            moving_average,
+        )
+
+        data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = moving_average(data, 3)
+
+        assert result.shape == data.shape
+        assert np.isclose(result[2], 3.0)
+
     def test_stl_decomposition(self) -> None:
         """Test STL decomposition."""
         from data_processor.core.time_series_decomposition import (


### PR DESCRIPTION
## Summary
- extract the public time-series decomposition enums and dataclasses into a dedicated contracts module
- extract low-level smoothing and autocorrelation helpers into a focused helper module
- preserve the existing public facade imports while reducing the monolith size of `time_series_decomposition.py`

## Root Cause
`time_series_decomposition.py` was carrying public contracts, orchestration, and numerical helper kernels in a single oversized module, which kept issue #1970 open even after other hotspot files had already been split.

## Validation
- `uv run --no-project --python 3.12 --with ruff ruff check --fix src/data_processing/data_processor/python/data_processor/core/time_series_decomposition.py src/data_processing/data_processor/python/data_processor/core/time_series_decomposition_helpers.py src/data_processing/data_processor/python/tests/test_advanced_analysis.py`
- `uv run --no-project --python 3.12 --with pytest --with numpy --with pandas --with numba --with scipy python -m pytest src/data_processing/data_processor/python/tests/test_advanced_analysis.py -k "helper_module_exposes_moving_average_kernel or contracts_module_re_exports_public_types or stl_decomposition or decompose_time_series_function or seasonality_detection" -q`

Closes #1970