### PR TITLE
⚡ Bolt: Memoize AnalyticsSuite chart data to prevent GC overhead

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.30                                     |
-| **Last Spec Update**    | 2026-04-07                                 |
+| **Spec Version**        | 1.1.31                                     |
+| **Last Spec Update**    | 2026-04-08                                 |
 
 ## 2. Purpose & Mission
 
@@ -488,6 +488,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-07 | 1.1.28  | Optimized `AnalyticsSuite` Pearson correlation by preserving the PR's single-pass accumulation and variance-clamping path while widening the helper to accept pre-allocated `Float64Array` inputs from the newer analytics data flow.                                                                                                                                                                                                                  |
 | 2026-04-07 | 1.1.29  | Decomposed the PSA GUI into focused `ui/` modules while tightening the compatibility export surface to immutable `__all__` tuples in both the facade module and the extracted UI package.                                                                                                                                                                                                                                                              |
 | 2026-04-07 | 1.1.30  | Extracted the public enums/dataclass contracts and low-level helper kernels for `time_series_decomposition` into focused support modules, leaving the main module centered on decomposition orchestration while preserving the existing public import surface through the compatibility facade.                                                                                                                                                      |
+| 2026-04-08 | 1.1.31  | Memoize AnalyticsSuite chart data using useMemo and optimize the scatter regression component with a single-pass loop, drastically reducing React rendering and GC overhead.                                                                                                                                                                                                                                                                        |
 ---
 
 <!--
@@ -515,3 +516,4 @@ Active development with stable core, continuous tool expansion, and web API in p
 - The PCA power iteration algorithm in `AnalyticsSuite` has been optimized to remove `.map()` and `.reduce()` from the tight inner loop, using pre-allocated arrays and standard `for` loops to eliminate thousands of allocations per execution.
 - PlotView WebGL rendering uses pre-allocated `Float64Array` buffers and single-pass loops instead of `data.map()`, eliminating O(N) intermediate array allocations for large datasets.
 - Pearson correlation matrix computations utilize a single-pass loop algorithm, calculating sums concurrently to drastically reduce iteration overhead compared to two-pass implementations, while carefully mitigating numerical instability via clamping.
+- Recharts component props in `AnalyticsSuite` are memoized using `useMemo` hooks to provide stable references and prevent expensive internal re-renders.

--- a/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
+++ b/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
@@ -500,6 +500,42 @@ export function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuit
     setRegression(result);
   }, [data, regXSignal, regYSignal, regDegree]);
 
+  // Memoize PCA chart data
+  const pcaScreeData = useMemo(() => {
+    if (!pca) return [];
+    return pca.explainedVariance.map((ev, i) => ({
+      name: `PC${i + 1}`,
+      variance: +(ev * 100).toFixed(1),
+      cumulative: +(pca.cumulativeVariance[i] * 100).toFixed(1),
+    }));
+  }, [pca]);
+
+  const pcaScatterData = useMemo(() => {
+    if (!pca || pca.numComponents < 2) return [];
+    return pca.scores.map((s) => ({ x: s[0], y: s[1] }));
+  }, [pca]);
+
+  // Memoize Regression chart data
+  const regressionScatterData = useMemo(() => {
+    if (!regression) return [];
+    // ⚡ Bolt Optimization: Use single-pass for loop to build scatter data, avoiding chained .map().filter() and GC overhead
+    const result = [];
+    for (let i = 0; i < data.length; i++) {
+      const row = data[i];
+      const x = row[regression.xSignal];
+      const y = row[regression.ySignal];
+      if (typeof x === 'number' && typeof y === 'number') {
+        result.push({ x, y });
+      }
+    }
+    return result;
+  }, [data, regression]);
+
+  const regressionResidualsData = useMemo(() => {
+    if (!regression) return [];
+    return regression.residuals.map((r, i) => ({ index: i, residual: r }));
+  }, [regression]);
+
   if (data.length === 0 || activeSignals.length < 2) {
     return (
       <div className="card">
@@ -580,13 +616,7 @@ export function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuit
             <div className="card-header">Scree Plot (Variance Explained)</div>
             <div className="card-body h-56">
               <ResponsiveContainer width="100%" height="100%">
-                <BarChart
-                  data={pca.explainedVariance.map((ev, i) => ({
-                    name: `PC${i + 1}`,
-                    variance: +(ev * 100).toFixed(1),
-                    cumulative: +(pca.cumulativeVariance[i] * 100).toFixed(1),
-                  }))}
-                >
+                <BarChart data={pcaScreeData}>
                   <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
                   <XAxis dataKey="name" stroke="#94a3b8" />
                   <YAxis stroke="#94a3b8" label={{ value: '%', angle: -90, position: 'insideLeft', fill: '#94a3b8' }} />
@@ -624,11 +654,8 @@ export function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuit
                       label={{ value: `PC2 (${(pca.explainedVariance[1] * 100).toFixed(1)}%)`, angle: -90, position: 'insideLeft', fill: '#94a3b8' }}
                     />
                     <Tooltip contentStyle={{ backgroundColor: '#1e293b', border: 'none' }} />
-                    <Scatter
-                      data={pca.scores.map((s) => ({ x: s[0], y: s[1] }))}
-                      fill="#3b82f6"
-                    >
-                      {pca.scores.map((_, i) => (
+                    <Scatter data={pcaScatterData} fill="#3b82f6">
+                      {pcaScatterData.map((_, i) => (
                         <Cell key={i} fill="#3b82f6" opacity={0.6} />
                       ))}
                     </Scatter>
@@ -763,13 +790,7 @@ export function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuit
                       <Tooltip contentStyle={{ backgroundColor: '#1e293b', border: 'none' }} />
                       <Scatter
                         name="Data"
-                        data={data
-                          .map((row) => ({
-                            x: typeof row[regression.xSignal] === 'number' ? row[regression.xSignal] : undefined,
-                            y: typeof row[regression.ySignal] === 'number' ? row[regression.ySignal] : undefined,
-                          }))
-                          .filter((d) => d.x !== undefined && d.y !== undefined)
-                        }
+                        data={regressionScatterData}
                         fill="#3b82f6"
                         opacity={0.5}
                       />
@@ -783,9 +804,7 @@ export function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuit
                 <div className="card-header">Residual Plot</div>
                 <div className="card-body h-48">
                   <ResponsiveContainer width="100%" height="100%">
-                    <LineChart
-                      data={regression.residuals.map((r, i) => ({ index: i, residual: r }))}
-                    >
+                    <LineChart data={regressionResidualsData}>
                       <CartesianGrid strokeDasharray="3 3" stroke="#334155" />
                       <XAxis dataKey="index" stroke="#94a3b8" />
                       <YAxis stroke="#94a3b8" />


### PR DESCRIPTION
💡 What: Extracted inline data mapping for Recharts components into `useMemo` hooks and replaced chained array operations for regression scatter plots with a single-pass loop.
🎯 Why: Passing new object references inline to charting libraries triggers massive and expensive internal re-renders. Furthermore, `.map().filter()` chains create severe garbage collection overhead in data-heavy components.
📊 Impact: Eliminates redundant chart component re-renders during React cycles and avoids allocating thousands of intermediate object wrappers, minimizing memory GC pauses.
🔬 Measurement: Run `npm run type-check` inside `src/data_processing/data_processor/web` to ensure types match correctly. Run the local preview and toggle parameters in the Analytics Suite Regression/PCA tabs to observe stutter-free transitions.

---
*PR created automatically by Jules for task [14329396813529447617](https://jules.google.com/task/14329396813529447617) started by @dieterolson*