### PR TITLE
🎨 Palette: Video control accessibility and keyboard focus improvements

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.30                                     |
-| **Last Spec Update**    | 2026-04-07                                 |
+| **Spec Version**        | 1.1.31                                     |
+| **Last Spec Update**    | 2026-04-08                                 |
 
 ## 2. Purpose & Mission
 

--- a/src/media_processing/video_processor/apps/web/components/video/FrameNavigator.tsx
+++ b/src/media_processing/video_processor/apps/web/components/video/FrameNavigator.tsx
@@ -59,8 +59,9 @@ export default function FrameNavigator({
         <button
           onClick={handlePreviousFrame}
           disabled={disabled || currentFrame <= 0}
-          className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
           title="Previous Frame"
+          aria-label="Previous Frame"
         >
           ‹
         </button>
@@ -73,6 +74,7 @@ export default function FrameNavigator({
             value={currentFrame}
             onChange={(e) => handleFrameInput(parseInt(e.target.value) || 0)}
             disabled={disabled}
+            aria-label="Current frame number"
             className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
           />
           <span className="text-sm text-gray-600">/ {totalFrames - 1}</span>
@@ -81,8 +83,9 @@ export default function FrameNavigator({
         <button
           onClick={handleNextFrame}
           disabled={disabled || currentFrame >= totalFrames - 1}
-          className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
           title="Next Frame"
+          aria-label="Next Frame"
         >
           ›
         </button>

--- a/src/media_processing/video_processor/apps/web/components/video/VideoEditor.tsx
+++ b/src/media_processing/video_processor/apps/web/components/video/VideoEditor.tsx
@@ -166,7 +166,8 @@ export default function VideoEditor({
                 })
               }
               disabled={disabled || videoDuration === 0}
-              className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600 disabled:opacity-50"
+              aria-label="Trim start time"
+              className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600 disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             />
           </div>
           <div>
@@ -186,7 +187,8 @@ export default function VideoEditor({
                 })
               }
               disabled={disabled || videoDuration === 0}
-              className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600 disabled:opacity-50"
+              aria-label="Trim end time"
+              className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-blue-600 disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
             />
           </div>
         </div>
@@ -202,8 +204,9 @@ export default function VideoEditor({
               key={angle}
               onClick={() => setRotation(angle)}
               disabled={disabled}
+              aria-label={`Rotate ${angle} degrees`}
               className={`
-                px-3 py-2 text-sm font-medium rounded-md transition-colors
+                px-3 py-2 text-sm font-medium rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none
                 ${
                   rotation === angle
                     ? 'bg-blue-600 text-white'
@@ -221,7 +224,7 @@ export default function VideoEditor({
       <button
         onClick={handleExport}
         disabled={disabled || isProcessing || !videoFile}
-        className="w-full px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        className="w-full px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
       >
         {isProcessing ? 'Processing...' : 'Export Video'}
       </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the frame number input, previous/next frame buttons, rotation buttons, and trim start/end range sliders. Added `focus-visible:ring-2` to these controls and the export button.
🎯 Why: Screen reader users previously heard "button" or "slider" without context for these essential video editing tools. Keyboard users could not see which control they were focused on because standard focus outlines were suppressed without a replacement.
♿ Accessibility: Improves perceivability for screen reader users and operability for keyboard-only users. Tested tab order and visual focus states via Playwright screenshot. All changes use existing standard Tailwind utility classes.

---
*PR created automatically by Jules for task [14104262231850938115](https://jules.google.com/task/14104262231850938115) started by @dieterolson*