### PR TITLE
⚡ Bolt: Prevent unnecessary re-renders in heavy visualization components

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.32                                     |
-| **Last Spec Update**    | 2026-04-08                                 |
+| **Spec Version**        | 1.1.33                                     |
+| **Last Spec Update**    | 2026-04-09                                 |
 
 ## 2. Purpose & Mission
 
@@ -490,6 +490,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-07 | 1.1.30  | Extracted the public enums/dataclass contracts and low-level helper kernels for `time_series_decomposition` into focused support modules, leaving the main module centered on decomposition orchestration while preserving the existing public import surface through the compatibility facade.                                                                                                                                                      |
 | 2026-04-08 | 1.1.31  | Memoize AnalyticsSuite chart data using useMemo and optimize the scatter regression component with a single-pass loop, drastically reducing React rendering and GC overhead.                                                                                                                                                                                                                                                                        |
 | 2026-04-08 | 1.1.32  | Optimized data array filtering in `useDataProcessor.ts` by replacing `Array.push()` calls with `Float64Array` buffers in `calculateTrendline`, and replacing chained `filter()` passes in `trimTimeRange` with a single-pass `for` loop that avoids creating and resizing intermediate arrays.                                                                                                                                                                        |
+| 2026-04-09 | 1.1.33  | Wrapped DataTableView, PlotView, and AnalyticsSuite in `React.memo`, and memoized activeSignals with `useMemo` to prevent expensive visualization re-renders on unrelated UI state changes. |
 ---
 
 <!--

--- a/src/data_processing/data_processor/web/src/App.tsx
+++ b/src/data_processing/data_processor/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, memo } from 'react';
 import { Database, Settings, BarChart3, Table, Calculator, Clock, Scissors, LineChart, HelpCircle, FlaskConical } from 'lucide-react';
 import {
   FileUpload,
@@ -392,7 +392,7 @@ interface DataTableViewProps {
   selectedSignals: string[];
 }
 
-function DataTableView({ data, selectedSignals }: DataTableViewProps) {
+const DataTableView = memo(function DataTableView({ data, selectedSignals }: DataTableViewProps) {
   if (data.length === 0 || selectedSignals.length === 0) {
     return (
       <div className="card">
@@ -451,6 +451,6 @@ function DataTableView({ data, selectedSignals }: DataTableViewProps) {
       </div>
     </div>
   );
-}
+});
 
 export default App;

--- a/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
+++ b/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
@@ -8,7 +8,7 @@
  *
  * See issue #607.
  */
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, memo } from 'react';
 import {
   BarChart,
   Bar,
@@ -471,13 +471,15 @@ function correlationColor(r: number): string {
   return r >= 0 ? COLORS_POSITIVE[4 - idx] : COLORS_NEGATIVE[4 - idx];
 }
 
-export function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuiteProps) {
+export const AnalyticsSuite = memo(function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuiteProps) {
   const [tab, setTab] = useState<AnalyticsTab>('correlation');
   const [regXSignal, setRegXSignal] = useState<string>(selectedSignals[0] ?? '');
   const [regYSignal, setRegYSignal] = useState<string>(selectedSignals[1] ?? selectedSignals[0] ?? '');
   const [regDegree, setRegDegree] = useState<number>(1);
 
-  const activeSignals = selectedSignals.length > 0 ? selectedSignals : signals.slice(0, 5);
+  const activeSignals = useMemo(() => {
+    return selectedSignals.length > 0 ? selectedSignals : signals.slice(0, 5);
+  }, [selectedSignals, signals]);
 
   // Correlation
   const correlation = useMemo<CorrelationMatrix | null>(() => {
@@ -826,6 +828,6 @@ export function AnalyticsSuite({ data, signals, selectedSignals }: AnalyticsSuit
       )}
     </div>
   );
-}
+});
 
 export default AnalyticsSuite;

--- a/src/data_processing/data_processor/web/src/components/PlotView.tsx
+++ b/src/data_processing/data_processor/web/src/components/PlotView.tsx
@@ -7,7 +7,7 @@
  * No 1000-point downsampling limit — Plotly handles large datasets via WebGL.
  */
 
-import { useMemo } from 'react';
+import { useMemo, memo } from 'react';
 import Plot from 'react-plotly.js';
 import { BarChart2 } from 'lucide-react';
 import type { DataRow } from '../types';
@@ -64,7 +64,7 @@ interface PlotViewProps {
 
 // ── Component ───────────────────────────────────────────────────────────────
 
-export function PlotView({
+export const PlotView = memo(function PlotView({
   data,
   selectedSignals,
   plotlyData,
@@ -182,6 +182,6 @@ export function PlotView({
       </div>
     </div>
   );
-}
+});
 
 export default PlotView;


### PR DESCRIPTION
This PR implements frontend micro-optimizations targeted at the Data Processor web application. 

It wraps heavy, visualization-intensive components (`PlotView`, `AnalyticsSuite`, and `DataTableView`) in `React.memo` to prevent them from re-rendering due to trivial state updates in their parent component (`App.tsx`), such as switching UI tabs or panels. 

Additionally, it memoizes the `activeSignals` array calculation in `AnalyticsSuite.tsx` using `useMemo` to ensure referential stability. Without this, the inline fallback array `signals.slice(0, 5)` would create a new reference every render, defeating the existing `useMemo` optimizations for PCA and Correlation calculations downstream.

---
*PR created automatically by Jules for task [7808621211872318403](https://jules.google.com/task/7808621211872318403) started by @dieterolson*