### PR TITLE
feat: publish pendulum provider pack

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.34                                     |
+| **Spec Version**        | 1.1.35                                     |
 | **Last Spec Update**    | 2026-04-09                                 |
 
 ## 2. Purpose & Mission
@@ -491,6 +491,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-08 | 1.1.31  | Memoize AnalyticsSuite chart data using useMemo and optimize the scatter regression component with a single-pass loop, drastically reducing React rendering and GC overhead.                                                                                                                                                                                                                                                                        |
 | 2026-04-08 | 1.1.32  | Optimized data array filtering in `useDataProcessor.ts` by replacing `Array.push()` calls with `Float64Array` buffers in `calculateTrendline`, and replacing chained `filter()` passes in `trimTimeRange` with a single-pass `for` loop that avoids creating and resizing intermediate arrays.                                                                                                                                                                        |
 | 2026-04-09 | 1.1.33  | Added a loading spinner and `aria-pressed` states to the `VideoEditor.tsx` component in the video processor web application to improve user experience and accessibility during video export operations.                                                                                                                                                                        |
+| 2026-04-09 | 1.1.35  | Added a shared provider-pack manifest for the pendulum simulator under `src/pendulum_simulator`, plus a repo-local validator and regression tests that keep the manifest aligned with the real package entry point, working directory, Python path, icon asset, and launcher metadata required for future UpstreamDrift shared-launch integration. |
 | 2026-04-09 | 1.1.34  | Wrapped DataTableView, PlotView, and AnalyticsSuite in `React.memo`, and memoized activeSignals with `useMemo` to prevent expensive visualization re-renders on unrelated UI state changes. |
 ---
 

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts that are importable from the repo test suite."""

--- a/scripts/pendulum_provider_manifest.py
+++ b/scripts/pendulum_provider_manifest.py
@@ -1,0 +1,137 @@
+"""Validation helpers for the shared pendulum provider manifest."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PENDULUM_PROVIDER_MANIFEST = (
+    REPO_ROOT / "src" / "pendulum_simulator" / "model_pack.yaml"
+)
+
+_REQUIRED_TOP_LEVEL_FIELDS = (
+    "manifest_version",
+    "pack_id",
+    "pack_name",
+    "provider",
+    "models",
+)
+_REQUIRED_MODEL_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "type",
+    "path",
+    "source_root",
+    "working_dir",
+    "python_paths",
+    "capabilities",
+    "launcher",
+)
+_REQUIRED_LAUNCHER_FIELDS = ("category", "logo", "status")
+
+
+def load_pendulum_provider_manifest(
+    path: Path = PENDULUM_PROVIDER_MANIFEST,
+) -> dict[str, Any]:
+    """Load the pendulum provider manifest from disk."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("pendulum provider manifest must deserialize to a mapping")
+    return data
+
+
+def _require_fields(
+    payload: dict[str, Any], required_fields: tuple[str, ...], *, label: str
+) -> None:
+    missing = [field for field in required_fields if field not in payload]
+    if missing:
+        raise ValueError(f"{label} missing required fields: {missing}")
+
+
+def _resolve_repo_relative_path(
+    repo_root: Path, relative_path: str, *, label: str
+) -> Path:
+    path = (repo_root / relative_path).resolve(strict=False)
+    if not path.exists():
+        raise ValueError(f"{label} does not exist: {path}")
+    return path
+
+
+def validate_pendulum_provider_manifest(
+    repo_root: Path = REPO_ROOT,
+    path: Path = PENDULUM_PROVIDER_MANIFEST,
+) -> dict[str, Any]:
+    """Validate the pendulum provider manifest against the local repo layout."""
+    manifest = load_pendulum_provider_manifest(path)
+    _require_fields(manifest, _REQUIRED_TOP_LEVEL_FIELDS, label="manifest")
+
+    models = manifest["models"]
+    if not isinstance(models, list) or not models:
+        raise ValueError("manifest must contain at least one model entry")
+
+    model_ids: set[str] = set()
+    for model in models:
+        if not isinstance(model, dict):
+            raise ValueError("model entries must be mappings")
+        _require_fields(
+            model, _REQUIRED_MODEL_FIELDS, label=f"model[{model.get('id', '?')}]"
+        )
+
+        model_id = model["id"]
+        if not isinstance(model_id, str) or not model_id.strip():
+            raise ValueError("model id must be a non-empty string")
+        if model_id in model_ids:
+            raise ValueError(f"duplicate model id: {model_id}")
+        model_ids.add(model_id)
+
+        source_root = _resolve_repo_relative_path(
+            repo_root,
+            str(model["source_root"]),
+            label=f"{model_id}.source_root",
+        )
+        artifact_path = (source_root / str(model["path"])).resolve(strict=False)
+        if not artifact_path.exists():
+            raise ValueError(f"{model_id}.path does not exist: {artifact_path}")
+
+        working_dir = _resolve_repo_relative_path(
+            repo_root,
+            str(model["working_dir"]),
+            label=f"{model_id}.working_dir",
+        )
+        if working_dir != source_root:
+            raise ValueError(
+                f"{model_id}.working_dir must match source_root for the shared pendulum pack"
+            )
+
+        python_paths = model["python_paths"]
+        if not isinstance(python_paths, list) or not python_paths:
+            raise ValueError(f"{model_id}.python_paths must be a non-empty list")
+        for index, python_path in enumerate(python_paths):
+            _resolve_repo_relative_path(
+                repo_root,
+                str(python_path),
+                label=f"{model_id}.python_paths[{index}]",
+            )
+
+        capabilities = model["capabilities"]
+        if not isinstance(capabilities, list) or not capabilities:
+            raise ValueError(f"{model_id}.capabilities must be a non-empty list")
+
+        launcher = model["launcher"]
+        if not isinstance(launcher, dict):
+            raise ValueError(f"{model_id}.launcher must be a mapping")
+        _require_fields(
+            launcher, _REQUIRED_LAUNCHER_FIELDS, label=f"{model_id}.launcher"
+        )
+        if launcher["category"] != "tool":
+            raise ValueError(f"{model_id}.launcher.category must be 'tool'")
+
+        logo_path = (source_root / str(launcher["logo"])).resolve(strict=False)
+        if not logo_path.exists():
+            raise ValueError(f"{model_id}.launcher.logo does not exist: {logo_path}")
+
+    return manifest

--- a/src/pendulum_simulator/model_pack.yaml
+++ b/src/pendulum_simulator/model_pack.yaml
@@ -1,0 +1,29 @@
+manifest_version: "1.0.0"
+pack_id: "tools-pendulum-simulator"
+pack_name: "Tools Pendulum Simulator"
+provider: "tools"
+models:
+  - id: "pendulum_simulator"
+    name: "Pendulum Simulator"
+    description: "Shared pendulum simulation, analysis, and optimization suite for double, triple, and golfer upper-body models."
+    type: "special_app"
+    path: "src/double_pendulum_golf/__main__.py"
+    source_root: "src/pendulum_simulator"
+    working_dir: "src/pendulum_simulator"
+    python_paths:
+      - "src/pendulum_simulator/src"
+    capabilities:
+      - "pendulum"
+      - "simulation"
+      - "optimization"
+      - "biomechanics"
+    tags:
+      - "golf"
+      - "double-pendulum"
+      - "triple-pendulum"
+      - "golfer"
+    launcher:
+      category: "tool"
+      logo: "src/double_pendulum_golf/resources/pendulum_icon.png"
+      status: "provider_ready"
+      web_route: "/tools/pendulum-simulator"

--- a/tests/test_pendulum_provider_manifest.py
+++ b/tests/test_pendulum_provider_manifest.py
@@ -1,0 +1,61 @@
+"""Regression tests for the shared pendulum provider manifest."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from scripts.pendulum_provider_manifest import (
+    PENDULUM_PROVIDER_MANIFEST,
+    REPO_ROOT,
+    validate_pendulum_provider_manifest,
+)
+
+
+def test_pendulum_provider_manifest_validates_against_repo_layout() -> None:
+    """The published pendulum pack should resolve cleanly from the repo root."""
+    manifest = validate_pendulum_provider_manifest()
+
+    assert manifest["pack_id"] == "tools-pendulum-simulator"
+    assert manifest["provider"] == "tools"
+    assert len(manifest["models"]) == 1
+
+
+def test_pendulum_provider_manifest_declares_shared_launcher_metadata() -> None:
+    """The pendulum pack should expose shared-launch metadata for UpstreamDrift."""
+    manifest = validate_pendulum_provider_manifest()
+    entry = manifest["models"][0]
+
+    assert entry["capabilities"] == [
+        "pendulum",
+        "simulation",
+        "optimization",
+        "biomechanics",
+    ]
+    assert entry["launcher"] == {
+        "category": "tool",
+        "logo": "src/double_pendulum_golf/resources/pendulum_icon.png",
+        "status": "provider_ready",
+        "web_route": "/tools/pendulum-simulator",
+    }
+
+
+def test_pendulum_provider_manifest_points_at_console_entry_module() -> None:
+    """The provider path should track the installed console entry module."""
+    manifest = validate_pendulum_provider_manifest()
+    entry = manifest["models"][0]
+    pyproject_path = REPO_ROOT / "src" / "pendulum_simulator" / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+    assert pyproject["project"]["scripts"]["pendulum-golf"] == (
+        "double_pendulum_golf.__main__:main"
+    )
+    assert entry["path"] == "src/double_pendulum_golf/__main__.py"
+
+
+def test_pendulum_provider_manifest_stays_in_expected_location() -> None:
+    """The shared pendulum manifest should live alongside the pendulum source tree."""
+    assert PENDULUM_PROVIDER_MANIFEST == (
+        REPO_ROOT / "src" / "pendulum_simulator" / "model_pack.yaml"
+    )
+    assert Path(PENDULUM_PROVIDER_MANIFEST).is_file()


### PR DESCRIPTION
## Summary
- add a shared provider-pack manifest for the pendulum simulator so Tools can publish launcher-compatible pendulum content without UpstreamDrift-specific wiring
- add a repo-local manifest validator and regression tests that keep entry-point, path, icon, and launcher metadata aligned with the real package layout
- update SPEC.md for the new shared-launch contract surface

## Testing
- python -m pytest tests/test_pendulum_provider_manifest.py -q
- python -m ruff check scripts/pendulum_provider_manifest.py tests/test_pendulum_provider_manifest.py
- python -m ruff format --check scripts/pendulum_provider_manifest.py tests/test_pendulum_provider_manifest.py

Closes #1979