### PR TITLE
🎨 Palette: Add keyboard focus indicators to VideoPlayer controls

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -493,6 +493,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-09 | 1.1.33  | Added a loading spinner and `aria-pressed` states to the `VideoEditor.tsx` component in the video processor web application to improve user experience and accessibility during video export operations.                                                                                                                                                                        |
 | 2026-04-09 | 1.1.35  | Added a shared provider-pack manifest for the pendulum simulator under `src/pendulum_simulator`, plus a repo-local validator and regression tests that keep the manifest aligned with the real package entry point, working directory, Python path, icon asset, and launcher metadata required for future UpstreamDrift shared-launch integration. |
 | 2026-04-09 | 1.1.34  | Wrapped DataTableView, PlotView, and AnalyticsSuite in `React.memo`, and memoized activeSignals with `useMemo` to prevent expensive visualization re-renders on unrelated UI state changes. |
+| 2026-04-10 | 1.1.36  | Add explicit focus-visible styles to the interactive buttons (Upload New Video, Play/Pause, Mute/Unmute) within the `VideoPlayer` component for improved keyboard navigation visibility. |
 ---
 
 <!--

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.36                                     |
+| **Spec Version**        | 1.1.37                                     |
 | **Last Spec Update**    | 2026-04-10                                 |
 
 ## 2. Purpose & Mission
@@ -493,7 +493,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-04-09 | 1.1.33  | Added a loading spinner and `aria-pressed` states to the `VideoEditor.tsx` component in the video processor web application to improve user experience and accessibility during video export operations.                                                                                                                                                                        |
 | 2026-04-09 | 1.1.35  | Added a shared provider-pack manifest for the pendulum simulator under `src/pendulum_simulator`, plus a repo-local validator and regression tests that keep the manifest aligned with the real package entry point, working directory, Python path, icon asset, and launcher metadata required for future UpstreamDrift shared-launch integration. |
 | 2026-04-09 | 1.1.34  | Wrapped DataTableView, PlotView, and AnalyticsSuite in `React.memo`, and memoized activeSignals with `useMemo` to prevent expensive visualization re-renders on unrelated UI state changes. |
-| 2026-04-10 | 1.1.36  | Add explicit focus-visible styles to the interactive buttons (Upload New Video, Play/Pause, Mute/Unmute) within the `VideoPlayer` component for improved keyboard navigation visibility. |
+| 2026-04-10 | 1.1.37  | Add explicit focus-visible styles to the interactive buttons (Upload New Video, Play/Pause, Mute/Unmute) within the `VideoPlayer` component for improved keyboard navigation visibility. |
 ---
 
 <!--

--- a/src/media_processing/video_processor/apps/web/components/video/VideoPlayer.tsx
+++ b/src/media_processing/video_processor/apps/web/components/video/VideoPlayer.tsx
@@ -112,7 +112,7 @@ export default function VideoPlayer({
         <h2 className="text-lg font-semibold text-gray-900">Video Player</h2>
         <button
           onClick={onClear}
-          className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+          className="px-3 py-1.5 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >
           Upload New Video
         </button>
@@ -174,7 +174,7 @@ export default function VideoPlayer({
           <div className="flex items-center space-x-4">
             <button
               onClick={togglePlay}
-              className="p-2 text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
+              className="p-2 text-gray-700 hover:bg-gray-100 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
               aria-label={isPlaying ? 'Pause' : 'Play'}
             >
               {isPlaying ? (
@@ -191,7 +191,7 @@ export default function VideoPlayer({
             <div className="flex items-center space-x-2">
               <button
                 onClick={toggleMute}
-                className="p-2 text-gray-700 hover:bg-gray-100 rounded-md transition-colors"
+                className="p-2 text-gray-700 hover:bg-gray-100 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 aria-label={isMuted ? 'Unmute' : 'Mute'}
               >
                 {isMuted || volume === 0 ? (


### PR DESCRIPTION
💡 What: Added explicit `focus-visible` styles to the interactive buttons (Upload New Video, Play/Pause, Mute/Unmute) within the `VideoPlayer` component.
🎯 Why: Standard interactive buttons in custom UI components often lack clear focus indicators, which creates a "focus trap" or invisible focus state for users navigating via keyboard. This makes the primary video controls much easier to use without a mouse.
📸 Before/After: Before this change, tabbing through the video player buttons showed no clear visual indication of which button was active. After this change, a distinct blue ring appears around the focused button.
♿ Accessibility: Improves WCAG compliance by ensuring interactive elements have a visible focus state, directly aiding users who rely on keyboard navigation.

---
*PR created automatically by Jules for task [6046547399666899220](https://jules.google.com/task/6046547399666899220) started by @dieterolson*