### PR TITLE
[codex] Use logging in secrets scanner example

### DIFF
--- a/src/python/src/utils/secrets_scanner.py
+++ b/src/python/src/utils/secrets_scanner.py
@@ -4,11 +4,13 @@ Scans Python source files for patterns that may indicate hardcoded secrets,
 API keys, passwords, or tokens. Designed for pre-commit / CI integration.
 
 Usage:
+    import logging
     from utils.secrets_scanner import scan_file, scan_directory
 
+    logger = logging.getLogger(__name__)
     issues = scan_directory("src/")
     for issue in issues:
-        print(f"{issue['file']}:{issue['line']}: {issue['pattern']}")
+        logger.warning("%s:%s: %s", issue["file"], issue["line"], issue["pattern"])
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Updates the `secrets_scanner` usage example to use the `logging` module instead of `print(...)`.
- Clears the remaining Python `print(...)` match under `src/` reported by the refresh issue.

## Validation

- `rg -n "^\\s*print\\(" src --glob '*.py'`
- `python3 -m pytest tests/architecture/test_layer_boundaries.py -q`

Refs #2011