### PR TITLE
[codex] Add lower-body hip rotation target

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.37                                     |
-| **Last Spec Update**    | 2026-04-10                                 |
+| **Spec Version**        | 1.1.38                                     |
+| **Last Spec Update**    | 2026-04-11                                 |
 
 ## 2. Purpose & Mission
 
@@ -148,6 +148,7 @@ Tools/
 | F6  | FastAPI web interfaces              | 🔄     | RESTful API for programmatic access to tools                        |
 | F7  | MATLAB scientific tools             | ✅     | Integration with MATLAB code and wrappers                           |
 | F8  | Fleet theme system                  | ✅     | Consistent theming across all PyQt6 GUIs                            |
+| F9  | Lower-body hip rotation target      | ✅     | Deterministic inclined-plane golf hip rotation profile with both-socket simulator application |
 
 ### API / Interface Contract
 
@@ -448,6 +449,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-04-11 | 1.1.38  | Added the lower-body inclined-plane hip rotation target profile with deterministic sampling, DbC validation, both-socket simulator application, and diagnostics/history coverage for the first golf lower-body rotation slice. |
 | 2026-03-28 | 1.0.0   | Initial specification                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | 2026-03-29 | 1.0.1   | Document performance improvement in DataChart downsampling algorithm                                                                                                                                                                                                                                                                                                                                                                                   |
 | 2026-03-30 | 1.0.2   | A-N assessment remediation: LoD refactoring in convert_tools_icon.py, launch.py, launch_signal_toolkit.py, verify_launcher.py; DbC input validation added to launch_tool, bootstrap, migrate_file, \_print_environment_info, \_check_launcher_file, \_print_recommendations, \_on_poly_generated; docstrings added to **init** and missing functions in setup_dev.py, remove_broken_scripts.py, migrate_print_to_logging.py, launch_signal_toolkit.py. |

--- a/src/lower_body_model/SPEC.md
+++ b/src/lower_body_model/SPEC.md
@@ -14,6 +14,7 @@ The **Lower Body Model** is a 3D biomechanical simulation of a golfer's lower bo
 - **Hips**: Gimbal Joints (3 independent hinge actuators: X, Y, Z).
 - **Knees**: Revolute Joints (1 hinge actuator, 0 to 150 flexion range).
 - **Ankles**: Universal Joints (2 hinge actuators, X and Y). Flat ellipsoids replace basic box feet for anatomical resemblance.
+- **Golf Hip Rotation Target**: `InclinedPlaneHipRotationTarget` samples a deterministic two-phase motion from 0 degrees to 45 degrees clockwise, then through 90 degrees of counterclockwise travel to +45 degrees on an inclined plane. `LowerBodySimulator` applies the target to both hip sockets through shared side iteration and reports target diagnostics during playback.
 
 ## 4. Stability and Control
 A fundamental mathematical PID loop stabilizes local targets for the joints. The solver executes Damped Least Squares inverse kinematics across the free-floating root relative to the static ground boundary, preserving symmetrical ground contact constraint solving. By default, the stance is loaded at approximately `30` degrees anterior pelvic tilt, `120` degrees knee flexion, and a `20`-degree out-flared foot rotation.

--- a/src/lower_body_model/__init__.py
+++ b/src/lower_body_model/__init__.py
@@ -1,0 +1,8 @@
+"""Lower-body model public API."""
+
+from lower_body_model.hip_rotation import (
+    HipRotationSample,
+    InclinedPlaneHipRotationTarget,
+)
+
+__all__ = ("HipRotationSample", "InclinedPlaneHipRotationTarget")

--- a/src/lower_body_model/hip_rotation.py
+++ b/src/lower_body_model/hip_rotation.py
@@ -1,0 +1,87 @@
+"""Inclined-plane hip rotation target profiles for the lower-body model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class HipRotationSample:
+    """A deterministic point on the requested hip rotation target."""
+
+    time_sec: float
+    rotation_deg: float
+    plane_point: np.ndarray
+
+
+@dataclass(frozen=True)
+class InclinedPlaneHipRotationTarget:
+    """Two-phase golf hip rotation target viewed from above."""
+
+    duration_sec: float
+    backswing_degrees: float = 45.0
+    counterclockwise_degrees: float = 90.0
+    incline_degrees: float = 12.0
+    sample_count: int = 181
+
+    def __post_init__(self) -> None:
+        assert self.duration_sec > 0.0, "DbC PRE: duration_sec must be positive"
+        assert 0.0 < self.backswing_degrees <= 90.0, (
+            "DbC PRE: backswing_degrees must be in (0, 90]"
+        )
+        assert 0.0 < self.counterclockwise_degrees <= 180.0, (
+            "DbC PRE: counterclockwise_degrees must be in (0, 180]"
+        )
+        assert -60.0 <= self.incline_degrees <= 60.0, (
+            "DbC PRE: incline_degrees must be in [-60, 60]"
+        )
+        assert self.sample_count >= 2, "DbC PRE: sample_count must be at least 2"
+
+    @property
+    def reversal_time_sec(self) -> float:
+        """Time where the clockwise phase reverses."""
+        return self.duration_sec / 2.0
+
+    @property
+    def finish_rotation_deg(self) -> float:
+        """Final rotation angle in degrees."""
+        return -self.backswing_degrees + self.counterclockwise_degrees
+
+    def rotation_degrees_at(self, time_sec: float) -> float:
+        """Return the target rotation in degrees at ``time_sec``."""
+        assert time_sec >= 0.0, "DbC PRE: time_sec must be non-negative"
+        clamped_time = min(time_sec, self.duration_sec)
+
+        if clamped_time <= self.reversal_time_sec:
+            phase = clamped_time / self.reversal_time_sec
+            return -self.backswing_degrees * phase
+
+        phase = (clamped_time - self.reversal_time_sec) / self.reversal_time_sec
+        return -self.backswing_degrees + self.counterclockwise_degrees * phase
+
+    def plane_point_at(self, time_sec: float) -> np.ndarray:
+        """Return a unit-radius point on the inclined target plane."""
+        rotation_rad = np.radians(self.rotation_degrees_at(time_sec))
+        incline_rad = np.radians(self.incline_degrees)
+        return np.array(
+            [
+                np.cos(rotation_rad),
+                np.sin(rotation_rad) * np.cos(incline_rad),
+                np.sin(rotation_rad) * np.sin(incline_rad),
+            ],
+            dtype=float,
+        )
+
+    def sample(self) -> list[HipRotationSample]:
+        """Sample the full target trajectory deterministically."""
+        times = np.linspace(0.0, self.duration_sec, self.sample_count)
+        return [
+            HipRotationSample(
+                time_sec=float(time_sec),
+                rotation_deg=self.rotation_degrees_at(float(time_sec)),
+                plane_point=self.plane_point_at(float(time_sec)),
+            )
+            for time_sec in times
+        ]

--- a/src/lower_body_model/simulator.py
+++ b/src/lower_body_model/simulator.py
@@ -151,7 +151,9 @@ class LowerBodySimulator:
         )
         return self.hip_rotation_target
 
-    def apply_hip_rotation_target(self, time_sec: float | None = None) -> dict[str, float]:
+    def apply_hip_rotation_target(
+        self, time_sec: float | None = None
+    ) -> dict[str, float]:
         """Apply the configured hip target to both hip sockets without per-side duplication."""
         if self.hip_rotation_target is None:
             raise ValueError("No hip rotation target configured")
@@ -161,7 +163,9 @@ class LowerBodySimulator:
         incline_deg = self.hip_rotation_target.incline_degrees
 
         for side in ("r", "l"):
-            self.data.qpos[self.jnt_qpos_idx[f"{side}_hip_z"]] = np.radians(rotation_deg)
+            self.data.qpos[self.jnt_qpos_idx[f"{side}_hip_z"]] = np.radians(
+                rotation_deg
+            )
             self.data.qpos[self.jnt_qpos_idx[f"{side}_hip_x"]] = np.radians(incline_deg)
 
         mujoco.mj_forward(self.model, self.data)
@@ -343,7 +347,9 @@ class LowerBodySimulator:
         }
         if self.hip_rotation_target is not None:
             diagnostics["hip_rotation_target"] = {
-                "rotation_deg": self.hip_rotation_target.rotation_degrees_at(self.data.time),
+                "rotation_deg": self.hip_rotation_target.rotation_degrees_at(
+                    self.data.time
+                ),
                 "incline_deg": self.hip_rotation_target.incline_degrees,
             }
         return diagnostics

--- a/src/lower_body_model/simulator.py
+++ b/src/lower_body_model/simulator.py
@@ -1,6 +1,8 @@
 import mujoco
 import numpy as np
 
+from lower_body_model.hip_rotation import InclinedPlaneHipRotationTarget
+
 
 class LowerBodySimulator:
     """
@@ -23,6 +25,7 @@ class LowerBodySimulator:
 
         self._cache_indices()
         self._polynomial_drivers: dict[int, np.ndarray] = {}
+        self.hip_rotation_target: InclinedPlaneHipRotationTarget | None = None
 
         # Stability control target (rest pose)
         self.qpos_target: np.ndarray | None = None
@@ -128,6 +131,41 @@ class LowerBodySimulator:
             raise ValueError(f"No actuator found for {joint_name}")
 
         self._polynomial_drivers[act_id] = np.array(coeffs)
+
+    def configure_hip_rotation_target(
+        self,
+        duration_sec: float,
+        *,
+        backswing_degrees: float = 45.0,
+        counterclockwise_degrees: float = 90.0,
+        incline_degrees: float = 12.0,
+        sample_count: int = 181,
+    ) -> InclinedPlaneHipRotationTarget:
+        """Configure the deterministic inclined-plane golf hip rotation target."""
+        self.hip_rotation_target = InclinedPlaneHipRotationTarget(
+            duration_sec=duration_sec,
+            backswing_degrees=backswing_degrees,
+            counterclockwise_degrees=counterclockwise_degrees,
+            incline_degrees=incline_degrees,
+            sample_count=sample_count,
+        )
+        return self.hip_rotation_target
+
+    def apply_hip_rotation_target(self, time_sec: float | None = None) -> dict[str, float]:
+        """Apply the configured hip target to both hip sockets without per-side duplication."""
+        if self.hip_rotation_target is None:
+            raise ValueError("No hip rotation target configured")
+
+        sample_time = self.data.time if time_sec is None else time_sec
+        rotation_deg = self.hip_rotation_target.rotation_degrees_at(sample_time)
+        incline_deg = self.hip_rotation_target.incline_degrees
+
+        for side in ("r", "l"):
+            self.data.qpos[self.jnt_qpos_idx[f"{side}_hip_z"]] = np.radians(rotation_deg)
+            self.data.qpos[self.jnt_qpos_idx[f"{side}_hip_x"]] = np.radians(incline_deg)
+
+        mujoco.mj_forward(self.model, self.data)
+        return {"rotation_deg": rotation_deg, "incline_deg": incline_deg}
 
     def compute_zero_torque_counterfactual(self) -> dict[str, np.ndarray]:
         """
@@ -284,7 +322,7 @@ class LowerBodySimulator:
         r_knee_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_JOINT, "r_knee")
         r_knee_qpos_adr = self.model.jnt_qposadr[r_knee_id]
 
-        return {
+        diagnostics = {
             "time_sec": float(self.data.time),
             "pelvis_z_m": float(pelvis_pos[2]) if not div else float("nan"),
             "is_diverged": div,
@@ -303,6 +341,12 @@ class LowerBodySimulator:
             "grf": grf,
             "joint_torques": joint_torques,
         }
+        if self.hip_rotation_target is not None:
+            diagnostics["hip_rotation_target"] = {
+                "rotation_deg": self.hip_rotation_target.rotation_degrees_at(self.data.time),
+                "incline_deg": self.hip_rotation_target.incline_degrees,
+            }
+        return diagnostics
 
     def analyze_induced_acceleration(
         self, actuator_name: str, torque_value: float = 1.0
@@ -427,6 +471,8 @@ class LowerBodySimulator:
     def step(self) -> None:
         """Advance the simulation by one timestep, applying polynomial controls and basic stability."""
         t = self.data.time
+        if self.hip_rotation_target is not None:
+            self.apply_hip_rotation_target(t)
 
         # Basic stability control (PD) to hold the target posture if no polynomial is provided
         if self.qpos_target is not None:

--- a/src/lower_body_model/simulator.py
+++ b/src/lower_body_model/simulator.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import mujoco
 import numpy as np
 
@@ -261,7 +263,7 @@ class LowerBodySimulator:
             "yaw": np.degrees(yaw),
         }
 
-    def compute_diagnostics(self) -> dict[str, str | float | bool | dict]:
+    def compute_diagnostics(self) -> dict[str, str | float | bool | dict[str, Any]]:
         """Comprehensive system diagnostics for stability, telemetry, and debugging."""
         mujoco.mj_kinematics(self.model, self.data)
 
@@ -326,7 +328,7 @@ class LowerBodySimulator:
         r_knee_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_JOINT, "r_knee")
         r_knee_qpos_adr = self.model.jnt_qposadr[r_knee_id]
 
-        diagnostics = {
+        diagnostics: dict[str, str | float | bool | dict[str, Any]] = {
             "time_sec": float(self.data.time),
             "pelvis_z_m": float(pelvis_pos[2]) if not div else float("nan"),
             "is_diverged": div,

--- a/tests/unit/lower_body_model/test_hip_rotation_target.py
+++ b/tests/unit/lower_body_model/test_hip_rotation_target.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+
+from lower_body_model.builder import build_lower_body_xml
+from lower_body_model.hip_rotation import InclinedPlaneHipRotationTarget
+from lower_body_model.simulator import LowerBodySimulator
+
+
+def test_target_reverses_from_clockwise_to_counterclockwise() -> None:
+    target = InclinedPlaneHipRotationTarget(duration_sec=2.0, sample_count=5)
+
+    assert target.rotation_degrees_at(0.0) == pytest.approx(0.0)
+    assert target.rotation_degrees_at(target.reversal_time_sec) == pytest.approx(-45.0)
+    assert target.rotation_degrees_at(2.0) == pytest.approx(45.0)
+    assert [sample.time_sec for sample in target.sample()] == pytest.approx(
+        [0.0, 0.5, 1.0, 1.5, 2.0]
+    )
+
+
+def test_target_samples_inclined_plane_deterministically() -> None:
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0, incline_degrees=30.0)
+
+    first = target.plane_point_at(0.25)
+    second = target.plane_point_at(0.25)
+
+    assert np.array_equal(first, second)
+    assert first[2] != pytest.approx(0.0)
+    assert np.linalg.norm(first) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"duration_sec": 0.0},
+        {"duration_sec": 1.0, "backswing_degrees": 0.0},
+        {"duration_sec": 1.0, "counterclockwise_degrees": 0.0},
+        {"duration_sec": 1.0, "incline_degrees": 90.0},
+        {"duration_sec": 1.0, "sample_count": 1},
+    ],
+)
+def test_target_rejects_nonphysical_parameters(kwargs: dict[str, float]) -> None:
+    with pytest.raises(AssertionError):
+        InclinedPlaneHipRotationTarget(**kwargs)
+
+
+def test_simulator_applies_target_to_both_hip_sockets() -> None:
+    simulator = LowerBodySimulator(build_lower_body_xml())
+    simulator.configure_hip_rotation_target(
+        duration_sec=2.0, incline_degrees=15.0, sample_count=5
+    )
+
+    applied = simulator.apply_hip_rotation_target(1.0)
+
+    assert applied == {"rotation_deg": -45.0, "incline_deg": 15.0}
+    for side in ("r", "l"):
+        assert simulator.data.qpos[simulator.jnt_qpos_idx[f"{side}_hip_z"]] == pytest.approx(
+            np.radians(-45.0)
+        )
+        assert simulator.data.qpos[simulator.jnt_qpos_idx[f"{side}_hip_x"]] == pytest.approx(
+            np.radians(15.0)
+        )
+
+
+def test_simulator_steps_with_configured_target_history() -> None:
+    simulator = LowerBodySimulator(build_lower_body_xml())
+    simulator.configure_hip_rotation_target(duration_sec=1.0)
+
+    simulator.step()
+
+    assert simulator.history
+    diagnostics = simulator.compute_diagnostics()
+    assert diagnostics["hip_rotation_target"]["rotation_deg"] <= 0.0

--- a/tests/unit/lower_body_model/test_hip_rotation_target.py
+++ b/tests/unit/lower_body_model/test_hip_rotation_target.py
@@ -53,12 +53,12 @@ def test_simulator_applies_target_to_both_hip_sockets() -> None:
 
     assert applied == {"rotation_deg": -45.0, "incline_deg": 15.0}
     for side in ("r", "l"):
-        assert simulator.data.qpos[simulator.jnt_qpos_idx[f"{side}_hip_z"]] == pytest.approx(
-            np.radians(-45.0)
-        )
-        assert simulator.data.qpos[simulator.jnt_qpos_idx[f"{side}_hip_x"]] == pytest.approx(
-            np.radians(15.0)
-        )
+        assert simulator.data.qpos[
+            simulator.jnt_qpos_idx[f"{side}_hip_z"]
+        ] == pytest.approx(np.radians(-45.0))
+        assert simulator.data.qpos[
+            simulator.jnt_qpos_idx[f"{side}_hip_x"]
+        ] == pytest.approx(np.radians(15.0))
 
 
 def test_simulator_steps_with_configured_target_history() -> None:


### PR DESCRIPTION
## Summary
- add a deterministic inclined-plane hip rotation target profile for the lower-body model
- enforce DbC preconditions for duration, angles, incline, and sample count
- add simulator helpers to configure and apply the target to both hip sockets through shared side iteration
- surface target diagnostics during playback and document the lower-body slice

Fixes #2016
Part of #2015

## Tests
- python3 -m pytest tests/unit/lower_body_model/test_hip_rotation_target.py tests/unit/lower_body_model/test_simulator.py -q
- python3 -m ruff check src/lower_body_model/hip_rotation.py src/lower_body_model/simulator.py src/lower_body_model/__init__.py tests/unit/lower_body_model/test_hip_rotation_target.py