### PR TITLE
[codex] Surface lower-body hip target history diagnostics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.38                                     |
+| **Spec Version**        | 1.1.39                                     |
 | **Last Spec Update**    | 2026-04-11                                 |
 
 ## 2. Purpose & Mission
@@ -449,6 +449,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-04-11 | 1.1.39  | Extended lower-body simulator history playback diagnostics so cached frames expose the configured inclined-plane hip rotation target for scrub-based analysis and verification. |
 | 2026-04-11 | 1.1.38  | Added the lower-body inclined-plane hip rotation target profile with deterministic sampling, DbC validation, both-socket simulator application, and diagnostics/history coverage for the first golf lower-body rotation slice. |
 | 2026-03-28 | 1.0.0   | Initial specification                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 | 2026-03-29 | 1.0.1   | Document performance improvement in DataChart downsampling algorithm                                                                                                                                                                                                                                                                                                                                                                                   |

--- a/src/lower_body_model/SPEC.md
+++ b/src/lower_body_model/SPEC.md
@@ -14,7 +14,7 @@ The **Lower Body Model** is a 3D biomechanical simulation of a golfer's lower bo
 - **Hips**: Gimbal Joints (3 independent hinge actuators: X, Y, Z).
 - **Knees**: Revolute Joints (1 hinge actuator, 0 to 150 flexion range).
 - **Ankles**: Universal Joints (2 hinge actuators, X and Y). Flat ellipsoids replace basic box feet for anatomical resemblance.
-- **Golf Hip Rotation Target**: `InclinedPlaneHipRotationTarget` samples a deterministic two-phase motion from 0 degrees to 45 degrees clockwise, then through 90 degrees of counterclockwise travel to +45 degrees on an inclined plane. `LowerBodySimulator` applies the target to both hip sockets through shared side iteration and reports target diagnostics during playback.
+- **Golf Hip Rotation Target**: `InclinedPlaneHipRotationTarget` samples a deterministic two-phase motion from 0 degrees to 45 degrees clockwise, then through 90 degrees of counterclockwise travel to +45 degrees on an inclined plane. `LowerBodySimulator` applies the target to both hip sockets through shared side iteration, reports target diagnostics during playback, and snapshots the target state into history frames for scrub-based verification.
 
 ## 4. Stability and Control
 A fundamental mathematical PID loop stabilizes local targets for the joints. The solver executes Damped Least Squares inverse kinematics across the free-floating root relative to the static ground boundary, preserving symmetrical ground contact constraint solving. By default, the stance is loaded at approximately `30` degrees anterior pelvic tilt, `120` degrees knee flexion, and a `20`-degree out-flared foot rotation.

--- a/src/lower_body_model/simulator.py
+++ b/src/lower_body_model/simulator.py
@@ -35,10 +35,22 @@ class LowerBodySimulator:
         self.kd_stability = 0.0
 
         # Simulation history for scrubbing (QPOS, QVEL, TIME)
-        self.history: list[dict[str, np.ndarray | float]] = []
+        self.history: list[dict[str, Any]] = []
         self.max_history_length = 5000
 
         mujoco.mj_forward(self.model, self.data)
+
+    def _current_hip_rotation_target_diagnostics(
+        self, time_sec: float
+    ) -> dict[str, float] | None:
+        """Return the configured hip rotation target diagnostics for a sample time."""
+        if self.hip_rotation_target is None:
+            return None
+
+        return {
+            "rotation_deg": self.hip_rotation_target.rotation_degrees_at(time_sec),
+            "incline_deg": self.hip_rotation_target.incline_degrees,
+        }
 
     def setup_initial_pose(
         self,
@@ -347,13 +359,11 @@ class LowerBodySimulator:
             "grf": grf,
             "joint_torques": joint_torques,
         }
-        if self.hip_rotation_target is not None:
-            diagnostics["hip_rotation_target"] = {
-                "rotation_deg": self.hip_rotation_target.rotation_degrees_at(
-                    self.data.time
-                ),
-                "incline_deg": self.hip_rotation_target.incline_degrees,
-            }
+        hip_rotation_target = self._current_hip_rotation_target_diagnostics(
+            self.data.time
+        )
+        if hip_rotation_target is not None:
+            diagnostics["hip_rotation_target"] = hip_rotation_target
         return diagnostics
 
     def analyze_induced_acceleration(
@@ -527,6 +537,9 @@ class LowerBodySimulator:
                 "qpos": self.data.qpos.copy(),
                 "qvel": self.data.qvel.copy(),
                 "ctrl": self.data.ctrl.copy(),
+                "hip_rotation_target": self._current_hip_rotation_target_diagnostics(
+                    self.data.time
+                ),
             }
         )
 
@@ -544,6 +557,18 @@ class LowerBodySimulator:
         self.data.qvel[:] = frame["qvel"]
         self.data.ctrl[:] = frame["ctrl"]
         mujoco.mj_forward(self.model, self.data)
+
+    def get_history_diagnostics(self, index: int) -> dict[str, Any]:
+        """Return playback diagnostics for a cached history frame."""
+        if not self.history or index < 0 or index >= len(self.history):
+            raise IndexError("History frame index out of range")
+
+        frame = self.history[index]
+        diagnostics: dict[str, Any] = {
+            "time_sec": float(frame["time"]),
+            "hip_rotation_target": frame["hip_rotation_target"],
+        }
+        return diagnostics
 
     def clear_history(self) -> None:
         """Empties execution memory logs."""

--- a/tests/unit/lower_body_model/test_hip_rotation_target.py
+++ b/tests/unit/lower_body_model/test_hip_rotation_target.py
@@ -70,3 +70,22 @@ def test_simulator_steps_with_configured_target_history() -> None:
     assert simulator.history
     diagnostics = simulator.compute_diagnostics()
     assert diagnostics["hip_rotation_target"]["rotation_deg"] <= 0.0
+
+
+def test_history_frame_exposes_hip_rotation_target_diagnostics() -> None:
+    simulator = LowerBodySimulator(build_lower_body_xml())
+    target = simulator.configure_hip_rotation_target(
+        duration_sec=2.0, incline_degrees=15.0, sample_count=5
+    )
+
+    simulator.step()
+
+    frame = simulator.history[-1]
+    history_diag = simulator.get_history_diagnostics(0)
+
+    assert frame["hip_rotation_target"] is not None
+    assert history_diag["time_sec"] == pytest.approx(frame["time"])
+    assert history_diag["hip_rotation_target"]["rotation_deg"] == pytest.approx(
+        target.rotation_degrees_at(frame["time"])
+    )
+    assert history_diag["hip_rotation_target"]["incline_deg"] == pytest.approx(15.0)


### PR DESCRIPTION
Refs #2015

Summary:
- Snapshot the configured hip rotation target into each simulation history frame.
- Add a small accessor for playback/history diagnostics.
- Cover the history snapshot with a focused regression test.
- Update the lower-body model SPEC to note scrub-based verification support.

Validation:
- python3 -m pytest tests/unit/lower_body_model/test_hip_rotation_target.py tests/unit/lower_body_model/test_simulator.py -q
- python3 -m ruff check src/lower_body_model/simulator.py tests/unit/lower_body_model/test_hip_rotation_target.py tests/unit/lower_body_model/test_simulator.py
- python3 -m mypy src/lower_body_model/simulator.py tests/unit/lower_body_model/test_hip_rotation_target.py