### PR TITLE
feat(lower_body_model): inclined-plane pelvis rotation driver

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.42                                     |
+| **Spec Version**        | 1.1.43                                     |
 | **Last Spec Update**    | 2026-04-11                                 |
 
 ## 2. Purpose & Mission
@@ -449,6 +449,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-04-11 | 1.1.43  | Added inclined-plane pelvis rotation driver to the lower-body simulator: `set_pelvis_inclined_rotation(target, ...)` wrenches the pelvis free joint via `data.xfrc_applied` each step so the body tracks an inclined rotation axis (spine angle) plus a smoothstep-ramped lateral weight shift during the downswing. New `InclinedPlaneHipRotationTarget.lateral_shift_m`, `lateral_shift_at(t)`, and `target_quaternion_at(t)` with full DbC. |
 | 2026-04-11 | 1.1.42  | Anatomically-shaped lower-body pelvis: composite of inertial host ellipsoid plus five mass=0 visual-only landmark geoms (sacrum, bilateral iliac wings, bright-red ASIS spheres, pubic symphysis) so pelvic tilt is visually unambiguous in the viewer without any change to dynamics. |
 | 2026-04-11 | 1.1.41  | Added a full reset control to the lower-body PyQt panel that stops playback, clears history, returns MuJoCo time to zero, preserves loaded golf hip rotation targets, and reapplies the target pose at `t=0`. |
 | 2026-04-11 | 1.1.40  | Added `tools.shared.python.model_generation.editor` compatibility exports (including `TextEditor` alias) to support removing duplicate model editor implementations in downstream repos that consume Tools as a dependency. |

--- a/src/lower_body_model/SPEC.md
+++ b/src/lower_body_model/SPEC.md
@@ -7,7 +7,7 @@ The **Lower Body Model** is a 3D biomechanical simulation of a golfer's lower bo
 - **DRY (Don't Repeat Yourself)**: The MuJoCo XML is constructed dynamically by `builder.py`, generating symmetrical left/right leg elements parametrically based on identical sub-routines mapped onto python strings.
 - **LOD (Law of Demeter)**: Components interact precisely through restricted interfaces. `main.py` interfaces with `LowerBodySimulator`, and only `LowerBodySimulator` manipulates `mujoco.MjData` and `mujoco.MjModel`.
 - **TDD (Test-Driven Development)**: Comprehensive coverage validates ZTCF calculation outputs, inverse kinematics stability, valid polynomial joint drivers, and mass-integrity matching inside XML generation.
-- **DbC (Design by Contract)**: Public entry points raise `TypeError` for wrong types and `ValueError` for out-of-range values, per the repository-wide CLAUDE.md rule. `setup_initial_pose`, `inverse_kinematics`, `build_lower_body_xml`, `InclinedPlaneHipRotationTarget.__post_init__`, and `set_pelvis_inclined_rotation` enforce all preconditions this way.
+- **DbC (Design by Contract)**: Public entry points raise `TypeError` for wrong types and `ValueError` for out-of-range values per the repository-wide CLAUDE.md rule. `setup_initial_pose`, `inverse_kinematics`, `build_lower_body_xml`, `InclinedPlaneHipRotationTarget.__post_init__`, and `set_pelvis_inclined_rotation` all validate preconditions this way, including the lateral shift range.
 
 ## 3. Kinematic Implementation
 

--- a/src/lower_body_model/hip_rotation.py
+++ b/src/lower_body_model/hip_rotation.py
@@ -18,13 +18,27 @@ class HipRotationSample:
 
 @dataclass(frozen=True)
 class InclinedPlaneHipRotationTarget:
-    """Two-phase golf hip rotation target viewed from above."""
+    """Two-phase golf hip rotation target viewed from above.
+
+    Models the rotation of the pelvis around an axis that is tilted forward
+    by ``incline_degrees`` (the golfer's spine angle). Phase one is a
+    clockwise backswing to ``-backswing_degrees``; phase two is a
+    counterclockwise downswing of ``counterclockwise_degrees`` from the
+    reversal point, both in equal halves of ``duration_sec``.
+
+    A lateral shift profile (``lateral_shift_m``) is layered on top:
+    during the backswing the pelvis stays centered, and during the
+    downswing it smoothly translates by up to ``lateral_shift_m`` metres
+    in the lateral (+Y) direction via a smoothstep ramp — mirroring the
+    golfer's weight shift to the front foot.
+    """
 
     duration_sec: float
     backswing_degrees: float = 45.0
     counterclockwise_degrees: float = 90.0
     incline_degrees: float = 12.0
     sample_count: int = 181
+    lateral_shift_m: float = 0.0
 
     def __post_init__(self) -> None:
         if self.duration_sec <= 0.0:
@@ -45,6 +59,11 @@ class InclinedPlaneHipRotationTarget:
         if self.sample_count < 2:
             raise ValueError(
                 f"sample_count must be at least 2, got {self.sample_count}"
+            )
+        if not -0.5 <= self.lateral_shift_m <= 0.5:
+            raise ValueError(
+                f"lateral_shift_m must be in [-0.5, 0.5] metres, "
+                f"got {self.lateral_shift_m}"
             )
 
     @property
@@ -81,6 +100,49 @@ class InclinedPlaneHipRotationTarget:
                 np.sin(rotation_rad) * np.sin(incline_rad),
             ],
             dtype=float,
+        )
+
+    def lateral_shift_at(self, time_sec: float) -> float:
+        """Return the lateral (+Y) shift in metres at ``time_sec``.
+
+        Zero during the backswing; during the downswing a smoothstep
+        ramp ``s(p) = 3p^2 - 2p^3`` from 0 to ``lateral_shift_m``.
+        """
+        if time_sec < 0.0:
+            raise ValueError(f"time_sec must be non-negative, got {time_sec}")
+        clamped_time = min(time_sec, self.duration_sec)
+        if clamped_time <= self.reversal_time_sec:
+            return 0.0
+        phase = (clamped_time - self.reversal_time_sec) / self.reversal_time_sec
+        smoothstep = 3.0 * phase * phase - 2.0 * phase * phase * phase
+        return float(self.lateral_shift_m * smoothstep)
+
+    def target_quaternion_at(self, time_sec: float) -> np.ndarray:
+        """Return the target pelvis quaternion (w, x, y, z) at ``time_sec``.
+
+        The rotation axis is the world-Z axis tilted forward by
+        ``incline_degrees`` about the +Y (lateral) axis; the rotation
+        amount is ``rotation_degrees_at(time_sec)``.
+        """
+        if time_sec < 0.0:
+            raise ValueError(f"time_sec must be non-negative, got {time_sec}")
+
+        incline_rad = np.radians(self.incline_degrees)
+        axis = np.array(
+            [
+                np.sin(incline_rad),  # forward (X) component from forward lean
+                0.0,
+                np.cos(incline_rad),  # remaining vertical (Z) component
+            ],
+            dtype=float,
+        )
+        axis /= np.linalg.norm(axis)
+
+        angle_rad = np.radians(self.rotation_degrees_at(time_sec))
+        half = 0.5 * angle_rad
+        s = np.sin(half)
+        return np.array(
+            [np.cos(half), axis[0] * s, axis[1] * s, axis[2] * s], dtype=float
         )
 
     def sample(self) -> list[HipRotationSample]:

--- a/src/lower_body_model/simulator.py
+++ b/src/lower_body_model/simulator.py
@@ -29,6 +29,16 @@ class LowerBodySimulator:
         self._polynomial_drivers: dict[int, np.ndarray] = {}
         self.hip_rotation_target: InclinedPlaneHipRotationTarget | None = None
 
+        # Inclined-plane pelvis driver state.
+        self._pelvis_driver_target: InclinedPlaneHipRotationTarget | None = None
+        self._pelvis_driver_origin: np.ndarray | None = None
+        self._pelvis_driver_gains: dict[str, float] = {
+            "position_kp": 500.0,
+            "position_kd": 50.0,
+            "orientation_kp": 200.0,
+            "orientation_kd": 20.0,
+        }
+
         # Stability control target (rest pose)
         self.qpos_target: np.ndarray | None = None
         self.kp_stability = 0.0
@@ -181,6 +191,117 @@ class LowerBodySimulator:
             sample_count=sample_count,
         )
         return self.hip_rotation_target
+
+    def set_pelvis_inclined_rotation(
+        self,
+        target: InclinedPlaneHipRotationTarget,
+        *,
+        position_kp: float = 500.0,
+        position_kd: float = 50.0,
+        orientation_kp: float = 200.0,
+        orientation_kd: float = 20.0,
+    ) -> None:
+        """Configure an inclined-plane driver that actuates the pelvis free joint.
+
+        Each call to :meth:`step` will apply a PD tracking force/torque to the
+        pelvis body via ``data.xfrc_applied``, driving the free joint towards
+        ``target.target_quaternion_at(t)`` and the lateral position towards
+        ``origin + target.lateral_shift_at(t) * Y``. The current pelvis x,y,z
+        position is captured as the origin at the moment of the call.
+
+        Args:
+            target: The inclined-plane rotation target to drive.
+            position_kp: Proportional gain on pelvis linear position error (N/m).
+            position_kd: Derivative gain on pelvis linear velocity (Ns/m).
+            orientation_kp: Proportional gain on pelvis rotation error (Nm/rad).
+            orientation_kd: Derivative gain on pelvis angular velocity (Nms/rad).
+
+        Raises:
+            TypeError: If ``target`` is not an ``InclinedPlaneHipRotationTarget``
+                or any gain is not a real number.
+            ValueError: If any gain is negative.
+        """
+        if not isinstance(target, InclinedPlaneHipRotationTarget):
+            raise TypeError(
+                "target must be an InclinedPlaneHipRotationTarget, got "
+                f"{type(target).__name__}"
+            )
+        for name, value in (
+            ("position_kp", position_kp),
+            ("position_kd", position_kd),
+            ("orientation_kp", orientation_kp),
+            ("orientation_kd", orientation_kd),
+        ):
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(
+                    f"{name} must be a real number, got {type(value).__name__}"
+                )
+            if value < 0.0:
+                raise ValueError(f"{name} must be non-negative, got {value}")
+
+        self._pelvis_driver_target = target
+        self._pelvis_driver_origin = self.data.xpos[self.pelvis_body_id].copy()
+        self._pelvis_driver_gains = {
+            "position_kp": float(position_kp),
+            "position_kd": float(position_kd),
+            "orientation_kp": float(orientation_kp),
+            "orientation_kd": float(orientation_kd),
+        }
+
+    def clear_pelvis_inclined_rotation(self) -> None:
+        """Remove any configured inclined-plane pelvis driver and zero forces."""
+        self._pelvis_driver_target = None
+        self._pelvis_driver_origin = None
+        if self.data.xfrc_applied.shape[0] > self.pelvis_body_id:
+            self.data.xfrc_applied[self.pelvis_body_id] = 0.0
+
+    def _apply_pelvis_inclined_driver(self) -> None:
+        """Apply the PD tracking wrench for the configured pelvis driver."""
+        target = self._pelvis_driver_target
+        origin = self._pelvis_driver_origin
+        if target is None or origin is None:
+            return
+
+        t = float(self.data.time)
+        gains = self._pelvis_driver_gains
+
+        # Linear tracking: origin + lateral_shift_at(t) * +Y.
+        desired_pos = origin.copy()
+        desired_pos[1] += target.lateral_shift_at(t)
+        cur_pos = self.data.xpos[self.pelvis_body_id]
+        lin_err = desired_pos - cur_pos
+        lin_vel = self.data.qvel[0:3]
+        lin_force = gains["position_kp"] * lin_err - gains["position_kd"] * lin_vel
+
+        # Angular tracking: body quat -> target quat -> error quat -> axis-angle.
+        target_quat = target.target_quaternion_at(t)
+        cur_quat = self.data.xquat[self.pelvis_body_id].copy()
+
+        # err_quat = target * conj(cur)
+        cur_conj = np.array([cur_quat[0], -cur_quat[1], -cur_quat[2], -cur_quat[3]])
+        err_quat = np.zeros(4)
+        mujoco.mju_mulQuat(err_quat, target_quat, cur_conj)
+
+        # Ensure shortest-arc (positive w).
+        if err_quat[0] < 0.0:
+            err_quat = -err_quat
+
+        # Axis-angle: angle = 2 * acos(w); axis = vec / sin(angle/2).
+        w = float(np.clip(err_quat[0], -1.0, 1.0))
+        vec = err_quat[1:4]
+        vec_norm = float(np.linalg.norm(vec))
+        if vec_norm > 1e-9:
+            angle = 2.0 * float(np.arccos(w))
+            if angle > np.pi:
+                angle -= 2.0 * np.pi
+            ang_err = (vec / vec_norm) * angle
+        else:
+            ang_err = np.zeros(3)
+        ang_vel = self.data.qvel[3:6]
+        torque = gains["orientation_kp"] * ang_err - gains["orientation_kd"] * ang_vel
+
+        self.data.xfrc_applied[self.pelvis_body_id, 0:3] = lin_force
+        self.data.xfrc_applied[self.pelvis_body_id, 3:6] = torque
 
     def apply_hip_rotation_target(
         self, time_sec: float | None = None
@@ -512,6 +633,11 @@ class LowerBodySimulator:
         t = self.data.time
         if self.hip_rotation_target is not None:
             self.apply_hip_rotation_target(t)
+
+        # Apply the inclined-plane pelvis driver before mj_step so its wrench
+        # is integrated along with every other external force this tick.
+        if self._pelvis_driver_target is not None:
+            self._apply_pelvis_inclined_driver()
 
         # Basic stability control (PD) to hold the target posture if no polynomial is provided
         if self.qpos_target is not None:

--- a/tests/unit/lower_body_model/test_hip_rotation_target.py
+++ b/tests/unit/lower_body_model/test_hip_rotation_target.py
@@ -49,6 +49,101 @@ def test_rotation_degrees_at_rejects_negative_time() -> None:
         target.rotation_degrees_at(-0.1)
 
 
+def test_lateral_shift_at_is_zero_during_backswing_and_smoothsteps_to_finish() -> None:
+    target = InclinedPlaneHipRotationTarget(
+        duration_sec=2.0, lateral_shift_m=0.08, sample_count=2
+    )
+
+    assert target.lateral_shift_at(0.0) == pytest.approx(0.0)
+    assert target.lateral_shift_at(0.5) == pytest.approx(0.0)
+    assert target.lateral_shift_at(1.0) == pytest.approx(0.0)
+    # At mid-downswing the smoothstep value is s(0.5) = 0.5.
+    assert target.lateral_shift_at(1.5) == pytest.approx(0.08 * 0.5, abs=1e-6)
+    assert target.lateral_shift_at(2.0) == pytest.approx(0.08, abs=1e-6)
+
+
+def test_lateral_shift_at_rejects_negative_time() -> None:
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0, lateral_shift_m=0.05)
+    with pytest.raises(ValueError):
+        target.lateral_shift_at(-0.1)
+
+
+def test_lateral_shift_m_range_enforced() -> None:
+    with pytest.raises(ValueError):
+        InclinedPlaneHipRotationTarget(duration_sec=1.0, lateral_shift_m=1.0)
+
+
+def test_target_quaternion_at_zero_rotation_is_identity() -> None:
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0, incline_degrees=12.0)
+    q = target.target_quaternion_at(0.0)
+    assert q[0] == pytest.approx(1.0)
+    assert np.allclose(q[1:], 0.0)
+
+
+def test_target_quaternion_at_rotation_axis_reflects_incline() -> None:
+    """A non-zero incline must push the rotation axis off pure +Z."""
+    target = InclinedPlaneHipRotationTarget(
+        duration_sec=2.0, incline_degrees=30.0, backswing_degrees=45.0
+    )
+    # Use the reversal point where rotation_deg = -backswing_degrees.
+    q = target.target_quaternion_at(1.0)
+    # Axis-angle: vec = sin(angle/2) * axis.
+    vec = q[1:]
+    vec_norm = np.linalg.norm(vec)
+    assert vec_norm > 0.0
+    axis = vec / vec_norm
+    # With incline=30 the axis has a significant X component (sin(30)=0.5).
+    assert abs(axis[0]) > 0.3
+    assert axis[1] == pytest.approx(0.0, abs=1e-6)
+    assert abs(axis[2]) > 0.7
+
+
+def test_simulator_pelvis_driver_tracks_lateral_shift() -> None:
+    target = InclinedPlaneHipRotationTarget(
+        duration_sec=1.0,
+        backswing_degrees=10.0,
+        counterclockwise_degrees=20.0,
+        incline_degrees=5.0,
+        lateral_shift_m=0.10,
+    )
+    sim = LowerBodySimulator(build_lower_body_xml())
+    sim.setup_initial_pose()
+    sim.set_pelvis_inclined_rotation(target)
+
+    initial_y = float(sim.data.xpos[sim.pelvis_body_id][1])
+
+    # Drive the simulator to just past the reversal point.
+    while sim.data.time < 0.9:
+        sim.step()
+
+    final_y = float(sim.data.xpos[sim.pelvis_body_id][1])
+    # The pelvis should have shifted in +Y during the downswing phase.
+    assert final_y - initial_y > 0.01, (
+        f"expected +Y shift; got {final_y - initial_y:.4f}"
+    )
+
+
+def test_set_pelvis_inclined_rotation_rejects_bad_gains() -> None:
+    sim = LowerBodySimulator(build_lower_body_xml())
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0)
+    with pytest.raises(ValueError):
+        sim.set_pelvis_inclined_rotation(target, position_kp=-1.0)
+    with pytest.raises(TypeError):
+        sim.set_pelvis_inclined_rotation(target, orientation_kp="loose")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        sim.set_pelvis_inclined_rotation("not a target")  # type: ignore[arg-type]
+
+
+def test_clear_pelvis_inclined_rotation_removes_driver() -> None:
+    sim = LowerBodySimulator(build_lower_body_xml())
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0, lateral_shift_m=0.05)
+    sim.set_pelvis_inclined_rotation(target)
+    sim.step()
+    sim.clear_pelvis_inclined_rotation()
+    assert sim._pelvis_driver_target is None
+    assert np.allclose(sim.data.xfrc_applied[sim.pelvis_body_id], 0.0)
+
+
 def test_simulator_applies_target_to_both_hip_sockets() -> None:
     simulator = LowerBodySimulator(build_lower_body_xml())
     simulator.configure_hip_rotation_target(


### PR DESCRIPTION
## Summary
Implements issue #2025. Adds a simulator-level driver that actuates the pelvis free joint along an inclined rotation axis (the golfer's spine-angle plane) while also executing a lateral weight shift during the downswing.

This is distinct from the pre-existing \`hip_rotation_target\` which drove the leg hip sockets via qpos; the new driver wrenches the pelvis body itself through \`data.xfrc_applied\` on every \`step()\`.

## Changes to \`InclinedPlaneHipRotationTarget\`
- New field **\`lateral_shift_m\`** (default 0.0, validated to [-0.5, 0.5] m).
- New method **\`lateral_shift_at(t)\`** — zero during the backswing, then a smoothstep ramp \`3p² − 2p³\` from 0 to \`lateral_shift_m\` across the downswing. Smoothstep (not linear) so lateral velocity is zero at both endpoints, avoiding a jerk discontinuity when the driver hands over.
- New method **\`target_quaternion_at(t)\`** — returns the pelvis target quaternion by rotating the world +Z axis by \`rotation_degrees_at(t)\` about an axis tilted forward by \`incline_degrees\`. With \`incline_degrees=0\` this is a pure Z-axis yaw.

## Changes to \`LowerBodySimulator\`
- **\`set_pelvis_inclined_rotation(target, position_kp, position_kd, orientation_kp, orientation_kd)\`** — configure the driver and snapshot the current pelvis position as the lateral origin. Full DbC: \`TypeError\` if \`target\` isn't an \`InclinedPlaneHipRotationTarget\` or a gain is non-numeric; \`ValueError\` if any gain is negative.
- **\`clear_pelvis_inclined_rotation()\`** — remove the driver and zero the pelvis wrench.
- **\`_apply_pelvis_inclined_driver()\`** — compute linear and angular errors and fill \`data.xfrc_applied[pelvis_body_id]\` with a PD tracking wrench. The angular error uses the shortest-arc error quaternion \`target · conj(current)\` converted to axis-angle.
- **\`step()\`** now calls the driver just before \`mj_step\` so the wrench is integrated along with the rest of the dynamics.

## Design decision: soft PD, not kinematic override
The driver is a **soft** PD tracker, not a kinematic override. A kinematic override would have decoupled the upper body from ground reaction forces, making the model useless for the counterfactual / induced-acceleration analyses it exists to support. Soft PD keeps the dynamics real; you can tune the gains to be stiff enough to dominate the spine-angle trajectory while still letting GRFs matter.

## Tests
- **\`lateral_shift_at\`**
  - zero during the entire backswing
  - smoothstep value of \`0.5 * lateral_shift_m\` at mid-downswing
  - full \`lateral_shift_m\` at finish
  - raises \`ValueError\` on negative time
- **\`lateral_shift_m\`** range enforcement [-0.5, 0.5]
- **\`target_quaternion_at\`**
  - identity at \`t=0\` (rotation = 0)
  - non-zero incline rotates the axis off pure +Z (X-component reflects \`sin(incline)\`)
- **Simulator integration**
  - pelvis actually shifts in +Y by >1 cm during the downswing under the driver
  - DbC rejection of bad gains and non-target arguments
  - \`clear_pelvis_inclined_rotation\` zeroes the pelvis wrench

## Test plan
- [ ] \`ruff check\` / \`ruff format --check\` — pass locally.
- [ ] CI \`pytest tests/unit/lower_body_model/test_hip_rotation_target.py\` — needs mujoco (CI only).
- [ ] Visual check in PyQt6 viewer showing pelvis tracks an inclined swing plane with lateral shift (manual, post-merge).

Closes #2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)