### PR TITLE
refactor(lower_body_model): DRY/LOD cache + contract tests

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.43                                     |
+| **Spec Version**        | 1.1.44                                     |
 | **Last Spec Update**    | 2026-04-11                                 |
 
 ## 2. Purpose & Mission
@@ -449,6 +449,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-04-11 | 1.1.44  | Lower-body simulator DRY/LOD refactor: centralized mj_name2id lookups into a single cache populated in `_cache_indices` (joints, actuators, sites, geoms, bodies), eliminated reflective lookups from hot paths (`step`, `compute_diagnostics`, `inverse_kinematics`, `set_joint_polynomial`, `analyze_induced_acceleration`), and decomposed `compute_diagnostics` into `_collect_tracking_error`, `_collect_joint_torques`, `_collect_ground_reaction_forces`. Added contract test suite locking down the public API surface (`-m contract`). |
 | 2026-04-11 | 1.1.43  | Added inclined-plane pelvis rotation driver to the lower-body simulator: `set_pelvis_inclined_rotation(target, ...)` wrenches the pelvis free joint via `data.xfrc_applied` each step so the body tracks an inclined rotation axis (spine angle) plus a smoothstep-ramped lateral weight shift during the downswing. New `InclinedPlaneHipRotationTarget.lateral_shift_m`, `lateral_shift_at(t)`, and `target_quaternion_at(t)` with full DbC. |
 | 2026-04-11 | 1.1.42  | Anatomically-shaped lower-body pelvis: composite of inertial host ellipsoid plus five mass=0 visual-only landmark geoms (sacrum, bilateral iliac wings, bright-red ASIS spheres, pubic symphysis) so pelvic tilt is visually unambiguous in the viewer without any change to dynamics. |
 | 2026-04-11 | 1.1.41  | Added a full reset control to the lower-body PyQt panel that stops playback, clears history, returns MuJoCo time to zero, preserves loaded golf hip rotation targets, and reapplies the target pose at `t=0`. |

--- a/src/lower_body_model/SPEC.md
+++ b/src/lower_body_model/SPEC.md
@@ -5,7 +5,7 @@ The **Lower Body Model** is a 3D biomechanical simulation of a golfer's lower bo
 
 ## 2. Architecture & Design Principles
 - **DRY (Don't Repeat Yourself)**: The MuJoCo XML is constructed dynamically by `builder.py`, generating symmetrical left/right leg elements parametrically based on identical sub-routines mapped onto python strings.
-- **LOD (Law of Demeter)**: Components interact precisely through restricted interfaces. `main.py` interfaces with `LowerBodySimulator`, and only `LowerBodySimulator` manipulates `mujoco.MjData` and `mujoco.MjModel`.
+- **LOD (Law of Demeter)**: Components interact precisely through restricted interfaces. `main.py` interfaces with `LowerBodySimulator`, and only `LowerBodySimulator` manipulates `mujoco.MjData` and `mujoco.MjModel`. All MuJoCo id lookups (`mj_name2id`) are cached in `_cache_indices` at construction; hot-path methods (`step`, `compute_diagnostics`, `inverse_kinematics`, `analyze_induced_acceleration`) read from the cache rather than reaching into MuJoCo's reflective API.
 - **TDD (Test-Driven Development)**: Comprehensive coverage validates ZTCF calculation outputs, inverse kinematics stability, valid polynomial joint drivers, and mass-integrity matching inside XML generation.
 - **DbC (Design by Contract)**: Public entry points raise `TypeError` for wrong types and `ValueError` for out-of-range values per the repository-wide CLAUDE.md rule. `setup_initial_pose`, `inverse_kinematics`, `build_lower_body_xml`, `InclinedPlaneHipRotationTarget.__post_init__`, and `set_pelvis_inclined_rotation` all validate preconditions this way, including the lateral shift range.
 

--- a/src/lower_body_model/simulator.py
+++ b/src/lower_body_model/simulator.py
@@ -122,13 +122,10 @@ class LowerBodySimulator:
 
         mujoco.mj_kinematics(self.model, self.data)
 
-        # Drop the pelvis until feet touch the ground
-        # foot_z is the current site Z height. The site is at local z=-0.04 in the foot ellipsoid.
-        # So when the site is at global Z=0.04, the bottom of the foot ellipsoid (z=-0.08 local) is at global Z=0.
-        r_foot_id = mujoco.mj_name2id(
-            self.model, mujoco.mjtObj.mjOBJ_SITE, "r_foot_center"
-        )
-        foot_z = self.data.site_xpos[r_foot_id][2]
+        # Drop the pelvis until feet touch the ground.
+        # The foot site is at local z=-0.04 in the foot ellipsoid, so when the
+        # site's global Z equals 0.04 the bottom of the ellipsoid touches z=0.
+        foot_z = self.data.site_xpos[self.site_ids["r_foot_center"]][2]
 
         # Free joint first 3 qpos are root x, y, z
         self.data.qpos[2] -= foot_z - 0.04
@@ -139,13 +136,40 @@ class LowerBodySimulator:
         self.qpos_target = self.data.qpos.copy()
 
     def _cache_indices(self) -> None:
-        """Pre-compute indices for fast lookup."""
-        self.jnt_qpos_idx = {}
+        """Pre-compute MuJoCo ids so hot paths don't reach into name lookups.
+
+        Everything the simulator needs to reference by id is looked up exactly
+        once, here. `compute_diagnostics`, `analyze_induced_acceleration`,
+        `step`, and `inverse_kinematics` all read from these caches instead
+        of calling ``mj_name2id`` repeatedly on every frame.
+        """
+        self.jnt_qpos_idx: dict[str, int] = {}
+        self.jnt_dof_idx: dict[str, int] = {}
+        self.act_ids: dict[str, int] = {}
+        self.site_ids: dict[str, int] = {}
+        self.geom_ids: dict[str, int] = {}
+
         for name in self.joint_names:
             if name is None:
                 continue
-            idx = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_JOINT, name)
-            self.jnt_qpos_idx[name] = self.model.jnt_qposadr[idx]
+            jnt_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_JOINT, name)
+            self.jnt_qpos_idx[name] = int(self.model.jnt_qposadr[jnt_id])
+            self.jnt_dof_idx[name] = int(self.model.jnt_dofadr[jnt_id])
+
+        for i in range(self.model.nu):
+            act_name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_ACTUATOR, i)
+            if act_name is not None:
+                self.act_ids[act_name] = i
+
+        for site in ("r_foot_center", "l_foot_center"):
+            self.site_ids[site] = mujoco.mj_name2id(
+                self.model, mujoco.mjtObj.mjOBJ_SITE, site
+            )
+
+        for geom in ("floor", "r_foot_geom", "l_foot_geom"):
+            self.geom_ids[geom] = mujoco.mj_name2id(
+                self.model, mujoco.mjtObj.mjOBJ_GEOM, geom
+            )
 
         self.pelvis_body_id = mujoco.mj_name2id(
             self.model, mujoco.mjtObj.mjOBJ_BODY, "pelvis"
@@ -156,21 +180,16 @@ class LowerBodySimulator:
         mujoco.mj_forward(self.model, self.data)
 
     def set_joint_polynomial(self, joint_name: str, coeffs: list[float]) -> None:
-        """
-        Drive a joint using a polynomial function evaluated over time.
-        coeffs: highest degree first (e.g. polyval format) or lowest degree first.
-        We will assume standard np.polyval format: highest degree first.
-        """
-        if joint_name not in self.actuator_names:
-            # Maybe the actuator is named act_{joint_name}
-            act_name = f"act_{joint_name}"
-        else:
-            act_name = joint_name
+        """Drive the named joint's actuator with a polynomial ``np.polyval``.
 
-        act_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_ACTUATOR, act_name)
+        ``joint_name`` may be either the bare joint name (``r_hip_x``) or the
+        full actuator name (``act_r_hip_x``). Raises ``ValueError`` if no
+        actuator exists for the joint.
+        """
+        act_name = joint_name if joint_name.startswith("act_") else f"act_{joint_name}"
+        act_id = self.act_ids.get(act_name, -1)
         if act_id == -1:
             raise ValueError(f"No actuator found for {joint_name}")
-
         self._polynomial_drivers[act_id] = np.array(coeffs)
 
     def configure_hip_rotation_target(
@@ -393,70 +412,23 @@ class LowerBodySimulator:
         }
 
     def compute_diagnostics(self) -> dict[str, str | float | bool | dict[str, Any]]:
-        """Comprehensive system diagnostics for stability, telemetry, and debugging."""
+        """Return a telemetry snapshot: pose, tracking error, torques, GRF."""
         mujoco.mj_kinematics(self.model, self.data)
-
-        # Base telemetry
-        pelvis_pos = self.data.xpos[
-            mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, "pelvis")
-        ]
+        pelvis_pos = self.data.xpos[self.pelvis_body_id]
         div = bool(np.any(np.isnan(self.data.qpos)) or np.any(np.isnan(self.data.qvel)))
-
-        max_err = 0.0
-        active_torques = 0.0
-        joint_torques = {}
         history_len = len(self.history)
 
-        # Ground reaction force extraction (Right and Left Foot)
-        grf = {"right_z": 0.0, "left_z": 0.0}
+        if div:
+            max_err = 0.0
+            active_torques = 0.0
+            joint_torques: dict[str, float] = {}
+            grf = {"right_z": 0.0, "left_z": 0.0}
+        else:
+            max_err = self._collect_tracking_error()
+            active_torques, joint_torques = self._collect_joint_torques()
+            grf = self._collect_ground_reaction_forces()
 
-        if not div:
-            for act_name, q_idx in self.jnt_qpos_idx.items():
-                if self.qpos_target is not None:
-                    err = abs(self.data.qpos[q_idx] - self.qpos_target[q_idx])
-                    if err > max_err:
-                        max_err = err
-
-                # Check control commands
-                act_id = mujoco.mj_name2id(
-                    self.model, mujoco.mjtObj.mjOBJ_ACTUATOR, f"act_{act_name}"
-                )
-                if act_id != -1:
-                    trq = float(self.data.ctrl[act_id])
-                    active_torques += abs(trq)
-                    joint_torques[act_name] = trq
-
-            # Ground Reaction Forces explicitly. Geom names come from builder.py;
-            # using geom-scope names avoids collisions with the body names.
-            right_foot_geom = mujoco.mj_name2id(
-                self.model, mujoco.mjtObj.mjOBJ_GEOM, "r_foot_geom"
-            )
-            left_foot_geom = mujoco.mj_name2id(
-                self.model, mujoco.mjtObj.mjOBJ_GEOM, "l_foot_geom"
-            )
-            floor_geom = mujoco.mj_name2id(
-                self.model, mujoco.mjtObj.mjOBJ_GEOM, "floor"
-            )
-
-            for i in range(self.data.ncon):
-                contact = self.data.contact[i]
-                is_floor = contact.geom1 == floor_geom or contact.geom2 == floor_geom
-                is_r_foot = (
-                    contact.geom1 == right_foot_geom or contact.geom2 == right_foot_geom
-                )
-                is_l_foot = (
-                    contact.geom1 == left_foot_geom or contact.geom2 == left_foot_geom
-                )
-
-                if is_floor and is_r_foot:
-                    grf["right_z"] += float(
-                        self.data.efc_force[contact.efc_address]
-                    )  # Primary normal force
-                elif is_floor and is_l_foot:
-                    grf["left_z"] += float(self.data.efc_force[contact.efc_address])
-
-        r_knee_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_JOINT, "r_knee")
-        r_knee_qpos_adr = self.model.jnt_qposadr[r_knee_id]
+        r_knee_qpos_adr = self.jnt_qpos_idx["r_knee"]
 
         diagnostics: dict[str, str | float | bool | dict[str, Any]] = {
             "time_sec": float(self.data.time),
@@ -484,6 +456,47 @@ class LowerBodySimulator:
             diagnostics["hip_rotation_target"] = hip_rotation_target
         return diagnostics
 
+    def _collect_tracking_error(self) -> float:
+        """Return the largest per-joint qpos error against the stability target."""
+        if self.qpos_target is None:
+            return 0.0
+        max_err = 0.0
+        for q_idx in self.jnt_qpos_idx.values():
+            err = abs(float(self.data.qpos[q_idx] - self.qpos_target[q_idx]))
+            if err > max_err:
+                max_err = err
+        return max_err
+
+    def _collect_joint_torques(self) -> tuple[float, dict[str, float]]:
+        """Return (sum |torque|, per-actuator torque dict) from data.ctrl."""
+        active = 0.0
+        torques: dict[str, float] = {}
+        for joint_name in self.jnt_qpos_idx:
+            act_id = self.act_ids.get(f"act_{joint_name}")
+            if act_id is None:
+                continue
+            trq = float(self.data.ctrl[act_id])
+            active += abs(trq)
+            torques[joint_name] = trq
+        return active, torques
+
+    def _collect_ground_reaction_forces(self) -> dict[str, float]:
+        """Return vertical GRF on each foot accumulated over current contacts."""
+        grf = {"right_z": 0.0, "left_z": 0.0}
+        floor = self.geom_ids.get("floor", -1)
+        r_foot = self.geom_ids.get("r_foot_geom", -1)
+        l_foot = self.geom_ids.get("l_foot_geom", -1)
+        for i in range(self.data.ncon):
+            contact = self.data.contact[i]
+            touches_floor = contact.geom1 == floor or contact.geom2 == floor
+            if not touches_floor:
+                continue
+            if contact.geom1 == r_foot or contact.geom2 == r_foot:
+                grf["right_z"] += float(self.data.efc_force[contact.efc_address])
+            elif contact.geom1 == l_foot or contact.geom2 == l_foot:
+                grf["left_z"] += float(self.data.efc_force[contact.efc_address])
+        return grf
+
     def analyze_induced_acceleration(
         self, actuator_name: str, torque_value: float = 1.0
     ) -> dict[str, float]:
@@ -494,9 +507,7 @@ class LowerBodySimulator:
 
         Returns the induced linear and angular acceleration of the pelvis.
         """
-        act_id = mujoco.mj_name2id(
-            self.model, mujoco.mjtObj.mjOBJ_ACTUATOR, actuator_name
-        )
+        act_id = self.act_ids.get(actuator_name, -1)
         if act_id == -1:
             raise ValueError(f"No actuator found for {actuator_name}")
 
@@ -583,12 +594,8 @@ class LowerBodySimulator:
         self.data.qpos[0:3] = target_pos_arr
         self.data.qpos[3:7] = target_quat_arr
 
-        r_foot_id = mujoco.mj_name2id(
-            self.model, mujoco.mjtObj.mjOBJ_SITE, "r_foot_center"
-        )
-        l_foot_id = mujoco.mj_name2id(
-            self.model, mujoco.mjtObj.mjOBJ_SITE, "l_foot_center"
-        )
+        r_foot_id = self.site_ids["r_foot_center"]
+        l_foot_id = self.site_ids["l_foot_center"]
 
         # Nominal foot site targets (match the rest-pose builder placement).
         r_target = np.array([0.05, -0.15, -0.03])
@@ -639,33 +646,16 @@ class LowerBodySimulator:
         if self._pelvis_driver_target is not None:
             self._apply_pelvis_inclined_driver()
 
-        # Basic stability control (PD) to hold the target posture if no polynomial is provided
+        # PD stability loop to hold the target posture. Everything here reads
+        # from pre-cached indices; no mj_name2id calls in the hot path.
         if self.qpos_target is not None:
-            # We want to apply controls for all named actuators to track qpos_target
-            # Root DOFs (first 7 in qpos) shouldn't be controlled by joint actuators
             for joint_name, q_idx in self.jnt_qpos_idx.items():
-                act_name = f"act_{joint_name}"
-                act_id = mujoco.mj_name2id(
-                    self.model, mujoco.mjtObj.mjOBJ_ACTUATOR, act_name
-                )
-
-                if act_id == -1:
+                act_id = self.act_ids.get(f"act_{joint_name}")
+                if act_id is None or act_id in self._polynomial_drivers:
                     continue
-
-                if act_id in self._polynomial_drivers:
-                    continue  # Driven by polynomial instead
-
-                # Joint DOF index in qvel is q_idx - 1 (since root has 7 qpos but 6 qvel)
-                # But a cleaner way is mapping joint id to qvel index:
-                jnt_id = mujoco.mj_name2id(
-                    self.model, mujoco.mjtObj.mjOBJ_JOINT, joint_name
-                )
-                v_idx = self.model.jnt_dofadr[jnt_id]
-
+                v_idx = self.jnt_dof_idx[joint_name]
                 q_err = self.data.qpos[q_idx] - self.qpos_target[q_idx]
                 v_err = self.data.qvel[v_idx]
-
-                # PD control
                 self.data.ctrl[act_id] = (
                     -self.kp_stability * q_err - self.kd_stability * v_err
                 )

--- a/tests/unit/lower_body_model/test_public_api_contract.py
+++ b/tests/unit/lower_body_model/test_public_api_contract.py
@@ -1,0 +1,230 @@
+"""Contract tests for the lower_body_model public API.
+
+These tests lock down the surface that downstream repos (UpstreamDrift,
+Gasification_Model) and in-repo callers rely on. Breaking any of them is
+a signal that a public API change slipped through without a deprecation
+path. They are kept deliberately shallow — we check signatures, return
+keys, exception types, and existence rather than deep behaviour, which
+is covered by the regular unit tests.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import numpy as np
+import pytest
+
+from lower_body_model import HipRotationSample, InclinedPlaneHipRotationTarget
+from lower_body_model.builder import build_lower_body_xml
+from lower_body_model.hip_rotation import (
+    HipRotationSample as DirectSample,
+)
+from lower_body_model.hip_rotation import (
+    InclinedPlaneHipRotationTarget as DirectTarget,
+)
+from lower_body_model.simulator import LowerBodySimulator
+
+pytestmark = pytest.mark.contract
+
+
+# ---------------------------------------------------------------------------
+# Package-level exports
+# ---------------------------------------------------------------------------
+
+
+def test_package_exports_hip_rotation_types() -> None:
+    assert HipRotationSample is DirectSample
+    assert InclinedPlaneHipRotationTarget is DirectTarget
+
+
+# ---------------------------------------------------------------------------
+# build_lower_body_xml signature
+# ---------------------------------------------------------------------------
+
+
+def test_build_lower_body_xml_signature() -> None:
+    sig = inspect.signature(build_lower_body_xml)
+    expected = {
+        "thigh_mass",
+        "calf_mass",
+        "foot_mass",
+        "pelvis_mass",
+        "thigh_length",
+        "calf_length",
+        "pelvis_width",
+    }
+    assert expected.issubset(sig.parameters.keys())
+    for name in expected:
+        assert sig.parameters[name].default is not inspect.Parameter.empty
+
+
+def test_build_lower_body_xml_returns_mjcf_str() -> None:
+    xml = build_lower_body_xml()
+    assert isinstance(xml, str)
+    assert xml.startswith("<mujoco")
+
+
+# ---------------------------------------------------------------------------
+# InclinedPlaneHipRotationTarget contract
+# ---------------------------------------------------------------------------
+
+
+def test_target_public_fields_and_defaults() -> None:
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0)
+    for field in (
+        "duration_sec",
+        "backswing_degrees",
+        "counterclockwise_degrees",
+        "incline_degrees",
+        "sample_count",
+        "lateral_shift_m",
+    ):
+        assert hasattr(target, field), f"missing field: {field}"
+
+
+def test_target_public_methods_present() -> None:
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0)
+    for method_name in (
+        "rotation_degrees_at",
+        "plane_point_at",
+        "lateral_shift_at",
+        "target_quaternion_at",
+        "sample",
+    ):
+        assert callable(getattr(target, method_name)), f"missing: {method_name}"
+
+
+def test_target_sample_returns_hip_rotation_samples() -> None:
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0, sample_count=3)
+    samples = target.sample()
+    assert len(samples) == 3
+    assert all(isinstance(s, HipRotationSample) for s in samples)
+    for s in samples:
+        assert hasattr(s, "time_sec")
+        assert hasattr(s, "rotation_deg")
+        assert hasattr(s, "plane_point")
+
+
+# ---------------------------------------------------------------------------
+# LowerBodySimulator surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simulator() -> LowerBodySimulator:
+    return LowerBodySimulator(build_lower_body_xml())
+
+
+def test_simulator_public_methods_present(simulator: LowerBodySimulator) -> None:
+    """Locked-down public method surface.
+
+    Do not remove or rename any of these without a deprecation shim;
+    downstream repos and the PyQt6 control panel call into them by name.
+    """
+    required = (
+        "setup_initial_pose",
+        "reset",
+        "set_joint_polynomial",
+        "configure_hip_rotation_target",
+        "apply_hip_rotation_target",
+        "set_pelvis_inclined_rotation",
+        "clear_pelvis_inclined_rotation",
+        "compute_zero_torque_counterfactual",
+        "compute_pelvis_kinematics",
+        "compute_diagnostics",
+        "analyze_induced_acceleration",
+        "inverse_kinematics",
+        "step",
+        "restore_frame",
+        "get_history_diagnostics",
+        "clear_history",
+    )
+    for name in required:
+        assert callable(getattr(simulator, name, None)), f"missing: {name}"
+
+
+def test_compute_pelvis_kinematics_return_shape(
+    simulator: LowerBodySimulator,
+) -> None:
+    result = simulator.compute_pelvis_kinematics()
+    for key in ("x_forward", "y_lateral", "z_vertical", "roll", "pitch", "yaw"):
+        assert key in result
+        assert isinstance(result[key], float)
+
+
+def test_compute_diagnostics_return_shape(simulator: LowerBodySimulator) -> None:
+    simulator.setup_initial_pose()
+    diag = simulator.compute_diagnostics()
+    for key in (
+        "time_sec",
+        "pelvis_z_m",
+        "is_diverged",
+        "max_tracking_err_deg",
+        "total_applied_torque_nm",
+        "r_knee_deg",
+        "history_frames",
+        "grf",
+        "joint_torques",
+    ):
+        assert key in diag, f"diagnostics missing {key}"
+    assert isinstance(diag["grf"], dict)
+    assert {"right_z", "left_z"}.issubset(diag["grf"].keys())
+
+
+def test_analyze_induced_acceleration_return_shape(
+    simulator: LowerBodySimulator,
+) -> None:
+    iaa = simulator.analyze_induced_acceleration("act_r_hip_x", 1.0)
+    for key in (
+        "forward_accel",
+        "lateral_accel",
+        "vertical_accel",
+        "roll_accel",
+        "pitch_accel",
+        "yaw_accel",
+    ):
+        assert key in iaa
+
+
+def test_setup_initial_pose_raises_value_error_type(
+    simulator: LowerBodySimulator,
+) -> None:
+    """DbC: out-of-range inputs must raise ValueError exactly."""
+    with pytest.raises(ValueError):
+        simulator.setup_initial_pose(hip_anterior_tilt=999.0)
+
+
+def test_inverse_kinematics_return_type(simulator: LowerBodySimulator) -> None:
+    simulator.setup_initial_pose()
+    pos = simulator.data.qpos[0:3].copy()
+    quat = simulator.data.qpos[3:7].copy()
+    result = simulator.inverse_kinematics(pos, quat, max_iters=5)
+    assert isinstance(result, bool)
+
+
+def test_set_pelvis_inclined_rotation_uses_target_type(
+    simulator: LowerBodySimulator,
+) -> None:
+    target = InclinedPlaneHipRotationTarget(
+        duration_sec=1.0, lateral_shift_m=0.05, incline_degrees=10.0
+    )
+    simulator.set_pelvis_inclined_rotation(target)
+    # Stepping should be a no-op in terms of API (returns None).
+    assert simulator.step() is None
+
+
+def test_analyze_induced_acceleration_raises_value_error_on_missing_actuator(
+    simulator: LowerBodySimulator,
+) -> None:
+    with pytest.raises(ValueError):
+        simulator.analyze_induced_acceleration("act_does_not_exist", 1.0)
+
+
+def test_target_quaternion_at_returns_numpy_quaternion() -> None:
+    target = InclinedPlaneHipRotationTarget(duration_sec=1.0)
+    q = target.target_quaternion_at(0.5)
+    assert isinstance(q, np.ndarray)
+    assert q.shape == (4,)
+    # Unit norm.
+    assert float(np.linalg.norm(q)) == pytest.approx(1.0, abs=1e-6)


### PR DESCRIPTION
## Summary
Closes the first slice of issues #2026 (DRY/LOD refactor) and #2027 (test coverage expansion).

## DRY / LOD

### Centralized MuJoCo id cache
\`_cache_indices\` now builds one dict per object class, so every reflective \`mj_name2id\` lookup happens exactly once at construction:

| Cache | Populated for |
|---|---|
| \`jnt_qpos_idx\` | each joint -> qpos address |
| \`jnt_dof_idx\` | each joint -> dof address (was recomputed every step) |
| \`act_ids\` | each actuator name -> id |
| \`site_ids\` | foot site names -> id |
| \`geom_ids\` | floor / r_foot_geom / l_foot_geom -> id |
| \`pelvis_body_id\` | body id for pelvis |

Hot paths previously did ad-hoc lookups. With the cache they're algorithmic dict reads:

- **\`step()\`** PD loop — previously called \`mj_name2id\` twice per joint per step (actuator id + joint dof address). 12 joints × 200 Hz = ~4800 reflective calls per simulated second. **Now zero.**
- **\`compute_diagnostics\`** — used to look up the pelvis body, r_knee joint, floor geom, and both foot geoms every call.
- **\`inverse_kinematics\`** — used to look up both foot sites on every invocation.
- **\`set_joint_polynomial\`**, **\`analyze_induced_acceleration\`** — reflective actuator lookups replaced with cache reads.

### \`compute_diagnostics\` decomposition (LOD)
The 80-line monolith is split into three private helpers, each < 20 lines and doing one thing:

- \`_collect_tracking_error()\` → max |qpos − target|
- \`_collect_joint_torques()\` → (sum |τ|, per-joint dict)
- \`_collect_ground_reaction_forces()\` → {right_z, left_z} from active contacts

The public method now just assembles the dict and delegates, so extending telemetry is additive instead of rewriting a megafunction.

## Contract tests (#2027)
New file \`tests/unit/lower_body_model/test_public_api_contract.py\`, marked \`@pytest.mark.contract\`. Locks the public API surface that downstream repos (UpstreamDrift, Gasification_Model) and the PyQt6 control panel depend on.

- Package exports (\`HipRotationSample\`, \`InclinedPlaneHipRotationTarget\`)
- \`build_lower_body_xml\` signature + parameter defaults + MJCF return
- \`InclinedPlaneHipRotationTarget\` public fields (incl. new \`lateral_shift_m\`) and public methods (incl. \`target_quaternion_at\`, \`lateral_shift_at\`)
- \`LowerBodySimulator\` public method surface — 16 method names locked
- Return-dict shapes for \`compute_pelvis_kinematics\`, \`compute_diagnostics\`, \`analyze_induced_acceleration\`
- DbC exception types (\`ValueError\` on out-of-range \`setup_initial_pose\`, \`ValueError\` on missing actuator)
- \`target_quaternion_at\` returns a unit-norm (4,) numpy quaternion

These are deliberately shallow — shape over behaviour, which is what contract tests are for. **A PR like #2013 that silently deleted \`hip_rotation.py\` would have failed these immediately**, which is exactly the regression-detection value the contract suite is meant to provide.

## Test plan
- [ ] \`ruff check\` / \`ruff format --check\` pass locally
- [ ] CI runs \`pytest tests/unit/lower_body_model/ -m contract\` and regular \`-m unit\`
- [ ] Contract tests lock down the surface for future PRs

Closes #2027
Partially addresses #2026 (follow-up tracked for leg XML builder DRY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)