### PR TITLE
chore(ci): hardcode all workflows to d-sorg-fleet (temp, end-of-month)

### DIFF
--- a/.github/workflows/codeql-analysis.yml.disabled
+++ b/.github/workflows/codeql-analysis.yml.disabled
@@ -5,6 +5,6 @@ on:
 
 jobs:
   disabled:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - run: echo "CodeQL is disabled."


### PR DESCRIPTION
Temporarily routes all jobs to self-hosted fleet to conserve GitHub Actions minutes for the rest of the month. 1 workflow file updated (codeql-analysis.yml.disabled). Revert with: git revert HEAD