### PR TITLE
test: restore 25% coverage floor via smoke-slice expansion and new tests

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -198,7 +198,9 @@ jobs:
         run: |
           # CVE-2026-4539: pygments 2.19.2 vulnerability with no fix version available yet.
           # Ignored until a patched release is published upstream.
-          pip-audit -r requirements.txt --ignore-vuln CVE-2026-4539
+          # Use python -m pip_audit to ensure we use the venv-installed binary,
+          # not the system-wide one which may have a broken dep chain.
+          python -m pip_audit -r requirements.txt --ignore-vuln CVE-2026-4539
 
       # - name: Secrets Scan (gitleaks)
       #   if: secrets.GITLEAKS_LICENSE != ''

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -90,7 +90,7 @@ jobs:
           pip install -r requirements.txt
           pip install fastapi
           pip install httpx pytest-cov
-          pip install ruff==0.14.10 mypy==1.13.0 bandit==1.7.7 pip-audit types-PyYAML types-requests
+          pip install ruff==0.14.10 mypy==1.13.0 bandit==1.7.7 pip-audit sortedcontainers types-PyYAML types-requests
 
       - name: Collect Changed Python Files
         run: |

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -264,11 +264,11 @@ jobs:
             # Only collect changed tests from the repo-level tests/ directory.
             # src/**/tests/ are package-local tests requiring per-package deps
             # (ezdxf, signal_bus, GPU libs, Qt display, etc.) not installed in CI.
-            git diff --name-only "$BASE_SHA" HEAD -- 'tests/test_*.py' 'tests/**/*test.py' > changed_test_files.txt
+            git diff --name-only "$BASE_SHA" HEAD -- 'tests/test_*.py' 'tests/**/test_*.py' 'tests/**/*test.py' > changed_test_files.txt
           elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            git diff --name-only "${{ github.event.before }}" HEAD -- 'tests/test_*.py' 'tests/**/*test.py' > changed_test_files.txt
+            git diff --name-only "${{ github.event.before }}" HEAD -- 'tests/test_*.py' 'tests/**/test_*.py' 'tests/**/*test.py' > changed_test_files.txt
           else
-            git diff --name-only HEAD~1 HEAD -- 'tests/test_*.py' 'tests/**/*test.py' > changed_test_files.txt || echo "No previous commit found (initial commit?)"
+            git diff --name-only HEAD~1 HEAD -- 'tests/test_*.py' 'tests/**/test_*.py' 'tests/**/*test.py' > changed_test_files.txt || echo "No previous commit found (initial commit?)"
           fi
           cat changed_test_files.txt
 
@@ -308,6 +308,8 @@ jobs:
             "tests/test_env_utils.py"
             "tests/test_logging_utils.py"
             "tests/test_os_utils.py"
+            # Notes model coverage (keeps total coverage above 25% floor)
+            "tests/shared/python/notes/test_models.py"
           )
           if [ -s changed_test_files.txt ]; then
             mapfile -t changed_test_files < changed_test_files.txt

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -280,6 +280,19 @@ jobs:
             "tests/shared/python/process_calculators/test_constants.py"
             # Tools manifest integrity
             "tests/scripts/test_generate_tools_json.py"
+            # Coverage policy gate itself (protects CI infrastructure).
+            # Added alongside shared utility tests to restore the 25% total
+            # coverage floor after PR #2049 dropped it to 24.99%.
+            "tests/scripts/test_check_coverage_policy.py"
+            # Shared Python utilities (file/env/csv/logging/os).
+            # These modules are pure-Python and widely imported; adding their
+            # existing tests to the smoke slice adds ~2% to total coverage
+            # and provides headroom above the 25% floor.
+            "tests/test_file_utils.py"
+            "tests/test_csv_utils.py"
+            "tests/test_env_utils.py"
+            "tests/test_logging_utils.py"
+            "tests/test_os_utils.py"
           )
           if [ -s changed_test_files.txt ]; then
             mapfile -t changed_test_files < changed_test_files.txt

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -85,7 +85,16 @@ jobs:
           sudo apt-get -o DPkg::Lock::Timeout=300 install -y libgl1 libegl1 libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2-dev libxi6 libxtst6
 
       - name: Install Dependencies
+        # Force-reinstall sortedcontainers (and hypothesis) before anything
+        # else: the shared self-hosted runner toolcache occasionally carries a
+        # half-installed `sortedcontainers` where pip metadata claims 2.4.0 but
+        # the package namespace is missing exports (e.g. `SortedSet`). A plain
+        # `pip install` then sees "Requirement already satisfied" and does not
+        # repair the cache, which breaks `pip-audit` (via cyclonedx) and any
+        # hypothesis-using pytest run (see PR #2054 / #2056 quality-gate
+        # failures; mirrors UpstreamDrift ci-standard.yml fix).
         run: |
+          pip install --force-reinstall --no-deps "sortedcontainers>=2.4.0" "hypothesis>=6.0.0"
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install fastapi
@@ -232,7 +241,11 @@ jobs:
           sudo apt-get -o DPkg::Lock::Timeout=300 install -y libgl1 libegl1 libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2-dev libxi6 libxtst6
 
       - name: Install Dependencies
+        # See quality-gate Install Dependencies for the rationale — the shared
+        # toolcache can carry a stale `sortedcontainers` that makes hypothesis
+        # fail during pytest_terminal_summary.
         run: |
+          pip install --force-reinstall --no-deps "sortedcontainers>=2.4.0" "hypothesis>=6.0.0"
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install fastapi

--- a/config/coverage_baseline.json
+++ b/config/coverage_baseline.json
@@ -1,1 +1,4 @@
-{"total_percent": 25.08, "package_percent": {"src/shared/python/notes": 54.46}}
+{
+  "total_percent": 27.3,
+  "package_percent": { "src/shared/python/notes": 54.46 }
+}

--- a/tests/scripts/test_check_coverage_policy.py
+++ b/tests/scripts/test_check_coverage_policy.py
@@ -1,0 +1,424 @@
+"""Tests for scripts/check_coverage_policy.py.
+
+Verifies coverage policy gate logic:
+- ``parse_coverage`` correctly aggregates per-package and total coverage from
+  a Cobertura XML report.
+- ``_pct`` rounds line rates to two decimal places.
+- ``main`` exits 0 when policy is satisfied and 1 when a threshold is breached,
+  writing the trend JSON artifact either way.
+
+This module is executed as a standalone script by CI, so we load it via
+``importlib.util`` (mirroring ``tests/scripts/test_check_coverage_gates.py``).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def _load_module() -> ModuleType:
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "scripts" / "check_coverage_policy.py"
+    spec = importlib.util.spec_from_file_location(
+        "tools_check_coverage_policy", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ── Synthetic coverage.xml fixtures ──────────────────────────────────────
+
+_COVERAGE_XML_TEMPLATE = """<?xml version="1.0" ?>
+<coverage line-rate="{line_rate}" version="7.0">
+  <packages>
+    <package name="pkg">
+      <classes>
+{classes}
+      </classes>
+    </package>
+  </packages>
+</coverage>
+"""
+
+_CLASS_TEMPLATE = """        <class filename="{filename}">
+          <lines>
+{lines}
+          </lines>
+        </class>"""
+
+
+def _render_class(filename: str, hits_by_line: dict[int, int]) -> str:
+    line_elems = "\n".join(
+        f'            <line number="{n}" hits="{h}"/>'
+        for n, h in sorted(hits_by_line.items())
+    )
+    return _CLASS_TEMPLATE.format(filename=filename, lines=line_elems)
+
+
+def _write_coverage_xml(
+    path: Path,
+    line_rate: float,
+    classes: list[tuple[str, dict[int, int]]],
+) -> Path:
+    rendered = "\n".join(_render_class(fn, lines) for fn, lines in classes)
+    path.write_text(
+        _COVERAGE_XML_TEMPLATE.format(line_rate=line_rate, classes=rendered),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ── _pct ─────────────────────────────────────────────────────────────────
+
+
+class TestPct:
+    def test_converts_ratio_to_percent(self) -> None:
+        module = _load_module()
+        assert module._pct(0.25) == 25.0
+
+    def test_rounds_to_two_decimals(self) -> None:
+        module = _load_module()
+        assert module._pct(0.123456) == 12.35
+
+    def test_zero(self) -> None:
+        module = _load_module()
+        assert module._pct(0.0) == 0.0
+
+    def test_one(self) -> None:
+        module = _load_module()
+        assert module._pct(1.0) == 100.0
+
+
+# ── parse_coverage ───────────────────────────────────────────────────────
+
+
+class TestParseCoverage:
+    def test_returns_total_from_line_rate_attr(self, tmp_path: Path) -> None:
+        module = _load_module()
+        xml = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.4242,
+            classes=[("pkg_a/mod.py", {1: 1, 2: 0})],
+        )
+        result = module.parse_coverage(xml, tracked_prefixes=[])
+        assert result["total_percent"] == 42.42
+
+    def test_aggregates_covered_lines_for_tracked_prefix(self, tmp_path: Path) -> None:
+        module = _load_module()
+        xml = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.5,
+            classes=[
+                ("pkg_a/mod1.py", {1: 1, 2: 1, 3: 0, 4: 0}),
+                ("pkg_a/mod2.py", {1: 1, 2: 0}),
+                ("pkg_b/mod.py", {1: 1, 2: 1, 3: 1}),
+            ],
+        )
+        result = module.parse_coverage(xml, tracked_prefixes=["pkg_a", "pkg_b"])
+        # pkg_a: 3/6 = 50%; pkg_b: 3/3 = 100%
+        assert result["package_percent"] == {"pkg_a": 50.0, "pkg_b": 100.0}
+
+    def test_tracked_prefix_with_no_matching_files_is_zero(
+        self, tmp_path: Path
+    ) -> None:
+        module = _load_module()
+        xml = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.25,
+            classes=[("other/mod.py", {1: 1, 2: 0})],
+        )
+        result = module.parse_coverage(xml, tracked_prefixes=["missing"])
+        assert result["package_percent"] == {"missing": 0.0}
+
+    def test_empty_tracked_prefix_list(self, tmp_path: Path) -> None:
+        module = _load_module()
+        xml = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.1,
+            classes=[("pkg/mod.py", {1: 1})],
+        )
+        result = module.parse_coverage(xml, tracked_prefixes=[])
+        assert result == {"total_percent": 10.0, "package_percent": {}}
+
+    def test_prefix_matches_using_startswith(self, tmp_path: Path) -> None:
+        """Prefixes are matched via str.startswith, not regex or path components."""
+        module = _load_module()
+        xml = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.5,
+            classes=[
+                ("src/shared/notes/a.py", {1: 1, 2: 1}),
+                ("src/shared/notes_alt/b.py", {1: 0, 2: 0}),
+            ],
+        )
+        # Both filenames start with "src/shared/notes"
+        result = module.parse_coverage(xml, tracked_prefixes=["src/shared/notes"])
+        # covered=2 (from a.py), valid=4 total -> 50%
+        assert result["package_percent"]["src/shared/notes"] == 50.0
+
+
+# ── main ─────────────────────────────────────────────────────────────────
+
+
+def _write_policy_and_baseline(
+    tmp_path: Path,
+    *,
+    minimum_total_percent: float = 25.0,
+    max_total_drop_percent: float = 2.0,
+    tracked_packages: dict[str, float] | None = None,
+    baseline_total: float = 25.08,
+    baseline_packages: dict[str, float] | None = None,
+) -> tuple[Path, Path]:
+    policy = tmp_path / "policy.json"
+    baseline = tmp_path / "baseline.json"
+    policy.write_text(
+        json.dumps(
+            {
+                "minimum_total_percent": minimum_total_percent,
+                "max_total_drop_percent": max_total_drop_percent,
+                "tracked_packages": tracked_packages or {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    baseline.write_text(
+        json.dumps(
+            {
+                "total_percent": baseline_total,
+                "package_percent": baseline_packages or {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return policy, baseline
+
+
+class TestMain:
+    def test_passes_when_total_meets_minimum(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        module = _load_module()
+        cov = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.30,
+            classes=[("pkg/mod.py", {1: 1, 2: 1, 3: 0})],
+        )
+        policy, baseline = _write_policy_and_baseline(
+            tmp_path, minimum_total_percent=25.0, baseline_total=29.0
+        )
+        out = tmp_path / "trend.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check_coverage_policy.py",
+                "--coverage-file",
+                str(cov),
+                "--policy-file",
+                str(policy),
+                "--baseline-file",
+                str(baseline),
+                "--output-json",
+                str(out),
+            ],
+        )
+        assert module.main() == 0
+        captured = capsys.readouterr()
+        assert "Coverage policy passed." in captured.out
+        assert out.exists()
+        trend = json.loads(out.read_text(encoding="utf-8"))
+        assert trend["total_percent"] == 30.0
+
+    def test_fails_when_total_below_minimum(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        module = _load_module()
+        cov = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.10,
+            classes=[("pkg/mod.py", {1: 1, 2: 0, 3: 0, 4: 0})],
+        )
+        policy, baseline = _write_policy_and_baseline(
+            tmp_path, minimum_total_percent=25.0
+        )
+        out = tmp_path / "trend.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check_coverage_policy.py",
+                "--coverage-file",
+                str(cov),
+                "--policy-file",
+                str(policy),
+                "--baseline-file",
+                str(baseline),
+                "--output-json",
+                str(out),
+            ],
+        )
+        assert module.main() == 1
+        captured = capsys.readouterr()
+        assert "Coverage policy failed" in captured.err
+        assert "below minimum" in captured.err
+        assert out.exists()  # trend is still written
+
+    def test_fails_when_regression_exceeds_max_drop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        module = _load_module()
+        # Total = 26%, baseline = 30%, allowed drop = 2% -> 26 < 30-2 = 28 -> regression
+        cov = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.26,
+            classes=[("pkg/mod.py", {1: 1, 2: 0})],
+        )
+        policy, baseline = _write_policy_and_baseline(
+            tmp_path,
+            minimum_total_percent=10.0,
+            max_total_drop_percent=2.0,
+            baseline_total=30.0,
+        )
+        out = tmp_path / "trend.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check_coverage_policy.py",
+                "--coverage-file",
+                str(cov),
+                "--policy-file",
+                str(policy),
+                "--baseline-file",
+                str(baseline),
+                "--output-json",
+                str(out),
+            ],
+        )
+        assert module.main() == 1
+        captured = capsys.readouterr()
+        assert "regressed beyond allowed drop" in captured.err
+
+    def test_fails_when_tracked_package_below_threshold(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        module = _load_module()
+        cov = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.5,
+            classes=[("pkg_a/mod.py", {1: 1, 2: 0, 3: 0, 4: 0})],
+        )
+        # pkg_a actual = 25%, threshold = 50% -> fail
+        policy, baseline = _write_policy_and_baseline(
+            tmp_path,
+            minimum_total_percent=10.0,
+            tracked_packages={"pkg_a": 50.0},
+        )
+        out = tmp_path / "trend.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check_coverage_policy.py",
+                "--coverage-file",
+                str(cov),
+                "--policy-file",
+                str(policy),
+                "--baseline-file",
+                str(baseline),
+                "--output-json",
+                str(out),
+            ],
+        )
+        assert module.main() == 1
+        captured = capsys.readouterr()
+        assert "pkg_a" in captured.err
+        assert "below threshold" in captured.err
+
+    def test_tracked_package_reported_in_stdout(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        module = _load_module()
+        cov = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.6,
+            classes=[("pkg_a/mod.py", {1: 1, 2: 1, 3: 1, 4: 0})],
+        )
+        policy, baseline = _write_policy_and_baseline(
+            tmp_path,
+            minimum_total_percent=10.0,
+            tracked_packages={"pkg_a": 50.0},
+            baseline_total=60.0,
+        )
+        out = tmp_path / "trend.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check_coverage_policy.py",
+                "--coverage-file",
+                str(cov),
+                "--policy-file",
+                str(policy),
+                "--baseline-file",
+                str(baseline),
+                "--output-json",
+                str(out),
+            ],
+        )
+        assert module.main() == 0
+        captured = capsys.readouterr()
+        assert "total:" in captured.out
+        assert "pkg_a:" in captured.out
+
+    def test_trend_json_written_on_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        module = _load_module()
+        cov = _write_coverage_xml(
+            tmp_path / "cov.xml",
+            line_rate=0.05,
+            classes=[("pkg/mod.py", {1: 0, 2: 0})],
+        )
+        policy, baseline = _write_policy_and_baseline(
+            tmp_path, minimum_total_percent=25.0
+        )
+        out = tmp_path / "trend.json"
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "check_coverage_policy.py",
+                "--coverage-file",
+                str(cov),
+                "--policy-file",
+                str(policy),
+                "--baseline-file",
+                str(baseline),
+                "--output-json",
+                str(out),
+            ],
+        )
+        assert module.main() == 1
+        trend = json.loads(out.read_text(encoding="utf-8"))
+        assert trend["total_percent"] == 5.0
+        assert "package_percent" in trend


### PR DESCRIPTION
## Summary

- **Problem:** Main CI has been failing since PR #2049 merged (2026-04-13), which dropped total coverage from 25.08% to 24.99% — 0.04 points below the 25.0% floor in `config/coverage_policy.json`. This blocks PRs #2052 (Bolt perf) and #2053 (Palette a11y) on the `Coverage Policy Gate` step.
- **Policy:** TDD compliance requires ratcheting coverage *upward*, never lowering the floor. `minimum_total_percent` in `config/coverage_policy.json` is **intentionally untouched**.
- **Fix:** Raise measured coverage by (a) adding 15 new unit tests for the coverage gate script itself and (b) pulling five existing shared-utility test modules into the CI smoke slice.

## Changes

- **New** `tests/scripts/test_check_coverage_policy.py` — 15 tests covering `_pct`, `parse_coverage`, and `main` in `scripts/check_coverage_policy.py` (pass/fail paths, tracked-package thresholds, regression detection, trend JSON output). The gate script was previously untested despite being load-bearing CI infrastructure.
- **Updated** `.github/workflows/ci-standard.yml` — expand the `core_tests` smoke slice with:
  - `tests/scripts/test_check_coverage_policy.py` (new)
  - `tests/test_file_utils.py`
  - `tests/test_csv_utils.py`
  - `tests/test_env_utils.py`
  - `tests/test_logging_utils.py`
  - `tests/test_os_utils.py`
  These existing tests already pass and cover pure-Python modules but were not previously in the smoke set that CI measures coverage against.
- **Updated** `config/coverage_baseline.json` — ratchet total from 25.08% to 27.3% to lock in the improvement (the `max_total_drop_percent` regression gate now triggers below 25.3%).

## Local verification

Running the exact CI invocation against this branch:

```
$ python3 -m pytest ${core_tests[@]} -m "not live_simulation" \
    --import-mode=importlib --cov=. --cov-report=xml:coverage.xml \
    --cov-fail-under=0
591 passed

$ python3 scripts/check_coverage_policy.py \
    --coverage-file coverage.xml \
    --policy-file config/coverage_policy.json \
    --baseline-file config/coverage_baseline.json
- total: 27.3%
- src/shared/python/notes: 54.46%
Coverage policy passed.
```

Baseline → measured → floor:

| Before | After | Floor | Headroom |
|--------|-------|-------|----------|
| 24.99% | 27.30% | 25.0% | +2.30% |

## Test plan

- [x] New tests pass locally (`pytest tests/scripts/test_check_coverage_policy.py` → 15 passed)
- [x] Full smoke slice passes locally (591 passed)
- [x] `ruff check` and `ruff format --check` clean on new file
- [x] `scripts/check_coverage_policy.py` exits 0 with updated policy+baseline
- [ ] CI `Coverage Policy Gate` green on this PR
- [ ] After merge, PRs #2052 and #2053 unblocked (they need to rebase to pick up the expanded `core_tests`)

## Unblocks

- #2052 (Bolt: optimize `calculateStatistics` two-pass overhead)
- #2053 (Palette: ARIA label for custom unit remove button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)