### PR TITLE
fix(ci): install sortedcontainers to fix pip-audit CycloneDX crash

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -189,7 +189,9 @@ jobs:
         run: |
           # CVE-2026-4539: pygments 2.19.2 vulnerability with no fix version available yet.
           # Ignored until a patched release is published upstream.
-          pip-audit -r requirements.txt --ignore-vuln CVE-2026-4539
+          # Use python -m pip_audit to ensure we use the venv-installed binary,
+          # not the system-wide one which may have a broken dep chain.
+          python -m pip_audit -r requirements.txt --ignore-vuln CVE-2026-4539
 
       # - name: Secrets Scan (gitleaks)
       #   if: secrets.GITLEAKS_LICENSE != ''

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -90,7 +90,7 @@ jobs:
           pip install -r requirements.txt
           pip install fastapi
           pip install httpx pytest-cov
-          pip install ruff==0.14.10 mypy==1.13.0 bandit==1.7.7 pip-audit types-PyYAML types-requests
+          pip install ruff==0.14.10 mypy==1.13.0 bandit==1.7.7 pip-audit sortedcontainers types-PyYAML types-requests
 
       - name: Collect Changed Python Files
         run: |


### PR DESCRIPTION
## Summary

- pip-audit uses cyclonedx-python-lib which requires sortedcontainers, but that transitive dep was not being installed
- This caused a ModuleNotFoundError on all quality-gate CI jobs across every PR
- Fix: add sortedcontainers to the quality-gate install step in ci-standard.yml

## Test plan
- [ ] quality-gate job passes on this PR itself (no Python source changes, only CI config)
- [ ] PRs #2052, #2053, #2055 can be re-run and quality-gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)