### PR TITLE
fix(ci): force-reinstall sortedcontainers in quality-gate and tests

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -39,7 +39,16 @@ jobs:
           sudo apt-get install -y libgl1 libegl1 libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2-dev libxi6 libxtst6
 
       - name: Install Dependencies
+        # Force-reinstall sortedcontainers (and hypothesis) before anything
+        # else: the shared self-hosted runner toolcache occasionally carries a
+        # half-installed `sortedcontainers` where pip metadata claims 2.4.0 but
+        # the package namespace is missing exports (e.g. `SortedSet`). A plain
+        # `pip install` then sees "Requirement already satisfied" and does not
+        # repair the cache, which breaks `pip-audit` (via cyclonedx) and any
+        # hypothesis-using pytest run (see PR #2054 / #2056 quality-gate
+        # failures; mirrors UpstreamDrift ci-standard.yml fix).
         run: |
+          pip install --force-reinstall --no-deps "sortedcontainers>=2.4.0" "hypothesis>=6.0.0"
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install fastapi
@@ -206,7 +215,11 @@ jobs:
           sudo apt-get install -y libgl1 libegl1 libxrandr2 libxss1 libxcursor1 libxcomposite1 libasound2-dev libxi6 libxtst6
 
       - name: Install Dependencies
+        # See quality-gate Install Dependencies for the rationale — the shared
+        # toolcache can carry a stale `sortedcontainers` that makes hypothesis
+        # fail during pytest_terminal_summary.
         run: |
+          pip install --force-reinstall --no-deps "sortedcontainers>=2.4.0" "hypothesis>=6.0.0"
           pip install --upgrade pip
           pip install -r requirements.txt
           pip install fastapi


### PR DESCRIPTION
## Summary

- The shared self-hosted runner toolcache occasionally carries a half-installed `sortedcontainers` where pip metadata claims `2.4.0` but the package namespace is missing exports (e.g. `SortedSet`). A plain `pip install sortedcontainers` then sees "Requirement already satisfied" and does not repair the cache, which breaks `pip-audit` (via `cyclonedx`) and breaks pytest runs whose hypothesis plugin writes a terminal summary.
- Symptom observed on PRs #2054 and #2056 `quality-gate`:
  ```
  from sortedcontainers import SortedSet
  ModuleNotFoundError: No module named 'sortedcontainers'
  ```
- This PR prepends a `--force-reinstall --no-deps` install of `sortedcontainers>=2.4.0` and `hypothesis>=6.0.0` to the first `Install Dependencies` step in both the `quality-gate` and `tests` jobs of `.github/workflows/ci-standard.yml`.
- Mirrors the already-landed fix in `UpstreamDrift/.github/workflows/ci-standard.yml` (the `tests` matrix job and `shared-tools-consumer-contracts` job both use the same pattern).

## Why on staging, not on a single PR branch

PR #2056 carries a weaker workaround on its own branch (`pip install … sortedcontainers …` without `--force-reinstall --no-deps`, which the pip cache can silently no-op on). Landing this on `staging` means every subsequent PR automatically picks up the robust fix without each PR having to carry its own CI workflow patch.

## Scope

- `.github/workflows/ci-standard.yml`: 2 steps edited (`quality-gate -> Install Dependencies`, `tests -> Install Dependencies`).
- No change to: coverage floor, file-size budget, mypy filters, or any gate threshold.
- Comment in each step points at the UD reference and explains the toolcache-corruption root cause.

## Note on file-size budget (Tools #2056, test_simulation_panel.py)

That file's 500-LOC crunch is a per-branch problem — staging has it at 406 LOC and only PR #2056's branch pushed it to 500. PR #2056 already carries its own reduction commit (`fix(ci): reduce test_simulation_panel.py to 500 LOC (file-size budget)`, SHA `13a1730c`), so there is nothing for this PR to do on that front. If a future PR approaches the 500-LOC ceiling on that file, the standard remedy is to split off a logically-separate test class into a companion file; do **not** add a blanket exception in `scripts/monolith_baseline.txt` for freshly-introduced test files.

## Test plan

- [ ] `quality-gate` job (this PR): `Security Scan (pip-audit)` step runs to completion without `ModuleNotFoundError: No module named 'sortedcontainers'`.
- [ ] `tests` matrix job (this PR): 3.10 / 3.11 / 3.12 all pass `Run Tests with Coverage`.
- [ ] `file-size-budget` job stays green (no src changes in this PR).
- [ ] `workflow-lint` and `actionlint` stay green.