### PR TITLE
perf(stats): apply remaining Bolt micro-optimizations to calculateStatistics

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.53                                     |
+| **Spec Version**        | 1.1.54                                     |
 | **Last Spec Update**    | 2026-04-14                                 |
 
 ## 2. Purpose & Mission

--- a/src/data_processing/data_processor/web/src/hooks/useDataProcessor.ts
+++ b/src/data_processing/data_processor/web/src/hooks/useDataProcessor.ts
@@ -44,16 +44,18 @@ export function useDataProcessor() {
   const [state, setState] = useState<DataProcessorState>(initialState);
 
   const calculateStatistics = useCallback((data: DataRow[], signals: string[]): Statistics => {
-    // Bolt: Optimize calculateStatistics using Float64Array and single-pass iterations instead of map/filter/reduce
+    // ⚡ Bolt: Optimize calculateStatistics using Float64Array and single-pass iterations instead of map/filter/reduce
     // Performance impact: Reduces execution time by ~80% for large datasets and minimizes memory allocation
+    // Delay typed-array allocation until valid count is known to avoid O(N) allocation for sparse datasets.
     const stats: Statistics = {};
+    const dataLen = data.length;
 
     for (const signal of signals) {
       let count = 0;
       let sum = 0;
 
       // Pass 1: count and sum
-      for (let i = 0; i < data.length; i++) {
+      for (let i = 0; i < dataLen; i++) {
         const v = data[i][signal];
         if (typeof v === 'number' && !Number.isNaN(v)) {
           sum += v;
@@ -70,10 +72,11 @@ export function useDataProcessor() {
       let j = 0;
 
       // Pass 2: calculate variance and collect for sorting
-      for (let i = 0; i < data.length; i++) {
+      for (let i = 0; i < dataLen; i++) {
         const v = data[i][signal];
         if (typeof v === 'number' && !Number.isNaN(v)) {
-          varianceSum += (v - mean) ** 2;
+          const diff = v - mean;
+          varianceSum += diff * diff;
           vals[j++] = v;
         }
       }
@@ -82,12 +85,16 @@ export function useDataProcessor() {
 
       vals.sort(); // Typed array sort is faster and numeric by default
 
+      const median = count % 2 === 0
+        ? (vals[count / 2 - 1] + vals[count / 2]) / 2
+        : vals[Math.floor(count / 2)];
+
       stats[signal] = {
         mean,
         std: Math.sqrt(variance),
         min: vals[0],
         max: vals[count - 1],
-        median: vals[Math.floor(count / 2)],
+        median,
       };
     }
 


### PR DESCRIPTION
## Summary\n\nClean rebase of the calculateStatistics Bolt optimization from PR #2052 onto current main.\n\nAll infrastructure fixes from that PR (#2054 coverage floor, #2057 sortedcontainers) are already in main. This PR contains only the actual JS performance changes.\n\n## Changes to useDataProcessor.ts\n\n1. Hoist data.length out of inner loops into dataLen const\n2. Replace (v - mean) ** 2 with diff * diff (avoids Math.pow overhead)\n3. Fix even-count median calculation: old code always used loor(count/2) which picks the upper-middle; correct formula averages als[count/2-1] and als[count/2]\n\nAll other Bolt optimizations (Float64Array, single-pass loops) were already in main from the original PR commits.