### PR TITLE
refactor(editor): GH-1998 convert assert to ValueError DbC in text_editor

### DIFF
--- a/src/shared/python/model_generation/editor/text_editor.py
+++ b/src/shared/python/model_generation/editor/text_editor.py
@@ -139,7 +139,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Args:
             max_history: Maximum number of undo states to keep
         """
-        assert max_history is not None, "max_history must be provided"
+        if max_history is None:
+            raise ValueError("max_history must be provided")
         self._content: str = ""
         self._original_content: str = ""
         self._file_path: Path | None = None
@@ -186,7 +187,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
             content: URDF XML content
             description: Description for history
         """
-        assert content is not None, "content must be provided"
+        if content is None:
+            raise ValueError("content must be provided")
         self._content = content
         self._original_content = content
         self._file_path = None
@@ -248,7 +250,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             List of validation messages
         """
-        assert content is not None, "content must be provided"
+        if content is None:
+            raise ValueError("content must be provided")
         if content == self._content:
             return []
 
@@ -284,7 +287,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             Validation messages
         """
-        assert position is not None, "position must be provided"
+        if position is None:
+            raise ValueError("position must be provided")
         new_content = self._content[:position] + text + self._content[position:]
         return self.set_content(new_content, description)
 
@@ -305,7 +309,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             Validation messages
         """
-        assert start is not None, "start must be provided"
+        if start is None:
+            raise ValueError("start must be provided")
         new_content = self._content[:start] + self._content[end:]
         return self.set_content(new_content, description)
 
@@ -328,7 +333,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             Validation messages
         """
-        assert start is not None, "start must be provided"
+        if start is None:
+            raise ValueError("start must be provided")
         new_content = self._content[:start] + text + self._content[end:]
         return self.set_content(new_content, description)
 
@@ -349,7 +355,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             Validation messages
         """
-        assert element_name is not None, "element_name must be provided"
+        if element_name is None:
+            raise ValueError("element_name must be provided")
         if old_content not in self._content:
             logger.warning(f"Content not found: {old_content[:50]}...")
             return []
@@ -393,7 +400,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             Line content or None
         """
-        assert line_number is not None, "line_number must be provided"
+        if line_number is None:
+            raise ValueError("line_number must be provided")
         lines = self._content.splitlines()
         if 1 <= line_number <= len(lines):
             return lines[line_number - 1]
@@ -412,7 +420,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             List of (line, column, matched_text) tuples
         """
-        assert pattern is not None, "pattern must be provided"
+        if pattern is None:
+            raise ValueError("pattern must be provided")
         results = []
         lines = self._content.splitlines()
 
@@ -448,7 +457,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             Number of replacements made
         """
-        assert search is not None, "search must be provided"
+        if search is None:
+            raise ValueError("search must be provided")
         if regex:
             new_content, count = re.subn(search, replace, self._content)
         else:
@@ -496,7 +506,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         indent: str = "  ",
     ) -> None:
         """Recursively add indentation to XML element."""
-        assert elem is not None, "elem must be provided"
+        if elem is None:
+            raise ValueError("elem must be provided")
         i = "\n" + level * indent
         if len(elem):
             if not elem.text or not elem.text.strip():
@@ -522,7 +533,8 @@ class URDFTextEditor(TextEditorDiffMixin, URDFValidationMixin, EditorHistoryMixi
         Returns:
             Dict with element info or None
         """
-        assert line is not None, "line must be provided"
+        if line is None:
+            raise ValueError("line must be provided")
         lines = self._content.splitlines()
         if line < 1 or line > len(lines):
             return None

--- a/src/shared/python/model_generation/editor/text_editor_diff_mixin.py
+++ b/src/shared/python/model_generation/editor/text_editor_diff_mixin.py
@@ -61,7 +61,8 @@ class TextEditorDiffMixin:
 
     def _compute_diff(self, original: str, modified: str) -> DiffResult:
         """Compute diff between two strings."""
-        assert original is not None, "original must be provided"
+        if original is None:
+            raise ValueError("original must be provided")
         from .text_editor import DiffHunk, DiffResult
 
         original_lines = original.splitlines(keepends=True)
@@ -155,7 +156,8 @@ class TextEditorDiffMixin:
         Returns:
             List of (left_line, right_line, change_type) tuples.
         """
-        assert context_lines is not None, "context_lines must be provided"
+        if context_lines is None:
+            raise ValueError("context_lines must be provided")
         if original is None:
             original = self._original_content
         if modified is None:

--- a/src/shared/python/model_generation/editor/text_editor_history_mixin.py
+++ b/src/shared/python/model_generation/editor/text_editor_history_mixin.py
@@ -92,7 +92,8 @@ class EditorHistoryMixin:
         Returns:
             True if successful
         """
-        assert index is not None, "index must be provided"
+        if index is None:
+            raise ValueError("index must be provided")
         if index < 0 or index >= len(self._history):
             logger.error(f"Invalid version index: {index}")
             return False
@@ -106,7 +107,8 @@ class EditorHistoryMixin:
         """Add current content to history."""
         from .text_editor import EditorVersion
 
-        assert description is not None, "description must be provided"
+        if description is None:
+            raise ValueError("description must be provided")
         checksum = hashlib.md5(
             self._content.encode(), usedforsecurity=False
         ).hexdigest()

--- a/src/shared/python/model_generation/editor/text_editor_validation_mixin.py
+++ b/src/shared/python/model_generation/editor/text_editor_validation_mixin.py
@@ -113,7 +113,8 @@ class URDFValidationMixin:
         """Check root is <robot> with a name. Return False to abort."""
         from .text_editor import ValidationMessage, ValidationSeverity
 
-        assert root is not None, "root must be provided"
+        if root is None:
+            raise ValueError("root must be provided")
         if root.tag != "robot":
             messages.append(
                 ValidationMessage(
@@ -145,7 +146,8 @@ class URDFValidationMixin:
         """Validate link elements and return name→element map."""
         from .text_editor import ValidationMessage, ValidationSeverity
 
-        assert root is not None, "root must be provided"
+        if root is None:
+            raise ValueError("root must be provided")
         links: dict[str, ET.Element] = {}
 
         for link_elem in root.findall("link"):
@@ -190,7 +192,8 @@ class URDFValidationMixin:
         """Validate inertial/mass properties of a link."""
         from .text_editor import ValidationMessage, ValidationSeverity
 
-        assert link_elem is not None, "link_elem must be provided"
+        if link_elem is None:
+            raise ValueError("link_elem must be provided")
         inertial = link_elem.find("inertial")
         if inertial is None:
             return
@@ -245,7 +248,8 @@ class URDFValidationMixin:
         """Validate joint elements (type, parent/child, limits)."""
         from .text_editor import ValidationMessage, ValidationSeverity
 
-        assert root is not None, "root must be provided"
+        if root is None:
+            raise ValueError("root must be provided")
         seen: dict[str, ET.Element] = {}
 
         for joint_elem in root.findall("joint"):
@@ -350,7 +354,8 @@ class URDFValidationMixin:
         """Detect links that are not connected to any joint."""
         from .text_editor import ValidationMessage, ValidationSeverity
 
-        assert root is not None, "root must be provided"
+        if root is None:
+            raise ValueError("root must be provided")
         child_links = set()
         for joint_elem in root.findall("joint"):
             child_elem = joint_elem.find("child")
@@ -379,7 +384,8 @@ class URDFValidationMixin:
     def _find_element_line(self, elem: ET.Element) -> int:
         """Find the line number of an element (approximate)."""
         # This is a simple heuristic - search for element in content
-        assert elem is not None, "elem must be provided"
+        if elem is None:
+            raise ValueError("elem must be provided")
         ET.tostring(elem, encoding="unicode")
         tag_start = f"<{elem.tag}"
 


### PR DESCRIPTION
## Summary

Partial resolution of #1998. Converts `assert X is not None, "..."` preconditions in the URDF text editor module to `if X is None: raise ValueError("...")` so they match the stricter DbC pattern already enforced in downstream UpstreamDrift.

This is the first of three deliverables on #1998:
1. **This PR** — make Tools' text_editor canonical style match UpstreamDrift's DbC pattern.
2. **UpstreamDrift PR (follow-up)** — port Tools' mixin split (`text_editor_history_mixin`, `text_editor_validation_mixin`) into UpstreamDrift and extend the existing `test_editor_tools_drift.py` guard to cover `text_editor.py`.
3. **New tracking issue (follow-up)** — fleet-wide dedup of the remaining ~300 shared/python filenames.

## Why

Python elides `assert` statements under `-O`, so `assert X is not None` silently vanishes in production. UpstreamDrift already enforces `raise ValueError` in its mirror of these files and has a drift guard (`test_editor_tools_drift.py`) pinning sha256 baselines for the leaf editor modules. Aligning Tools' style here is a prerequisite for closing the intentional divergence between the two copies of `text_editor.py` without weakening either side's contracts.

## Scope

Four files only, all referenced by issue #1998:
- `src/shared/python/model_generation/editor/text_editor.py` (12 conversions)
- `src/shared/python/model_generation/editor/text_editor_diff_mixin.py` (2)
- `src/shared/python/model_generation/editor/text_editor_history_mixin.py` (2)
- `src/shared/python/model_generation/editor/text_editor_validation_mixin.py` (6)

**Out of scope (intentionally):** `frankenstein_editor.py`, `editor_modifications.py`, `editor_clipboard.py` still use the old `assert` pattern. Converting those is tracked as a follow-up; this PR stays narrow per #1998's scope.

## Behavioral delta

None on CPython default settings. Under `-O` the preconditions now fire a `ValueError` instead of being stripped. No callers in Tools rely on asserts being stripped (verified by running the `test_text_editor_hash` and broader `model_generation/` suite: 95 passed).

## Test plan

- [x] `python3 -m ruff check src/shared/python/model_generation/editor/` — All checks passed
- [x] `python3 -m ruff format --check src/shared/python/model_generation/editor/` — 9 files already formatted
- [x] `python3 -m pytest tests/shared/python/model_generation/ --timeout=30` — 95 passed
- [x] File-size budget: baseline grandfathers touched files; no new violations
- [ ] CI green on `staging` target

Refs: #1998