### PR TITLE
[codex] replace runtime asserts with exceptions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.59                                     |
-| **Last Spec Update**    | 2026-04-16                                 |
+| **Spec Version**        | 1.1.61                                     |
+| **Last Spec Update**    | 2026-04-17                                 |
 
 ## 2. Purpose & Mission
 
@@ -454,6 +454,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-17 | 1.1.61  | Replaced runtime `assert` validation in asteroid-jumper physics, rotation-converter UI helpers, and scripting console execution with explicit exceptions so invalid caller input remains guarded under optimized Python. |
 | 2026-04-16 | 1.1.60  | Hardened launcher process handling by validating tool names, cleaning up spawned process groups, surfacing explicit model-conversion errors, and regression-testing temporary-file cleanup paths. |
 | 2026-04-16 | 1.1.59  | Removed stale root-level debug artifacts (`.ci_trigger.py`, `MUJOCO_LOG.TXT`, `error_log.txt`, `wave_log.txt`, and the empty marker file ending in `Last`), added root-scoped ignore rules for those paths, and locked the hygiene policy with regression tests. |
 | 2026-04-16 | 1.1.58  | Hardened GitHub archive extraction in the model-generation repository helper by validating zip members before unpacking so repository downloads cannot escape the destination directory. |

--- a/src/asteroid_jumper/physics.py
+++ b/src/asteroid_jumper/physics.py
@@ -3,10 +3,8 @@
 All state is represented as plain dataclasses; no Qt dependencies.
 Physics uses Newtonian rigid-body mechanics in 2-D.
 
-Design-by-Contract:
-  - Every public function validates its preconditions via assertions.
-  - Physical quantities carry SI-like units (mass in kg, length in m, etc.)
-    but we deliberately keep "toy" scales: asteroid radius ~10 m.
+Physical quantities carry SI-like units (mass in kg, length in m, etc.)
+but we deliberately keep "toy" scales: asteroid radius ~10 m.
 """
 
 from __future__ import annotations
@@ -27,15 +25,18 @@ class Vec2(NamedTuple):
     y: float = 0.0
 
     def __add__(self, other: object) -> Vec2:  # noqa: PYI034  # override with wider type
-        assert isinstance(other, Vec2), "Vec2 + Vec2 required"
+        if not isinstance(other, Vec2):
+            raise TypeError("Vec2 + Vec2 required")
         return Vec2(self.x + other.x, self.y + other.y)
 
     def __sub__(self, other: object) -> Vec2:  # noqa: PYI034  # override with wider type
-        assert isinstance(other, Vec2), "Vec2 - Vec2 required"
+        if not isinstance(other, Vec2):
+            raise TypeError("Vec2 - Vec2 required")
         return Vec2(self.x - other.x, self.y - other.y)
 
     def __mul__(self, scalar: object) -> Vec2:
-        assert isinstance(scalar, int | float), "Vec2 * scalar required"
+        if not isinstance(scalar, int | float):
+            raise TypeError("Vec2 * scalar required")
         return Vec2(self.x * scalar, self.y * scalar)
 
     def __rmul__(self, scalar: object) -> Vec2:
@@ -97,10 +98,12 @@ class RigidBody:
     angular_vel: float = 0.0  # rad/s
 
     def __post_init__(self) -> None:
-        assert self.mass > 0, f"mass must be positive, got {self.mass}"
-        assert self.moment_of_inertia > 0, (
-            f"moment_of_inertia must be positive, got {self.moment_of_inertia}"
-        )
+        if self.mass <= 0:
+            raise ValueError(f"mass must be positive, got {self.mass}")
+        if self.moment_of_inertia <= 0:
+            raise ValueError(
+                f"moment_of_inertia must be positive, got {self.moment_of_inertia}"
+            )
 
     @property
     def speed(self) -> float:
@@ -125,20 +128,28 @@ class RigidBody:
 
 def moment_of_inertia_ellipse(mass: float, a: float, b: float) -> float:
     """Moment of inertia for a solid ellipse with semi-axes a, b."""
-    assert mass > 0
-    assert a > 0 and b > 0
+    if mass <= 0:
+        raise ValueError(f"mass must be positive, got {mass}")
+    if a <= 0 or b <= 0:
+        raise ValueError(f"ellipse semi-axes must be positive, got a={a}, b={b}")
     return 0.25 * mass * (a**2 + b**2)
 
 
 def moment_of_inertia_disk(mass: float, radius: float) -> float:
     """Moment of inertia for a solid disk."""
-    assert mass > 0 and radius > 0
+    if mass <= 0:
+        raise ValueError(f"mass must be positive, got {mass}")
+    if radius <= 0:
+        raise ValueError(f"radius must be positive, got {radius}")
     return 0.5 * mass * radius**2
 
 
 def moment_of_inertia_rod(mass: float, length: float) -> float:
     """Moment of inertia for a thin rod about its centre."""
-    assert mass > 0 and length > 0
+    if mass <= 0:
+        raise ValueError(f"mass must be positive, got {mass}")
+    if length <= 0:
+        raise ValueError(f"length must be positive, got {length}")
     return mass * length**2 / 12.0
 
 
@@ -171,7 +182,8 @@ def compute_jump_impulse(
         (jumper_impulse, asteroid_torque_impulse, jumper_torque_impulse)
         where torques are scalar (z-component of r Ã— J).
     """
-    assert force_magnitude >= 0, "force_magnitude must be non-negative"
+    if force_magnitude < 0:
+        raise ValueError("force_magnitude must be non-negative")
 
     J = Vec2(
         force_magnitude * math.cos(force_direction_rad),
@@ -204,7 +216,8 @@ GRAVITY: Vec2 = Vec2(0.0, 0.0)  # Deep space â€” no gravity by default
 
 def integrate_body(body: RigidBody, dt: float) -> None:
     """Semi-implicit Euler integration step for *body* (mutates in place)."""
-    assert dt > 0, f"dt must be positive, got {dt}"
+    if dt <= 0:
+        raise ValueError(f"dt must be positive, got {dt}")
     body.pos = body.pos + body.vel * dt
     body.angle += body.angular_vel * dt
 
@@ -233,8 +246,12 @@ class SpringLaunch:
     elapsed: float = 0.0
 
     def __post_init__(self) -> None:
-        assert self.total_impulse >= 0
-        assert self.duration > 0
+        if self.total_impulse < 0:
+            raise ValueError(
+                f"total_impulse must be non-negative, got {self.total_impulse}"
+            )
+        if self.duration <= 0:
+            raise ValueError(f"duration must be positive, got {self.duration}")
 
     @property
     def is_complete(self) -> bool:
@@ -247,7 +264,8 @@ class SpringLaunch:
         Returns the (impulse, asteroid_torque, jumper_torque) for this step,
         or None if the launch is already complete.
         """
-        assert dt > 0
+        if dt <= 0:
+            raise ValueError(f"dt must be positive, got {dt}")
         if self.is_complete:
             return None
         remaining = self.duration - self.elapsed
@@ -287,7 +305,8 @@ class SimState:
     time: float = 0.0
 
     def __post_init__(self) -> None:
-        assert self.asteroid is not self.jumper, "asteroid and jumper must differ"
+        if self.asteroid is self.jumper:
+            raise ValueError("asteroid and jumper must differ")
 
     @property
     def total_linear_momentum(self) -> Vec2:
@@ -312,7 +331,8 @@ class SimState:
 
 def step_simulation(state: SimState, dt: float) -> None:
     """Advance the simulation by *dt* seconds (mutates *state*)."""
-    assert dt > 0
+    if dt <= 0:
+        raise ValueError(f"dt must be positive, got {dt}")
 
     if state.spring is not None and not state.spring.is_complete:
         result = state.spring.step(dt)

--- a/src/rotation_converter/ui/pyqt6/main_window.py
+++ b/src/rotation_converter/ui/pyqt6/main_window.py
@@ -94,11 +94,13 @@ class RotationConverterMainWindow(QMainWindow):
 
     def _build_menus(self) -> None:
         menu_bar = self.menuBar()
-        assert menu_bar is not None
+        if menu_bar is None:
+            raise RuntimeError("Rotation converter menu bar is unavailable")
 
         # File menu
         file_menu = menu_bar.addMenu("&File")
-        assert file_menu is not None
+        if file_menu is None:
+            raise RuntimeError("Rotation converter File menu is unavailable")
         quit_action = QAction("&Quit", self)
         quit_action.setShortcut("Ctrl+Q")
         quit_action.triggered.connect(self.close)
@@ -106,7 +108,8 @@ class RotationConverterMainWindow(QMainWindow):
 
         # Help menu
         help_menu = menu_bar.addMenu("&Help")
-        assert help_menu is not None
+        if help_menu is None:
+            raise RuntimeError("Rotation converter Help menu is unavailable")
         about = QAction("&About", self)
         about.triggered.connect(self._show_about)
         help_menu.addAction(about)

--- a/src/rotation_converter/ui/pyqt6/plot_helpers.py
+++ b/src/rotation_converter/ui/pyqt6/plot_helpers.py
@@ -53,7 +53,8 @@ def fmt_vec(v: np.ndarray, decimals: int = 6) -> str:
 
 def fmt_mat(M: np.ndarray, decimals: int = 6) -> str:
     """Format a numpy matrix as a multi-line string."""
-    assert M is not None, "M must be provided"
+    if M is None:
+        raise ValueError("M must be provided")
     lines: list[str] = []
     for row in M:
         lines.append("  ".join(f"{x: .{decimals}f}" for x in row))
@@ -100,7 +101,8 @@ def get_plot_colors() -> dict[str, Any]:
 
 def style_figure(fig: Figure, ax: Any = None) -> None:
     """Apply current theme colours to a matplotlib figure."""
-    assert fig is not None, "fig must be provided"
+    if fig is None:
+        raise ValueError("fig must be provided")
     c = get_plot_colors()
     fig.set_facecolor(c["bg"])
     if ax is not None:

--- a/src/shared/python/scripting/scripting_env.py
+++ b/src/shared/python/scripting/scripting_env.py
@@ -141,7 +141,7 @@ class ConsoleEnvironment:
         except Exception as e:  # noqa: BLE001
             sys.stderr.write(f"Error loading user library: {e}\n")
 
-    def execute(self, source: str) -> tuple[str, str]:
+    def execute(self, source: str | None) -> tuple[str, str]:
         """Execute a block of source code, capturing stdout and stderr.
 
         Args:
@@ -150,7 +150,8 @@ class ConsoleEnvironment:
         Returns:
             (stdout_output, stderr_output)
         """
-        assert source is not None, "source must be provided"
+        if source is None:
+            raise ValueError("source must be provided")
         if not source.strip():
             return "", ""
 

--- a/tests/rotation_converter/test_plot_helpers.py
+++ b/tests/rotation_converter/test_plot_helpers.py
@@ -1,0 +1,28 @@
+"""Tests for rotation-converter plotting helper validation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from matplotlib.figure import Figure
+
+from rotation_converter.ui.pyqt6.plot_helpers import fmt_mat, style_figure
+
+
+def test_fmt_mat_rejects_none_matrix() -> None:
+    with pytest.raises(ValueError, match="M must be provided"):
+        fmt_mat(None)
+
+
+def test_fmt_mat_formats_numpy_matrix() -> None:
+    assert fmt_mat(np.eye(2), decimals=1) == " 1.0   0.0\n 0.0   1.0"
+
+
+def test_style_figure_rejects_none_figure() -> None:
+    with pytest.raises(ValueError, match="fig must be provided"):
+        style_figure(None)
+
+
+def test_style_figure_accepts_figure_without_axes() -> None:
+    fig = Figure()
+    style_figure(fig)

--- a/tests/rotation_converter/test_scripting_env.py
+++ b/tests/rotation_converter/test_scripting_env.py
@@ -60,6 +60,11 @@ class TestConsoleEnvironment(unittest.TestCase):
         out, err = self.env.execute("1/0")
         self.assertIn("ZeroDivisionError: division by zero", err)
 
+    def test_execute_none_source_raises_value_error(self) -> None:
+        """None source is programmer error even when Python assertions are disabled."""
+        with self.assertRaisesRegex(ValueError, "source must be provided"):
+            self.env.execute(None)
+
     def test_user_functions(self) -> None:
         """Test saving and loading user-defined functions."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_asteroid_jumper/test_physics.py
+++ b/tests/test_asteroid_jumper/test_physics.py
@@ -54,6 +54,14 @@ class TestVec2:
         v = Vec2(2, 3) * 2.0
         assert v == Vec2(4, 6)
 
+    def test_addition_rejects_non_vector(self) -> None:
+        with pytest.raises(TypeError, match="Vec2 \\+ Vec2 required"):
+            Vec2(1, 2) + object()
+
+    def test_scalar_multiply_rejects_non_numeric(self) -> None:
+        with pytest.raises(TypeError, match="Vec2 \\* scalar required"):
+            Vec2(1, 2) * object()
+
     def test_rmul(self) -> None:
         v = 3.0 * Vec2(1, 2)
         assert v == Vec2(3, 6)
@@ -106,15 +114,15 @@ class TestRigidBody:
         assert body.moment_of_inertia == 5.0
 
     def test_negative_mass_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError, match="mass must be positive"):
             RigidBody(mass=-1.0, moment_of_inertia=1.0)
 
     def test_zero_mass_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError, match="mass must be positive"):
             RigidBody(mass=0.0, moment_of_inertia=1.0)
 
     def test_zero_moi_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError, match="moment_of_inertia must be positive"):
             RigidBody(mass=1.0, moment_of_inertia=0.0)
 
     def test_speed_at_rest(self) -> None:
@@ -155,12 +163,16 @@ class TestMomentOfInertia:
         assert moment_of_inertia_rod(12.0, 1.0) == pytest.approx(1.0)
 
     def test_disk_zero_radius_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError, match="radius must be positive"):
             moment_of_inertia_disk(1.0, 0.0)
 
     def test_ellipse_zero_axis_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError, match="ellipse semi-axes must be positive"):
             moment_of_inertia_ellipse(1.0, 0.0, 1.0)
+
+    def test_rod_zero_length_raises(self) -> None:
+        with pytest.raises(ValueError, match="length must be positive"):
+            moment_of_inertia_rod(1.0, 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -224,6 +236,10 @@ class TestComputeJumpImpulse:
         assert J.length() == pytest.approx(0.0)
         assert at == pytest.approx(0.0)
         assert jt == pytest.approx(0.0)
+
+    def test_negative_force_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="force_magnitude must be non-negative"):
+            compute_jump_impulse(-1.0, 0.0, Vec2(), Vec2(), Vec2(1, 0))
 
 
 class TestApplyImpulse:
@@ -291,7 +307,7 @@ class TestSpringLaunch:
         assert result is None
 
     def test_invalid_duration_raises(self) -> None:
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError, match="duration must be positive"):
             SpringLaunch(
                 total_impulse=100.0,
                 force_direction_rad=0.0,
@@ -300,6 +316,22 @@ class TestSpringLaunch:
                 jumper_com=Vec2(0, 1),
                 duration=0.0,  # invalid
             )
+
+    def test_negative_total_impulse_raises(self) -> None:
+        with pytest.raises(ValueError, match="total_impulse must be non-negative"):
+            SpringLaunch(
+                total_impulse=-1.0,
+                force_direction_rad=0.0,
+                contact_point=Vec2(),
+                asteroid_com=Vec2(),
+                jumper_com=Vec2(0, 1),
+                duration=0.1,
+            )
+
+    def test_step_zero_dt_raises(self) -> None:
+        spring = self._make_spring()
+        with pytest.raises(ValueError, match="dt must be positive"):
+            spring.step(0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +353,7 @@ class TestIntegration:
 
     def test_zero_dt_raises(self) -> None:
         body = RigidBody(mass=1.0, moment_of_inertia=1.0)
-        with pytest.raises((AssertionError, ValueError)):
+        with pytest.raises(ValueError, match="dt must be positive"):
             integrate_body(body, 0.0)
 
 
@@ -340,6 +372,16 @@ class TestMomentumConservation:
         state = self._system_at_rest()
         p = state.total_linear_momentum
         assert p.length() == pytest.approx(0.0)
+
+    def test_sim_state_rejects_same_body(self) -> None:
+        body = RigidBody(mass=1.0, moment_of_inertia=1.0)
+        with pytest.raises(ValueError, match="asteroid and jumper must differ"):
+            SimState(asteroid=body, jumper=body)
+
+    def test_step_simulation_zero_dt_raises(self) -> None:
+        state = self._system_at_rest()
+        with pytest.raises(ValueError, match="dt must be positive"):
+            step_simulation(state, 0.0)
 
     def test_momentum_conserved_through_colinear_jump(self) -> None:
         state = self._system_at_rest()


### PR DESCRIPTION
## Summary
- Replace runtime assertion validation in asteroid-jumper physics with explicit ValueError/TypeError exceptions.
- Replace rotation-converter UI helper assertions with explicit RuntimeError/ValueError failures.
- Replace scripting console source assertion with an explicit ValueError and add regression coverage, including optimized-Python validation.

Refs #2087

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --noconftest -o addopts='' tests/test_asteroid_jumper/test_physics.py tests/rotation_converter/test_scripting_env.py tests/rotation_converter/test_plot_helpers.py -q
- PYTHONOPTIMIZE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest --noconftest -o addopts='' tests/test_asteroid_jumper/test_physics.py::TestRigidBody::test_negative_mass_raises tests/test_asteroid_jumper/test_physics.py::TestIntegration::test_zero_dt_raises tests/rotation_converter/test_scripting_env.py::TestConsoleEnvironment::test_execute_none_source_raises_value_error tests/rotation_converter/test_plot_helpers.py::test_fmt_mat_rejects_none_matrix -q
- python3 -m ruff check src/asteroid_jumper/physics.py src/rotation_converter/ui/pyqt6/main_window.py src/rotation_converter/ui/pyqt6/plot_helpers.py src/shared/python/scripting/scripting_env.py tests/test_asteroid_jumper/test_physics.py tests/rotation_converter/test_scripting_env.py tests/rotation_converter/test_plot_helpers.py
- git diff --check && python3 -m py_compile src/asteroid_jumper/physics.py src/rotation_converter/ui/pyqt6/main_window.py src/rotation_converter/ui/pyqt6/plot_helpers.py src/shared/python/scripting/scripting_env.py