### PR TITLE
🎨 Palette: [Inline Error Feedback & Focus Improvements]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-04-13 - Contextless Raw Timers
 **Learning:** Raw dynamic text like "03:45" or "105.4" provides no contextual meaning to screen readers if the visual context (like a pulsing red record dot or surrounding icon) is purely decorative or uses aria-hidden.
 **Action:** When displaying timers, numeric readings, or dynamic status values, prepend a visually `<span className="sr-only">` label (e.g., `<span className="sr-only">Recording duration:</span>`) right before the raw value so assistive tech announces "Recording duration: 03:45" instead of just "zero three colon four five". Ensure purely decorative visual context like pulsing dots have `aria-hidden="true"`.
+
+## 2026-04-14 - [Inline Error Feedback & Focus Improvements]
+**Learning:** Native `alert()` dialogs used for errors (e.g., failed exports or imports) disrupt user flow, block interaction, and break from the app's visual theme. Furthermore, some interactive UI elements may lack keyboard focus rings.
+**Action:** Replace `alert()` with inline UI elements (e.g., `<div role="alert">`) to provide non-blocking error feedback. Always ensure custom or unstyled buttons include `focus-visible` utility classes to support keyboard navigation.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 <!--
   TEMPLATE VERSION: 1.0.0
-  LAST UPDATED: 2026-04-16
+  LAST UPDATED: 2026-04-17
 
   This is the canonical specification template for all repositories in the
   D-sorganization fleet. Every repo MUST have a SPEC.md at its root.
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.61                                     |
+| **Spec Version**        | 1.1.62                                     |
 | **Last Spec Update**    | 2026-04-17                                 |
 
 ## 2. Purpose & Mission
@@ -454,6 +454,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-17 | 1.1.62  | Enhanced video editor UX by replacing native alert dialogs with inline accessible errors and ensuring proper focus styles. |
 | 2026-04-17 | 1.1.61  | Replaced runtime `assert` validation in asteroid-jumper physics, rotation-converter UI helpers, and scripting console execution with explicit exceptions so invalid caller input remains guarded under optimized Python. |
 | 2026-04-16 | 1.1.60  | Hardened launcher process handling by validating tool names, cleaning up spawned process groups, surfacing explicit model-conversion errors, and regression-testing temporary-file cleanup paths. |
 | 2026-04-16 | 1.1.59  | Removed stale root-level debug artifacts (`.ci_trigger.py`, `MUJOCO_LOG.TXT`, `error_log.txt`, `wave_log.txt`, and the empty marker file ending in `Last`), added root-scoped ignore rules for those paths, and locked the hygiene policy with regression tests. |

--- a/src/media_processing/video_processor/apps/web/components/annotations/AnnotationExport.tsx
+++ b/src/media_processing/video_processor/apps/web/components/annotations/AnnotationExport.tsx
@@ -7,7 +7,7 @@ import {
     importAnnotationsFromJSON,
 } from '@/lib/video/annotationExporter';
 import * as fabric from 'fabric';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 interface AnnotationExportProps {
   annotations: fabric.Object[];
@@ -27,6 +27,7 @@ export default function AnnotationExportComponent({
   disabled = false,
 }: AnnotationExportProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const handleExport = () => {
     if (!canvas) return;
@@ -41,10 +42,12 @@ export default function AnnotationExportComponent({
   };
 
   const handleImport = () => {
+    setError(null);
     fileInputRef.current?.click();
   };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setError(null);
     const file = event.target.files?.[0];
     if (!file || !canvas) return;
 
@@ -55,7 +58,7 @@ export default function AnnotationExportComponent({
         void importAnnotationsFromJSON(jsonData, canvas);
       } catch (error) {
         console.error('Failed to import annotations:', error);
-        alert('Failed to import annotations. Please check the file format.');
+        setError('Failed to import annotations. Please check the file format.');
       }
     };
     reader.readAsText(file);
@@ -72,14 +75,14 @@ export default function AnnotationExportComponent({
         <button
           onClick={handleExport}
           disabled={disabled || annotations.length === 0}
-          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >
           Export Annotations
         </button>
         <button
           onClick={handleImport}
           disabled={disabled || !canvas}
-          className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         >
           Import Annotations
         </button>
@@ -91,6 +94,11 @@ export default function AnnotationExportComponent({
           className="hidden"
         />
       </div>
+      {error && (
+        <div role="alert" className="p-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md">
+          {error}
+        </div>
+      )}
       <div className="text-xs text-gray-500">
         {annotations.length} annotation{annotations.length !== 1 ? 's' : ''} on current frame
       </div>

--- a/src/media_processing/video_processor/apps/web/components/video/VideoEditor.tsx
+++ b/src/media_processing/video_processor/apps/web/components/video/VideoEditor.tsx
@@ -30,6 +30,7 @@ export default function VideoEditor({
   disabled = false,
 }: VideoEditorProps) {
   const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [trimRange, setTrimRange] = useState<TrimRange>({ start: 0, end: 0 });
   const [cropArea, _setCropArea] = useState<CropArea | null>(null);
   const [rotation, setRotation] = useState<RotationAngle>(0);
@@ -70,6 +71,7 @@ export default function VideoEditor({
     if (!videoFile || disabled || isProcessing) return;
 
     setIsProcessing(true);
+    setError(null);
 
     try {
       await loadFFmpeg();
@@ -126,7 +128,7 @@ export default function VideoEditor({
       onExport(blob);
     } catch (error) {
       console.error('Export error:', error);
-      alert('Failed to export video. Please try again.');
+      setError('Failed to export video. Please try again.');
     } finally {
       setIsProcessing(false);
     }
@@ -221,6 +223,12 @@ export default function VideoEditor({
           ))}
         </div>
       </div>
+
+      {error && (
+        <div role="alert" className="p-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md">
+          {error}
+        </div>
+      )}
 
       <button
         onClick={handleExport}


### PR DESCRIPTION
### 💡 What
- Replaced the browser native `alert()` dialogs in `VideoEditor.tsx` and `AnnotationExport.tsx` with standard React state-driven error messages.
- Wrapped these new error outputs in a semantic `<div role="alert">` element to ensure screen readers will announce failures immediately.
- Added explicit `focus-visible` Tailwind classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500`) to the 'Export Annotations' and 'Import Annotations' buttons.

### 🎯 Why
- Native `alert()` dialogs block the main thread, disrupt the user's workflow context, and cannot be styled to match the application's theme, making them feel archaic and out of place.
- Interactive elements that trigger actions (like exports or imports) must have visible focus rings when navigated via keyboard to ensure users know where their focus lies.

### 📸 Before/After
*(See Playwright verification images attached showing the inline styled error messages matching the rest of the application theme.)*

### ♿ Accessibility
- Introduced `role="alert"` for the error messages to actively notify screen reader users when an export or import action fails.
- Improved keyboard navigability by explicitly specifying clear visual focus rings on critical interactive action buttons.

---
*PR created automatically by Jules for task [2211256235219982023](https://jules.google.com/task/2211256235219982023) started by @dieterolson*