### PR TITLE
Reject non-finite asteroid jumper timesteps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.64                                     |
-| **Last Spec Update**    | 2026-04-17                                 |
+| **Spec Version**        | 1.1.65                                     |
+| **Last Spec Update**    | 2026-04-18                                 |
 
 ## 2. Purpose & Mission
 
@@ -129,6 +129,7 @@ Tools/
 | Document Processing      | `src/document_processing/`                                                             | PDF extraction, text processing                                                                                                        |
 | Media Processing         | `src/media_processing/`                                                                | Audio and video utilities                                                                                                              |
 | Scientific Modeling      | `src/scientific_modeling/`                                                             | Thermal, mechanical, chemical simulations                                                                                              |
+| Asteroid Jumper          | `src/asteroid_jumper/`                                                                 | Rigid-body toy simulation with explicit finite-positive timestep and physics-parameter validation                                      |
 | Web Services             | `src/web_applications/api/`                                                            | FastAPI endpoints and integrations                                                                                                     |
 | Unit Converter WSGI      | `src/web_applications/unit_converter/`                                                  | Flask web application with a production WSGI entry point; debug mode is development-only and gated by `FLASK_DEBUG`                  |
 | Rust Kernels             | `rust_core/`                                                                           | High-performance mathematical operations                                                                                               |
@@ -455,6 +456,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-18 | 1.1.65  | Hardened asteroid-jumper physics validation so non-finite timesteps and physics parameters are rejected with explicit `ValueError`s instead of propagating NaN or infinity through simulation state. |
 | 2026-04-17 | 1.1.64  | Optimized `applyFilter` loop in `useDataProcessor.ts` by replacing the object spread operator with manual property copying to eliminate significant garbage collection overhead during large dataset processing. |
 | 2026-04-17 | 1.1.63  | Hardened model-generation GitHub repository downloads by requiring HTTPS retrievals and validating mesh output paths so API-provided mesh names cannot escape the destination directory; kept the unit-converter development WSGI debugger disabled unless `FLASK_DEBUG=1` is explicitly set. |
 | 2026-04-17 | 1.1.62  | Enhanced video editor UX by replacing native alert dialogs with inline accessible errors and ensuring proper focus styles. |

--- a/src/asteroid_jumper/physics.py
+++ b/src/asteroid_jumper/physics.py
@@ -83,6 +83,16 @@ class Vec2(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
+def _require_positive(name: str, value: float) -> None:
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}")
+
+
+def _require_non_negative(name: str, value: float) -> None:
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(f"{name} must be non-negative, got {value}")
+
+
 @dataclass
 class RigidBody:
     """Mutable state for a single 2-D rigid body.
@@ -98,12 +108,8 @@ class RigidBody:
     angular_vel: float = 0.0  # rad/s
 
     def __post_init__(self) -> None:
-        if self.mass <= 0:
-            raise ValueError(f"mass must be positive, got {self.mass}")
-        if self.moment_of_inertia <= 0:
-            raise ValueError(
-                f"moment_of_inertia must be positive, got {self.moment_of_inertia}"
-            )
+        _require_positive("mass", self.mass)
+        _require_positive("moment_of_inertia", self.moment_of_inertia)
 
     @property
     def speed(self) -> float:
@@ -128,28 +134,23 @@ class RigidBody:
 
 def moment_of_inertia_ellipse(mass: float, a: float, b: float) -> float:
     """Moment of inertia for a solid ellipse with semi-axes a, b."""
-    if mass <= 0:
-        raise ValueError(f"mass must be positive, got {mass}")
-    if a <= 0 or b <= 0:
+    _require_positive("mass", mass)
+    if not math.isfinite(a) or not math.isfinite(b) or a <= 0 or b <= 0:
         raise ValueError(f"ellipse semi-axes must be positive, got a={a}, b={b}")
     return 0.25 * mass * (a**2 + b**2)
 
 
 def moment_of_inertia_disk(mass: float, radius: float) -> float:
     """Moment of inertia for a solid disk."""
-    if mass <= 0:
-        raise ValueError(f"mass must be positive, got {mass}")
-    if radius <= 0:
-        raise ValueError(f"radius must be positive, got {radius}")
+    _require_positive("mass", mass)
+    _require_positive("radius", radius)
     return 0.5 * mass * radius**2
 
 
 def moment_of_inertia_rod(mass: float, length: float) -> float:
     """Moment of inertia for a thin rod about its centre."""
-    if mass <= 0:
-        raise ValueError(f"mass must be positive, got {mass}")
-    if length <= 0:
-        raise ValueError(f"length must be positive, got {length}")
+    _require_positive("mass", mass)
+    _require_positive("length", length)
     return mass * length**2 / 12.0
 
 
@@ -182,8 +183,7 @@ def compute_jump_impulse(
         (jumper_impulse, asteroid_torque_impulse, jumper_torque_impulse)
         where torques are scalar (z-component of r Ã— J).
     """
-    if force_magnitude < 0:
-        raise ValueError("force_magnitude must be non-negative")
+    _require_non_negative("force_magnitude", force_magnitude)
 
     J = Vec2(
         force_magnitude * math.cos(force_direction_rad),
@@ -216,8 +216,7 @@ GRAVITY: Vec2 = Vec2(0.0, 0.0)  # Deep space â€” no gravity by default
 
 def integrate_body(body: RigidBody, dt: float) -> None:
     """Semi-implicit Euler integration step for *body* (mutates in place)."""
-    if dt <= 0:
-        raise ValueError(f"dt must be positive, got {dt}")
+    _require_positive("dt", dt)
     body.pos = body.pos + body.vel * dt
     body.angle += body.angular_vel * dt
 
@@ -246,12 +245,8 @@ class SpringLaunch:
     elapsed: float = 0.0
 
     def __post_init__(self) -> None:
-        if self.total_impulse < 0:
-            raise ValueError(
-                f"total_impulse must be non-negative, got {self.total_impulse}"
-            )
-        if self.duration <= 0:
-            raise ValueError(f"duration must be positive, got {self.duration}")
+        _require_non_negative("total_impulse", self.total_impulse)
+        _require_positive("duration", self.duration)
 
     @property
     def is_complete(self) -> bool:
@@ -264,8 +259,7 @@ class SpringLaunch:
         Returns the (impulse, asteroid_torque, jumper_torque) for this step,
         or None if the launch is already complete.
         """
-        if dt <= 0:
-            raise ValueError(f"dt must be positive, got {dt}")
+        _require_positive("dt", dt)
         if self.is_complete:
             return None
         remaining = self.duration - self.elapsed
@@ -331,8 +325,7 @@ class SimState:
 
 def step_simulation(state: SimState, dt: float) -> None:
     """Advance the simulation by *dt* seconds (mutates *state*)."""
-    if dt <= 0:
-        raise ValueError(f"dt must be positive, got {dt}")
+    _require_positive("dt", dt)
 
     if state.spring is not None and not state.spring.is_complete:
         result = state.spring.step(dt)

--- a/tests/test_asteroid_jumper/test_physics.py
+++ b/tests/test_asteroid_jumper/test_physics.py
@@ -333,6 +333,12 @@ class TestSpringLaunch:
         with pytest.raises(ValueError, match="dt must be positive"):
             spring.step(0.0)
 
+    @pytest.mark.parametrize("dt", [math.nan, math.inf, -math.inf])
+    def test_step_non_finite_dt_raises(self, dt: float) -> None:
+        spring = self._make_spring()
+        with pytest.raises(ValueError, match="dt must be positive"):
+            spring.step(dt)
+
 
 # ---------------------------------------------------------------------------
 # Integration
@@ -355,6 +361,12 @@ class TestIntegration:
         body = RigidBody(mass=1.0, moment_of_inertia=1.0)
         with pytest.raises(ValueError, match="dt must be positive"):
             integrate_body(body, 0.0)
+
+    @pytest.mark.parametrize("dt", [math.nan, math.inf, -math.inf])
+    def test_non_finite_dt_raises(self, dt: float) -> None:
+        body = RigidBody(mass=1.0, moment_of_inertia=1.0)
+        with pytest.raises(ValueError, match="dt must be positive"):
+            integrate_body(body, dt)
 
 
 # ---------------------------------------------------------------------------
@@ -382,6 +394,12 @@ class TestMomentumConservation:
         state = self._system_at_rest()
         with pytest.raises(ValueError, match="dt must be positive"):
             step_simulation(state, 0.0)
+
+    @pytest.mark.parametrize("dt", [math.nan, math.inf, -math.inf])
+    def test_step_simulation_non_finite_dt_raises(self, dt: float) -> None:
+        state = self._system_at_rest()
+        with pytest.raises(ValueError, match="dt must be positive"):
+            step_simulation(state, dt)
 
     def test_momentum_conserved_through_colinear_jump(self) -> None:
         state = self._system_at_rest()


### PR DESCRIPTION
Closes #2128

## Summary
- Require finite positive `dt` values in asteroid jumper integration and spring stepping
- Apply finite guards to related positive/non-negative physics preconditions
- Update `SPEC.md` for the asteroid-jumper validation contract required by the spec freshness gate

## Tests / Validation
- `uvx ruff check src\asteroid_jumper\physics.py tests\test_asteroid_jumper\test_physics.py`
- `uvx ruff format --check src\asteroid_jumper\physics.py tests\test_asteroid_jumper\test_physics.py`
- `PYTHONPATH=src uvx --with pytest pytest -p no:cacheprovider tests\test_asteroid_jumper\test_physics.py -q` (66 passed)
- `python scripts\check_minimum_test_contract.py`
- `python scripts\check_module_size_budget.py --max-lines 1200 --include src`
- `python scripts\check_repo_topology.py`
- `git diff --check`

## Notes
- The implementation keeps the existing public physics API and centralizes scalar validation in small helpers.
- CI is currently queued at the self-hosted `pick-runner` stage because all `d-sorg-fleet` runners report offline.