### PR TITLE
Remove plugin-only pytest addopts

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.64                                     |
-| **Last Spec Update**    | 2026-04-17                                 |
+| **Spec Version**        | 1.1.65                                     |
+| **Last Spec Update**    | 2026-04-18                                 |
 
 ## 2. Purpose & Mission
 
@@ -455,6 +455,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-18 | 1.1.65  | Simplified root pytest addopts in `pyproject.toml` by removing benchmark and xdist-specific defaults so repository-level test runs do not require those plugins outside focused plugin test contexts. |
 | 2026-04-17 | 1.1.64  | Optimized `applyFilter` loop in `useDataProcessor.ts` by replacing the object spread operator with manual property copying to eliminate significant garbage collection overhead during large dataset processing. |
 | 2026-04-17 | 1.1.63  | Hardened model-generation GitHub repository downloads by requiring HTTPS retrievals and validating mesh output paths so API-provided mesh names cannot escape the destination directory; kept the unit-converter development WSGI debugger disabled unless `FLASK_DEBUG=1` is explicitly set. |
 | 2026-04-17 | 1.1.62  | Enhanced video editor UX by replacing native alert dialogs with inline accessible errors and ensuring proper focus styles. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,7 +227,7 @@ testpaths = ["tests", "src", "src/pendulum_simulator/tests"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-ra -q --strict-markers --strict-config --durations=20 --benchmark-disable -n auto --dist loadscope -m \"not live_simulation\" -p no:xvfb"
+addopts = "-ra -q --strict-markers --strict-config --durations=20 -m \"not live_simulation\" -p no:xvfb"
 pythonpath = ["src"]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",


### PR DESCRIPTION
Closes #2129

## Summary
- Remove plugin-only pytest addopts from shared config so pytest can start without optional plugins

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --version