### PR TITLE
Register pytest marker contracts

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -75,7 +75,9 @@ jobs:
 
       - name: Reject Raw Merge Conflict Markers
         run: |
-          if grep -rne '<<<<<<< HEAD' . --exclude-dir=.git --exclude-dir=.github; then
+          conflict_marker='<<<<<'
+          conflict_marker="${conflict_marker}<< HEAD"
+          if grep -rne "$conflict_marker" . --exclude-dir=.git --exclude-dir=.github; then
             echo "::error::Raw git merge conflict markers found!"
             exit 1
           fi
@@ -233,7 +235,9 @@ jobs:
 
       - name: Reject Raw Merge Conflict Markers
         run: |
-          if grep -rne '<<<<<<< HEAD' . --exclude-dir=.git --exclude-dir=.github; then
+          conflict_marker='<<<<<'
+          conflict_marker="${conflict_marker}<< HEAD"
+          if grep -rne "$conflict_marker" . --exclude-dir=.git --exclude-dir=.github; then
             echo "::error::Raw git merge conflict markers found!"
             exit 1
           fi

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.69                                     |
+| **Spec Version**        | 1.1.70                                     |
 | **Last Spec Update**    | 2026-04-18                                 |
 
 ## 2. Purpose & Mission
@@ -261,6 +261,11 @@ Test pyramid with unit tests at the base, integration tests for tool interaction
 | DWSIM       | `tests/dwsim/`       | pytest    | `@pytest.mark.dwsim`       |
 | Slow        | `tests/slow/`        | pytest    | `@pytest.mark.slow`        |
 
+`pytest.ini` registers every marker required by `CLAUDE.md`, including benchmark,
+scientific, headless-safe, OpenGL, and parity markers. Pytest runs with strict
+marker validation and strict xfail handling so stale marker names or unexpected
+passes fail early in CI.
+
 ### Coverage Requirements
 
 | Scope         | Minimum | Current | Enforced By                |
@@ -456,6 +461,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-18 | 1.1.70  | Test configuration hygiene: registered the complete CLAUDE.md marker set in `pytest.ini`, enabled strict xfail handling, and added a contract-test backbone for the ODE solver, pressure-drop calculator, and rotation-converter calc backend request/response models. |
 | 2026-04-18 | 1.1.69  | Stopped the bot CI trigger workflow from using stale external credentials for repository checkout and PR/check API operations so bot-authored PRs use repo-scoped workflow credentials for required check discovery. |
 | 2026-04-18 | 1.1.68  | Restricted Data Processor web row-copy paths to own enumerable properties via a shared `Object.keys` helper and added regression coverage to prevent inherited prototype keys from being copied into processed rows. |
 | 2026-04-18 | 1.1.67  | Filter deleted test files out of the CI changed-test list so PRs that intentionally remove stale tests do not pass non-existent paths to pytest. |

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,15 +60,20 @@ markers =
     integration: mark test as integration test (may use external resources)
     e2e: mark test as end-to-end test (full system test)
     slow: mark test as slow running (> 5 seconds)
+    benchmark: mark test as benchmark/performance measurement
     performance: mark test for performance benchmarking
+    scientific: mark test as scientific/numerical validation
     requires_network: mark test as requiring network connectivity
     requires_database: mark test as requiring database connection
     requires_gpu: mark test as requiring GPU/CUDA
+    requires_gl: mark test as requiring OpenGL/graphics acceleration
+    headless_safe: mark test as safe to run in headless CI environments
     smoke: mark test as smoke test (basic sanity check)
     regression: mark test for regression testing
     asyncio: mark test as async test
     contract: mark test as contract test
     acceptance: mark test as acceptance test
+    parity: mark test as cross-implementation parity validation
     dwsim: mark test as requiring DWSIM runtime
     live_simulation: tests requiring live DWSIM simulation access
     gui: tests that require a GUI environment
@@ -79,6 +84,7 @@ markers =
     flaky: tests that are known to fail intermittently
     tools_contracts: tests verifying shared tools libraries interfaces
 
+xfail_strict = true
 
 # =============================================================================
 # Output and Reporting

--- a/tests/contract/test_calc_backend_contract_surface.py
+++ b/tests/contract/test_calc_backend_contract_surface.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
-
 from calc_backend.contracts.ode_solver import ODESolverRequest, ODESolverResponse
 from calc_backend.contracts.pressure_drop import (
     PressureDropRequest,
@@ -16,6 +14,7 @@ from calc_backend.contracts.rotation_converter import (
     RotationConverterRequest,
     RotationConverterResponse,
 )
+from pydantic import ValidationError
 
 
 @pytest.mark.contract

--- a/tests/contract/test_calc_backend_contract_surface.py
+++ b/tests/contract/test_calc_backend_contract_surface.py
@@ -1,0 +1,133 @@
+"""Contract tests for downstream-critical calc backend API models."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from calc_backend.contracts.ode_solver import ODESolverRequest, ODESolverResponse
+from calc_backend.contracts.pressure_drop import (
+    PressureDropRequest,
+    PressureDropResponse,
+)
+from calc_backend.contracts.rotation_converter import (
+    ReferenceFrameConversionRequest,
+    ReferenceFrameConversionResponse,
+    RotationConverterRequest,
+    RotationConverterResponse,
+)
+
+
+@pytest.mark.contract
+@pytest.mark.parametrize(
+    ("model", "expected_fields"),
+    [
+        (
+            ODESolverRequest,
+            {
+                "derivatives",
+                "parameters",
+                "initial_conditions",
+                "t_start",
+                "t_end",
+                "num_points",
+            },
+        ),
+        (
+            ODESolverResponse,
+            {"times", "solutions", "variable_summaries", "success", "message"},
+        ),
+        (
+            PressureDropRequest,
+            {
+                "pipe_diameter_m",
+                "pipe_length_m",
+                "roughness_m",
+                "flow_rate_kg_s",
+                "temperature_k",
+                "pressure_pa",
+                "molecular_weight_kg_mol",
+            },
+        ),
+        (
+            PressureDropResponse,
+            {
+                "pressure_drop_pa",
+                "reynolds_number",
+                "friction_factor",
+                "velocity_m_s",
+                "flow_regime",
+                "density_kg_m3",
+                "viscosity_pa_s",
+            },
+        ),
+        (
+            RotationConverterRequest,
+            {"type", "value", "euler_convention"},
+        ),
+        (
+            RotationConverterResponse,
+            {"representations"},
+        ),
+        (
+            ReferenceFrameConversionRequest,
+            {
+                "operation",
+                "transform",
+                "twist",
+                "rotation_matrix",
+                "translation",
+                "so3_vector",
+                "so3_matrix",
+            },
+        ),
+        (
+            ReferenceFrameConversionResponse,
+            {
+                "operation",
+                "results",
+                "explanation_markdown",
+                "explanation_latex",
+            },
+        ),
+    ],
+)
+def test_calc_backend_contract_fields_are_stable(model, expected_fields):
+    """Public request/response contracts keep downstream-visible field names."""
+    assert set(model.model_fields) == expected_fields
+
+
+@pytest.mark.contract
+def test_ode_solver_request_rejects_too_few_output_points():
+    with pytest.raises(ValidationError):
+        ODESolverRequest(
+            derivatives={"y": "-k*y"},
+            parameters={"k": 0.1},
+            initial_conditions={"y": 1.0},
+            num_points=1,
+        )
+
+
+@pytest.mark.contract
+def test_pressure_drop_request_rejects_non_positive_pipe_diameter():
+    with pytest.raises(ValidationError):
+        PressureDropRequest(
+            pipe_diameter_m=0.0,
+            pipe_length_m=10.0,
+            flow_rate_kg_s=1.0,
+            temperature_k=300.0,
+            pressure_pa=101325.0,
+            molecular_weight_kg_mol=0.028,
+        )
+
+
+@pytest.mark.contract
+def test_rotation_converter_request_rejects_unknown_representation():
+    with pytest.raises(ValidationError):
+        RotationConverterRequest(type="matrix", value=[1.0, 0.0, 0.0, 0.0])
+
+
+@pytest.mark.contract
+def test_reference_frame_request_requires_operation_specific_payload():
+    with pytest.raises(ValidationError):
+        ReferenceFrameConversionRequest(operation="twist_frame_conversion")


### PR DESCRIPTION
## Summary
- register the missing CLAUDE.md pytest markers in pytest.ini
- enable strict xfail handling
- add contract tests for the ODE solver, pressure-drop, and rotation-converter calc backend API models
- refresh SPEC.md for the test configuration contract

Closes #2096

## Tests
- python -m pytest -q tests\\contract\\test_calc_backend_contract_surface.py
- python -m pytest --markers