### PR TITLE
fix(ci): run quality-gate on docs-only PRs to satisfy branch protection

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -12,9 +12,9 @@ on:
       - ".gitignore"
   pull_request:
     types: [opened, synchronize, reopened]
+    # NOTE: **.md intentionally NOT excluded so quality-gate runs on docs-only
+    # PRs and satisfies branch protection required status checks.
     paths-ignore:
-      - "docs/**"
-      - "**.md"
       - "LICENSE"
       - ".gitignore"
   workflow_dispatch:


### PR DESCRIPTION
Removing **.md from pull_request paths-ignore so quality-gate runs on docs-only PRs, satisfying branch protection required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)