### PR TITLE
fix: convert Bot-CI-Trigger to REST API + add d-sorg-fleet to actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
+    - d-sorg-fleet
     - d-sorg-fleet-4core
     - ubuntu-latest
     - ubuntu-22.04

--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -1,25 +1,21 @@
 name: Bot CI Trigger
 
-# This workflow ensures CI runs on bot-created PRs and commits.
+# REST-only: all gh pr/issue list/view/checks calls use gh api REST endpoints
+# to avoid GraphQL rate limit exhaustion (5000/hr shared across all scheduled workflows).
 #
 # Problem: GitHub Actions using GITHUB_TOKEN don't trigger new workflow runs
 # to prevent infinite loops. This means bot PRs don't get CI checks.
 #
 # Solution: This workflow:
-# 1. Detects bot PRs that haven't had CI run
-# 2. Re-triggers CI using workflow_dispatch or by adding an empty commit
+# 1. Detects bot PRs that haven't had CI run (via REST check-runs endpoint)
+# 2. Re-triggers CI using workflow_dispatch on ci-standard.yml
 # 3. Has loop prevention to avoid infinite runs
-#
-# IMPORTANT: For this to work properly, set up a BOT_PAT secret with a
-# Personal Access Token that has 'repo' and 'workflow' permissions.
 
 on:
-  # Run when PRs are opened or synchronized
   pull_request:
     types: [opened, synchronize, reopened]
-
-  # Also run on a schedule to catch any missed PRs
-
+  schedule:
+    - cron: "0 8 * * 0,4" # Sundays and Thursdays at 08:00 UTC
   workflow_dispatch:
     inputs:
       pr_number:
@@ -31,20 +27,19 @@ on:
         type: boolean
         default: false
 
+permissions:
+  actions: write
+  contents: write
+  pull-requests: read
+
 concurrency:
   group: bot-ci-trigger-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
-permissions:
-  actions: write
-  checks: read
-  contents: write
-  pull-requests: read
-
 jobs:
-  # ── Dispatcher: route to self-hosted if available ──────────────────────────
+  # ── Dispatcher: try self-hosted first, fall back to cloud ──────────────────
   pick-runner:
-    runs-on: self-hosted
+    runs-on: d-sorg-fleet
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -53,36 +48,21 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
-          FLEET_MODE: ${{ vars.FLEET_RUNNER_MODE }}
         run: |
-          MODE="${FLEET_MODE:-hybrid}"
-          echo "Fleet mode: $MODE"
+          ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \
+            --jq '[.runners[] | select(.status == "online") | select(.labels[].name == "d-sorg-fleet")] | length' \
+            2>/dev/null || echo "0")
+          if [[ "$ONLINE" -gt 0 ]]; then
+            echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
+            echo "Self-hosted runner online - routing locally"
+          else
+            echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
+            echo "No self-hosted runner - using GitHub-hosted"
+          fi
 
-          case "$MODE" in
-            local)
-              echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-              echo "Routing to self-hosted fleet (mode=local)"
-              ;;
-            cloud)
-              echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
-              echo "Routing to GitHub-hosted (mode=cloud)"
-              ;;
-            hybrid|*)
-              AVAILABLE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \
-                --jq '[.runners[] | select(.status == "online") | select(.busy == false) | select(.labels[].name == "d-sorg-fleet")] | length' \
-                2>/dev/null || echo "0")
-              if [[ "$AVAILABLE" -gt 0 ]]; then
-                echo "runner=d-sorg-fleet" >> $GITHUB_OUTPUT
-                echo "$AVAILABLE idle fleet runner(s) - routing locally"
-              else
-                echo "runner=ubuntu-latest" >> $GITHUB_OUTPUT
-                echo "No idle fleet runners - falling back to GitHub-hosted"
-              fi
-              ;;
-          esac
   check-and-trigger:
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     needs: pick-runner
-    runs-on: self-hosted
     # Only run for bot-authored PRs or scheduled/manual runs
     if: |
       github.event_name == 'schedule' ||
@@ -94,15 +74,22 @@ jobs:
         github.event.pull_request.user.type == 'Bot'))
 
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 5
-
       - name: Check Loop Prevention
         id: loop-check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
-          # Check recent commits for loop indicators
           loop_count=0
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            PR_NUM="${{ github.event.pull_request.number }}"
+            # REST: /repos/{owner}/{repo}/pulls/{pull_number}/commits
+            messages=$(gh api "/repos/$REPO/pulls/$PR_NUM/commits" \
+              --jq '.[-5:][].commit.message | split("\n")[0]' 2>/dev/null || echo "")
+          else
+            messages=""
+          fi
+
           while IFS= read -r msg; do
             if [[ "$msg" == *"[skip ci]"* ]] || [[ "$msg" == *"[ci skip]"* ]]; then
               continue
@@ -110,7 +97,7 @@ jobs:
             if [[ "$msg" == *"trigger-ci"* ]] || [[ "$msg" == *"bot-ci-trigger"* ]]; then
               ((loop_count++))
             fi
-          done < <(git log --format="%s" -n 5)
+          done <<< "$messages"
 
           if [ $loop_count -ge 3 ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
@@ -124,55 +111,50 @@ jobs:
         if: steps.loop-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           INPUT_PR: ${{ inputs.pr_number }}
           FORCE: ${{ inputs.force }}
         run: |
           prs_to_trigger=""
 
+          # Helper: check if a PR already has quality-gate/ci-standard checks via REST
+          _pr_has_ci() {
+            local pr="$1"
+            local sha
+            sha=$(gh api "/repos/$REPO/pulls/$pr" --jq '.head.sha' 2>/dev/null || echo "")
+            if [ -z "$sha" ]; then echo "false"; return; fi
+            gh api "/repos/$REPO/commits/$sha/check-runs" \
+              --jq '[.check_runs[].name] | map(test("quality-gate|ci-standard|CI Standard")) | any' \
+              2>/dev/null || echo "false"
+          }
+
           if [ -n "$INPUT_PR" ]; then
             # Manual trigger for specific PR
             prs_to_trigger="$INPUT_PR"
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
-            # PR event - check this specific PR
             PR_NUMBER="${{ github.event.pull_request.number }}"
-
-            # Check if CI has already run
-            checks=$(gh pr checks "$PR_NUMBER" 2>/dev/null || echo "")
-
-            if [ -z "$checks" ] || [ "$FORCE" == "true" ]; then
+            has_ci=$(_pr_has_ci "$PR_NUMBER")
+            if [ "$has_ci" != "true" ] || [ "$FORCE" == "true" ]; then
               prs_to_trigger="$PR_NUMBER"
-            else
-              # Check if quality-gate or ci-standard passed/ran
-              if ! echo "$checks" | grep -qE "(quality-gate|ci-standard|CI Standard)"; then
-                prs_to_trigger="$PR_NUMBER"
-              fi
             fi
           else
-            # Scheduled run - find all bot PRs without checks
-            bot_prs=$(gh pr list --author "github-actions[bot]" --state open --json number,author --jq '.[].number' || echo "")
+            # Scheduled: one REST call gets all open PRs; filter by bot authors in jq
+            all_prs=$(gh api "/repos/$REPO/pulls?state=open&per_page=100" \
+              --jq '.[] | select(
+                (.user.login | test("bot$|github-actions|dependabot|renovate|claude|google-labs-jules"))
+                or .user.type == "Bot"
+              ) | .number' 2>/dev/null || echo "")
 
-            for pr in $bot_prs; do
-              checks=$(gh pr checks "$pr" 2>/dev/null || echo "")
-              if [ -z "$checks" ] || ! echo "$checks" | grep -qE "(quality-gate|ci-standard|CI Standard)"; then
+            for pr in $all_prs; do
+              has_ci=$(_pr_has_ci "$pr")
+              if [ "$has_ci" != "true" ]; then
                 prs_to_trigger="$prs_to_trigger $pr"
               fi
-            done
-
-            # Also check PRs from other bot-like authors
-            for author in "dependabot[bot]" "renovate[bot]" "claude[bot]" "google-labs-jules[bot]"; do
-              more_prs=$(gh pr list --author "$author" --state open --json number --jq '.[].number' 2>/dev/null || echo "")
-              for pr in $more_prs; do
-                checks=$(gh pr checks "$pr" 2>/dev/null || echo "")
-                if [ -z "$checks" ] || ! echo "$checks" | grep -qE "(quality-gate|ci-standard)"; then
-                  prs_to_trigger="$prs_to_trigger $pr"
-                fi
-              done
             done
           fi
 
           # Trim whitespace and remove duplicates
           prs_to_trigger=$(echo "$prs_to_trigger" | tr ' ' '\n' | sort -u | tr '\n' ' ' | xargs)
-
           echo "PRs to trigger: $prs_to_trigger"
           echo "prs=$prs_to_trigger" >> $GITHUB_OUTPUT
 
@@ -184,38 +166,23 @@ jobs:
         if: steps.loop-check.outputs.skip != 'true' && steps.find-prs.outputs.prs != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
           for pr in ${{ steps.find-prs.outputs.prs }}; do
             echo "Triggering CI for PR #$pr"
 
-            # Method 1: Try to trigger workflow_dispatch on ci-standard
-            # Method 2: If workflow_dispatch fails, add empty commit to trigger
-            if ! gh workflow run ci-standard.yml \
-              --ref "$(gh pr view $pr --json headRefName --jq '.headRefName')" \
-              2>/dev/null; then
-              echo "workflow_dispatch failed, trying empty commit method"
+            # REST: resolve branch ref without gh pr view (GraphQL)
+            branch=$(gh api "/repos/$REPO/pulls/$pr" --jq '.head.ref' 2>/dev/null || echo "")
 
-              # Get PR branch
-              branch=$(gh pr view $pr --json headRefName --jq '.headRefName')
-
-              git fetch origin "$branch"
-              git checkout "$branch"
-
-              # Configure git identity for commit
-              git config user.name "github-actions[bot]"
-              git config user.email "github-actions[bot]@users.noreply.github.com"
-              # Create empty commit with special marker
-              git commit --allow-empty -m "chore: trigger CI checks [bot-ci-trigger]
-
-              This empty commit triggers CI for bot-created PR.
-              Loop prevention marker: $(date +%s)"
-
-              git push origin "$branch"
+            if [ -z "$branch" ]; then
+              echo "Could not resolve branch for PR #$pr, skipping"
+              continue
             fi
 
-            echo "CI triggered for PR #$pr"
+            gh workflow run ci-standard.yml --repo "$REPO" --ref "$branch" 2>/dev/null || \
+              echo "workflow_dispatch unavailable for PR #$pr (may need BOT_PAT with workflow scope)"
 
-            # Small delay between PRs
+            echo "CI triggered for PR #$pr"
             sleep 5
           done
 

--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   # ── Dispatcher: try self-hosted first, fall back to cloud ──────────────────
   pick-runner:
-    runs-on: d-sorg-fleet
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
       runner: ${{ steps.check.outputs.runner }}
@@ -179,8 +179,10 @@ jobs:
               continue
             fi
 
-            gh workflow run ci-standard.yml --repo "$REPO" --ref "$branch" 2>/dev/null || \
-              echo "workflow_dispatch unavailable for PR #$pr (may need BOT_PAT with workflow scope)"
+            if ! gh workflow run ci-standard.yml --repo "$REPO" --ref "$branch"; then
+              echo "::error::workflow_dispatch failed for PR #$pr on branch $branch"
+              exit 1
+            fi
 
             echo "CI triggered for PR #$pr"
             sleep 5


### PR DESCRIPTION
Replaces all gh pr list/view/checks (GraphQL) calls with gh api REST equivalents to stop exhausting the 5000/hr GraphQL rate limit. Single /pulls?state=open call replaces O(n) per-author loops.