### PR TITLE
chore(deps): align Python version pins and lint/test manifests (#2093, #2094)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,7 +180,7 @@ repos:
 # =============================================================================
 
 default_language_version:
-  python: python3.11
+  python: python3.11  # Matches pyproject requires-python and ruff target-version
 
 # Files to always exclude from all hooks
 exclude: |

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 	@echo ""
 	@echo "  make install   - Install dependencies"
 	@echo "  make lint      - Run linters (ruff, mypy)"
-	@echo "  make format    - Format code (black, ruff)"
+	@echo "  make format    - Format code (ruff format)"
 	@echo "  make test      - Run pytest"
 	@echo "  make check     - Run all checks (lint + test)"
 	@echo "  make clean     - Remove build artifacts"
@@ -36,9 +36,9 @@ lint:
 	python -m mypy . --config-file mypy.ini || true
 
 # Format code
+# ruff format replaces black in this repo (see requirements.txt note);
+# the legacy `python -m black .` invocation was removed as part of #2094.
 format:
-	@echo "Running black..."
-	python -m black .
 	@echo "Running ruff format..."
 	python -m ruff format .
 	@echo "Running ruff fix..."

--- a/SPEC.md
+++ b/SPEC.md
@@ -24,11 +24,11 @@
 | **Repository Name**     | `Tools`                                    |
 | **GitHub URL**          | `https://github.com/D-sorganization/Tools` |
 | **Owner**               | D-sorganization                            |
-| **Primary Language(s)** | Python 3.10+, Rust, JavaScript, TypeScript |
+| **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.80                                     |
-| **Last Spec Update**    | 2026-04-19 (updated for PR #2157)          |
+| **Spec Version**        | 1.1.81                                     |
+| **Last Spec Update**    | 2026-04-19 (updated for PR #2161)          |
 
 ## 2. Purpose & Mission
 
@@ -45,7 +45,7 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 - Offer FastAPI web interfaces for programmatic and integration access
 - Provide MATLAB scientific code integration and wrappers
 - Maintain fleet theme system for consistent UI across all tools
-- Support multiple Python versions (3.10, 3.11, 3.12) with comprehensive test matrix
+- Support multiple Python versions (3.11, 3.12) with comprehensive test matrix
 
 ### Non-Goals
 
@@ -462,6 +462,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-19 | 1.1.81  | Aligned dependency metadata with the supported Python and toolchain baseline: Python package metadata now starts at Python 3.11, lint/type configuration shares that floor, Black was removed from the canonical format path, and the reproducible requirements lock includes the pytest timeout and benchmark plugins declared by the development manifests (PR #2161).                                                                                                                                                                                               |
 | 2026-04-19 | 1.1.80  | Hardened model-generation archive extraction and URDF mesh resolution by normalizing archive member paths, rejecting traversal or absolute members before extraction, and preserving unsafe mesh references as text instead of resolving them to local files (PR #2157).                                                                                                                                                                                                                                                                                              |
 | 2026-04-19 | 1.1.79  | Consolidated stale Tools PR fixes covering shared rotation primitives, data processor background worker error surfacing and UI offload, PDF renamer API-key/CORS hardening, narrower exception fallbacks, shared GUI boundary checks, and lower-body manifest registration; also tightened NumPy return typing for the rotation modern robotics helpers checked by quality-gate (PR #2149).                                                                                                                                                                         |
 | 2026-04-19 | 1.1.78  | Optimized `TimeRangePanel.tsx` in `data-processor-web` by computing time-column ranges in a single pass and avoiding `Math.min`/`Math.max` spread calls that can overflow the call stack on large datasets (PR #2156).                                                                                                                                                                                                                                                                                                                                             |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ud-tools"
 version = "0.3.0"
 description = "Shared engineering tools: URDF generation, signal processing, and process calculators."
 readme = "src/shared/python/README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = {text = "MIT"}
 authors = [
     {name = "UpstreamDrift Team"}
@@ -94,7 +94,7 @@ dev = [
     "pytest-xdist>=3.0.0",
     "pytest-timeout>=2.0.0",
     "pytest-benchmark>=4.0.0",
-    "ruff>=0.1.0",
+    "ruff>=0.14,<1.0",  # Pinned floor matches requirements-lock (0.14.10); block the 1.x rewrite
     "mypy>=1.0.0",
 ]
 
@@ -137,7 +137,7 @@ exclude = [
 # =============================================================================
 [tool.ruff]
 # Target Python 3.11 (matches CI environment)
-target-version = "py311"
+target-version = "py311"  # Matches requires-python floor; src/ uses 3.11 stdlib (tomllib)
 line-length = 88  # Matches Black standard (88 chars)
 
 # Exclude generated code and standard noise
@@ -260,7 +260,7 @@ exclude_lines = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"  # Matches pyproject requires-python and ruff target-version
 files = ["src"]
 mypy_path = "src"
 ignore_missing_imports = true

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -13,7 +13,6 @@ sympy==1.14.0
 pytest==8.4.1
 pytest-cov==7.0.0
 ruff==0.14.10
-black==26.3.1
 mypy==1.13.0
 bandit==1.9.3
 types-PyYAML==6.0.12.20250915

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -12,6 +12,8 @@ sympy==1.14.0
 # Testing & Quality Assurance
 pytest==8.4.1
 pytest-cov==7.0.0
+pytest-timeout==2.4.0
+pytest-benchmark==5.2.3
 ruff==0.14.10
 mypy==1.13.0
 bandit==1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ sympy>=1.12  # Symbolic mathematics and algebra
 # Testing & Quality Assurance
 pytest>=8.2.0  # Testing framework
 pytest-cov  # Coverage plugin for pytest (code coverage metrics)
-ruff  # Fast Python linter and formatter (replaces flake8/black)
+pytest-timeout>=2.0.0  # Per-test timeouts (matches pyproject dev extras)
+pytest-benchmark>=4.0.0  # Benchmarks (matches pyproject dev extras)
+ruff>=0.14,<1.0  # Fast Python linter and formatter (replaces flake8/black); pinned floor matches lock
 mypy==1.13.0  # Static type checker for Python (pinned to match CI workflow)
 types-PyYAML  # Type stubs for PyYAML (static typing)
 types-requests  # Type stubs for requests library (static typing)


### PR DESCRIPTION
## Summary

Closes #2093, #2094.

## #2093 — Python version drift

Four separate declarations of the supported Python version were pointing in three directions:

| Config | Before | After |
| --- | --- | --- |
| `pyproject.toml` `requires-python` | `>=3.10` | `>=3.11` |
| `pyproject.toml` `[tool.mypy] python_version` | `"3.10"` | `"3.11"` |
| `pyproject.toml` `[tool.ruff] target-version` | `"py311"` | unchanged |
| `.pre-commit-config.yaml` `default_language_version.python` | `python3.11` | unchanged |

CI only tests 3.11 and 3.12 (no workflow invokes 3.10), and `src/` already uses py311 stdlib (`tomllib` in tests). The `>=3.10` floor was nominal, not supported in practice. Bumping the floor to match CI reality also aligns mypy and the package classifiers, so the same code generates the same type signatures locally and in CI.

## #2094 — Dependency manifest drift

| Drift | Fix |
| --- | --- |
| pyproject `ruff>=0.1.0` vs `requirements-lock.txt ruff==0.14.10` | pyproject → `ruff>=0.14,<1.0` (matches lock floor, blocks eventual 1.x rewrite) |
| `requirements-lock.txt` pins `black==26.3.1` but pyproject never declared black; `Makefile` still ran `python -m black .` | Removed black line from lock; `make format` now only runs `ruff format` + `ruff check --fix` (the comment on the ruff line in requirements.txt already said ruff replaces black) |
| `pytest-timeout` and `pytest-benchmark` in pyproject dev extras but missing from requirements.txt and requirements-lock.txt | Added both to requirements.txt and pinned them in requirements-lock.txt |

## Impact

- CI Python matrix unaffected (was already 3.11/3.12).
- Downstream repos (UpstreamDrift, Gasification_Model) declare `>=3.10` but test only 3.11/3.12; no consumer regression expected.
- `make format` no longer errors "command not found: black" after a fresh install (black wasn't installable from pyproject; the Makefile call worked only because some dev happened to have it in their global env).
- Ruff behavior: unchanged — target-version already py311.

## Test plan

- [ ] CI `quality-gate` (ruff, mypy) still green
- [x] Fresh venv `pip install --dry-run -r requirements.txt` resolves pytest-timeout and pytest-benchmark
- [x] `make -n format` confirms the format path runs ruff only
- [x] `python3 scripts/check_tools_manifest_layout.py`
- [x] `python3 -m pytest tests/scripts/test_check_tools_manifest_layout.py tests/test_pendulum_provider_manifest.py`

