### PR TITLE
docs: fix SPEC.md tool count and remove stale README launcher entries (#2097)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,32 +74,6 @@ The repository provides a unified launcher system for accessing all tools. The c
 
 See [Launcher Hierarchy & Guide](docs/LAUNCHERS.md) for detailed documentation.
 
-#### Launcher Hierarchy
-
-1. **`UnifiedToolsLauncher.py`** (Primary) - Use this for all new development and general usage
-
-   - Location: Repository root
-   - Type: PyQt6 GUI application
-   - Status: ✅ Active and maintained
-   - Entry point: `python UnifiedToolsLauncher.py`
-
-2. **`launch_tools_main.py`** (Legacy CLI) - Deprecated
-
-   - Location: Repository root
-   - Type: Command-line interface
-   - Status: ⚠️ Deprecated - retained for backwards compatibility only
-   - Migration: Use `UnifiedToolsLauncher.py` instead
-
-3. **`Launcher.py`** (Legacy GUI) - No longer maintained
-   - Location: Repository root (if exists)
-   - Type: Original GUI launcher
-   - Status: ❌ Migrated to `UnifiedToolsLauncher.py`
-   - Migration: Use `UnifiedToolsLauncher.py` instead
-
-> **Important:** `tools_launcher.py` does not exist and any references to it are outdated. Use `UnifiedToolsLauncher.py` as the canonical entry point.
-
-> **Note:** Legacy launchers will be removed in v2.0. Please migrate to `UnifiedToolsLauncher.py`.
-
 ## 🚀 Quick Start
 
 ### Prerequisites

--- a/SPEC.md
+++ b/SPEC.md
@@ -32,13 +32,13 @@
 
 ## 2. Purpose & Mission
 
-Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
+Comprehensive monorepo housing 29+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
 
 ### Goals
 
-- Deliver 45+ modular engineering calculation tools with consistent interfaces
+- Deliver 29+ modular engineering calculation tools with consistent interfaces
 - Provide PyQt6 GUI launcher (UnifiedToolsLauncher) for tool discovery and execution
 - Implement plugin discovery and loading system for extensibility
 - Build Rust numerical kernels for performance-critical operations
@@ -124,7 +124,7 @@ Tools/
 | Shared Utilities         | `src/python/shared_utilities/`                                                         | Common functions, decorators, error handling                                                                                                                                                                        |
 | Pressure Drop Calculator | `src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/` | Facade-driven gas pressure-drop workflows with extracted API, validation, reference, results, and engine-domain helper modules                                                                                      |
 | Model Generation API     | `src/shared/python/model_generation/api/`                                              | Route facade with framework-specific Flask and FastAPI adapters behind a compatibility shim, plus repository download helpers that require HTTPS downloads and validate archive and mesh paths to prevent traversal |
-| Engineering Tools        | `src/tools/`                                                                           | 45+ specialized calculation and processing tools                                                                                                                                                                    |
+| Engineering Tools        | `src/tools/`                                                                           | 29+ specialized calculation and processing tools                                                                                                                                                                    |
 | Data Processing          | `src/data_processing/`                                                                 | Pipelines, transformers, validators, and facade-based data-processor core modules for exporter, ANOVA, vectorized filter workflows, and pickle-safe file I/O defaults                                               |
 | Document Processing      | `src/document_processing/`                                                             | PDF extraction, text processing                                                                                                                                                                                     |
 | Media Processing         | `src/media_processing/`                                                                | Audio and video utilities                                                                                                                                                                                           |
@@ -142,7 +142,7 @@ Tools/
 | #   | Feature                             | Status | Description                                                                                   |
 | --- | ----------------------------------- | ------ | --------------------------------------------------------------------------------------------- |
 | F1  | UnifiedToolsLauncher (PyQt6 GUI)    | ✅     | Main entry point with tool discovery, search, favorites, and launch                           |
-| F2  | 45+ engineering calculation tools   | ✅     | Diverse tools for calculations, conversions, analysis                                         |
+| F2  | 29+ engineering calculation tools   | ✅     | Diverse tools for calculations, conversions, analysis                                         |
 | F3  | Rust math primitives                | ✅     | Performance-critical numerical operations in Rust                                             |
 | F4  | Shared upstream_drift_tools library | ✅     | Common utilities for drift detection and analysis                                             |
 | F5  | Plugin discovery system             | ✅     | Auto-discover tools via plugin registry, support dynamic loading                              |

--- a/TOOLS_INDEX.md
+++ b/TOOLS_INDEX.md
@@ -1,7 +1,7 @@
 # Tools Repository Index
 
-> Last updated: 2026-02-27
-> Canonical inventory: docs/development/TOOLS_REPOSITORY_INVENTORY_2026-02-27.md
+> Last updated: 2026-04-19
+> Canonical inventory: docs/development/TOOLS_REPOSITORY_INVENTORY_2026-04-17.md
 
 This file is the stable entry point for tool discovery. The dated inventory document contains the current, machine-verified surface map and implementation gaps.
 


### PR DESCRIPTION
## Summary

Closes #2097 (partial — addresses the 3 highest-priority items).

Three doc accuracy fixes from the 2026-04-17 adversarial review (§DOC-H1, DOC-H2, DOC-H3):

**1. SPEC.md tool count (DOC-H1)**
- `45+` → `29+` in three places (Purpose, Goals, Features table)
- Rationale: src/ has 29 tool directories; tool_surface_contract.json lists 21 registered tools; "29+" is the honest current floor

**2. README.md legacy launcher section removed (DOC-H2)**
- Deleted the "Launcher Hierarchy" subsection listing `launch_tools_main.py` and `Launcher.py`, neither of which exist in the repository
- `UnifiedToolsLauncher.py` is the sole entry point; the `docs/LAUNCHERS.md` link is retained for full hierarchy docs
- Net: -26 lines

**3. TOOLS_INDEX.md inventory pointer updated (DOC-H3)**
- "Last updated" date: `2026-02-27` → `2026-04-19`
- Canonical inventory: `TOOLS_REPOSITORY_INVENTORY_2026-02-27.md` → `TOOLS_REPOSITORY_INVENTORY_2026-04-17.md` (the newer file already exists in docs/development/)

## Deferred to follow-up

- CHANGELOG.md version bump (§DOC-M CHANGELOG) — requires a proper release decision
- Missing READMEs for asteroid_jumper, document_processing, lower_body_model, shared, verification — separate issue scope

## Test plan

- [x] `python3 -m ruff check .` — only pre-existing violations (no Python files changed)
- [ ] CI passes (no source changes)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>