### PR TITLE
ci: upgrade Node.js 20 -> 24 in workflows (#525)

### DIFF
--- a/.github/workflows/Code-Metrics.yml
+++ b/.github/workflows/Code-Metrics.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install jscpd
         run: npm install -g jscpd

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Jules
         run: |

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install
         run: npm install -g @google/jules

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install
         run: npm install -g @google/jules

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node
         if: steps.changes.outputs.files != ''
         uses: actions/setup-node@v6
-        with: { node-version: "20" }
+        with: { node-version: "24" }
 
       - name: Install & Auth Jules
         if: steps.changes.outputs.files != ''

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         if: steps.jules.outputs.enabled == 'true'
-        with: { node-version: "20" }
+        with: { node-version: "24" }
       - run: npm install -g @google/jules
         if: steps.jules.outputs.enabled == 'true'
       - run: jules auth --token ${{ secrets.JULES_API_KEY }}

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/Jules-Tech-Custodian.yml
+++ b/.github/workflows/Jules-Tech-Custodian.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v6
         with: { python-version: "3.11" }
       - uses: actions/setup-node@v6
-        with: { node-version: "20" }
+        with: { node-version: "24" }
       - run: |
           npm install -g @google/jules
           pip install ruff==0.14.10

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -27,7 +27,7 @@ jobs:
           echo "files=$FILES_FLAT" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-node@v6
-        with: { node-version: "20" }
+        with: { node-version: "24" }
       - run: npm install -g @google/jules
 
       - name: Generate Tests

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to NPM

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

Node.js 20 reaches End-of-Life on **2026-04-30**. This PR upgrades all 17 workflow files from Node `20` -> `24` on the staging branch.

## Scope

Tightly scoped re-cut of #2169 which had drifted to 190 commits / 1101 files and was not mergeable. This PR contains **only** the node-version bump in `.github/workflows/*.yml`.

## Files changed

- Code-Metrics.yml
- Jules-Assessment-Generator.yml
- Jules-Assessment-Remediator.yml
- Jules-Code-Quality-Fixer.yml
- Jules-Code-Quality-Reviewer.yml
- Jules-Completist.yml
- Jules-Comprehensive-Assessment.yml
- Jules-Critics-Comments.yml
- Jules-Documentation-Scribe.yml
- Jules-Hotfix-Creator.yml
- Jules-Issue-Resolver.yml
- Jules-Laymans-Terms-Writer.yml
- Jules-Sentinel.yml
- Jules-Tech-Custodian.yml
- Jules-Test-Generator.yml
- publish-artifacts.yml
- tauri-build.yml

## Test plan
- [ ] CI passes with Node 24
- [ ] No workflow syntax errors

Closes #525
Supersedes #2169