### PR TITLE
fix(qt): offload Data Processor NN training to QThread worker (#2090)

### DIFF
--- a/src/data_processing/data_processor/python/data_processor/ui/async_workers.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/async_workers.py
@@ -152,3 +152,53 @@ class ProcessingWorker(QThread):
         except Exception as exc:  # noqa: BLE001 - prevent uncaught Qt thread failures
             logger.error("Processing failed in worker thread: %s", exc, exc_info=True)
             self.error.emit(str(exc))
+
+
+class NeuralNetworkTrainingWorker(QThread):
+    """Train a neural network off the Qt main thread.
+
+    Neural network training is by far the slowest analysis offered by the
+    Data Processor; running it on the UI thread freezes the whole window.
+    This worker owns a ``NeuralNetworkTrainer`` instance, invokes ``train``
+    on ``data`` in a background thread, and emits either ``result_ready``
+    with the returned training result object or ``error`` with a message.
+    """
+
+    result_ready = pyqtSignal(object)
+    error = pyqtSignal(str)
+    progress = pyqtSignal(int)
+
+    def __init__(
+        self,
+        data: pd.DataFrame,
+        config: dict[str, Any],
+        trainer: Any | None = None,
+    ) -> None:
+        if data is None:
+            raise ValueError("data must be provided")
+        if config is None:
+            raise ValueError("config must be provided")
+        super().__init__()
+        self.data = data
+        self.config = dict(config)
+        self._trainer = trainer
+
+    def run(self) -> None:
+        try:
+            self.progress.emit(5)
+            trainer = self._trainer
+            if trainer is None:
+                from data_processor.core.neural_network import NeuralNetworkTrainer
+
+                trainer = NeuralNetworkTrainer(self.config)
+            self.progress.emit(20)
+            result = trainer.train(self.data)
+            self.progress.emit(100)
+            self.result_ready.emit(result)
+        except Exception as exc:  # noqa: BLE001 - prevent uncaught Qt thread failures
+            logger.error(
+                "Neural network training failed in worker thread: %s",
+                exc,
+                exc_info=True,
+            )
+            self.error.emit(str(exc))

--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py
@@ -246,6 +246,7 @@ class DataProcessorMainWindow(
         self.output_directory: str = str(Path.home() / "Documents")
         self._load_worker: DataLoadWorker | None = None
         self._processing_worker = None
+        self._nn_worker = None
 
         # Settings
         self.settings = QSettings("DataProcessor", "DataProcessorGUI")

--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window_analysis.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window_analysis.py
@@ -318,21 +318,72 @@ class AnalysisMixin:
             QMessageBox.critical(self, "Surface Plot Error", f"Plot failed:\n{e}")
 
     def _run_nn_analysis(self, config: dict) -> None:
-        """Run neural network training from Analysis tab."""
+        """Run neural network training from Analysis tab.
+
+        Training runs on a background ``QThread`` so the Qt event loop keeps
+        spinning and the UI stays responsive on large datasets. The Train
+        button is disabled for the duration and re-enabled when the worker
+        finishes (either via ``result_ready`` or ``error``).
+        """
         if not (config is not None):
             raise ValueError("config must be provided")
         if self.current_data is None:
             QMessageBox.warning(self, "No Data", "Load data first.")
             return
 
-        try:
-            from data_processor.core.neural_network import NeuralNetworkTrainer
+        # Prevent overlapping runs.
+        existing = getattr(self, "_nn_worker", None)
+        if existing is not None and existing.isRunning():
+            QMessageBox.information(
+                self,
+                "Training In Progress",
+                "A neural network is already training. Wait for it to finish.",
+            )
+            return
 
-            trainer = NeuralNetworkTrainer(config)
-            result = trainer.train(self.current_data)
+        from data_processor.ui.async_workers import NeuralNetworkTrainingWorker
+
+        nn_widget = self.analysis_panel.nn_widget
+        train_btn = getattr(nn_widget, "train_btn", None)
+        progress_bar = getattr(nn_widget, "progress_bar", None)
+        if train_btn is not None:
+            train_btn.setEnabled(False)
+        if progress_bar is not None:
+            progress_bar.setVisible(True)
+            progress_bar.setValue(0)
+
+        worker = NeuralNetworkTrainingWorker(self.current_data, config)
+        self._nn_worker = worker
+        worker.result_ready.connect(self._on_nn_training_finished)
+        worker.error.connect(self._on_nn_training_error)
+        worker.finished.connect(self._on_nn_training_cleanup)
+        if progress_bar is not None:
+            worker.progress.connect(progress_bar.setValue)
+        self.status_bar.set_status("Training neural network...")
+        worker.start()
+
+    def _on_nn_training_finished(self, result: object) -> None:
+        try:
             self.analysis_panel.nn_widget.display_results(result)
             self.status_bar.set_status("Neural network training complete")
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to display NN result: %s", exc, exc_info=True)
+            QMessageBox.critical(self, "NN Error", f"Display failed:\n{exc}")
 
-        except ImportError as e:
-            logger.error(f"Neural network training failed: {e}", exc_info=True)
-            QMessageBox.critical(self, "NN Error", f"Training failed:\n{e}")
+    def _on_nn_training_error(self, message: str) -> None:
+        logger.error("Neural network training failed: %s", message)
+        self.status_bar.set_status("Neural network training failed")
+        QMessageBox.critical(self, "NN Error", f"Training failed:\n{message}")
+
+    def _on_nn_training_cleanup(self) -> None:
+        nn_widget = self.analysis_panel.nn_widget
+        train_btn = getattr(nn_widget, "train_btn", None)
+        progress_bar = getattr(nn_widget, "progress_bar", None)
+        if train_btn is not None:
+            train_btn.setEnabled(True)
+        if progress_bar is not None:
+            progress_bar.setVisible(False)
+        worker = getattr(self, "_nn_worker", None)
+        if worker is not None:
+            worker.deleteLater()
+        self._nn_worker = None

--- a/src/data_processing/data_processor/python/tests/test_nn_training_worker.py
+++ b/src/data_processing/data_processor/python/tests/test_nn_training_worker.py
@@ -1,0 +1,113 @@
+"""Tests for NeuralNetworkTrainingWorker.
+
+Verifies that neural network training runs off the Qt main thread so the
+event loop stays responsive while a long training job is in flight.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("PyQt6", reason="PyQt6 is required for Qt worker tests")
+pytest.importorskip("pytestqt", reason="pytest-qt is required for Qt worker tests")
+
+from PyQt6.QtCore import QThread  # noqa: E402
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+app = QApplication.instance()
+if app is None:
+    app = QApplication(sys.argv)
+
+from data_processor.ui.async_workers import (  # noqa: E402
+    NeuralNetworkTrainingWorker,
+)
+
+
+class _SlowTrainer:
+    """Fake trainer whose ``train`` call blocks long enough to detect UI freeze."""
+
+    def __init__(self, duration_s: float = 0.4) -> None:
+        self.duration_s = duration_s
+        self.train_thread: int | None = None
+
+    def train(self, data: pd.DataFrame) -> dict:
+        # Capture the OS thread id so the test can confirm the call is
+        # off the main thread.
+        self.train_thread = int(QThread.currentThreadId())  # type: ignore[arg-type]
+        time.sleep(self.duration_s)
+        return {"ok": True, "rows": len(data)}
+
+
+@pytest.fixture
+def sample_df() -> pd.DataFrame:
+    return pd.DataFrame({"x": range(100), "y": range(100)})
+
+
+def test_worker_runs_off_main_thread(qtbot: Any, sample_df: pd.DataFrame) -> None:
+    """The trainer's ``train`` method must execute on a worker thread."""
+    trainer = _SlowTrainer(duration_s=0.2)
+    worker = NeuralNetworkTrainingWorker(sample_df, {"epochs": 1}, trainer=trainer)
+
+    main_thread_id = int(QThread.currentThreadId())  # type: ignore[arg-type]
+
+    results: list[object] = []
+    worker.result_ready.connect(results.append)
+    worker.start()
+
+    qtbot.waitUntil(lambda: bool(results), timeout=5000)
+    worker.wait(2000)
+
+    assert results == [{"ok": True, "rows": 100}]
+    assert trainer.train_thread is not None
+    assert trainer.train_thread != main_thread_id, (
+        "train() ran on the Qt main thread — UI would freeze"
+    )
+
+
+def test_worker_ui_stays_responsive(qtbot: Any, sample_df: pd.DataFrame) -> None:
+    """While the worker runs, the Qt event loop must still process events."""
+    trainer = _SlowTrainer(duration_s=0.5)
+    worker = NeuralNetworkTrainingWorker(sample_df, {"epochs": 1}, trainer=trainer)
+
+    done = []
+    worker.result_ready.connect(lambda r: done.append(r))
+    worker.start()
+
+    # If the UI thread were blocked, qtbot.waitUntil would itself stall.
+    # The tight poll here confirms the event loop is alive during training.
+    ticks = 0
+
+    def still_ticking() -> bool:
+        nonlocal ticks
+        ticks += 1
+        return bool(done)
+
+    qtbot.waitUntil(still_ticking, timeout=5000)
+    worker.wait(2000)
+    assert ticks > 1, "Event loop did not tick during training — UI was blocked"
+
+
+def test_worker_emits_error_on_failure(qtbot: Any, sample_df: pd.DataFrame) -> None:
+    trainer = MagicMock()
+    trainer.train.side_effect = RuntimeError("boom")
+    worker = NeuralNetworkTrainingWorker(sample_df, {"epochs": 1}, trainer=trainer)
+
+    errors: list[str] = []
+    worker.error.connect(errors.append)
+    worker.start()
+    qtbot.waitUntil(lambda: bool(errors), timeout=5000)
+    worker.wait(2000)
+    assert errors == ["boom"]
+
+
+def test_worker_rejects_missing_inputs() -> None:
+    with pytest.raises(ValueError):
+        NeuralNetworkTrainingWorker(None, {"epochs": 1})
+    with pytest.raises(ValueError):
+        NeuralNetworkTrainingWorker(pd.DataFrame({"a": [1]}), None)


### PR DESCRIPTION
## Summary

Partial fix for #2090 — Data Processor blocks UI thread on file I/O and analysis.

- Added `NeuralNetworkTrainingWorker` (`QThread` subclass with `result_ready` / `error` / `progress` signals) to `data_processor.ui.async_workers`.
- Rewired `AnalysisMixin._run_nn_analysis` to run training off the main thread, disable the Train button, drive the existing NN progress bar, and dispatch `display_results` / `QMessageBox` from signal slots.
- Reject overlapping training runs with an informational dialog.
- Added `tests/test_nn_training_worker.py` using `pytest-qt`'s `qtbot.waitUntil` to assert (a) training runs on a worker thread, (b) the Qt event loop keeps ticking during training, and (c) exceptions surface via the `error` signal.

CSV loading is already offloaded via the existing `DataLoadWorker`. Neural-network training was the slowest remaining synchronous analysis. Filter / integrate / differentiate already use `ProcessingWorker`. PCA, ANOVA, regression, and surface plots remain on the UI thread and can be moved in follow-up PRs — this PR keeps scope tight per the triage constraints.

Closes #2090 partial — 2 of ~6 expensive operations now offloaded.

## Notes for reviewers

- Algorithms are untouched — only threading wiring changes.
- `pytest-qt` is already available in the dev environment (pendulum and chat test suites use it). It is not explicitly declared in the root `pyproject.toml` extras; if the CI environment does not install it, the new test file is marked with `pytest.importorskip("pytestqt", ...)` and will skip cleanly.
- `main_window_analysis.py` has pre-existing mixin `[attr-defined]` mypy errors (`self.current_data`, `self.analysis_panel`, etc.). New handlers follow the same established pattern; no new error categories introduced. `async_workers.py` and the new test file are mypy-clean.

## Test plan

- [x] `ruff check` + `ruff format --check` on all touched files pass
- [x] `mypy` on `async_workers.py` and `test_nn_training_worker.py` clean
- [x] `pytest tests/test_nn_training_worker.py` — 4/4 pass locally (QT_QPA_PLATFORM=offscreen)
- [ ] CI green on the branch

spec-exempt — fleet triage, no SPEC.md changes needed.

Fleet old-issue triage — wave 19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)