### PR TITLE
feat(GH1693): add DRY guard test — prevent re-introduction of urdf_builder_gui root-level duplicates

### DIFF
--- a/.gaai/project/contexts/artefacts/impl-reports/GH1693.impl-report.md
+++ b/.gaai/project/contexts/artefacts/impl-reports/GH1693.impl-report.md
@@ -1,0 +1,35 @@
+---
+id: GH1693
+type: impl-report
+status: complete
+created_at: 2026-04-20
+---
+
+# GH1693 Implementation Report: Remove Duplicate Files in urdf_builder_gui
+
+## Summary
+
+- The 5 duplicate root-level module files (contracts.py, theme.py, anthropometric_model.py,
+  urdf_generator.py, preview_generator.py) were already removed from `src/urdf_builder_gui/`
+  via merged PR #1758. The canonical source is `src/urdf_builder_gui/python/urdf_builder_gui/`.
+- Added `TestNoRootLevelDuplicates` guard test class to prevent re-introduction of duplicates.
+
+## Changes
+
+| File | Purpose |
+|------|---------|
+| `src/urdf_builder_gui/tests/test_urdf_builder_gui.py` | Added `TestNoRootLevelDuplicates` class with 1 guard test (AC1+AC2) |
+
+## Acceptance Criteria Check
+
+| AC | Status | Notes |
+|----|--------|-------|
+| AC1 — issue #1693 resolved | PASS | Duplicates removed via PR #1758; no root-level copies remain |
+| AC2 — all new code has tests | PASS | `TestNoRootLevelDuplicates.test_root_level_duplicates_do_not_exist` added |
+| AC3 — ruff check passes | PASS | Zero violations |
+| AC4 — no new print() in src/ | PASS | No print() added |
+| AC5 — PR created targeting staging | PENDING | PR creation is next step |
+
+## Test Results
+
+72/72 tests pass in `src/urdf_builder_gui/tests/`

--- a/.gaai/project/contexts/artefacts/memory-deltas/GH1693.memory-delta.md
+++ b/.gaai/project/contexts/artefacts/memory-deltas/GH1693.memory-delta.md
@@ -1,0 +1,22 @@
+---
+id: GH1693
+type: memory-delta
+created_at: 2026-04-20
+---
+
+# GH1693 Memory Delta
+
+## Pattern: Packaging layout with path-bridging __init__.py
+
+The `src/urdf_builder_gui/` module uses a dual-directory layout where:
+- `src/urdf_builder_gui/__init__.py` is a bridge that adds `python/urdf_builder_gui/` to `__path__`
+- `src/urdf_builder_gui/python/urdf_builder_gui/` is the canonical package
+
+This pattern enables the module to be both a standalone tool (in the `src/` tree)
+and a properly installable Python package (in `python/`). Future modules with GUI
+components may use the same pattern.
+
+## Guard Test Pattern
+
+When removing duplicate files as a DRY fix, add a `TestNoRootLevelDuplicates`-style
+guard test that verifies the deleted files do NOT exist. This prevents re-introduction.

--- a/.gaai/project/contexts/artefacts/qa-reports/GH1693.qa-report.md
+++ b/.gaai/project/contexts/artefacts/qa-reports/GH1693.qa-report.md
@@ -1,0 +1,42 @@
+---
+id: GH1693
+type: qa-report
+verdict: PASS
+created_at: 2026-04-20
+---
+
+# GH1693 QA Report
+
+## Verdict: PASS
+
+## Test Results
+
+- **Test Suite:** `python3 -m pytest src/urdf_builder_gui/tests/ -v --timeout=60`
+- **Result:** 72/72 PASSED (0 failures, 0 errors)
+- **New tests:** `TestNoRootLevelDuplicates::test_root_level_duplicates_do_not_exist` — PASS
+
+## Linting
+
+- `ruff check src/urdf_builder_gui/`: All checks passed
+- `ruff format --check src/urdf_builder_gui/`: All files already formatted
+
+## No print() calls
+
+- Confirmed: no `print()` calls in `src/urdf_builder_gui/` (excluding tests)
+
+## DRY Compliance
+
+- Root-level duplicate files confirmed absent: contracts.py, theme.py,
+  anthropometric_model.py, urdf_generator.py, preview_generator.py
+- Canonical location: `src/urdf_builder_gui/python/urdf_builder_gui/`
+- Guard test prevents re-introduction
+
+## Acceptance Criteria
+
+| AC | Status |
+|----|--------|
+| AC1 — issue resolved | PASS |
+| AC2 — new code has tests | PASS |
+| AC3 — ruff check passes | PASS |
+| AC4 — no print() in src/ | PASS |
+| AC5 — PR created | PENDING (next step) |

--- a/src/urdf_builder_gui/tests/test_urdf_builder_gui.py
+++ b/src/urdf_builder_gui/tests/test_urdf_builder_gui.py
@@ -583,3 +583,40 @@ class TestIntegration:
             for attr in ["ixx", "iyy", "izz"]:
                 val = float(inertia_el.get(attr, "0"))
                 assert val > 0, f"Non-positive {attr}={val}"
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# DRY Enforcement: Guard against re-introduction of duplicate files
+# ═══════════════════════════════════════════════════════════════════════
+
+
+class TestNoRootLevelDuplicates:
+    """Guard: root-level module copies must not exist after DRY cleanup (GH1693).
+
+    The canonical location for urdf_builder_gui modules is
+    src/urdf_builder_gui/python/urdf_builder_gui/.
+    Root-level copies are dead code and must not be present.
+    """
+
+    _REMOVED_MODULES = [
+        "contracts.py",
+        "anthropometric_model.py",
+        "urdf_generator.py",
+        "preview_generator.py",
+        "theme.py",
+    ]
+
+    def test_root_level_duplicates_do_not_exist(self) -> None:
+        """Verify no root-level module copies exist (DRY enforcement)."""
+        from pathlib import Path
+
+        root_dir = Path(__file__).resolve().parent.parent
+        present: list[str] = []
+        for mod_name in self._REMOVED_MODULES:
+            if (root_dir / mod_name).exists():
+                present.append(mod_name)
+
+        assert not present, (
+            "Root-level module copies re-introduced (DRY violation, GH1693):\n"
+            + "\n".join(f"  - {m}" for m in present)
+        )


### PR DESCRIPTION
## Summary

- Closes #1693: 6 files were duplicated between `src/urdf_builder_gui/` and `src/urdf_builder_gui/python/urdf_builder_gui/`. The 5 duplicate module files were removed via PR #1758.
- Adds `TestNoRootLevelDuplicates` guard test to enforce the DRY fix is permanent — verifies that `contracts.py`, `theme.py`, `anthropometric_model.py`, `urdf_generator.py`, and `preview_generator.py` do NOT exist at the root level.
- The canonical package location (`python/urdf_builder_gui/`) is the single source of truth.

## Test Results

- Tests: 72/72 pass (`+1` new guard test)
- Ruff check: clean
- Ruff format: clean
- QA Verdict: PASS

## Changes Delivered

| File | Purpose |
|------|---------|
| `src/urdf_builder_gui/tests/test_urdf_builder_gui.py` | Added `TestNoRootLevelDuplicates` class — DRY guard test (AC1+AC2) |

## Story

- ID: GH1693
- Artefact: .gaai/project/contexts/artefacts/stories/GH1693.story.md
- Related: PR #1758 (merged — removed the 5 duplicate files)

🤖 Generated with [GAAI Delivery Agent](https://github.com/Fr-e-d/GAAI-framework)