### PR TITLE
fix: shell-safe rate-limit snippet in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -680,7 +680,8 @@ d = json.load(sys.stdin)['resources']
 for k in ['core', 'graphql']:
     r = d[k]
     reset = datetime.datetime.fromtimestamp(r['reset']).strftime('%H:%M:%S')
-    print(f'{k}: {r["remaining"]}/{r["limit"]} remaining — resets {reset}')
+    rem, lim = r['remaining'], r['limit']
+    print(f'{k}: {rem}/{lim} remaining — resets {reset}')
 "
 ```
 


### PR DESCRIPTION
## Summary

- `r["remaining"]` and `r["limit"]` inside `python3 -c "..."` had unescaped double quotes that were consumed by Bash
- Python received `r[remaining]` and raised `NameError`
- Fix: introduce `rem, lim = r['remaining'], r['limit']` before the `print()` call, eliminating inner double-quote dict access

## Test plan

- [ ] Copy the snippet and run it in a fresh shell — should print rate-limit info without errors
- [ ] CI quality-gate / lint passes (AGENTS.md change only)

Closes #2193

🤖 Generated with [Claude Code](https://claude.com/claude-code)