### PR TITLE
⚡ Bolt: [performance improvement] Optimize array allocations in PCA calculate loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Optimize Array Methods in PCA Calculation
+**Learning:** Chained array methods like `.reduce()` and `.map()` on arrays (e.g. eigenvalues in PCA calculations) cause noticeable garbage collection and allocation overhead in performance-critical sections.
+**Action:** Replace chained `.reduce()` and `.map()` calls with single-pass `for` loops that pre-allocate target arrays (`new Array(size)`) to avoid intermediate array creation.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 <!--
   TEMPLATE VERSION: 1.0.0
-  LAST UPDATED: 2026-04-23
+  LAST UPDATED: 2026-04-24
 
   This is the canonical specification template for all repositories in the
   D-sorganization fleet. Every repo MUST have a SPEC.md at its root.
@@ -611,6 +611,10 @@ Active development with stable core, continuous tool expansion, and web API in p
 - Pearson correlation matrix computations utilize a single-pass loop algorithm, calculating sums concurrently to drastically reduce iteration overhead compared to two-pass implementations, while carefully mitigating numerical instability via clamping.
 - Recharts component props in `AnalyticsSuite` are memoized using `useMemo` hooks to provide stable references and prevent expensive internal re-renders.
 - Exponential and power trendline calculations use pre-allocated arrays and single-pass loops instead of functional chaining to minimize GC pauses.
+
+### Version 1.1.67
+
+- **Performance**: Optimized array allocations in PCA calculate loop inside `AnalyticsSuite.tsx` by replacing chained `.reduce()` and `.map()` calls with single-pass `for` loops.
 
 ### Version 1.1.66
 

--- a/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
+++ b/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
@@ -236,13 +236,24 @@ function computePCA(data: DataRow[], signals: string[], numComponents?: number):
     }
   }
 
-  const totalVar = eigenvalues.reduce((a, b) => a + b, 0) || 1;
-  const explained = eigenvalues.map((e) => e / totalVar);
-  const cumulative: number[] = [];
-  explained.reduce((acc, e, i) => {
-    cumulative[i] = acc + e;
-    return cumulative[i];
-  }, 0);
+  // ⚡ Bolt Optimization: Replace chained reduce() and map() with a single-pass loop
+  // Performance impact: Avoids multiple intermediate array allocations and callback overhead.
+  let totalVar = 0;
+  for (let i = 0; i < eigenvalues.length; i++) {
+    totalVar += eigenvalues[i];
+  }
+  totalVar = totalVar || 1;
+
+  const explained = new Array<number>(eigenvalues.length);
+  const cumulative = new Array<number>(eigenvalues.length);
+  let currentCumulative = 0;
+
+  for (let i = 0; i < eigenvalues.length; i++) {
+    const e = eigenvalues[i] / totalVar;
+    explained[i] = e;
+    currentCumulative += e;
+    cumulative[i] = currentCumulative;
+  }
 
   // Scores (n x nc)
   const scores: number[][] = Array.from({ length: n }, () => new Array(nc));


### PR DESCRIPTION
💡 **What:** 
Optimized the variance array calculation (`totalVar`, `explained`, `cumulative`) in `computePCA` within `AnalyticsSuite.tsx` by replacing a chain of `.reduce()`, `.map()`, and `.reduce()` calls with standard single-pass `for` loops and pre-allocated arrays.

🎯 **Why:** 
Chained array methods trigger the creation of intermediate arrays and incur the overhead of multiple function callbacks. In mathematical tight loops, this causes unnecessary garbage collection and slows down execution.

📊 **Impact:** 
Eliminates intermediate array allocations for `totalVar` and `explained` mapping, reducing callback overhead and preventing GC pauses during PCA computations on datasets.

🔬 **Measurement:** 
Run `npm run type-check` in `src/data_processing/data_processor/web` to confirm TS compilation passes successfully. Performance gains can be tested by running PCA on large CSV data sets within the Analytics tab and observing reduced calculation jitter.

* `spec-exempt` label required as this is purely an internal algorithmic optimization.

---
*PR created automatically by Jules for task [14167030574098939336](https://jules.google.com/task/14167030574098939336) started by @dieterolson*