### PR TITLE
fix: restore src-shim contract imports for repo-root tool entry points (#2313)

### DIFF
--- a/src/tools/icon_utils.py
+++ b/src/tools/icon_utils.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from PIL import Image
 
-from shared.python.contracts import require
+try:
+    from shared.python.contracts import require
+except ImportError:  # pragma: no cover
+    _SRC = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(_SRC))
+    from shared.python.contracts import require
 
 logger = logging.getLogger(__name__)
 

--- a/src/tools/matlab_quality_utils.py
+++ b/src/tools/matlab_quality_utils.py
@@ -10,7 +10,12 @@ from datetime import datetime, timezone  # noqa: UP017
 from pathlib import Path
 from typing import Any
 
-from shared.python.contracts import require
+try:
+    from shared.python.contracts import require
+except ImportError:  # pragma: no cover
+    _SRC = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(_SRC))
+    from shared.python.contracts import require
 
 # Constants
 MATLAB_SCRIPT_TIMEOUT_SECONDS: int = 300

--- a/src/tools/quality_utils.py
+++ b/src/tools/quality_utils.py
@@ -6,7 +6,12 @@ import sys
 from pathlib import Path
 from re import Pattern
 
-from shared.python.contracts import require
+try:
+    from shared.python.contracts import require
+except ImportError:  # pragma: no cover
+    _SRC = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(_SRC))
+    from shared.python.contracts import require
 
 
 # ANSI colors for terminal output


### PR DESCRIPTION
Add try/except ImportError shim around `from shared.python.contracts import require` in three tool modules:

- `src/tools/quality_utils.py`
- `src/tools/matlab_quality_utils.py`
- `src/tools/icon_utils.py`

When invoked via `python src/tools/quality_utils.py --help` without PYTHONPATH, the direct import fails because `shared.python` is not on sys.path. The shim adds `src/` to sys.path temporarily so the import succeeds, while the normal package-style import still works when `src/` is already on PYTHONPATH.

Fixes #2313