### PR TITLE
fix(#2298): replace double-negation none checks with simplified form

### DIFF
--- a/src/shared/python/model_generation/api/rest_api_fastapi.py
+++ b/src/shared/python/model_generation/api/rest_api_fastapi.py
@@ -19,7 +19,7 @@ class FastAPIAdapter:
     """Adapter for FastAPI framework."""
 
     def __init__(self, api: ModelGenerationAPI) -> None:
-        if not (api is not None):
+        if api is None:
             raise ValueError("api must be provided")
         self.api = api
 

--- a/src/shared/python/model_generation/api/rest_api_flask.py
+++ b/src/shared/python/model_generation/api/rest_api_flask.py
@@ -16,7 +16,7 @@ class FlaskAdapter:
     """Adapter for Flask framework."""
 
     def __init__(self, api: ModelGenerationAPI) -> None:
-        if not (api is not None):
+        if api is None:
             raise ValueError("api must be provided")
         self.api = api
 

--- a/src/shared/python/model_generation/api/rest_api_routes.py
+++ b/src/shared/python/model_generation/api/rest_api_routes.py
@@ -53,7 +53,7 @@ class ModelGenerationAPI:
         Args:
             prefix: URL prefix for all routes
         """
-        if not (prefix is not None):
+        if prefix is None:
             raise ValueError("prefix must be provided")
         self.prefix = prefix
         self._routes: list[Route] = []
@@ -217,7 +217,7 @@ class ModelGenerationAPI:
 
     def _add_security_headers(self, response: APIResponse) -> None:
         """Add security headers to response."""
-        if not (response is not None):
+        if response is None:
             raise ValueError("response must be provided")
         response.headers["Content-Security-Policy"] = "default-src 'self'"
         response.headers["X-Content-Type-Options"] = "nosniff"
@@ -229,7 +229,7 @@ class ModelGenerationAPI:
     def handle_request(self, request: APIRequest) -> APIResponse:
         """Handle an API request."""
         # Find matching route
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         for route in self._routes:
             if route.method != request.method:
@@ -304,7 +304,7 @@ class ModelGenerationAPI:
 
     def generate_humanoid(self, request: APIRequest) -> APIResponse:
         """Generate humanoid URDF."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.builders.parametric_builder import ParametricBuilder
 
@@ -342,7 +342,7 @@ class ModelGenerationAPI:
 
     def generate_from_params(self, request: APIRequest) -> APIResponse:
         """Generate URDF from detailed parameters."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.builders.manual_builder import ManualBuilder
         from model_generation.core.types import (
@@ -393,7 +393,7 @@ class ModelGenerationAPI:
 
     def convert_simscape_to_urdf(self, request: APIRequest) -> APIResponse:
         """Convert SimScape MDL/SLX to URDF."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.converters.simscape import (
             ConversionConfig,
@@ -445,7 +445,7 @@ class ModelGenerationAPI:
 
     def convert_mjcf_to_urdf(self, request: APIRequest) -> APIResponse:
         """Convert MJCF to URDF."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.converters.mjcf_converter import MJCFConverter
 
@@ -474,7 +474,7 @@ class ModelGenerationAPI:
 
     def convert_urdf_to_mjcf(self, request: APIRequest) -> APIResponse:
         """Convert URDF to MJCF."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.converters.mjcf_converter import MJCFConverter
 
@@ -507,7 +507,7 @@ class ModelGenerationAPI:
 
     def validate_urdf(self, request: APIRequest) -> APIResponse:
         """Validate URDF content."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.editor.text_editor import (
             URDFTextEditor,
@@ -558,7 +558,7 @@ class ModelGenerationAPI:
 
     def parse_urdf(self, request: APIRequest) -> APIResponse:
         """Parse URDF and return structure."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.converters.urdf_parser import URDFParser
 
@@ -597,7 +597,7 @@ class ModelGenerationAPI:
 
     def calculate_inertia(self, request: APIRequest) -> APIResponse:
         """Calculate inertia for primitive shape."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.core.types import Inertia
 
@@ -661,7 +661,7 @@ class ModelGenerationAPI:
 
     def inertia_from_mesh(self, request: APIRequest) -> APIResponse:
         """Calculate inertia from mesh file."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         body = request.body or {}
 
@@ -729,7 +729,7 @@ class ModelGenerationAPI:
 
     def library_list_models(self, request: APIRequest) -> APIResponse:
         """List models in library."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.library import ModelLibrary
 
@@ -770,7 +770,7 @@ class ModelGenerationAPI:
 
     def library_get_model(self, request: APIRequest) -> APIResponse:
         """Get model details."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.library import ModelLibrary
 
@@ -799,7 +799,7 @@ class ModelGenerationAPI:
 
     def library_add_model(self, request: APIRequest) -> APIResponse:
         """Add model to library."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.library import ModelCategory, ModelLibrary
 
@@ -852,7 +852,7 @@ class ModelGenerationAPI:
 
     def library_remove_model(self, request: APIRequest) -> APIResponse:
         """Remove model from library."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.library import ModelLibrary
 
@@ -868,7 +868,7 @@ class ModelGenerationAPI:
 
     def library_download_model(self, request: APIRequest) -> APIResponse:
         """Download model URDF."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.library import ModelLibrary
 
@@ -892,7 +892,7 @@ class ModelGenerationAPI:
 
     def compose_models(self, request: APIRequest) -> APIResponse:
         """Compose model from multiple sources."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.editor import FrankensteinEditor
 
@@ -952,7 +952,7 @@ class ModelGenerationAPI:
 
     def diff_urdfs(self, request: APIRequest) -> APIResponse:
         """Compare two URDF files."""
-        if not (request is not None):
+        if request is None:
             raise ValueError("request must be provided")
         from model_generation.editor.text_editor import URDFTextEditor
 

--- a/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/engine/_flow_calculations.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/engine/_flow_calculations.py
@@ -227,7 +227,7 @@ def calculate_fitting_pressure_drop(
     Reference:
         Crane TP-410, Chapter 2: Resistance of Valves and Fittings
     """
-    if not (fittings is not None):
+    if fittings is None:
         raise ValueError("fittings must be provided")
     total_k = 0.0
     velocity_head = 0.5 * density * (velocity**2)
@@ -280,7 +280,7 @@ def calculate_elevation_pressure_drop(density: float, elevation_change: float) -
         (loss). Negative elevation_change (downward flow) results in negative
         pressure drop (gain).
     """
-    if not (density is not None):
+    if density is None:
         raise ValueError("density must be provided")
     dp_elevation = density * GRAVITY * elevation_change
 
@@ -312,7 +312,7 @@ def _iterate_compressible_pressure(
     Returns:
         Tuple of (converged_P2, is_choked). If choked, P2 is meaningless.
     """
-    if not (P1 is not None):
+    if P1 is None:
         raise ValueError("P1 must be provided")
     P2 = P2_initial
 
@@ -450,7 +450,7 @@ def calculate_expansion_factor(
         Crane TP-410, Section 2-2: Compressible Flow
         ISO 5167: Measurement of fluid flow
     """
-    if not (inlet_pressure is not None):
+    if inlet_pressure is None:
         raise ValueError("inlet_pressure must be provided")
     if inlet_pressure <= 0 or pressure_drop < 0:
         return 1.0
@@ -504,7 +504,7 @@ def calculate_erosional_velocity(
         - Intermittent service: C = 125-150
         - Solid-free service: C = 150-200
     """
-    if not (density is not None):
+    if density is None:
         raise ValueError("density must be provided")
     if service_type == "continuous":
         C = API_14E_C_CONTINUOUS

--- a/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/engine/_friction_factors.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/engine/_friction_factors.py
@@ -80,7 +80,7 @@ def friction_factor_colebrook(
         This is the most accurate correlation but requires iteration.
         The Moody diagram is a graphical representation of this equation.
     """
-    if not (reynolds_number is not None):
+    if reynolds_number is None:
         raise ValueError("reynolds_number must be provided")
     if reynolds_number < RE_LAMINAR_UPPER:
         return friction_factor_laminar(reynolds_number)
@@ -131,7 +131,7 @@ def friction_factor_swamee_jain(
     Note:
         Explicit formula, no iteration required. Excellent for computational efficiency.
     """
-    if not (reynolds_number is not None):
+    if reynolds_number is None:
         raise ValueError("reynolds_number must be provided")
     if reynolds_number < RE_LAMINAR_UPPER:
         return friction_factor_laminar(reynolds_number)
@@ -175,7 +175,7 @@ def friction_factor_churchill(
     Note:
         Single equation valid for all flow regimes. Very useful for transitional flow.
     """
-    if not (reynolds_number is not None):
+    if reynolds_number is None:
         raise ValueError("reynolds_number must be provided")
     Re = reynolds_number
 
@@ -214,7 +214,7 @@ def friction_factor_haaland(reynolds_number: float, relative_roughness: float) -
         Haaland, S.E. (1983): "Simple and Explicit Formulas for Friction Factor"
         J. Fluids Engineering, 105(1), 89-90
     """
-    if not (reynolds_number is not None):
+    if reynolds_number is None:
         raise ValueError("reynolds_number must be provided")
     if reynolds_number < RE_LAMINAR_UPPER:
         return friction_factor_laminar(reynolds_number)
@@ -244,7 +244,7 @@ def select_friction_factor_method(
     Raises:
         ValueError: If method is not recognized
     """
-    if not (method is not None):
+    if method is None:
         raise ValueError("method must be provided")
     method = method.lower()
 

--- a/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_interface.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_interface.py
@@ -392,7 +392,7 @@ def compare_friction_methods(
     Example:
         >>> compare_friction_methods(100000, 0.001)
     """
-    if not (reynolds_number is not None):
+    if reynolds_number is None:
         raise ValueError("reynolds_number must be provided")
 
     f_colebrook = friction_factor_colebrook(reynolds_number, relative_roughness)

--- a/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_results.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_results.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def _wrap_text(text: str, width: int) -> list[str]:
     """Wrap text to specified width."""
-    if not (text is not None):
+    if text is None:
         raise ValueError("text must be provided")
     words = text.split()
     lines = []
@@ -179,7 +179,7 @@ def _print_warnings_and_recommendations(
     results: dict[str, Any], show_recommendations: bool
 ) -> None:
     """Log warnings and engineering recommendations."""
-    if not (results is not None):
+    if results is None:
         raise ValueError("results must be provided")
     if results.get("warnings"):
         warnings = results["warnings"]
@@ -218,7 +218,7 @@ def print_results(
         title: Title for the output
         show_recommendations: Whether to show engineering recommendations
     """
-    if not (results is not None):
+    if results is None:
         raise ValueError("results must be provided")
     logger.info("\n" + "═" * 80)
     logger.info(f"  {title}  ".center(80, "═"))

--- a/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_units.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_units.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 def _convert_temperature(value: float, from_unit: str, to_unit: str) -> float:
     """Convert temperature between units."""
-    if not (value is not None):
+    if value is None:
         raise ValueError("value must be provided")
     from_unit = from_unit.upper()
     to_unit = to_unit.upper()

--- a/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_validation.py
+++ b/src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/pressure_drop_validation.py
@@ -56,7 +56,7 @@ def _validate_flow_params(
     errors: list[str],
 ) -> None:
     """Validate flow rate value and unit."""
-    if not (errors is not None):
+    if errors is None:
         raise ValueError("errors must be provided")
     if flow_rate is not None:
         if flow_rate <= 0:
@@ -86,7 +86,7 @@ def _validate_conditions(
     warnings: list[str],
 ) -> None:
     """Validate pressure and temperature values."""
-    if not (errors is not None):
+    if errors is None:
         raise ValueError("errors must be provided")
     if pressure is not None:
         if pressure <= 0:
@@ -116,7 +116,7 @@ def _validate_composition_and_fittings(
     warnings: list[str],
 ) -> None:
     """Validate gas composition and fitting specifications."""
-    if not (errors is not None):
+    if errors is None:
         raise ValueError("errors must be provided")
     if gas_composition:
         total = sum(gas_composition.values())
@@ -147,7 +147,7 @@ def _log_validation_report(
     is_valid: bool, errors: list[str], warnings: list[str]
 ) -> None:
     """Log a formatted validation report."""
-    if not (is_valid is not None):
+    if is_valid is None:
         raise ValueError("is_valid must be provided")
     logger.info(
         "\n╔═══════════════════════════════════════════════════════════════════╗"


### PR DESCRIPTION
## Summary

- Fixes #2298: replaces all 40 occurrences of `if not (x is not None):` with the semantically equivalent `if x is None:` across 9 files
- Pure readability cleanup — no logic changes, no behavior changes
- Removes the confusing double-negation pattern that bypasses DbC intent and obscures what the check actually does

## Files changed (9 files, 40 occurrences)

| File | Occurrences fixed |
|---|---|
| `model_generation/api/rest_api_routes.py` | 19 |
| `upstream_drift_tools/.../engine/_friction_factors.py` | 5 |
| `upstream_drift_tools/.../engine/_flow_calculations.py` | 5 |
| `upstream_drift_tools/.../pressure_drop_validation.py` | 4 |
| `upstream_drift_tools/.../pressure_drop_results.py` | 3 |
| `model_generation/api/rest_api_fastapi.py` | 1 |
| `model_generation/api/rest_api_flask.py` | 1 |
| `upstream_drift_tools/.../pressure_drop_interface.py` | 1 |
| `upstream_drift_tools/.../pressure_drop_units.py` | 1 |

## Test plan

- [x] Ruff check passes on all modified files (`All checks passed!`)
- [x] No logic changes — every `if not (x is not None):` is logically identical to `if x is None:`
- [ ] Run `python3 -m pytest tests/ -x -q` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)