### PR TITLE
fix(#2304): guard division-by-zero and chirp t_end=0 in signal_toolkit.Signal

### DIFF
--- a/src/shared/python/signal_toolkit/core.py
+++ b/src/shared/python/signal_toolkit/core.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 import numpy as np
 
@@ -31,7 +32,19 @@ class Signal:
         name: Optional name for the signal.
         units: Optional units string (e.g., 'N*m', 'rad/s').
         metadata: Additional metadata dictionary.
+
+    Class-level tolerance constants for time-array comparison in binary ops
+    (__add__, __sub__, __mul__, __truediv__).  Override at the class level
+    (e.g. ``Signal.TIME_ATOL = 1e-4``) to handle drifting sensor timestamps.
+
+        TIME_RTOL: relative tolerance for np.allclose (default 1e-5).
+        TIME_ATOL: absolute tolerance for np.allclose (default 1e-8).
     """
+
+    # Tolerances for time-array comparison in binary ops.  Override at the
+    # class level to accommodate sensor jitter.
+    TIME_RTOL: ClassVar[float] = 1e-5
+    TIME_ATOL: ClassVar[float] = 1e-8
 
     time: np.ndarray
     values: np.ndarray
@@ -160,7 +173,9 @@ class Signal:
         """Add two signals or add a constant."""
         assert other is not None, "other must be provided"
         if isinstance(other, Signal):
-            if not np.allclose(self.time, other.time):
+            if not np.allclose(
+                self.time, other.time, rtol=self.TIME_RTOL, atol=self.TIME_ATOL
+            ):
                 msg = "Signals must have the same time array for addition"
                 raise ValueError(msg)
             return Signal(
@@ -182,7 +197,9 @@ class Signal:
         """Multiply two signals or multiply by a constant."""
         assert other is not None, "other must be provided"
         if isinstance(other, Signal):
-            if not np.allclose(self.time, other.time):
+            if not np.allclose(
+                self.time, other.time, rtol=self.TIME_RTOL, atol=self.TIME_ATOL
+            ):
                 msg = "Signals must have the same time array for multiplication"
                 raise ValueError(msg)
             return Signal(
@@ -214,7 +231,9 @@ class Signal:
         """Subtract two signals or subtract a constant."""
         assert other is not None, "other must be provided"
         if isinstance(other, Signal):
-            if not np.allclose(self.time, other.time):
+            if not np.allclose(
+                self.time, other.time, rtol=self.TIME_RTOL, atol=self.TIME_ATOL
+            ):
                 msg = "Signals must have the same time array for subtraction"
                 raise ValueError(msg)
             return Signal(
@@ -236,9 +255,15 @@ class Signal:
         """Divide two signals or divide by a constant."""
         assert other is not None, "other must be provided"
         if isinstance(other, Signal):
-            if not np.allclose(self.time, other.time):
+            if not np.allclose(
+                self.time, other.time, rtol=self.TIME_RTOL, atol=self.TIME_ATOL
+            ):
                 msg = "Signals must have the same time array for division"
                 raise ValueError(msg)
+            if np.any(other.values == 0):
+                raise ValueError(
+                    "Division by zero: denominator Signal contains zero values"
+                )
             return Signal(
                 time=self.time.copy(),
                 values=self.values / other.values,
@@ -274,6 +299,10 @@ class Signal:
 
     def __rtruediv__(self, other: float | np.ndarray) -> Signal:
         """Support reverse division (e.g., 2 / signal)."""
+        if np.any(self.values == 0):
+            raise ValueError(
+                "Division by zero: denominator Signal contains zero values"
+            )
         return Signal(
             time=self.time.copy(),
             values=other / self.values,
@@ -510,6 +539,11 @@ class SignalGenerator:
         assert t is not None, "t must be provided"
         t_shifted = t - t[0]
         t_end = t_shifted[-1]
+        if t_end <= 0:
+            raise ValueError(
+                f"chirp() requires a positive time span; got t_end={t_end}"
+                " (check for repeated or non-monotonic timestamps)"
+            )
 
         if method == "linear":
             # Linear frequency sweep


### PR DESCRIPTION
Fixes #2304: (1) ValueError on zero-denominator in __truediv__/__rtruediv__; (2) ValueError when chirp() t_end<=0; (3) TIME_RTOL/TIME_ATOL ClassVar constants on Signal for adjustable timestamp tolerance. Tests: 21 signal + 18 Chaotic_Pendulum passed. Ruff clean.