### PR TITLE
fix: type-safety hardening

### DIFF
--- a/src/shared/python/signal_toolkit/calculus.py
+++ b/src/shared/python/signal_toolkit/calculus.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
+import typing
+
 import numpy as np
 from scipy import integrate
 from scipy.signal import savgol_filter
@@ -194,7 +196,7 @@ class Differentiator:
                 dy = np.gradient(y, t)
 
         else:
-            dy = np.gradient(y, t)
+            dy = np.gradient(y, t)  # type: ignore[unreachable]
 
         return dy
 
@@ -226,9 +228,9 @@ class Differentiator:
             t0, t1 = signal.time[idx - 1], signal.time[idx]
             y0, y1 = derivative_signal.values[idx - 1], derivative_signal.values[idx]
             alpha = (t_point - t0) / (t1 - t0) if t1 != t0 else 0
-            return y0 + alpha * (y1 - y0)
+            return float(y0 + alpha * (y1 - y0))
 
-        return derivative_signal.values[idx]
+        return float(derivative_signal.values[idx])
 
 
 class Integrator:
@@ -352,7 +354,7 @@ def compute_derivative(
     signal: Signal,
     order: int = 1,
     method: DifferentiationMethod = DifferentiationMethod.SAVGOL,
-    **kwargs,
+    **kwargs: typing.Any,
 ) -> Signal:
     """Convenience function to compute signal derivative.
 
@@ -535,7 +537,7 @@ def compute_arc_length(
     # Arc length element: ds = sqrt(1 + (dy/dt)^2) * dt
     ds = np.sqrt(1 + y_prime**2)
 
-    return _trapz(ds, signal.time)
+    return float(_trapz(ds, signal.time))
 
 
 def find_extrema(

--- a/src/shared/python/signal_toolkit/core.py
+++ b/src/shared/python/signal_toolkit/core.py
@@ -16,7 +16,7 @@ try:
     from contracts import require
 except ImportError:
 
-    def require(condition: object, message: str = "", *args: object) -> None:  # type: ignore[misc]
+    def require(condition: object, message: str = "", *args: object) -> None:
         """Fallback DbC require when pycontracts is not installed."""
         if not condition:
             raise ValueError(message)
@@ -101,7 +101,7 @@ class Signal:
         """Total duration in seconds."""
         if len(self.time) < 2:
             return 0.0
-        return self.time[-1] - self.time[0]
+        return float(self.time[-1] - self.time[0])
 
     @property
     def n_samples(self) -> int:

--- a/src/shared/python/signal_toolkit/io.py
+++ b/src/shared/python/signal_toolkit/io.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import typing
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -441,7 +442,7 @@ def import_from_csv(
     file_path: str | Path,
     time_column: str | int = 0,
     value_columns: str | int | list[str | int] | None = None,
-    **kwargs,
+    **kwargs: typing.Any,
 ) -> Signal | list[Signal]:
     """Import signal(s) from a CSV file (convenience function).
 
@@ -460,7 +461,7 @@ def import_from_csv(
 def export_to_csv(
     signal: Signal | list[Signal],
     file_path: str | Path,
-    **kwargs,
+    **kwargs: typing.Any,
 ) -> None:
     """Export signal(s) to a CSV file (convenience function).
 
@@ -489,7 +490,7 @@ class SignalLoader:
     def load(
         cls,
         file_path: str | Path,
-        **kwargs,
+        **kwargs: typing.Any,
     ) -> Signal | list[Signal]:
         """Load signal(s) from a file with automatic format detection.
 
@@ -609,7 +610,7 @@ class BatchProcessor:
     def load_all(
         self,
         pattern: str = "*.csv",
-        **kwargs,
+        **kwargs: typing.Any,
     ) -> dict[str, Signal | list[Signal]]:
         """Load all signals from matching files.
 
@@ -638,7 +639,7 @@ class BatchProcessor:
         pattern: str = "*.csv",
         output_dir: str | Path | None = None,
         output_format: str = "csv",
-        **kwargs,
+        **kwargs: typing.Any,
     ) -> dict[str, Signal | list[Signal]]:
         """Load, process, and optionally save all signals.
 
@@ -654,7 +655,7 @@ class BatchProcessor:
         """
         assert processor is not None, "processor must be provided"
         files = self.find_files(pattern)
-        results = {}
+        results: dict[str, Signal | list[Signal]] = {}
 
         if output_dir:
             output_dir = Path(output_dir)
@@ -679,9 +680,12 @@ class BatchProcessor:
                     if output_format == "csv":
                         SignalExporter.to_csv(processed, output_path)
                     elif output_format == "json":
+                        processed_single: Signal
                         if isinstance(processed, list):
-                            processed = processed[0]  # JSON only supports single signal
-                        SignalExporter.to_json(processed, output_path)
+                            processed_single = processed[0]  # JSON only supports single signal
+                        else:
+                            processed_single = processed
+                        SignalExporter.to_json(processed_single, output_path)
                     elif output_format == "npz":
                         SignalExporter.to_npz(processed, output_path)
 

--- a/src/shared/python/signal_toolkit/limits.py
+++ b/src/shared/python/signal_toolkit/limits.py
@@ -116,7 +116,7 @@ def _apply_saturation_values(
         result = _exponential_clip(normalized, smoothness)
 
     else:
-        result = np.clip(normalized, -1, 1)
+        result = np.clip(normalized, -1, 1)  # type: ignore[unreachable]
 
     # Scale back to original range and clamp to guarantee bounds
     # Postcondition: output ∈ [lower, upper] for all modes


### PR DESCRIPTION
Resolves the type-safety improvements from #2337 which conflicted. Closes #2337

## Changes applied

Manually rebased the following improvements from `chore/type-safety-hardening` onto `staging`:

- **calculus.py**: `import typing`, `**kwargs: typing.Any` on `compute_derivative`, explicit `float()` casts on `compute_at_point` returns and `compute_arc_length`, `# type: ignore[unreachable]` on defensive `else` branch
- **core.py**: `float()` cast on `duration` property return, removed stale `# type: ignore[misc]` from fallback `require`
- **io.py**: `import typing`, `**kwargs: typing.Any` on `import_from_csv`, `export_to_csv`, `SignalLoader.load`, `load_all`, `process_all`; `dict[str, Signal | list[Signal]]` annotation on `results`; `processed_single` variable to avoid mutating `processed` in JSON branch
- **limits.py**: `# type: ignore[unreachable]` on defensive `else` branch in `_apply_saturation_values`