### PR TITLE
🎨 Palette: Add accessible soft confirm for clear button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -64,3 +64,7 @@
 ## 2026-04-25 - [Dynamic Focus for Inline Validation]
 **Learning:** When inline form validation fails, relying solely on visual error states or `aria-invalid` attributes is insufficient. If keyboard focus remains unchanged, screen reader and keyboard users are not directed to the error, creating a confusing experience where the form submission seemingly does nothing.
 **Action:** When implementing inline form validation, always dynamically shift focus to the first invalid field using `.focus()` in addition to setting `aria-invalid="true"`. This prevents keyboard focus traps and ensures assistive technologies immediately announce the context of the error.
+
+## 2026-04-26 - [Dynamic Accessible Name for Soft Confirm Pattern]
+**Learning:** When using the soft confirm pattern on destructive actions (e.g., clear buttons changing to "CONFIRM?"), merely changing the text content (`textContent`) and providing `aria-live="polite"` on the parent does not update the accessible name of the button itself, leaving screen reader users without explicit context for the required secondary action.
+**Action:** Always dynamically manipulate the `aria-label` attribute (e.g., changing from "Clear all fields" to "Confirm clear all fields") concurrently with the visual text change, restoring it appropriately when the timeout occurs or the action completes.

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.107                                    |
-| **Last Spec Update**    | 2026-04-25                                 |
+| **Spec Version**        | 1.1.108                                    |
+| **Last Spec Update**    | 2026-04-26                                 |
 
 ## 2. Purpose & Mission
 
@@ -464,6 +464,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-04-26 | 1.1.108 | Improved accessibility for the calculator clear button's soft confirm state. Added `aria-live="polite"` to the parent row and dynamically toggled the `aria-label` between "Clear all fields" and "Confirm clear all fields" to keep screen reader users informed of the required secondary action. |
 | 2026-04-25 | 1.1.107 | Fixed StrEnum import compatibility for Python 3.10 by routing `steam_engine_calculator` and `video_processor` API modules through the existing `utils.compatibility` backport facade, eliminating import-time failures on the 3.10 CI interpreter. |
 | 2026-04-25 | 1.1.106 | Added dynamic focus shifting to inline form validation within the Unit Converter app's Custom Units modal. This prevents keyboard focus traps by focusing the first invalid input (`.focus()`) and marking it with `aria-invalid="true"`. |
 | 2026-04-23 | 1.1.103 | Tightened the shared `model_generation` unified-loader conversion contract so malformed MJCF/URDF XML parse failures are wrapped as `ConversionError`, converter-raised `ConversionError` instances propagate unchanged, and regression tests lock the typed error/logging behavior.                                                                                                                                                                                                                                                                                |

--- a/src/web_applications/calculator/static/app.js
+++ b/src/web_applications/calculator/static/app.js
@@ -240,14 +240,17 @@ function registerEvents() {
       renderTouchExpression();
 
       clearButton.textContent = "CLEAR";
+      clearButton.setAttribute("aria-label", "Clear all fields");
       delete clearButton.dataset.confirming;
       clearTimeout(clearConfirmTimeout);
     } else {
       clearButton.textContent = "CONFIRM?";
+      clearButton.setAttribute("aria-label", "Confirm clear all fields");
       clearButton.dataset.confirming = "true";
 
       clearConfirmTimeout = setTimeout(() => {
         clearButton.textContent = "CLEAR";
+        clearButton.setAttribute("aria-label", "Clear all fields");
         delete clearButton.dataset.confirming;
       }, 3000);
     }

--- a/src/web_applications/calculator/templates/index.html
+++ b/src/web_applications/calculator/templates/index.html
@@ -871,8 +871,8 @@ Ready.</pre
         </div>
       </section>
 
-      <section class="action-row">
-        <button type="button" id="clear" class="action secondary">CLEAR</button>
+      <section class="action-row" aria-live="polite">
+        <button type="button" id="clear" class="action secondary" aria-label="Clear all fields">CLEAR</button>
         <button type="button" id="execute" class="action primary">ENTER</button>
       </section>
     </div>


### PR DESCRIPTION
💡 **What**: Added `aria-live="polite"` to the action row in the calculator UI, and dynamically updated the `aria-label` of the Clear button during its "CONFIRM?" state.
🎯 **Why**: When using the soft confirm pattern to prevent accidental data loss on touch interfaces, screen reader users were unaware that the button's action and meaning changed, creating a confusing or broken experience.
📸 **Before/After**: The visual experience is exactly the same ("CLEAR" -> "CONFIRM?"), but the underlying accessibility tree now mirrors these state changes and announces them to assistive technologies.
♿ **Accessibility**: Provides robust screen reader announcements and semantic meaning for the destructive "Clear" action.

---
*PR created automatically by Jules for task [17986512319710494027](https://jules.google.com/task/17986512319710494027) started by @dieterolson*