### PR TITLE
sec(ci): add detect-secrets scanning baseline and pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,15 @@ repos:
         types_or: [yaml, markdown, json]
         exclude: '(\.py|\.m|package-lock\.json|\.ipynb)$'
 
+  # Detect-secrets - Secret keyword scanning (Issue #2356)
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        name: "detect-secrets (scan for secrets)"
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: ^(\.secrets\.baseline|package-lock\.json|__pycache__|.*\.egg-info)
+
   # -------------------------------------------------------------------------
   # Stage 4: Pre-push Hooks (Slower - PYTHON FILES ONLY)
   # -------------------------------------------------------------------------

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,99 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_by_default"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "verification_policies": []
+    },
+    {
+      "path": "detect_secrets.filters.gibberish.should_exclude_secret",
+      "language_model": "/home/dieterolson/.cache/detect_secrets/gibberish_model"
+    }
+  ],
+  "results": {},
+  "generated_at": "2026-04-29T11:00:00Z"
+}


### PR DESCRIPTION
Closes #2356

- Add detect-secrets baseline (audited, no real secrets)
- Add pre-commit hook enforcement
- Add CI scanning step