### PR TITLE
fix: add coverage report configuration and Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 #   make test     - Run tests
 #   make clean    - Clean build artifacts
 
-.PHONY: help lint format test clean install check all
+.PHONY: help lint format test coverage clean install check all
 
 # Default target
 help:
@@ -20,6 +20,7 @@ help:
 	@echo "  make test      - Run pytest"
 	@echo "  make check     - Run all checks (lint + test)"
 	@echo "  make clean     - Remove build artifacts"
+	@echo "  make coverage  - Run pytest with coverage and emit coverage.json"
 	@echo "  make all       - Install, format, lint, test"
 	@echo ""
 
@@ -48,6 +49,11 @@ format:
 test:
 	@echo "Running pytest..."
 	python -m pytest
+
+# Run tests with coverage and emit coverage.json
+coverage:
+	@echo "Running pytest with coverage..."
+	python -m pytest --cov=src --cov-report=json:coverage.json --cov-report=term-missing -n auto
 
 # Run all checks
 check: lint test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,9 @@ exclude_lines = [
     "pass",
 ]
 
+[tool.coverage.json]
+output = "coverage.json"
+
 [tool.mypy]
 python_version = "3.11"  # Matches pyproject requires-python and ruff target-version
 files = ["src"]


### PR DESCRIPTION
Closes #2354

## Summary
- Adds `[tool.coverage.json]` section to `pyproject.toml` to configure the output file (`coverage.json`) for JSON coverage reports
- Adds a `coverage` Makefile target: `pytest --cov=src --cov-report=json:coverage.json --cov-report=term-missing -n auto`
- Updates `.PHONY` and `make help` output to include the new target
- `coverage.json` was already present in `.gitignore` — no change needed there
- `--cov` was NOT added to pytest `addopts` to avoid slowing every test run

Note: This is a rebased version of PR #2386, which had merge conflicts after the critical file-restore merge (#2396).

## Test plan
- [ ] `make coverage` runs without error and produces `coverage.json`
- [ ] `make test` (normal test run) is unchanged — no coverage overhead
- [ ] `make help` lists the new `coverage` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)