### PR TITLE
fix: convert print() to logging in high-priority source files (batch 1)

### DIFF
--- a/scripts/enhanced_batch_fix_dry.py
+++ b/scripts/enhanced_batch_fix_dry.py
@@ -6,9 +6,13 @@ This script systematically fixes common DRY violations across the codebase
 with better pattern matching and import management.
 """
 
+import logging
 import re
 import sys
 from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 # Track total fixes
 TOTAL_FIXES = 0
@@ -380,7 +384,7 @@ def process_file(file_path: Path) -> int:
 
         return 0
     except Exception as e:  # noqa: BLE001
-        print(f"Error processing {file_path}: {e}", file=sys.stderr)
+        logger.error("Error processing %s: %s", file_path, e)
         return 0
 
 
@@ -410,9 +414,9 @@ def main() -> int:
     repo_root = Path("/home/dieterolson/Linux_Tools/Tools")
 
     # Find Python files
-    print("Finding Python files...")
+    logger.info("Finding Python files...")
     files = find_python_files(repo_root)
-    print(f"Found {len(files)} Python files")
+    logger.info("Found %d Python files", len(files))
 
     total_fixes = 0
     fixed_files = 0
@@ -420,11 +424,11 @@ def main() -> int:
     for file_path in sorted(files):
         fixes = process_file(file_path)
         if fixes > 0:
-            print(f"Fixed {fixes} violations in {file_path.relative_to(repo_root)}")
+            logger.info("Fixed %d violations in %s", fixes, file_path.relative_to(repo_root))
             total_fixes += fixes
             fixed_files += 1
 
-    print(f"\nTotal: {fixed_files} files, {total_fixes} violations fixed")
+    logger.info("Total: %d files, %d violations fixed", fixed_files, total_fixes)
     return 0
 
 

--- a/scripts/generate_assessments.py
+++ b/scripts/generate_assessments.py
@@ -1,4 +1,8 @@
+import logging
 import os
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 ASSESSMENT_DIR = "docs/assessments"
 ISSUES_DIR = "docs/assessments/issues"
@@ -172,7 +176,7 @@ for code, (name, grade, analysis) in assessments.items():
         f.write(f"## Grade: {grade}/10\n\n")
         f.write("## Analysis\n")
         f.write(analysis.strip() + "\n")
-    print(f"Generated {filepath}")
+    logger.info("Generated %s", filepath)
 
 # Generate Issues for Low Grades (< 5)
 issues = {
@@ -229,7 +233,7 @@ for code, (name, title, body) in issues.items():
             f.write("--- \nlabels: jules:assessment, needs-attention\n---\n\n")
             f.write(f"# {title}\n\n")
             f.write(body.strip() + "\n")
-        print(f"Generated {filepath}")
+        logger.info("Generated %s", filepath)
 
 
 # Generate Comprehensive Assessment
@@ -311,4 +315,4 @@ with open(os.path.join(ASSESSMENT_DIR, "Comprehensive_Assessment.md"), "w") as f
         "    - **Action**: Enforce a linting rule to ban `print()` in library code.\n"
     )
 
-print(f"Generated {os.path.join(ASSESSMENT_DIR, 'Comprehensive_Assessment.md')}")
+logger.info("Generated %s", os.path.join(ASSESSMENT_DIR, "Comprehensive_Assessment.md"))

--- a/scripts/generate_theme_screenshots.py
+++ b/scripts/generate_theme_screenshots.py
@@ -15,6 +15,7 @@ Usage:
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from pathlib import Path
@@ -29,6 +30,8 @@ if str(_REPO_ROOT) not in sys.path:
 from _bootstrap import bootstrap  # noqa: E402
 
 bootstrap(__file__)
+
+logger = logging.getLogger(__name__)
 
 from PyQt6.QtCore import QSize  # noqa: E402
 from PyQt6.QtWidgets import (  # noqa: E402
@@ -139,7 +142,7 @@ def generate_screenshots(output_dir: Path | None = None) -> list[Path]:
         out_path = output_dir / f"{safe_name}.png"
         pixmap.save(str(out_path))
         generated.append(out_path)
-        print(f"  Saved: {out_path.name}")
+        logger.info("  Saved: %s", out_path.name)
 
         window.close()
 
@@ -148,9 +151,11 @@ def generate_screenshots(output_dir: Path | None = None) -> list[Path]:
 
 def main() -> int:
     """Entry point."""
-    print(f"Generating theme previews for {len(BUILTIN_THEMES)} themes...")
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    logger.info("Generating theme previews for %d themes...", len(BUILTIN_THEMES))
     paths = generate_screenshots()
-    print(f"\nDone. {len(paths)} screenshots saved to {paths[0].parent}")
+    if paths:
+        logger.info("Done. %d screenshots saved to %s", len(paths), paths[0].parent)
     return 0
 
 


### PR DESCRIPTION
## Summary

Partial fix for #2363 — converts `print()` calls to proper `logging` calls in the 3 scripts with the most non-CLI print usage.

**Files converted:**
| File | print() calls removed | Notes |
|------|----------------------|-------|
| `scripts/generate_assessments.py` | 3 | Progress output → `logger.info()` |
| `scripts/generate_theme_screenshots.py` | 3 | Progress output → `logger.info()` |
| `scripts/enhanced_batch_fix_dry.py` | 5 | Progress + error output → `logger.info()` / `logger.error()` |

**Total: 11 print() calls converted to logging.**

## Context

A thorough audit of the codebase found:
- `src/` library code: **0 actual executable print() calls** — already enforced by `no-print-in-src` pre-commit hook and `test_gh1732_logging_consistency.py`
- `scripts/` directory: `T201` already suppressed in `ruff.toml` because these are CLI tools where print IS the output
- The 3 files in this PR used print() for internal progress/diagnostic feedback rather than user-facing output, making them good candidates for logging

The remaining `scripts/` print() calls (setup_hooks, migrate_csv_to_parquet, validate_themes, validate_workflows, check_local_only_workflows) are intentional CLI output and should stay as print().

Note: This is a rebased version of PR #2387, which had merge conflicts after the critical file-restore merge (#2396).

## Test plan

- [ ] `ruff check scripts/generate_assessments.py scripts/generate_theme_screenshots.py scripts/enhanced_batch_fix_dry.py` — no T201 violations (logging used correctly)
- [ ] AST-level check confirms 0 print() calls in converted files
- [ ] Existing `tests/test_gh1732_logging_consistency.py` continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)