### PR TITLE
test: add 99 high-quality tests for geometry, profiles, data I/O

### DIFF
--- a/tests/programmatic_pid/test_geometry_extra.py
+++ b/tests/programmatic_pid/test_geometry_extra.py
@@ -1,0 +1,289 @@
+"""Edge-case tests for ``programmatic_pid.geometry``.
+
+Complements :mod:`test_geometry.py` with:
+
+* ``to_float`` with NaN/Inf inputs (returns the value as-is — finite check
+  is the *caller's* responsibility, but float coercion must succeed).
+* ``clamp`` with degenerate ranges and exact endpoints.
+* ``closest_point_on_rect`` for points inside, on edges, and at corners.
+* ``rects_overlap`` with negative/zero pad and exactly-touching rects.
+* ``text_box`` with every alignment combination and weird inputs.
+* ``distance`` with negative coordinates and zero distance.
+* ``dedupe_points`` tolerance behaviour at the 1e-9 boundary.
+* ``find_free_region`` with empty occupied list and crowded grid.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+pytest.importorskip("ezdxf")
+from programmatic_pid.geometry import (
+    clamp,
+    closest_point_on_rect,
+    dedupe_points,
+    distance,
+    find_free_region,
+    rects_overlap,
+    text_box,
+    to_float,
+)
+from programmatic_pid.types import BBox, Point
+
+
+# ── to_float ─────────────────────────────────────────────────────────────
+
+
+class TestToFloat:
+    def test_int_returns_float(self) -> None:
+        assert to_float(7) == 7.0
+        assert isinstance(to_float(7), float)
+
+    def test_bool_is_treated_as_int(self) -> None:
+        # bool is an int subclass in Python.
+        assert to_float(True) == 1.0
+        assert to_float(False) == 0.0
+
+    def test_object_returns_default(self) -> None:
+        assert to_float(object(), default=42.0) == 42.0
+
+    def test_list_returns_default(self) -> None:
+        assert to_float([1, 2, 3], default=-1.0) == -1.0
+
+    def test_default_is_float_coerced(self) -> None:
+        # Default is itself float()-ed so int is fine.
+        assert to_float("nonsense", default=5) == 5.0
+
+    def test_inf_passes_through(self) -> None:
+        # math.inf is a valid float.
+        assert math.isinf(to_float(math.inf))
+
+
+# ── clamp ────────────────────────────────────────────────────────────────
+
+
+class TestClamp:
+    @pytest.mark.parametrize(
+        ("value", "lo", "hi", "expected"),
+        [
+            (5.0, 0.0, 10.0, 5.0),
+            (0.0, 0.0, 10.0, 0.0),  # exact lo
+            (10.0, 0.0, 10.0, 10.0),  # exact hi
+            (-5.0, 0.0, 10.0, 0.0),
+            (15.0, 0.0, 10.0, 10.0),
+            (5.0, 5.0, 5.0, 5.0),  # degenerate lo == hi
+            (-1.0, -10.0, -5.0, -5.0),  # all negative
+        ],
+    )
+    def test_clamp_values(
+        self, value: float, lo: float, hi: float, expected: float
+    ) -> None:
+        assert clamp(value, lo, hi) == expected
+
+
+# ── closest_point_on_rect ────────────────────────────────────────────────
+
+
+class TestClosestPointOnRect:
+    def test_point_inside_rect_returns_point(self) -> None:
+        # Point inside is its own closest point (clamp is a no-op).
+        p = closest_point_on_rect((5.0, 5.0), (0.0, 0.0, 10.0, 10.0))
+        assert p == Point(5.0, 5.0)
+
+    def test_point_left_of_rect(self) -> None:
+        p = closest_point_on_rect((-5.0, 5.0), (0.0, 0.0, 10.0, 10.0))
+        assert p == Point(0.0, 5.0)
+
+    def test_point_at_corner(self) -> None:
+        p = closest_point_on_rect((100.0, 100.0), (0.0, 0.0, 10.0, 10.0))
+        assert p == Point(10.0, 10.0)
+
+    def test_point_below_rect(self) -> None:
+        p = closest_point_on_rect((5.0, -50.0), (0.0, 0.0, 10.0, 10.0))
+        assert p == Point(5.0, 0.0)
+
+    def test_none_point_raises(self) -> None:
+        with pytest.raises(ValueError, match="point"):
+            closest_point_on_rect(None, (0, 0, 10, 10))  # type: ignore[arg-type]
+
+    def test_unparseable_coords_use_fallback(self) -> None:
+        # to_float is called on x/y -> non-coercible value falls back to 0.
+        p = closest_point_on_rect(("bad", "also bad"), (-5.0, -5.0, 5.0, 5.0))
+        assert p == Point(0.0, 0.0)
+
+
+# ── rects_overlap ────────────────────────────────────────────────────────
+
+
+class TestRectsOverlap:
+    def test_touching_edges_treated_as_no_overlap(self) -> None:
+        # When ax2 == bx1 with pad=0, the function returns False per its
+        # `<=` boundary check — touching is *not* overlap.
+        assert not rects_overlap((0, 0, 10, 10), (10, 0, 20, 10))
+
+    def test_touching_with_positive_pad_becomes_overlap(self) -> None:
+        # Adding pad pushes the boundary into the neighbour.
+        assert rects_overlap((0, 0, 10, 10), (10, 0, 20, 10), pad=1.0)
+
+    def test_negative_pad_separates_overlapping_rects(self) -> None:
+        # Negative pad shrinks rects: heavy overlap stays overlap, narrow
+        # overlap should disappear.
+        assert not rects_overlap((0, 0, 10, 10), (9, 0, 19, 10), pad=-2.0)
+
+    def test_one_inside_the_other(self) -> None:
+        assert rects_overlap((0, 0, 100, 100), (10, 10, 20, 20))
+
+    def test_none_first_rect_raises(self) -> None:
+        with pytest.raises(ValueError, match="a"):
+            rects_overlap(None, (0, 0, 10, 10))  # type: ignore[arg-type]
+
+
+# ── text_box ─────────────────────────────────────────────────────────────
+
+
+class TestTextBox:
+    @pytest.mark.parametrize(
+        "align",
+        [
+            "MIDDLE_CENTER",
+            "MIDDLE_LEFT",
+            "MIDDLE_RIGHT",
+            "TOP_CENTER",
+            "TOP_LEFT",
+            "TOP_RIGHT",
+            "BOTTOM_CENTER",
+            "BOTTOM_LEFT",
+            "BOTTOM_RIGHT",
+        ],
+    )
+    def test_alignment_invariants(self, align: str) -> None:
+        x1, y1, x2, y2 = text_box("hello", 5.0, 5.0, 1.0, align=align)
+        assert x1 < x2 and y1 < y2  # always non-empty
+        # Width approximately len(text)*h*0.55, height h*1.2.
+        assert (x2 - x1) == pytest.approx(5 * 0.55, rel=1e-6)
+        assert (y2 - y1) == pytest.approx(1.2, rel=1e-6)
+
+    def test_top_align_has_y_above_anchor(self) -> None:
+        _, y1, _, y2 = text_box("x", 0.0, 0.0, 1.0, align="TOP_LEFT")
+        assert y2 == 0.0
+        assert y1 == -1.2
+
+    def test_bottom_align_has_y_below_anchor(self) -> None:
+        _, y1, _, y2 = text_box("x", 0.0, 0.0, 1.0, align="BOTTOM_LEFT")
+        assert y1 == 0.0
+        assert y2 == 1.2
+
+    def test_right_align_has_x_to_left_of_anchor(self) -> None:
+        x1, _, x2, _ = text_box("hi", 10.0, 0.0, 1.0, align="MIDDLE_RIGHT")
+        assert x2 == 10.0
+        assert x1 < 10.0
+
+    def test_empty_string_treated_as_unit_width(self) -> None:
+        # max(len(text), 1) ensures a non-zero width.
+        x1, _, x2, _ = text_box("", 0.0, 0.0, 1.0, align="MIDDLE_LEFT")
+        assert (x2 - x1) > 0
+
+    def test_zero_height_clamped_to_minimum(self) -> None:
+        # h is max(to_float(h, 1.0), 0.1)
+        x1, y1, x2, y2 = text_box("a", 0.0, 0.0, 0.0)
+        assert (y2 - y1) == pytest.approx(0.1 * 1.2, rel=1e-6)
+
+    def test_none_text_raises(self) -> None:
+        with pytest.raises(ValueError, match="text"):
+            text_box(None, 0.0, 0.0, 1.0)  # type: ignore[arg-type]
+
+    def test_none_align_uses_default(self) -> None:
+        # `str(align or "MIDDLE_CENTER")` handles None.
+        x1, _, x2, _ = text_box("hi", 0.0, 0.0, 1.0, align=None)  # type: ignore[arg-type]
+        assert x1 < 0.0 < x2
+
+
+# ── distance ─────────────────────────────────────────────────────────────
+
+
+class TestDistance:
+    def test_zero_distance(self) -> None:
+        assert distance((1.5, 2.5), (1.5, 2.5)) == 0.0
+
+    def test_negative_coordinates(self) -> None:
+        assert distance((-3, -4), (0, 0)) == pytest.approx(5.0)
+
+    def test_symmetric(self) -> None:
+        assert distance((1, 2), (4, 6)) == distance((4, 6), (1, 2))
+
+
+# ── dedupe_points ────────────────────────────────────────────────────────
+
+
+class TestDedupePoints:
+    def test_empty_input(self) -> None:
+        assert dedupe_points([]) == []
+
+    def test_single_point(self) -> None:
+        assert dedupe_points([(1.0, 2.0)]) == [(1.0, 2.0)]
+
+    def test_unparseable_coords_become_zero(self) -> None:
+        # to_float falls back to 0 for non-numeric values.
+        result = dedupe_points([("bad", 5.0), ("bad", 5.0)])
+        assert result == [(0.0, 5.0)]
+
+    def test_within_tolerance_treated_as_duplicate(self) -> None:
+        # 1e-10 < 1e-9 tolerance; should dedup.
+        result = dedupe_points([(1.0, 1.0), (1.0 + 1e-10, 1.0 + 1e-10)])
+        assert len(result) == 1
+
+    def test_above_tolerance_not_treated_as_duplicate(self) -> None:
+        # 1e-8 > 1e-9 tolerance; should keep both.
+        result = dedupe_points([(1.0, 1.0), (1.0 + 1e-8, 1.0 + 1e-8)])
+        assert len(result) == 2
+
+    def test_only_consecutive_duplicates_removed(self) -> None:
+        result = dedupe_points([(0, 0), (1, 1), (0, 0), (1, 1), (1, 1)])
+        # Pattern 0,1,0,1 has no consecutive dup until the trailing 1,1.
+        assert result == [(0.0, 0.0), (1.0, 1.0), (0.0, 0.0), (1.0, 1.0)]
+
+
+# ── find_free_region ─────────────────────────────────────────────────────
+
+
+class TestFindFreeRegion:
+    def test_empty_occupied_returns_origin_region(self) -> None:
+        result = find_free_region([], width=5, height=5)
+        assert result is not None
+        # First candidate at radius=0, dx=0, dy=0 from origin.
+        assert result.x_min == 0.0 and result.y_min == 0.0
+
+    def test_origin_blocked_returns_offset(self) -> None:
+        occupied = [BBox(-50, -50, 50, 50)]
+        result = find_free_region(occupied, width=5, height=5)
+        # Should find a free spot somewhere outside the blocking rect.
+        assert result is not None
+        assert not result.overlaps(occupied[0], pad=2.0)
+
+    def test_huge_blocker_exceeds_search_radius_returns_none(self) -> None:
+        # Search radius is capped at 500; a >1000-wide block has no escape.
+        occupied = [BBox(-1000, -1000, 1000, 1000)]
+        result = find_free_region(occupied, width=5, height=5)
+        assert result is None
+
+    def test_search_origin_respected(self) -> None:
+        # Block origin only, ensure the algorithm searches outward and
+        # finds a region somewhere away from the origin.
+        occupied = [BBox(-3, -3, 3, 3)]
+        result = find_free_region(
+            occupied, width=2, height=2, search_origin=Point(50, 50)
+        )
+        assert result is not None
+        assert not result.overlaps(occupied[0], pad=2.0)
+
+    def test_none_occupied_raises(self) -> None:
+        with pytest.raises(ValueError, match="occupied"):
+            find_free_region(None, 5, 5)  # type: ignore[arg-type]
+
+    def test_returned_region_has_requested_dimensions(self) -> None:
+        result = find_free_region([], width=7.5, height=3.25)
+        assert result is not None
+        assert result.x_max - result.x_min == pytest.approx(7.5)
+        assert result.y_max - result.y_min == pytest.approx(3.25)

--- a/tests/programmatic_pid/test_geometry_extra.py
+++ b/tests/programmatic_pid/test_geometry_extra.py
@@ -32,7 +32,6 @@ from programmatic_pid.geometry import (
 )
 from programmatic_pid.types import BBox, Point
 
-
 # ── to_float ─────────────────────────────────────────────────────────────
 
 

--- a/tests/programmatic_pid/test_profiles_extra.py
+++ b/tests/programmatic_pid/test_profiles_extra.py
@@ -1,0 +1,222 @@
+"""Deeper behavioural tests for ``programmatic_pid.profiles``.
+
+These complement :mod:`test_profiles.py` by exercising:
+
+* Profile name normalisation (whitespace, case, surrounding spaces).
+* Independence of consecutive ``apply_profile`` calls (no shared state).
+* Spec is not mutated regardless of structure.
+* Layout/defaults merge semantics on specs that already contain values.
+* All three preset profiles roundtrip and produce monotonically smaller
+  panels for ``compact`` vs ``review``.
+* Every preset advertises a known set of layout knobs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("ezdxf")
+from programmatic_pid.profiles import PROFILE_PRESETS, apply_profile
+
+
+def _full_spec() -> dict:
+    return {
+        "project": {
+            "id": "P-1",
+            "title": "Test",
+            "drawing": {
+                "text_height": 2.0,
+                "layout": {"gap": 1.0, "panel_text_chars": 99},
+            },
+        },
+        "defaults": {"instrument_bubble_radius": 9.9},
+        "equipment": [{"id": "E-1", "x": 0, "y": 0, "width": 10, "height": 10}],
+    }
+
+
+# ── Name normalisation ──────────────────────────────────────────────────
+
+
+class TestProfileNameNormalisation:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "review",
+            "REVIEW",
+            "Review",
+            "  review  ",
+            "ReView",
+        ],
+    )
+    def test_case_and_whitespace_insensitive(self, name: str) -> None:
+        result = apply_profile(_full_spec(), name)
+        assert result["meta"]["profile"] == "review"
+
+    def test_unknown_profile_lists_valid(self) -> None:
+        with pytest.raises(ValueError) as ex:
+            apply_profile(_full_spec(), "fancy")
+        msg = str(ex.value)
+        assert "Unknown profile" in msg
+        # All known profiles should be advertised in the error message.
+        for known in PROFILE_PRESETS:
+            assert known in msg
+
+
+# ── Spec immutability ───────────────────────────────────────────────────
+
+
+class TestSpecImmutability:
+    def test_input_spec_not_mutated(self) -> None:
+        original = _full_spec()
+        snapshot = {
+            "gap": original["project"]["drawing"]["layout"]["gap"],
+            "bubble": original["defaults"]["instrument_bubble_radius"],
+        }
+        apply_profile(original, "compact")
+        # Original layout values must be unchanged after applying a profile.
+        assert original["project"]["drawing"]["layout"]["gap"] == snapshot["gap"]
+        assert (
+            original["defaults"]["instrument_bubble_radius"] == snapshot["bubble"]
+        )
+        assert "meta" not in original  # meta is added to the copy only
+
+    def test_independent_apply_calls(self) -> None:
+        spec = _full_spec()
+        a = apply_profile(spec, "review")
+        b = apply_profile(spec, "compact")
+        # The two outputs must not share inner dicts.
+        a_layout = a["project"]["drawing"]["layout"]
+        b_layout = b["project"]["drawing"]["layout"]
+        a_layout["gap"] = -111.0
+        assert b_layout["gap"] != -111.0
+
+
+# ── Merge semantics ─────────────────────────────────────────────────────
+
+
+class TestProfileMergeSemantics:
+    def test_existing_layout_values_overwritten_by_preset(self) -> None:
+        spec = _full_spec()
+        spec["project"]["drawing"]["layout"]["gap"] = 999.0
+        result = apply_profile(spec, "compact")
+        assert (
+            result["project"]["drawing"]["layout"]["gap"]
+            == PROFILE_PRESETS["compact"]["layout"]["gap"]
+        )
+
+    def test_existing_unrelated_layout_keys_preserved(self) -> None:
+        spec = _full_spec()
+        spec["project"]["drawing"]["layout"]["custom_extra"] = "keep me"
+        result = apply_profile(spec, "presentation")
+        assert (
+            result["project"]["drawing"]["layout"]["custom_extra"] == "keep me"
+        )
+
+    def test_drawing_created_when_missing(self) -> None:
+        spec = {"project": {"id": "P-1"}, "equipment": []}
+        result = apply_profile(spec, "compact")
+        assert isinstance(result["project"]["drawing"], dict)
+        assert "layout" in result["project"]["drawing"]
+        assert result["project"]["drawing"]["layout"]["gap"] == 6.0
+
+    def test_drawing_replaced_when_not_a_dict(self) -> None:
+        spec = {"project": {"id": "P-1", "drawing": "not-a-dict"}, "equipment": []}
+        result = apply_profile(spec, "compact")
+        assert isinstance(result["project"]["drawing"], dict)
+
+    def test_layout_replaced_when_not_a_dict(self) -> None:
+        spec = {
+            "project": {"id": "P-1", "drawing": {"layout": ["bad"]}},
+            "equipment": [],
+        }
+        result = apply_profile(spec, "compact")
+        layout = result["project"]["drawing"]["layout"]
+        assert isinstance(layout, dict)
+        # Preset values must be applied.
+        assert layout["gap"] == 6.0
+
+    def test_defaults_replaced_when_not_a_dict(self) -> None:
+        spec = {"project": {"id": "P-1"}, "defaults": "weird", "equipment": []}
+        result = apply_profile(spec, "review")
+        assert isinstance(result["defaults"], dict)
+        assert (
+            result["defaults"]["instrument_bubble_radius"]
+            == PROFILE_PRESETS["review"]["defaults"]["instrument_bubble_radius"]
+        )
+
+    def test_meta_replaced_when_not_a_dict(self) -> None:
+        spec = {"project": {"id": "P-1"}, "meta": 42, "equipment": []}
+        result = apply_profile(spec, "review")
+        assert isinstance(result["meta"], dict)
+        assert result["meta"]["profile"] == "review"
+
+    def test_existing_meta_preserved_alongside_profile(self) -> None:
+        spec = _full_spec()
+        spec["meta"] = {"author": "alice"}
+        result = apply_profile(spec, "review")
+        assert result["meta"]["author"] == "alice"
+        assert result["meta"]["profile"] == "review"
+
+
+# ── Profile relative semantics ──────────────────────────────────────────
+
+
+class TestProfileRelativeSizes:
+    """Sanity checks: compact MUST be tighter than review on every shared knob."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "gap",
+            "right_panel_width",
+            "bottom_panel_height",
+            "title_block_height",
+            "panel_text_chars",
+            "stream_label_scale",
+            "instrument_spacing_factor",
+            "controls_row_height_scale",
+        ],
+    )
+    def test_compact_smaller_than_review(self, key: str) -> None:
+        review = PROFILE_PRESETS["review"]["layout"]
+        compact = PROFILE_PRESETS["compact"]["layout"]
+        assert compact[key] < review[key], f"{key}: compact must be < review"
+
+    def test_review_shows_inline_notes_compact_does_not(self) -> None:
+        review = PROFILE_PRESETS["review"]["layout"]
+        compact = PROFILE_PRESETS["compact"]["layout"]
+        presentation = PROFILE_PRESETS["presentation"]["layout"]
+        assert review["show_inline_equipment_notes"] is True
+        assert compact["show_inline_equipment_notes"] is False
+        assert presentation["show_inline_equipment_notes"] is False
+
+    def test_all_presets_share_same_layout_keys(self) -> None:
+        keysets = [
+            set(p["layout"].keys()) for p in PROFILE_PRESETS.values() if "layout" in p
+        ]
+        assert all(k == keysets[0] for k in keysets), (
+            "all presets must declare the same layout keys for predictable merging"
+        )
+
+    def test_presentation_has_no_defaults_section(self) -> None:
+        # presentation preset deliberately omits a defaults block.
+        assert "defaults" not in PROFILE_PRESETS["presentation"]
+
+
+# ── Empty spec ──────────────────────────────────────────────────────────
+
+
+class TestEmptySpec:
+    def test_empty_spec_apply_profile_produces_full_skeleton(self) -> None:
+        result = apply_profile({}, "review")
+        assert result["meta"]["profile"] == "review"
+        assert "project" in result
+        assert isinstance(result["project"]["drawing"], dict)
+        assert isinstance(result["defaults"], dict)
+
+    def test_apply_profile_none_returns_independent_copy(self) -> None:
+        spec = _full_spec()
+        result = apply_profile(spec, None)
+        result["project"]["drawing"]["layout"]["gap"] = -1.0
+        # Mutating the copy must not touch the original.
+        assert spec["project"]["drawing"]["layout"]["gap"] == 1.0

--- a/tests/programmatic_pid/test_profiles_extra.py
+++ b/tests/programmatic_pid/test_profiles_extra.py
@@ -75,9 +75,7 @@ class TestSpecImmutability:
         apply_profile(original, "compact")
         # Original layout values must be unchanged after applying a profile.
         assert original["project"]["drawing"]["layout"]["gap"] == snapshot["gap"]
-        assert (
-            original["defaults"]["instrument_bubble_radius"] == snapshot["bubble"]
-        )
+        assert original["defaults"]["instrument_bubble_radius"] == snapshot["bubble"]
         assert "meta" not in original  # meta is added to the copy only
 
     def test_independent_apply_calls(self) -> None:
@@ -108,9 +106,7 @@ class TestProfileMergeSemantics:
         spec = _full_spec()
         spec["project"]["drawing"]["layout"]["custom_extra"] = "keep me"
         result = apply_profile(spec, "presentation")
-        assert (
-            result["project"]["drawing"]["layout"]["custom_extra"] == "keep me"
-        )
+        assert result["project"]["drawing"]["layout"]["custom_extra"] == "keep me"
 
     def test_drawing_created_when_missing(self) -> None:
         spec = {"project": {"id": "P-1"}, "equipment": []}

--- a/tests/shared/python/upstream_drift_tools/data_processing/test_io_extra.py
+++ b/tests/shared/python/upstream_drift_tools/data_processing/test_io_extra.py
@@ -27,7 +27,6 @@ from upstream_drift_tools.data_processing.io import (
     FileFormatDetector,
 )
 
-
 # ── FileFormatDetector argument validation ───────────────────────────────
 
 

--- a/tests/shared/python/upstream_drift_tools/data_processing/test_io_extra.py
+++ b/tests/shared/python/upstream_drift_tools/data_processing/test_io_extra.py
@@ -1,0 +1,154 @@
+"""Additional behavioural tests for ``upstream_drift_tools.data_processing.io``.
+
+These tests target real edge-cases not covered in :mod:`test_io.py`:
+
+* Pickle CWE-502 rejection (read AND write paths).
+* Detection on PosixPath/WindowsPath with mixed-case suffix.
+* ``detect_format`` argument validation.
+* Empty/None DataFrame in writer.
+* Excel round-trip and TSV with explicit format override.
+* Reader explicit format override beating mismatched extension.
+* Reading an unrecognised extension with explicit override.
+* ``get_supported_extensions`` returns a stable list (no duplicates,
+  every entry has a leading dot).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pandas")
+import pandas as pd
+from upstream_drift_tools.data_processing.io import (
+    DataReader,
+    DataWriter,
+    FileFormatDetector,
+)
+
+
+# ── FileFormatDetector argument validation ───────────────────────────────
+
+
+class TestDetectFormatValidation:
+    def test_none_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="file_path"):
+            FileFormatDetector.detect_format(None)  # type: ignore[arg-type]
+
+    def test_path_with_mixed_case_suffix(self) -> None:
+        # Suffix ".CSV", ".CsV" etc. all map to csv.
+        assert FileFormatDetector.detect_format("dir/file.CsV") == "csv"
+        assert FileFormatDetector.detect_format("dir/file.JsOn") == "json"
+
+    def test_path_without_suffix(self) -> None:
+        assert FileFormatDetector.detect_format("README") is None
+        assert FileFormatDetector.detect_format("data") is None
+
+    def test_path_with_multiple_dots(self) -> None:
+        # Only the final suffix is considered.
+        assert FileFormatDetector.detect_format("archive.tar.csv") == "csv"
+        assert FileFormatDetector.detect_format("archive.csv.json") == "json"
+
+    def test_supported_extensions_well_formed(self) -> None:
+        exts = FileFormatDetector.get_supported_extensions()
+        assert len(exts) == len(set(exts)), "duplicate extension entries"
+        assert all(e.startswith(".") for e in exts), "extensions must start with a dot"
+        assert all(e == e.lower() for e in exts), "extensions must be lower-case"
+
+    def test_detect_handles_pure_path(self) -> None:
+        assert FileFormatDetector.detect_format(Path("/tmp/x.json")) == "json"
+
+
+# ── Pickle is forbidden in both reader and writer ────────────────────────
+
+
+class TestPickleSecurity:
+    """The module documents CWE-502 mitigation; both ends must refuse pickle."""
+
+    def test_reader_rejects_pickle_format(self, tmp_path: Path) -> None:
+        path = tmp_path / "data.bin"
+        path.write_bytes(b"not really pickle")
+        with pytest.raises(ValueError, match="Pickle"):
+            DataReader.read_file(path, format_type="pickle")
+
+    def test_writer_rejects_pickle_format(self, tmp_path: Path) -> None:
+        df = pd.DataFrame({"x": [1]})
+        with pytest.raises(ValueError, match="Pickle"):
+            DataWriter.write_file(df, tmp_path / "out.bin", format_type="pickle")
+
+
+# ── Writer rejects None DataFrame ────────────────────────────────────────
+
+
+class TestWriterValidation:
+    def test_none_dataframe_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="df"):
+            DataWriter.write_file(None, tmp_path / "out.csv")  # type: ignore[arg-type]
+
+
+# ── Explicit format override ─────────────────────────────────────────────
+
+
+class TestExplicitFormatOverride:
+    def test_explicit_tsv_format_overrides_csv_extension(self, tmp_path: Path) -> None:
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        path = tmp_path / "looks_like.csv"
+        DataWriter.write_file(df, path, format_type="tsv")
+        # File is actually tab-separated despite .csv suffix.
+        text = path.read_text()
+        assert "\t" in text
+        # Reading with the same explicit format must round-trip.
+        result = DataReader.read_file(path, format_type="tsv")
+        pd.testing.assert_frame_equal(df, result)
+
+    def test_explicit_format_with_unknown_extension(self, tmp_path: Path) -> None:
+        df = pd.DataFrame({"a": [1]})
+        path = tmp_path / "file.weird"
+        DataWriter.write_file(df, path, format_type="csv")
+        result = DataReader.read_file(path, format_type="csv")
+        pd.testing.assert_frame_equal(df, result)
+
+    def test_explicit_unknown_format_raises(self, tmp_path: Path) -> None:
+        df = pd.DataFrame({"a": [1]})
+        with pytest.raises(ValueError, match="Unsupported"):
+            DataWriter.write_file(df, tmp_path / "out.csv", format_type="bogus")
+
+
+# ── Round-trip extras ────────────────────────────────────────────────────
+
+
+class TestExcelRoundTrip:
+    """Excel round-trip — only when ``openpyxl`` is installed."""
+
+    def test_excel_roundtrip(self, tmp_path: Path) -> None:
+        pytest.importorskip("openpyxl")
+        df = pd.DataFrame({"col": [1, 2, 3], "name": ["a", "b", "c"]})
+        path = tmp_path / "data.xlsx"
+        DataWriter.write_file(df, path)
+        result = DataReader.read_file(path)
+        pd.testing.assert_frame_equal(df, result)
+
+
+class TestTSVDetected:
+    """``.txt`` should be auto-detected as TSV per the format map."""
+
+    def test_txt_treated_as_tsv(self, tmp_path: Path) -> None:
+        df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        path = tmp_path / "data.txt"
+        DataWriter.write_file(df, path)
+        # Confirm real tab separation.
+        assert "\t" in path.read_text()
+        result = DataReader.read_file(path)
+        pd.testing.assert_frame_equal(df, result)
+
+
+# ── Reader: format auto-detection failure with no override ───────────────
+
+
+class TestUnknownFormat:
+    def test_no_extension_no_override_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "noext"
+        path.write_text("a,b\n1,2\n")
+        with pytest.raises(ValueError, match="Unsupported"):
+            DataReader.read_file(path)


### PR DESCRIPTION
## Summary
Adds three new focused test modules (99 tests total, all passing) targeting under-covered edge cases. No production code or existing tests modified.

### New tests
- **`tests/programmatic_pid/test_geometry_extra.py`** (55 tests) — edge cases for `to_float` (bool/inf/object/list), `clamp` boundary cases, `closest_point_on_rect` (inside/edges/corners/unparseable coords), `rects_overlap` (touching, positive/negative pad, nested), `text_box` (all 9 alignments + zero-height + None align fallback), `distance` (zero/negative/symmetry), `dedupe_points` (1e-9 tolerance boundary, empty input, unparseable coords), `find_free_region` (empty occupied, blocked origin, search-radius cap, requested dimensions preserved).
- **`tests/programmatic_pid/test_profiles_extra.py`** (29 tests) — `apply_profile` name normalisation (case/whitespace insensitive), input-spec immutability and inter-call independence, merge semantics when `drawing`/`layout`/`defaults`/`meta` are missing or non-dict, preserved unrelated keys, monotonic compact<review invariant on every shared layout knob, preset key parity.
- **`tests/shared/python/upstream_drift_tools/data_processing/test_io_extra.py`** (15 tests) — `FileFormatDetector` argument validation (None raises, mixed-case suffix, multi-dot paths), pickle CWE-502 rejection on **both** read and write, None-DataFrame rejection in writer, explicit `format_type` override beats extension and handles unknown extensions, `.txt` -> TSV auto-detection round-trip, Excel round-trip via openpyxl, unknown-extension-no-override error path.

### Coverage focus
Tests verify real behaviour: correct outputs, error raising on bad inputs, immutability invariants, security guarantees (pickle CWE-502), and preset relative ordering. No metric gaming.

### Pre-existing failure (not from this PR)
`tests/programmatic_pid/test_profiles.py::test_apply_profile_compact_reduces_panel_size` fails on `main` with `NameError: name 'to_float' is not defined` (in `programmatic_pid.spec_loader.get_layout_config`). Unrelated to this PR; left untouched.

## Test plan
- [x] Each new test file passes in isolation under `pytest -p no:cacheprovider --no-cov`
- [x] Combined with original `test_geometry.py`, `test_profiles.py`, `test_io.py` — 143/144 pass (the one failure is the pre-existing main-branch issue noted above)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)