### PR TITLE
fix: register lower_body_model in tool manifest (#2425)

### DIFF
--- a/src/shared/python/gui_launcher/tool_manifest.yaml
+++ b/src/shared/python/gui_launcher/tool_manifest.yaml
@@ -164,6 +164,20 @@ tools:
         - numpy
       settings_app: InertiaCalculator
 
+  - tool_name: lower_body_model
+    name: Lower Body Model
+    description: Simulate and inspect lower-body MuJoCo kinematics and controls
+    category: Biomechanics
+    icon: accessibility
+    pyqt6:
+      module: lower_body_model.launch_pyqt6
+      class: ControlPanel
+      dependencies:
+        - PyQt6
+        - mujoco
+        - numpy
+      settings_app: LowerBodyModel
+
   - tool_name: multi_param_analysis
     name: Multi-Parameter Analysis
     description: Run multi-parameter sensitivity analysis with grid evaluation


### PR DESCRIPTION
## Summary

Registers the `lower_body_model` tool in `src/shared/python/gui_launcher/tool_manifest.yaml`, completing Phase 4.2 module registration. The tool's source code already exists under `src/lower_body_model/` but was missing from the launcher manifest, so the GUI launcher could not discover it.

The new entry mirrors the canonical `GUI_INFO` dict defined in `src/lower_body_model/gui_registration.py`:

- `tool_name`: `lower_body_model`
- `name`: Lower Body Model
- `description`: Simulate and inspect lower-body MuJoCo kinematics and controls
- `category`: Biomechanics
- `icon`: accessibility
- `pyqt6.module`: `lower_body_model.launch_pyqt6`
- `pyqt6.class`: `ControlPanel`
- `pyqt6.dependencies`: PyQt6, mujoco, numpy
- `pyqt6.settings_app`: LowerBodyModel

The entry is placed alphabetically between `inertia_calculator` and `multi_param_analysis`. Total registered tool count is now 21 (was 20).

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('src/shared/python/gui_launcher/tool_manifest.yaml'))"` -> parses cleanly
- `grep -c "^  - tool_name:" src/shared/python/gui_launcher/tool_manifest.yaml` -> `21`
- `python3 scripts/check_tools_manifest_layout.py` -> no issues reported

Closes #2425

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgAxsJ2n6qwQXa6KWP8pRA)_