### PR TITLE
ci: enforce 10% coverage floor matching CLAUDE.md policy (#2406)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -402,9 +402,9 @@ jobs:
           # producing `pytest: error: unrecognized arguments: --cov=.`.
           if [ -s changed_test_files.txt ]; then
             mapfile -t changed_test_files < changed_test_files.txt
-            python -m pytest "${changed_test_files[@]}" "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=0
+            python -m pytest "${changed_test_files[@]}" "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=10
           else
-            python -m pytest "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=0
+            python -m pytest "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=10
           fi
 
       - name: Provider-Contract Suite (Exported Packages)


### PR DESCRIPTION
## Summary

CLAUDE.md states the CI requirement is "pytest with **10% coverage minimum**, must not regress on touched files," but two pytest invocations in `.github/workflows/ci-standard.yml` were passing `--cov-fail-under=0`, effectively disabling enforcement. This PR raises both to `--cov-fail-under=10` so CI matches the documented baseline.

- Changed-files branch (line 405): `--cov-fail-under=0` → `--cov-fail-under=10`
- Core-tests branch (line 407): `--cov-fail-under=0` → `--cov-fail-under=10`
- The Provider-Contract Suite step (line 432) already enforces 10% — left unchanged.
- `[tool.coverage.report] fail_under = 30` in `pyproject.toml` is **higher** than the documented floor and was **not** lowered, per the guidance to only raise existing values.

## Why this is safe

- The Provider-Contract Suite has already been running at `--cov-fail-under=10` without issue.
- Repo-level `fail_under = 30` in `pyproject.toml` indicates current coverage clears 10% comfortably for the affected scope.
- This is the smallest possible step that aligns CI with already-documented policy.

## Refs

- Refs #2406 (do not close — issue tracks ratcheting toward higher targets such as 60%; this PR only implements the immediate, achievable baseline).

## Test plan

- [ ] CI `ci-standard` workflow runs and the changed-files pytest step still passes with the 10% floor.
- [ ] No other steps in `ci-standard.yml` are affected (diff is two lines).
- [ ] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-standard.yml'))"` — verified locally).

https://claude.ai/code/session_01BgAxsJ2n6qwQXa6KWP8pRA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgAxsJ2n6qwQXa6KWP8pRA)_