### PR TITLE
chore: ignore .claude/worktrees agent workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ slprj/
 *.cursor-chat
 .vscode/
 .idea/
+.claude/worktrees/
 
 # OS
 .DS_Store


### PR DESCRIPTION
## Summary

The Claude Code harness creates per-agent worktrees under `.claude/worktrees/` when running parallel sub-agents in isolation mode. These are local-only checkouts and should not be tracked in git.

This PR adds `.claude/worktrees/` to `.gitignore` (alongside the existing `.cursor/`, `.vscode/`, `.idea/` entries) so the directory stops showing up as untracked.

## Test plan

- [x] `git status` shows clean working tree after change
- [x] No effect on any tracked files


---
_Generated by [Claude Code](https://claude.ai/code/session_01BgAxsJ2n6qwQXa6KWP8pRA)_