### PR TITLE
ci: enforce detect-secrets baseline on every PR (#2407)

### DIFF
--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -1,0 +1,46 @@
+name: Detect Secrets
+
+# Enforces the detect-secrets baseline: any new secret introduced by a PR
+# (or push to main) that is not already audited in `.secrets.baseline`
+# will cause this job to fail.
+#
+# See issue #2407 (Credential and secret management hardening).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install detect-secrets
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install detect-secrets
+
+      - name: Scan against baseline
+        run: |
+          detect-secrets scan --baseline .secrets.baseline
+
+      - name: Fail if baseline changed (new secret detected)
+        run: |
+          git diff --exit-code .secrets.baseline


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow `.github/workflows/detect-secrets.yml` that enforces the `.secrets.baseline` audited in PR #2391/#2399. On every `pull_request` and on pushes to `main`, the workflow:

- checks out the repo with `fetch-depth: 0`
- sets up Python 3.12 via `actions/setup-python@v5`
- `pip install detect-secrets`
- runs `detect-secrets scan --baseline .secrets.baseline`
- runs `git diff --exit-code .secrets.baseline` so the job fails when the scan introduces a new finding not already audited in the baseline

The job runs on `ubuntu-latest` (fast portable check, no self-hosted runner needed) with a 5-minute timeout and a concurrency group that cancels duplicate runs on the same ref.

## Scope / guardrails

- Additive only: a single new workflow file, no changes to existing CI workflows.
- `.secrets.baseline` is not modified.
- No pre-commit hook is added (out of scope for this PR).

## Refs

Refs #2407 (Credential and secret management hardening). Does not close — the issue scope is broader (e.g. baseline hygiene, pre-commit, docs).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/detect-secrets.yml'))"` parses cleanly
- [x] Local `detect-secrets scan --baseline .secrets.baseline` runs without error
- [ ] Workflow runs green on this PR after merge of any baseline-hygiene fixes
- [ ] Verify the workflow fails as expected when a synthetic secret is added in a follow-up test PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01BgAxsJ2n6qwQXa6KWP8pRA)_