### PR TITLE
fix(lint): resolve ruff warnings in validate_mypy_exclusions.py and tests

### DIFF
--- a/scripts/validate_mypy_exclusions.py
+++ b/scripts/validate_mypy_exclusions.py
@@ -41,7 +41,7 @@ def count_affected_files(patterns: set[str]) -> dict[str, int]:
 
         try:
             out = subprocess.run(cmd, capture_output=True, text=True, check=True)
-            count = len([l for l in out.stdout.splitlines() if l.strip()])
+            count = len([ln for ln in out.stdout.splitlines() if ln.strip()])
         except subprocess.CalledProcessError:
             count = 0
 
@@ -83,7 +83,7 @@ def main() -> int:
     # Validate no phantom exclusions
     phantoms = [p for p, c in results.items() if c == 0 and not p.endswith("tests/")]
     if phantoms:
-        print(f"\n⚠️  Phantom exclusions found (0 files matched):")
+        print("\n⚠️  Phantom exclusions found (0 files matched):")
         for p in phantoms:
             print(f"   - {p}")
 
@@ -100,7 +100,7 @@ def main() -> int:
         mypy_dirs = {p for p in patterns if p.startswith("src/") or p.startswith("tools/")}
         overlap = mypy_dirs & ruff_excluded
         if overlap:
-            print(f"\n🔍 Directories excluded by BOTH mypy and ruff:")
+            print("\n🔍 Directories excluded by BOTH mypy and ruff:")
             for o in sorted(overlap):
                 print(f"   - {o}")
 

--- a/scripts/validate_mypy_exclusions.py
+++ b/scripts/validate_mypy_exclusions.py
@@ -5,6 +5,7 @@ Design-by-Contract:
   - PRE: mypy.ini exists and is parseable
   - POST: Returns 0 if config is valid, 1 otherwise
 """
+
 from __future__ import annotations
 
 import re
@@ -97,7 +98,9 @@ def main() -> int:
             if line.startswith("src/") or line.startswith("tools/"):
                 ruff_excluded.add(line)
 
-        mypy_dirs = {p for p in patterns if p.startswith("src/") or p.startswith("tools/")}
+        mypy_dirs = {
+            p for p in patterns if p.startswith("src/") or p.startswith("tools/")
+        }
         overlap = mypy_dirs & ruff_excluded
         if overlap:
             print("\n🔍 Directories excluded by BOTH mypy and ruff:")

--- a/tests/test_mypy_exclusion_cleanup.py
+++ b/tests/test_mypy_exclusion_cleanup.py
@@ -3,6 +3,7 @@
 These tests verify that the mypy exclusion audit script correctly identifies
 phantom exclusions and calculates coverage impact.
 """
+
 from __future__ import annotations
 
 import sys
@@ -22,9 +23,7 @@ class TestParseMypyExcludes:
     def test_extracts_patterns_from_valid_ini(self, tmp_path: Path) -> None:
         ini = tmp_path / "mypy.ini"
         ini.write_text(
-            "[mypy]\n"
-            "exclude = (\\.*/tests/|src/foo\\.py)\n"
-            "warn_return_any = True\n"
+            "[mypy]\nexclude = (\\.*/tests/|src/foo\\.py)\nwarn_return_any = True\n"
         )
         patterns = vma.parse_mypy_excludes(ini)
         # strip("\\") removes the leading backslash from \.*/tests/
@@ -80,11 +79,7 @@ class TestMainSmoke:
 
     def test_main_returns_zero_on_valid_ini(self, tmp_path: Path) -> None:
         ini = tmp_path / "mypy.ini"
-        ini.write_text(
-            "[mypy]\n"
-            "exclude = (\\.*/tests/)\n"
-            "warn_return_any = True\n"
-        )
+        ini.write_text("[mypy]\nexclude = (\\.*/tests/)\nwarn_return_any = True\n")
         with patch.object(vma, "REPO_ROOT", tmp_path):
             rc = vma.main()
         assert rc == 0

--- a/tests/test_mypy_exclusion_cleanup.py
+++ b/tests/test_mypy_exclusion_cleanup.py
@@ -67,7 +67,9 @@ class TestCountAffectedFiles:
         """A pattern matching real tracked files should report >0."""
         fake_output = "src/data_processing/__init__.py\nsrc/data_processing/cli.py\n"
         with patch.object(
-            vma.subprocess, "run", return_value=MagicMock(stdout=fake_output, returncode=0)
+            vma.subprocess,
+            "run",
+            return_value=MagicMock(stdout=fake_output, returncode=0),
         ):
             results = vma.count_affected_files({"src/data_processing/"})
         assert results["src/data_processing/"] == 2


### PR DESCRIPTION
This PR addresses four ruff lint warnings in the mypy exclusion audit script and its tests.

## Changes
- **scripts/validate_mypy_exclusions.py**:
  - Replace ambiguous variable name `l` with `ln` (E741)
  - Remove extraneous f-string prefixes on static strings (F541)
  - Add trailing newline (W292)
- **tests/test_mypy_exclusion_cleanup.py**:
  - Fix line-too-long in mock setup by splitting across lines (E501)
  - Add trailing newline (W292)

## Verification
- [x] `ruff check scripts/validate_mypy_exclusions.py tests/test_mypy_exclusion_cleanup.py` passes cleanly
- [x] No runtime behavior changes
- [x] Changes are minimal and focused

## Related
Contributes to overall code-quality maintenance.