### PR TITLE
docs(developer-experience): improve onboarding, plugin system, and add docstrings (closes #2414)

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -210,8 +210,53 @@ Tools/
 | `QUICKSTART.md` | Quick reference for common tasks |
 | `requirements.txt` | Core Python dependencies |
 | `pyproject.toml` | Package metadata (name, version, entry points) |
-| `tools.json` | Registry of available tools |
-| `docs/PLUGIN_SYSTEM.md` | How tool discovery works |
+| `tools.json` | Registry of available tools (centralized, explicit ordering) |
+| `src/<tool>/tool_manifest.json` | Per-tool auto-discovery manifest |
+| `src/<tool>/gui_registration.py` | PyQt6 launcher metadata for a tool |
+| `docs/architecture/PLUGIN_SYSTEM.md` | Full plugin system reference |
+
+## Plugin System and Tool Registration
+
+Tools are registered with the launcher in two ways:
+
+### Auto-discovery (recommended for new tools)
+
+Drop a `tool_manifest.json` in the tool directory:
+
+```json
+{
+  "name": "My Tool",
+  "path": "launch_pyqt6.py",
+  "type": "python",
+  "description": "Brief description",
+  "category": "Development Tools"
+}
+```
+
+The launcher scans `src/` for these files at startup and includes them automatically.
+
+### Centralized registry (`tools.json`)
+
+Edit the root `tools.json` to add a tool with explicit ordering:
+
+```json
+{
+  "Development Tools": [
+    {
+      "name": "My Tool",
+      "path": "src/my_tool/launch_pyqt6.py",
+      "type": "python",
+      "desc": "Brief description"
+    }
+  ]
+}
+```
+
+### PyQt6 launcher integration (`gui_registration.py`)
+
+Every tool that opens a PyQt6 window must have a `gui_registration.py` in its root directory. This file exposes a `get_gui_info()` function returning the module path, widget class, dependencies, and minimum window size. See the full reference in [`docs/architecture/PLUGIN_SYSTEM.md`](architecture/PLUGIN_SYSTEM.md).
+
+---
 
 ## Making Your First Change
 
@@ -400,7 +445,7 @@ git commit -m "Your message"
 1. **Read the architecture**: `docs/ARCHITECTURE_OVERVIEW.md`
 2. **Build a simple tool**: Follow `docs/BUILD_A_TOOL.md` tutorial
 3. **Understand governance**: Read `CLAUDE.md` (critical for shared library work)
-4. **Check the plugin system**: `docs/PLUGIN_SYSTEM.md`
+4. **Check the plugin system**: `docs/architecture/PLUGIN_SYSTEM.md`
 5. **Review coding standards**: `docs/development/GUARDRAILS_GUIDELINES.md`
 
 ## Getting Help

--- a/docs/architecture/PLUGIN_SYSTEM.md
+++ b/docs/architecture/PLUGIN_SYSTEM.md
@@ -4,81 +4,357 @@
 
 The Tools repository supports two methods for tool registration:
 
-1. **Centralized Registration** (`tools.json`) - Manual, explicit tool registration
-2. **Automatic Discovery** (`tool_manifest.json`) - Automatic tool discovery via manifest files
+1. **Centralized Registration** (`tools.json`) — Manual, explicit tool registration
+2. **Automatic Discovery** (`tool_manifest.json`) — Per-tool manifest files for auto-discovery
 
-## Automatic Tool Discovery
+Both methods are supported simultaneously. Discovered tools are merged with `tools.json` entries at launcher startup.
 
-Tools can be automatically discovered by placing a `tool_manifest.json` file in their directory. This eliminates the need to manually edit `tools.json` when adding new tools.
+---
 
-### Creating a Tool Manifest
+## Manifest Format Reference
 
-Create a `tool_manifest.json` file in your tool's directory:
+### `tool_manifest.json` (per-tool auto-discovery)
+
+Place this file in the tool's root directory (e.g. `src/my_tool/tool_manifest.json`):
 
 ```json
 {
   "name": "My Awesome Tool",
-  "path": "main.py",
+  "path": "launch_pyqt6.py",
   "type": "python",
   "description": "A tool that does amazing things",
   "category": "Development Tools"
 }
 ```
 
-### Manifest Fields
+**Fields:**
 
-- **`name`** (required): Display name for the tool
-- **`path`** (optional): Relative path to the tool's entry point. If omitted, the system will search for `*.py` files in the directory
-- **`type`** (optional, default: `"python"`): Tool type (`python`, `matlab`, `web`, `browser`, `bat`)
-- **`description`** (optional): Tool description shown in the launcher
-- **`category`** (optional, default: `"Development Tools"`): Category for grouping tools
+| Field | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `name` | Yes | string | — | Display name shown in the launcher |
+| `path` | No | string | auto-detected | Relative path to the tool's entry point. Omit to let the system scan for `*.py` files |
+| `type` | No | string | `"python"` | Tool type: `python`, `matlab`, `web`, `browser`, `bat` |
+| `description` | No | string | `""` | Short description shown in the launcher tooltip |
+| `category` | No | string | `"Development Tools"` | Category for grouping tools in the launcher UI |
 
-### Example: Folder Tool Manifest
+### `tools.json` (centralized registry)
+
+The root `tools.json` groups tools by category. Each entry has:
 
 ```json
 {
-  "name": "Folder Packer Pro",
-  "path": "folder_packer_pro.py",
+  "Category Name": [
+    {
+      "name": "Tool Display Name",
+      "path": "src/my_tool/launch_pyqt6.py",
+      "type": "python",
+      "desc": "Short description"
+    }
+  ]
+}
+```
+
+**Fields:**
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | Yes | string | Display name |
+| `path` | Yes | string | Path relative to repo root |
+| `type` | Yes | string | `python`, `matlab`, `web`, `browser`, `bat` |
+| `desc` | No | string | Short description |
+
+---
+
+## GUI Registration (`gui_registration.py`)
+
+Every PyQt6 tool that appears in the unified launcher must expose a `gui_registration.py`
+module at its root directory. This file provides metadata the launcher uses to
+instantiate the tool's window.
+
+### Required Contract
+
+```python
+"""GUI registration for My Tool."""
+
+from __future__ import annotations
+from typing import Any
+
+GUI_INFO = {
+    "name": "My Tool",                   # Display name in the launcher
+    "tool_name": "my_tool",              # Unique snake_case identifier
+    "description": "Does something useful",
+    "category": "Process Simulation",    # Launcher tab/group
+    "icon": "wrench",                    # Icon name (see src/shared/python/icon_utils.py)
+    "pyqt6": {
+        "module": "my_tool.python.my_tool.ui.pyqt6.main_window",  # Fully-qualified module
+        "class": "MyToolWidget",          # Class to instantiate
+        "dependencies": ["PyQt6", "numpy"],
+        "settings_app": "MyTool",         # QSettings app name
+        "min_size": [900, 600],           # [width, height] in pixels
+    },
+    "web": {                             # Optional: omit if no web interface
+        "port": 5175,
+        "auto_open_browser": True,
+    },
+}
+
+
+def get_gui_info() -> dict[str, Any]:
+    """Return GUI registration information."""
+    return GUI_INFO
+```
+
+**Key requirements:**
+- The `get_gui_info()` function is the only public API the launcher calls
+- `tool_name` must be unique across all tools (the launcher uses it as a key)
+- `pyqt6.module` must be importable after `pip install -e .` or `python3 _bootstrap.py`
+- `pyqt6.class` must be a `QWidget` subclass that can be instantiated with no arguments
+
+---
+
+## Tool Discovery Flow
+
+```
+UnifiedToolsLauncher startup
+         │
+         ├─► Load tools.json  (centralized registry)
+         │         │
+         │         └─► Build initial tool list
+         │
+         ├─► Scan src/ for tool_manifest.json  (auto-discovery)
+         │         │
+         │         └─► Merge discovered tools into tool list
+         │                (duplicate names are deduplicated — tools.json wins)
+         │
+         ├─► Load gui_registration.py for each PyQt6 tool
+         │         │
+         │         └─► Populate launcher tabs with GUI_INFO metadata
+         │
+         └─► Present launcher UI
+```
+
+---
+
+## Adding a New Tool (Step-by-Step)
+
+### 1. Create the Tool Directory
+
+```bash
+mkdir -p src/my_tool/python/my_tool/ui/pyqt6
+touch src/my_tool/__init__.py
+touch src/my_tool/python/my_tool/__init__.py
+touch src/my_tool/python/my_tool/ui/__init__.py
+touch src/my_tool/python/my_tool/ui/pyqt6/__init__.py
+```
+
+### 2. Implement Core Logic
+
+```python
+# src/my_tool/python/my_tool/core.py
+"""Core calculation logic for My Tool."""
+
+from __future__ import annotations
+
+
+def calculate(inputs: dict) -> dict:
+    """Run the main calculation.
+
+    Args:
+        inputs: Dict with validated input parameters.
+
+    Returns:
+        Dict with calculation results.
+
+    Raises:
+        ValueError: If inputs fail validation.
+    """
+    # ... implementation ...
+    return {"result": 42.0}
+```
+
+### 3. Create the PyQt6 Main Window
+
+```python
+# src/my_tool/python/my_tool/ui/pyqt6/main_window.py
+"""PyQt6 main window for My Tool."""
+
+from __future__ import annotations
+import logging
+from PyQt6.QtWidgets import QWidget, QVBoxLayout, QLabel
+
+logger = logging.getLogger(__name__)
+
+
+class MyToolWidget(QWidget):
+    """Main window widget for My Tool."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("My Tool")
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("My Tool"))
+```
+
+### 4. Create `launch_pyqt6.py`
+
+```python
+# src/my_tool/launch_pyqt6.py
+"""Entry-point for launching My Tool as a standalone PyQt6 application."""
+
+from __future__ import annotations
+import logging
+import sys
+from pathlib import Path
+
+# Bootstrap: add repo paths before any package imports
+_root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_root / "src" / "shared" / "python"))
+sys.path.insert(0, str(_root / "src"))
+
+from upstream_drift_tools.bootstrap import ensure_paths
+ensure_paths(_root)
+
+from PyQt6.QtWidgets import QApplication
+from my_tool.ui.pyqt6.main_window import MyToolWidget
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Launch My Tool."""
+    logging.basicConfig(level=logging.INFO)
+    app = QApplication(sys.argv)
+    window = MyToolWidget()
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()
+```
+
+### 5. Create `gui_registration.py`
+
+See the [GUI Registration](#gui-registration-gui_registrationpy) section above for the required format.
+
+### 6. Create `tool_manifest.json`
+
+```json
+{
+  "name": "My Tool",
+  "path": "launch_pyqt6.py",
   "type": "python",
-  "description": "Project archiving and distribution tool",
+  "description": "Does something useful",
   "category": "Development Tools"
 }
 ```
 
-## Using the Plugin Manager
+### 7. Add to `tools.json` (Optional)
 
-The `PluginManager` class provides methods for tool discovery:
+If you want explicit control over ordering in the launcher:
 
-```python
-from pathlib import Path
-from python.src.core.plugin_manager import PluginManager
-
-repo_root = Path(__file__).parent
-manager = PluginManager(repo_root)
-
-# Load tools with automatic discovery
-tools = manager.load_tools_with_discovery()
-
-# Or scan for tools only
-discovered = manager.scan_for_tools()
+```json
+{
+  "Development Tools": [
+    {
+      "name": "My Tool",
+      "path": "src/my_tool/launch_pyqt6.py",
+      "type": "python",
+      "desc": "Does something useful"
+    }
+  ]
+}
 ```
 
-## Migration Path
+### 8. Write Tests
 
-1. **Existing tools**: Continue using `tools.json` (fully supported)
-2. **New tools**: Add `tool_manifest.json` for automatic discovery
-3. **Gradual migration**: Both methods work together - discovered tools are merged with `tools.json` entries
+```bash
+mkdir -p tests/my_tool
+touch tests/my_tool/__init__.py
+touch tests/my_tool/test_core.py
+touch tests/my_tool/test_contracts.py
+```
 
-## Benefits
+Contract tests guard the public API surface that downstream repos depend on:
 
-- **No manual registration**: Tools are discovered automatically
-- **Self-documenting**: Manifest files document tool metadata
-- **Version control friendly**: Each tool manages its own manifest
-- **Backward compatible**: Existing `tools.json` continues to work
+```python
+# tests/my_tool/test_contracts.py
+import pytest
+from my_tool.core import calculate
 
-## Future Enhancements
+@pytest.mark.contract
+def test_calculate_returns_dict():
+    """calculate() must always return a dict — downstream repos depend on this."""
+    result = calculate({"input": 1.0})
+    assert isinstance(result, dict)
+    assert "result" in result
+```
 
-- Support for `tool_manifest.yaml` format
-- Automatic icon discovery
-- Dependency declaration in manifests
-- Tool versioning and compatibility checks
+### 9. Validate CI Requirements
+
+```bash
+# Lint and format
+python3 -m ruff check .
+python3 -m ruff format .
+
+# Type checking
+python3 -m mypy src/my_tool/
+
+# Tests
+python3 -m pytest tests/my_tool/ -v -m "unit or contract"
+```
+
+---
+
+## Automatic Discovery vs Manual Registration
+
+| Aspect | `tool_manifest.json` | `tools.json` |
+|--------|---------------------|--------------|
+| Location | Per-tool directory | Repo root |
+| Ordering | Not guaranteed | Explicit |
+| Maintenance | Zero (self-describing) | Manual update required |
+| Discovery | Automatic at startup | Loaded once at startup |
+| Duplicates | Deduplicated (tools.json wins) | Authoritative |
+| Use case | New tools, rapid iteration | Stable tools needing ordered position |
+
+**Recommendation:** Use `tool_manifest.json` for new tools. Add to `tools.json` only
+if you need to control ordering or the tool is part of a stable public API.
+
+---
+
+## Troubleshooting
+
+### Tool does not appear in the launcher
+
+1. Check `tool_manifest.json` exists in the tool's root directory
+2. Check `tools.json` has an entry with the correct path
+3. Verify `launch_pyqt6.py` is executable: `python3 src/my_tool/launch_pyqt6.py`
+4. Check for import errors: `python3 -c "from my_tool.ui.pyqt6.main_window import MyToolWidget"`
+
+### ImportError when launching
+
+Most likely the bootstrap path is wrong. Check:
+
+```python
+# In launch_pyqt6.py, ensure _root points to the repo root:
+_root = Path(__file__).resolve().parents[2]  # adjust depth!
+# src/my_tool/launch_pyqt6.py → parents[0]=my_tool, parents[1]=src, parents[2]=repo root
+```
+
+### Tool launches but crashes
+
+Use the shared logger (never `print()`):
+
+```python
+import logging
+logger = logging.getLogger(__name__)
+logger.exception("Tool crashed: %s", e)
+```
+
+Run with `PYTHONPATH` set to see full tracebacks:
+```bash
+PYTHONPATH=src:src/shared/python python3 src/my_tool/launch_pyqt6.py
+```

--- a/src/shared/python/data_processing/processor.py
+++ b/src/shared/python/data_processing/processor.py
@@ -75,6 +75,7 @@ class DataProcessor:
 
     @dataframe.setter
     def dataframe(self, value: pd.DataFrame) -> None:
+        """Replace the working DataFrame directly (used by tests and pipeline code)."""
         self._df = value
 
     @property

--- a/src/shared/python/programmatic_pid/spec_loader.py
+++ b/src/shared/python/programmatic_pid/spec_loader.py
@@ -54,15 +54,22 @@ class SpecAccessor:
 
     @property
     def spec(self) -> SpecDict:
+        """Return the raw specification dictionary."""
         return self._spec
 
     @property
     def project(self) -> dict[str, Any]:
+        """Return the top-level ``project`` section, or an empty dict if absent."""
         p = self._spec.get("project")
         return p if isinstance(p, dict) else {}
 
     @property
     def drawing(self) -> dict[str, Any]:
+        """Return the drawing configuration dict.
+
+        Checks ``spec["drawing"]`` first, then ``spec["project"]["drawing"]``.
+        Returns an empty dict when neither is present.
+        """
         d = self._spec.get("drawing")
         if isinstance(d, dict):
             return d
@@ -92,6 +99,11 @@ class SpecAccessor:
 
     @property
     def layer_config(self) -> dict[str, Any]:
+        """Return the layer configuration dict.
+
+        Checks ``drawing["layers"]`` then falls back to ``spec["layers"]``.
+        Returns an empty dict when no layer config is defined.
+        """
         drawing = self.drawing
         layers = drawing.get("layers")
         if isinstance(layers, dict) and layers:
@@ -103,6 +115,11 @@ class SpecAccessor:
 
     @property
     def layout_config(self) -> dict[str, Any]:
+        """Return the layout configuration dict with validated defaults.
+
+        All numeric values are clamped to safe minima so downstream
+        rendering code never has to guard against nonsensical values.
+        """
         drawing = self.drawing
         layout = drawing.get("layout", {})
         if not isinstance(layout, dict):
@@ -141,31 +158,37 @@ class SpecAccessor:
 
     @property
     def defaults(self) -> dict[str, Any]:
+        """Return the ``defaults`` section, or an empty dict if absent."""
         d = self._spec.get("defaults", {})
         return d if isinstance(d, dict) else {}
 
     @property
     def equipment(self) -> list[dict[str, Any]]:
+        """Return the list of equipment entries, or ``[]`` if absent."""
         v = self._spec.get("equipment")
         return cast(list[dict[str, Any]], v) if isinstance(v, list) else []
 
     @property
     def instruments(self) -> list[dict[str, Any]]:
+        """Return the list of instrument entries, or ``[]`` if absent."""
         v = self._spec.get("instruments")
         return cast(list[dict[str, Any]], v) if isinstance(v, list) else []
 
     @property
     def streams(self) -> list[dict[str, Any]]:
+        """Return the list of process stream entries, or ``[]`` if absent."""
         v = self._spec.get("streams")
         return cast(list[dict[str, Any]], v) if isinstance(v, list) else []
 
     @property
     def control_loops(self) -> list[dict[str, Any]]:
+        """Return the list of control loop entries, or ``[]`` if absent."""
         v = self._spec.get("control_loops")
         return cast(list[dict[str, Any]], v) if isinstance(v, list) else []
 
     @property
     def interlocks(self) -> list[dict[str, Any]]:
+        """Return the list of interlock entries, or ``[]`` if absent."""
         v = self._spec.get("interlocks")
         return cast(list[dict[str, Any]], v) if isinstance(v, list) else []
 # ---------------------------------------------------------------------------
@@ -173,14 +196,35 @@ class SpecAccessor:
 # These are kept so that generator.py continues to work during migration.
 # ---------------------------------------------------------------------------
 def get_project(spec: SpecDict) -> dict[str, Any]:
+    """Return the ``project`` section from *spec*, or an empty dict.
+
+    Deprecated: use ``SpecAccessor(spec).project`` instead.
+    """
     p = spec.get("project")
     return p if isinstance(p, dict) else {}
+
+
 def get_drawing(spec: SpecDict) -> dict[str, Any]:
+    """Return the drawing configuration dict from *spec*.
+
+    Checks ``spec["drawing"]`` first, then ``spec["project"]["drawing"]``.
+
+    Deprecated: use ``SpecAccessor(spec).drawing`` instead.
+    """
     if "drawing" in spec and isinstance(spec["drawing"], dict):
         return spec["drawing"]
     d = get_project(spec).get("drawing")
     return cast(dict[str, Any], d) if isinstance(d, dict) else {}
+
+
 def ensure_drawing(spec: SpecDict) -> dict[str, Any]:
+    """Return or create the drawing dict inside *spec* (mutates *spec*).
+
+    Ensures that ``spec["project"]["drawing"]`` exists and returns it.
+    Used during spec preparation before rendering.
+
+    Deprecated: use ``SpecAccessor`` for read-only access instead.
+    """
     if "drawing" in spec and isinstance(spec["drawing"], dict):
         return spec["drawing"]
     project = spec.setdefault("project", {})
@@ -189,7 +233,16 @@ def ensure_drawing(spec: SpecDict) -> dict[str, Any]:
         drawing = {}
         project["drawing"] = drawing
     return cast(dict[str, Any], drawing)
+
+
 def get_text_config(spec: SpecDict) -> dict[str, float]:
+    """Return text height configuration as a plain dict.
+
+    Returns keys: ``title_height``, ``subtitle_height``, ``body_height``,
+    ``small_height`` (all floats in drawing units).
+
+    Deprecated: use ``SpecAccessor(spec).text_config`` instead.
+    """
     tc = SpecAccessor(spec).text_config
     return {
         "title_height": tc.title_height,
@@ -197,7 +250,19 @@ def get_text_config(spec: SpecDict) -> dict[str, float]:
         "body_height": tc.body_height,
         "small_height": tc.small_height,
     }
+
+
 def get_layout_config(spec: SpecDict) -> dict[str, Any]:
+    """Return the layout configuration dict with validated defaults.
+
+    Deprecated: use ``SpecAccessor(spec).layout_config`` instead.
+    """
     return SpecAccessor(spec).layout_config
+
+
 def get_layer_config(spec: SpecDict) -> dict[str, Any]:
+    """Return the layer configuration dict.
+
+    Deprecated: use ``SpecAccessor(spec).layer_config`` instead.
+    """
     return SpecAccessor(spec).layer_config

--- a/src/shared/python/programmatic_pid/types.py
+++ b/src/shared/python/programmatic_pid/types.py
@@ -29,6 +29,7 @@ class ValidationIssue:
     severity: str = "error"
 
     def to_dict(self) -> dict[str, str]:
+        """Serialize to a plain dict suitable for JSON output."""
         return {"path": self.path, "message": self.message, "severity": self.severity}
 
 


### PR DESCRIPTION
## Summary

- **PLUGIN_SYSTEM.md** rewritten from a short overview into a full developer reference: manifest field tables for both `tool_manifest.json` and `tools.json`, the `gui_registration.py` contract with a complete annotated example, a tool discovery flow diagram, a step-by-step guide for adding a new tool (directory structure → core logic → PyQt6 window → `launch_pyqt6.py` → `gui_registration.py` → manifest → CI validation), and a troubleshooting section for the most common issues
- **ONBOARDING.md** fixed a stale link (`docs/PLUGIN_SYSTEM.md` → `docs/architecture/PLUGIN_SYSTEM.md`) and added a "Plugin System and Tool Registration" section so a new developer understands auto-discovery vs centralized registry without needing to find the architecture doc separately
- **Docstrings** added to the public API surface that was missing them:
  - `SpecAccessor` properties: `spec`, `project`, `drawing`, `layer_config`, `layout_config`, `defaults`, `equipment`, `instruments`, `streams`, `control_loops`, `interlocks`
  - Backward-compat free functions: `get_project`, `get_drawing`, `ensure_drawing`, `get_text_config`, `get_layout_config`, `get_layer_config` — each notes its `SpecAccessor` equivalent
  - `ValidationIssue.to_dict()` in `types.py`
  - `DataProcessor.dataframe` setter in `data_processing/processor.py`

## Test plan

- [ ] New developer follows ONBOARDING.md from prerequisites through first change — verify steps are accurate
- [ ] Developer follows PLUGIN_SYSTEM.md "Adding a New Tool" guide — verify the tool appears in the launcher
- [ ] `python3 -m ruff check src/shared/python/programmatic_pid/ src/shared/python/data_processing/processor.py` — no new violations introduced (pre-existing F821 in spec_loader.py are unchanged)
- [ ] `python3 -m pytest tests/ -m unit -n auto -q` passes

Closes #2414

🤖 Generated with [Claude Code](https://claude.com/claude-code)