### PR TITLE
fix(architecture): fix import path collisions and add namespace isolation (closes #2405)

### DIFF
--- a/src/data_processing/__init__.py
+++ b/src/data_processing/__init__.py
@@ -1,0 +1,5 @@
+"""Data processing tools namespace package.
+
+Contains:
+  - data_processor: Signal processing and time-series analysis tool
+"""

--- a/src/document_processing/__init__.py
+++ b/src/document_processing/__init__.py
@@ -1,0 +1,5 @@
+"""Document processing tools namespace package.
+
+Contains:
+  - pdf_renamer: Intelligent PDF file renaming tool
+"""

--- a/src/media_processing/__init__.py
+++ b/src/media_processing/__init__.py
@@ -1,0 +1,6 @@
+"""Media processing tools namespace package.
+
+Contains:
+  - audio_processor: Audio processing utilities
+  - video_processor: Video processing utilities
+"""

--- a/src/pendulum_simulator/perf_test.py
+++ b/src/pendulum_simulator/perf_test.py
@@ -6,8 +6,8 @@ import time
 
 import numpy as np
 
-from src.double_pendulum_golf.physics import PendulumParams
-from src.double_pendulum_golf.simulation import make_polynomial_torque, run_simulation
+from double_pendulum_golf.physics import PendulumParams
+from double_pendulum_golf.simulation import make_polynomial_torque, run_simulation
 
 logger = logging.getLogger(__name__)
 

--- a/src/pendulum_simulator/test_sim.py
+++ b/src/pendulum_simulator/test_sim.py
@@ -6,8 +6,8 @@ import traceback
 
 import numpy as np
 
-from src.double_pendulum_golf.physics import PendulumParams
-from src.double_pendulum_golf.simulation import make_polynomial_torque, run_simulation
+from double_pendulum_golf.physics import PendulumParams
+from double_pendulum_golf.simulation import make_polynomial_torque, run_simulation
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ torque_func = make_polynomial_torque(
     [0],  # wrist
 )
 
-print("Running simulation...")  # noqa: T201
+logger.info("Running simulation...")
 try:
     result = run_simulation(
         params=params,
@@ -42,13 +42,11 @@ try:
         torque_func=torque_func,
         dt=0.005,
     )
-    print("✓ Simulation succeeded!")  # noqa: T201
-    print(f"  Steps: {result.n_steps}")  # noqa: T201
-    print(f"  Time range: {result.t[0]:.3f} to {result.t[-1]:.3f} s")  # noqa: T201
-    print(f"  Initial state: {result.states[0]}")  # noqa: T201
-    print(f"  Final state: {result.states[-1]}")  # noqa: T201
+    logger.info("Simulation succeeded!")
+    logger.info("  Steps: %d", result.n_steps)
+    logger.info("  Time range: %.3f to %.3f s", result.t[0], result.t[-1])
+    logger.info("  Initial state: %s", result.states[0])
+    logger.info("  Final state: %s", result.states[-1])
 except Exception as e:
-    print(f"✗ Simulation failed: {e}")  # noqa: T201
-    import traceback
-
+    logger.exception("Simulation failed: %s", e)
     traceback.print_exc()

--- a/src/python/tests/test_logger_utils.py
+++ b/src/python/tests/test_logger_utils.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from src.logger_utils import DEFAULT_SEED, set_seeds
+from logger_utils import DEFAULT_SEED, set_seeds
 
 
 class TestLoggerUtils:
@@ -33,6 +33,6 @@ class TestLoggerUtils:
         # ModuleNotFoundError (raised when None is in sys.modules) inherits from
         # ImportError
         with patch.dict(sys.modules, {"numpy": None}):
-            with patch("src.logger_utils.logger") as mock_logger:
+            with patch("logger_utils.logger") as mock_logger:
                 set_seeds()
                 mock_logger.warning.assert_called_once()


### PR DESCRIPTION
## Summary

Addresses the top actionable namespace/import collision issues from AUDIT_REPORT_2405.md and COLLISION_REPORT_2405.md. Focused on the 5 highest-impact collision points rather than a full rewrite.

### Changes

**1. Fix broken `src.` prefix imports in pendulum_simulator scripts**

`perf_test.py` and `test_sim.py` both imported with `from src.double_pendulum_golf import ...`, which only resolves if pytest is run from `src/pendulum_simulator/`. The canonical path — already set up by `conftest.py` injecting `src/pendulum_simulator/src/` into `sys.path` — is `from double_pendulum_golf import ...`. Fixed both files.

**2. Replace `print()` with `logging` in test_sim.py**

`test_sim.py` used `print()` with `# noqa: T201` suppression comments. CLAUDE.md rule: "No `print()` in `src/` — use logging". Replaced all 6 print statements with `logger.info()` / `logger.exception()`.

**3. Add `__init__.py` to category namespace directories**

`src/data_processing/`, `src/document_processing/`, and `src/media_processing/` are category parent directories (each contains one or more tool subdirectories) that were missing `__init__.py`. Without them, Python treats these as implicit namespace packages — which is fragile and causes IDE/import ambiguity. Adding `__init__.py` makes the package boundary explicit.

**4. Fix import and patch path in test_logger_utils.py**

`from src.logger_utils import ...` only works if `src/python/` is the CWD. Since `src/python/src/` is on `pythonpath` in `pyproject.toml`, the module resolves as `logger_utils`. Fixed the import and the `patch("src.logger_utils.logger")` target.

## Test plan

- [ ] `python3 -m ruff check src/pendulum_simulator/ src/data_processing/ src/document_processing/ src/media_processing/ src/python/tests/` — no violations
- [ ] `python3 -m ruff format --check` on changed files — no diffs
- [ ] `python3 -m pytest tests/ -m unit -n auto -q` — passes
- [ ] `python3 -m pytest src/pendulum_simulator/tests/ -v` — passes (if mujoco available)
- [ ] `python3 -c "import data_processing; import document_processing; import media_processing"` — no ImportError

Closes #2405

🤖 Generated with [Claude Code](https://claude.com/claude-code)