### PR TITLE
docs(architecture): add ADRs 002-006 covering module structure, API stability, formatter, plugins, and type safety (closes #2421)

### DIFF
--- a/docs/adr/ADR-002-shared-library-module-structure.md
+++ b/docs/adr/ADR-002-shared-library-module-structure.md
@@ -1,0 +1,123 @@
+# ADR-002: Shared Library and Module Namespace Structure
+
+- Status: Accepted
+- Date: 2026-05-01
+- Decision Makers: Tools maintainers
+- Related Issues/PRs: #2421, #2405
+
+## Context
+
+Tools is a shared engineering library consumed by two downstream repos:
+UpstreamDrift and Gasification_Model. Early development placed utilities
+in ad-hoc locations across the repository, creating ambiguous import paths
+and frequent import collisions when downstream repos updated their
+`sys.path` configurations.
+
+The key tensions were:
+
+1. **Discoverability vs. encapsulation** — a flat namespace is easy to
+   browse but invites circular imports across domains (e.g.
+   `signal_processing` pulling from `calculators`).
+2. **Monorepo convenience vs. package discipline** — developers naturally
+   reach for relative imports, but downstream consumers install the package
+   via `pip install ud-tools` and cannot rely on repo-relative paths.
+3. **Single package vs. multiple packages** — splitting into many packages
+   (one per domain) would enforce boundaries mechanically but increases
+   distribution and versioning overhead.
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A[Multiple ad-hoc modules] --> B{Namespace strategy?}
+    B -->|Flat namespace| C[Easy imports]
+    B -->|Layered namespace| D[Clear boundaries]
+    C --> E[Circular import risk]
+    D --> F[Enforced by LOD rule]
+    E --> G[Fragile downstream]
+    F --> H[Single installable package]
+    H --> I[Decision: Layered namespace under upstream_drift_tools]
+    G --> I
+```
+
+## Decision
+
+All shared library code lives under
+`src/shared/python/upstream_drift_tools/` and is distributed as the
+`ud-tools` pip package. The namespace is structured by domain:
+
+- `upstream_drift_tools.calculators` — unit-conversion and thermo calcs
+- `upstream_drift_tools.process_calculators` — process engineering calcs
+- `upstream_drift_tools.data_processing` — data IO and transformation
+- `upstream_drift_tools.utils` — cross-cutting utilities (logging, env)
+- `upstream_drift_tools.ui` — shared PyQt6 widgets and mixins
+- `upstream_drift_tools.theme` — plotting and visualization themes
+
+Modules within a domain may import from `upstream_drift_tools.utils` but
+must not import across domain boundaries (e.g. `calculators` must not
+import from `process_calculators`). This is the Law of Demeter (LOD)
+enforcement documented in CLAUDE.md.
+
+A top-level `contracts.py` re-exports the full Design-by-Contract (DbC)
+API so callers use `from contracts import require` without depending on
+internal paths.
+
+## Alternatives Considered
+
+1. **Multiple pip packages** (one per domain): Rejected — downstream repos
+   would need to manage independent version pins for each domain, and
+   cross-domain utility sharing would require a separate `tools-core`
+   package, increasing coordination overhead.
+2. **Flat single-level namespace**: Rejected — demonstrated in early
+   prototypes to cause circular import failures as the codebase grew past
+   20 modules.
+3. **Namespace packages (no `__init__.py`)**: Rejected — implicit namespace
+   packages make it harder to enforce `__all__` exports and break mypy's
+   type-stub discovery.
+
+## Component Diagram
+
+```mermaid
+graph TD
+    subgraph "ud-tools package"
+        UD[upstream_drift_tools]
+        UD --> CALC[calculators]
+        UD --> PROC[process_calculators]
+        UD --> DP[data_processing]
+        UD --> UTL[utils]
+        UD --> UI[ui]
+        UD --> TH[theme]
+        CALC --> UTL
+        PROC --> UTL
+        DP --> UTL
+        UI --> UTL
+        TH --> UTL
+    end
+    subgraph "Downstream"
+        UDF[UpstreamDrift]
+        GM[Gasification_Model]
+    end
+    UDF -->|pip install ud-tools| UD
+    GM -->|pip install ud-tools| UD
+```
+
+## Consequences
+
+- Positive: Downstream repos use stable `upstream_drift_tools.*` import
+  paths; `pip install ud-tools` gives them the whole library at a single
+  version.
+- Positive: LOD boundaries are checkable in CI via import-graph tests
+  (`tests/architecture/test_layer_boundaries.py`).
+- Negative: Adding a new domain requires creating a subdirectory,
+  `__init__.py`, a manifest entry, and a `py.typed` marker — more ceremony
+  than ad-hoc file additions.
+- Follow-up: Manifest CI validation (`manifests/`) ensures new modules are
+  registered before they reach downstream consumers. See #2405.
+
+## Validation
+
+- `tests/test_cross_repo_import_compatibility.py` — verifies every symbol
+  in `upstream_drift_tools.__all__` is importable.
+- `tests/architecture/test_layer_boundaries.py` — enforces that cross-domain
+  imports violating LOD are absent.
+- `pytest -m contract` — guards public API surface against regressions.

--- a/docs/adr/ADR-003-api-stability-policy.md
+++ b/docs/adr/ADR-003-api-stability-policy.md
@@ -1,0 +1,112 @@
+# ADR-003: API Stability and Backwards-Compatibility Policy
+
+- Status: Accepted
+- Date: 2026-05-01
+- Decision Makers: Tools maintainers
+- Related Issues/PRs: #2421, #2420
+
+## Context
+
+Tools is a shared library with two active downstream consumers
+(UpstreamDrift and Gasification_Model) that cannot always update
+simultaneously. Any change to a public function signature, return type, or
+exception behaviour is a breaking change for at least one downstream repo.
+
+Before this ADR there was no documented policy for:
+
+- What counts as a breaking change.
+- How long a deprecation period must last before removal.
+- How downstream repos are notified and coordinated.
+- How the API surface is mechanically tested.
+
+The result was accidental regressions discovered only when downstream CI
+failed after a Tools update was merged.
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A[Proposed public API change] --> B{Is it additive-only?}
+    B -->|Yes| C[Safe — no coordination needed]
+    B -->|No| D{Deprecation path exists?}
+    D -->|No| E[Block PR — add deprecation shim first]
+    D -->|Yes| F{Downstream PRs opened?}
+    F -->|No| E
+    F -->|Yes| G[Merge in coordinated release]
+    C --> H[Update __all__ + contract tests]
+    G --> H
+    H --> I[Merge to main]
+```
+
+## Decision
+
+### What Counts as a Breaking Change
+
+Any of the following to a symbol listed in `upstream_drift_tools.__all__`
+or exported from `src/contracts.py`:
+
+- Removing or renaming a function, class, or module.
+- Adding a required parameter to a function.
+- Changing a return type incompatibly (e.g. `float` → `list[float]`).
+- Changing an exception type raised for a documented error condition.
+- Removing a field from a Pydantic model used as a return type.
+
+Additive changes (new optional parameters with defaults, new fields in
+response models, new symbols in `__all__`) are not breaking.
+
+### Deprecation Protocol
+
+1. Add a `DeprecationWarning` shim that calls the new implementation.
+2. Update the docstring: `.. deprecated:: <version> Use <replacement>.`
+3. Keep the shim for **at least one minor release cycle** (one sprint).
+4. Open tracking issues in UpstreamDrift and Gasification_Model.
+5. Link those issues in the Tools PR description.
+6. Merge the removal PR only after downstream PRs are merged and closed.
+
+### Contract Tests
+
+Every public API function must have a `@pytest.mark.contract` test that:
+
+- Verifies the function is importable from `upstream_drift_tools`.
+- Calls the function with valid inputs and checks the return type.
+- Verifies expected exceptions are raised for invalid inputs.
+
+Contract tests live in `tests/contract/` or alongside the module in a
+`tests/` subdirectory. They run in CI as a required check.
+
+### Mechanical Enforcement
+
+The file `tool_surface_contract.json` snapshots all public API signatures.
+CI compares the current snapshot to `main` and fails if a signature has
+been removed or modified without a corresponding deprecation shim.
+
+## Alternatives Considered
+
+1. **Semantic Versioning with major bumps for breakage**: Rejected for a
+   shared library pinned by path/symlink rather than PyPI version — bumping
+   a major version does not automatically force downstream update.
+2. **No formal policy (rely on developer discipline)**: Rejected — caused
+   at least three uncoordinated regressions in the six months before this
+   ADR.
+3. **API freeze (no changes ever)**: Rejected — the library is actively
+   developed and the cost of a freeze outweighs the stability benefit.
+
+## Consequences
+
+- Positive: Downstream repos can trust that `pytest -m contract` passing
+  on Tools main means they will not break on update.
+- Positive: Deprecation shims give downstream teams a clear migration path
+  with a concrete deadline.
+- Negative: PR authors must open issues in two other repos for every
+  breaking change — more coordination overhead.
+- Negative: The `tool_surface_contract.json` snapshot must be regenerated
+  whenever a new public symbol is added, creating a small maintenance task.
+- Follow-up: Automate snapshot regeneration in a pre-commit hook. See #2420.
+
+## Validation
+
+- `pytest -m contract` — must pass on every PR.
+- `tool_surface_contract.json` diff check in CI — blocks any PR that
+  silently removes or renames a public symbol.
+- Cross-repo integration tests (`tests/integration/test_cross_repo_contracts.py`)
+  — import and call key APIs to catch signature drift before downstream CI runs.

--- a/docs/adr/ADR-004-ruff-formatter.md
+++ b/docs/adr/ADR-004-ruff-formatter.md
@@ -1,0 +1,99 @@
+# ADR-004: Ruff Format Over Black for Code Formatting
+
+- Status: Accepted
+- Date: 2026-05-01
+- Decision Makers: Tools maintainers
+- Related Issues/PRs: #2421
+
+## Context
+
+Python formatting tooling was previously a mix of Black (in some CI
+checks) and ad-hoc style guidelines (in others), leading to spurious diffs
+on every PR when contributors used different local formatters.
+
+The repository also uses Ruff as its primary linter (`ruff check`). Having
+two separate tools — Ruff for linting and Black for formatting — meant two
+separate installs, two separate CI steps, and two separate configuration
+files (`pyproject.toml` for Black settings, `ruff.toml` for lint rules).
+
+Black 24.x and Ruff format target the same 88-character line length and
+produce near-identical output for the overwhelming majority of code. The
+question was whether to consolidate on Ruff format or keep Black.
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A[Need canonical formatter] --> B{Already using Ruff for lint?}
+    B -->|Yes| C[Evaluate ruff format]
+    B -->|No| D[Evaluate Black standalone]
+    C --> E{Output compatible with Black?}
+    E -->|Yes, >99% identical| F[Consolidate on ruff format]
+    E -->|No| D
+    D --> G[Two-tool CI overhead]
+    F --> H[Single tool, single config]
+    H --> I[Decision: ruff format]
+    G --> J[Rejected]
+```
+
+## Decision
+
+Use `ruff format` (not Black) as the sole Python formatter across the
+entire repository. Configuration lives in `ruff.toml`:
+
+```toml
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+```
+
+Line length is 88 characters (matches historical Black default).
+
+CI runs two separate Ruff steps:
+1. `ruff check .` — linting (zero violations required).
+2. `ruff format --check .` — formatting (zero diffs required).
+
+Both steps must pass before a PR is mergeable.
+
+## Alternatives Considered
+
+1. **Black**: Near-identical output but requires a separate install and
+   `pyproject.toml` `[tool.black]` section. Rejected to eliminate
+   redundancy — Ruff format is already present as a dependency of
+   `ruff check`.
+2. **autopep8**: More conservative formatter; does not enforce a consistent
+   style for blank lines and trailing commas. Rejected — produces more
+   reviewer noise than opinionated formatters.
+3. **No enforced formatter (manual style)**: Rejected — proven by
+   experience to produce style debates in PR reviews and non-reproducible
+   diffs.
+4. **YAPF**: Highly configurable but slower and less integrated with the
+   existing Ruff toolchain. Rejected.
+
+## Consequences
+
+- Positive: Single tool (`ruff`) for both linting and formatting; one
+  config file (`ruff.toml`); one `pip install ruff` in CI.
+- Positive: `ruff format` is significantly faster than Black on large
+  files, reducing CI wall-clock time.
+- Positive: Output is Black-compatible, so contributors familiar with
+  Black see no surprises.
+- Negative: A small number of edge-case formatting differences between
+  Ruff format and Black exist (mainly around magic trailing commas and
+  string normalization). Contributors switching from Black projects may see
+  minor diffs on first run.
+- Negative: Ruff format is newer and its output may change across Ruff
+  versions — pinning `ruff` in `requirements-lock.txt` mitigates churn.
+- Follow-up: Pin `ruff` version in CI to avoid unexpected formatting
+  changes on Ruff upgrades.
+
+## Validation
+
+- `ruff format --check .` in CI — zero-diff requirement enforced on every
+  PR.
+- Pre-commit hook (optional, local): `ruff format .` before commit to avoid
+  CI failures.
+- `ruff check .` — linting step validates that `T201` (no `print()` in
+  `src/`) and other rules remain clean after formatting.

--- a/docs/adr/ADR-005-plugin-discovery-vs-registry.md
+++ b/docs/adr/ADR-005-plugin-discovery-vs-registry.md
@@ -1,0 +1,105 @@
+# ADR-005: Plugin Discovery vs. Centralized Registry
+
+- Status: Accepted
+- Date: 2026-05-01
+- Decision Makers: Tools maintainers
+- Related Issues/PRs: #2421
+
+## Context
+
+The Tools launcher must present every available tool in its UI. Early
+versions used a single hand-maintained `tools.json` file that catalogued
+every tool with its launch path, type, and description.
+
+As the repository grew to 30+ tools, `tools.json` became a merge-conflict
+hot-spot: every new tool required a PR that touched the registry file,
+conflicting with other in-flight PRs. Tool authors also frequently forgot
+to update the registry, leading to tools that existed in `src/` but were
+invisible to the launcher.
+
+The alternative — automatic filesystem discovery — risks picking up
+in-progress or incomplete tools that are not ready to surface.
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A[Add new tool to repo] --> B{Discovery strategy?}
+    B -->|Central registry only| C[Must edit tools.json]
+    B -->|Auto-discovery only| D[Picks up incomplete tools]
+    B -->|Both supported| E[Opt-in via tool_manifest.json]
+    C --> F[Merge conflicts]
+    D --> G[Noisy launcher]
+    E --> H[Tool author controls visibility]
+    F --> I[Rejected]
+    G --> I
+    H --> J[Decision: Dual-mode]
+```
+
+## Decision
+
+Support two registration modes simultaneously, merged at launcher startup:
+
+1. **Centralized registry** (`tools.json` in repo root) — explicit,
+   manually maintained, grouped by category. Used for stable tools and for
+   overriding display metadata.
+2. **Per-tool manifest** (`tool_manifest.json` in each tool's root
+   directory) — opt-in auto-discovery. A tool is discovered if and only if
+   it provides this file.
+
+Discovered tools are merged with `tools.json` at startup. If both sources
+contain an entry for the same tool (matched by launch path), the
+`tools.json` entry takes precedence, allowing global overrides of
+descriptions and categories without modifying per-tool files.
+
+Manifest CI validation (the `manifests/` directory and associated CI check)
+ensures that any new Python module added to `src/` either has a
+`tool_manifest.json` or an entry in `tools.json` before the PR is merged.
+
+## Alternatives Considered
+
+1. **Centralized registry only**: The original approach. Rejected because
+   it required every tool author to touch a shared file, creating merge
+   conflicts and forgotten registrations.
+2. **Auto-discovery only**: Rejected because incomplete or experimental
+   tools in `src/` would appear in the launcher before they are ready.
+3. **Entry-point plugins** (Python `importlib.metadata` entry points):
+   Rejected — requires `pip install -e .` for every tool, which is
+   incompatible with the current symlink-based development workflow.
+
+## Component Diagram
+
+```mermaid
+graph LR
+    subgraph "Launcher startup"
+        R[tools.json] --> M[Merge]
+        D[Scan for tool_manifest.json] --> M
+        M --> L[Launcher UI]
+    end
+    subgraph "CI"
+        V[Manifest validator] -->|fail if missing| PR[PR check]
+    end
+```
+
+## Consequences
+
+- Positive: New tools opt in to discovery by adding a single JSON file;
+  no shared file to conflict on.
+- Positive: `tools.json` remains the authoritative override for
+  display metadata, keeping global consistency without per-tool churn.
+- Positive: Manifest CI check prevents invisible tools and enforces
+  documentation discipline.
+- Negative: Two discovery mechanisms means the launcher code must handle
+  merge-conflict resolution logic (path-based deduplication).
+- Negative: Developers must remember that adding a `tool_manifest.json`
+  immediately makes the tool visible to all launcher users — premature
+  exposure is possible.
+- Follow-up: Add a `"status": "experimental"` field to `tool_manifest.json`
+  to allow hiding incomplete tools from the default launcher view.
+
+## Validation
+
+- Manifest CI check in `.github/workflows/` — rejects PRs adding modules
+  without a manifest or `tools.json` entry.
+- Launcher startup test — verifies merged tool list contains expected
+  entries and has no duplicates.

--- a/docs/adr/ADR-006-type-safety-mypy-strict.md
+++ b/docs/adr/ADR-006-type-safety-mypy-strict.md
@@ -1,0 +1,97 @@
+# ADR-006: Type Safety Enforcement with mypy and py.typed
+
+- Status: Accepted
+- Date: 2026-05-01
+- Decision Makers: Tools maintainers
+- Related Issues/PRs: #2421
+
+## Context
+
+Tools is a shared library. Downstream repos (UpstreamDrift,
+Gasification_Model) increasingly use type checkers (mypy, pyright) in
+their own CI pipelines. Without a `py.typed` marker and accurate type
+annotations in Tools, downstream type checkers treat the entire package as
+untyped (`Any`), silently losing type safety at the boundary.
+
+The codebase had partial annotations applied inconsistently — some modules
+were fully annotated, others had none. Running mypy in strict mode on the
+full repo produced hundreds of errors.
+
+The dilemma: requiring strict mode immediately would block all PRs until
+every file was annotated (months of work), but leaving type checking
+optional meant the annotation backlog would grow indefinitely.
+
+## Decision Flow
+
+```mermaid
+flowchart TD
+    A[Partial annotations] --> B{mypy strategy?}
+    B -->|Strict on all files| C[Blocks all PRs immediately]
+    B -->|No enforcement| D[Backlog grows forever]
+    B -->|Delta enforcement| E[Strict on changed files only]
+    E --> F[mypy_baseline.json tracks known errors]
+    F --> G[New files must be clean]
+    G --> H[Existing errors addressed incrementally]
+    C --> I[Rejected]
+    D --> I
+    H --> J[Decision: Delta enforcement + baseline]
+```
+
+## Decision
+
+Adopt a **delta enforcement** model:
+
+1. `src/py.typed` marker is present — downstream type checkers treat the
+   package as typed.
+2. mypy runs in strict mode on **changed files only** (delta CI step).
+   A PR that modifies a file must leave that file mypy-clean.
+3. `mypy_baseline.json` tracks known pre-existing errors in unmodified
+   files. The baseline count must not increase on any PR.
+4. New files added to `src/` must pass mypy strict with zero errors — no
+   grandfathering for new code.
+5. Pydantic models are used for all public API request/response types
+   (`calc_backend/contracts/`). Pydantic's runtime validation and
+   mypy plugin integration give both static and runtime type safety at API
+   boundaries.
+
+The `mypy.ini` configuration enables strict mode with a small set of
+pragmatic exclusions for third-party libraries that lack stubs.
+
+## Alternatives Considered
+
+1. **Full strict mode immediately**: Rejected — would have required 3+
+   months of annotation work before any feature PRs could merge.
+2. **No type checking**: Rejected — downstream repos began seeing `Any`
+   bleed from Tools into their own type graphs, masking real bugs.
+3. **pyright instead of mypy**: Evaluated — pyright is faster and stricter,
+   but mypy has broader plugin support (Pydantic, SQLAlchemy) and is the
+   tool most contributors already have configured locally. Deferred; can
+   revisit after annotation coverage improves.
+4. **Gradual typing with `# type: ignore` annotations**: Rejected as a
+   primary strategy — suppression comments mask errors permanently rather
+   than tracking them transparently.
+
+## Consequences
+
+- Positive: `py.typed` marker means downstream repos get accurate type
+  information from Tools immediately.
+- Positive: Delta enforcement keeps the PR review loop fast while
+  preventing the annotation debt from growing.
+- Positive: Pydantic models at API boundaries catch type mismatches at
+  runtime even if static analysis is incomplete.
+- Negative: The baseline mechanism requires discipline — developers must
+  not artificially inflate `mypy_baseline.json` to hide new errors.
+- Negative: `mypy --strict` on some older modules produces cascading
+  errors from missing `Optional` annotations; touched files require
+  non-trivial annotation work.
+- Follow-up: Track annotation coverage with `mypy --txt-report` in CI;
+  set a coverage floor that must not regress. See `MYPY_BASELINE_REPORT.md`.
+
+## Validation
+
+- `mypy --strict` on changed files — enforced as a required CI step.
+- `mypy_baseline.json` error count check — PR fails if count increases.
+- `pytest -m contract` — Pydantic validation errors surface at test time
+  if API model types drift.
+- `src/py.typed` presence — verified by packaging tests to ensure
+  downstream type checkers activate typed mode.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,3 +20,8 @@ This directory stores architecture decisions for cross-tool boundaries and share
 | ADR | Status | Summary |
 | --- | --- | --- |
 | [ADR-001](ADR-001-monorepo-workspaces.md) | Accepted | Defines monorepo workspace package boundaries and dependency direction. |
+| [ADR-002](ADR-002-shared-library-module-structure.md) | Accepted | Why the current layered namespace structure was chosen over flat or multi-package alternatives. |
+| [ADR-003](ADR-003-api-stability-policy.md) | Accepted | Policy for backwards-compatible API changes, deprecation protocol, and contract test requirements. |
+| [ADR-004](ADR-004-ruff-formatter.md) | Accepted | Why ruff format was chosen over Black as the canonical Python formatter. |
+| [ADR-005](ADR-005-plugin-discovery-vs-registry.md) | Accepted | Dual-mode plugin registration: per-tool manifests merged with centralized tools.json. |
+| [ADR-006](ADR-006-type-safety-mypy-strict.md) | Accepted | Type safety enforcement strategy using mypy delta CI and py.typed marker. |


### PR DESCRIPTION
## Summary

- Adds 5 new Architecture Decision Records (`ADR-002` through `ADR-006`) in `docs/adr/`
- Updates `docs/adr/README.md` index table to reference all new ADRs
- ADRs cover: layered namespace module structure (002), backwards-compatible API stability policy (003), ruff format over Black rationale (004), dual-mode plugin discovery vs. centralized registry (005), and mypy delta enforcement with `py.typed` (006)

## ADRs Added

| ADR | Decision |
|-----|----------|
| ADR-002 | Layered `upstream_drift_tools.*` namespace over flat or multi-package alternatives |
| ADR-003 | Deprecation protocol and contract test requirements for API changes |
| ADR-004 | `ruff format` over Black — single tool, single config, same 88-char output |
| ADR-005 | Dual-mode plugin registration: per-tool `tool_manifest.json` + central `tools.json` |
| ADR-006 | mypy strict delta CI enforcement + `py.typed` marker for downstream type safety |

## Test plan

- [ ] All ADR markdown files render correctly on GitHub
- [ ] Mermaid diagrams in each ADR are syntactically valid
- [ ] `docs/adr/README.md` index table links resolve to correct files
- [ ] No Python files changed — ruff check/format not applicable to this PR

Closes #2421

🤖 Generated with [Claude Code](https://claude.com/claude-code)