### PR TITLE
fix(api): add mesh upload size limit and guaranteed temp file cleanup

### DIFF
--- a/.github/workflows/Jules-Archivist.yml
+++ b/.github/workflows/Jules-Archivist.yml
@@ -1,11 +1,29 @@
 name: Jules Archivist
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Archivist                               │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Delete remote branches prefixed with "jules/" after they are merged     │
+# │    (git push origin --delete <branch>)                                     │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Delete main, master, or any non-jules/* branch                          │
+# │  • Close or merge pull requests                                             │
+# │  • Commit new code or modify file contents                                 │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Only triggered on pull_request.closed+merged (via Control Tower)        │
+# │  • Only targets branches matching "jules/" prefix — other branches ignored │
+# │  • Gracefully skips on API rate-limit errors                               │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
 
-# Grants access to delete remote branches.
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Dispatcher: route to self-hosted if available.
@@ -50,6 +68,10 @@ jobs:
   archive-tasks:
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
+    # Grant write only at this job level — branch deletion requires contents: write.
+    # pick-runner needs no write access.
+    permissions:
+      contents: write  # delete merged jules/* branches
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -1,5 +1,23 @@
 name: Jules Assessment Generator (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Assessment Generator                    │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run code quality / assessment tools and write reports to docs/           │
+# │  • Commit assessment markdown files to main (via git-auto-commit)          │
+# │  • Open issues to track findings                                           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify source code — reports only                                       │
+# │  • Merge PRs or delete branches                                            │
+# │  • Trigger other autonomous workflows                                      │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower — not triggered on push     │
+# │  • Commits are limited to docs/assessments/ path                          │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -7,14 +25,18 @@ on:
   # schedule:
   #   - cron: "0 8 * * 0,4"  # Daily at midnight UTC (overnight window)
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   generate-assessments:
     runs-on: ubuntu-latest
+    # Grant write only at this job level — assessment commits and issue creation
+    # happen here.
+    permissions:
+      contents: write  # commit assessment reports to docs/assessments/
+      issues: write    # open tracking issues for findings
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -1,5 +1,25 @@
 name: Jules Assessment Remediator (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Assessment Remediator                   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Pick the top N assessment findings and create one PR per fix            │
+# │  • Push code changes to a new remediation/* branch                        │
+# │  • Close GitHub issues that are resolved by the automated fixes            │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │  • Exceed MAX_ISSUES_PER_RUN (10) fixes per execution                     │
+# │  • Delete branches other than merged remediation/* branches                │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Manual dispatch or scheduled (0 8 * * 0,4) — not triggered on push     │
+# │  • dry_run input available to preview without creating PRs                 │
+# │  • Concurrency lock prevents simultaneous remediation runs                 │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Automated issue remediation workflow for assessment-identified issues
 # Creates PRs with automated fixes for the top N most impactful issues
 
@@ -40,10 +60,9 @@ on:
     # Daily at 5 AM PST (13:00 UTC) - runs after overnight assessments complete
     - cron: "0 8 * * 0,4"
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 # Prevent multiple remediation runs simultaneously
 concurrency:
@@ -58,6 +77,12 @@ jobs:
   remediate:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Grant write only at this job level — remediation creates branches, pushes
+    # fixes, opens PRs, and closes resolved issues.
+    permissions:
+      contents: write      # create remediation branch and push fixes
+      pull-requests: write # open PR with automated fixes
+      issues: write        # close issues that are resolved by the fixes
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/Jules-Auto-Rebase.yml
+++ b/.github/workflows/Jules-Auto-Rebase.yml
@@ -1,5 +1,22 @@
 name: Jules Auto-Rebase (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Auto-Rebase                             │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Rebase open PRs that are behind main (force-push to feature branch)     │
+# │  • Apply the "needs-rebase" label to PRs with unresolvable merge conflicts │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Touch main or any protected branch                                       │
+# │  • Merge PRs or create new branches                                         │
+# │  • Delete branches, manage issues, or trigger other workflows               │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Dispatched only by Control Tower on a fixed schedule                    │
+# │  • Conflicts are labelled, not resolved — human author must resolve        │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Replaces Jules-Conflict-Fix workflow
 # Automatically rebases PRs that are behind main
 # Labels PRs that have actual merge conflicts for manual resolution
@@ -8,9 +25,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -55,6 +72,11 @@ jobs:
   auto-rebase-prs:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — rebasing pushes to feature branches
+    # and may add labels. pick-runner needs no write access.
+    permissions:
+      contents: write      # force-push rebased feature branch
+      pull-requests: write # apply labels to conflicted PRs
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Jules-Auto-Refactor.yml
+++ b/.github/workflows/Jules-Auto-Refactor.yml
@@ -1,5 +1,23 @@
 name: Jules Auto-Refactor (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Auto-Refactor                           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run ruff/isort/autoflake on files with the most linting issues          │
+# │  • Create a new jules/auto-refactor/* branch and push the fixes            │
+# │  • Open a pull request with the automated improvements                     │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge the PR it creates                                            │
+# │  • Delete branches, manage issues, or trigger other workflows              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower — not triggered on push     │
+# │  • PR requires human review before merge                                   │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Replaces Jules-Tech-Custodian workflow
 # Finds files with the most linting issues and auto-fixes them
 # Creates a PR with the automated improvements
@@ -8,9 +26,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -55,6 +73,11 @@ jobs:
   auto-refactor:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — branch creation, fix pushes, and PR
+    # opening happen here. pick-runner needs no write access.
+    permissions:
+      contents: write      # create jules/auto-refactor-* branch and push fixes
+      pull-requests: write # open PR with automated refactor improvements
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -1,5 +1,26 @@
 name: Jules Auto-Repair (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Auto-Repair                             │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Push commits directly to the failing feature branch (not main/master)   │
+# │  • Run ruff, autoflake, and mypy to apply automated lint/type fixes        │
+# │  • Comment on the associated PR with repair status                         │
+# │  • Optionally invoke the Jules AI API to generate targeted fixes           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push to main or master (protected-branch guard enforced in script)      │
+# │  • Open, close, or merge pull requests                                     │
+# │  • Create or delete branches beyond the target repair branch               │
+# │  • Exceed MAX_REPAIR_ATTEMPTS commits within REPAIR_WINDOW_HOURS           │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Max repair commits per branch per 72-hour window (MAX_REPAIR_ATTEMPTS)  │
+# │  • Protected-branch guard: refuses to touch main/master                    │
+# │  • Loop-prevention: concurrency group prevents parallel repairs per branch │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Re-enabled with proper safeguards against PR explosion.
 # This workflow uses the Jules API for intelligent fixes when simple linting isn't enough.
 #
@@ -35,9 +56,9 @@ on:
         default: "5"
         type: string
 
+# Least-privilege top level: no write access until the job that needs it.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   actions: read
   checks: read
 
@@ -90,6 +111,11 @@ jobs:
   intelligent-repair:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — this is the only job that pushes commits
+    # or comments on PRs. pick-runner needs no write access.
+    permissions:
+      contents: write      # push repair commits to the target branch
+      pull-requests: write # post repair-status comment on the associated PR
     # Prevent multiple repairs on same branch simultaneously
     concurrency:
       group: auto-repair-${{ inputs.branch || github.event.workflow_run.head_branch }}

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -1,5 +1,24 @@
 name: Jules Code Quality Fixer (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Code Quality Fixer                      │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Parse the latest Code Quality Review assessment and select top findings │
+# │  • Create jules/cq-fix-* branches and push automated fixes                 │
+# │  • Open PRs and update related GitHub issues                               │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │  • Delete branches or trigger other workflows                              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower                             │
+# │  • dry_run input available to preview without creating branches/PRs        │
+# │  • Concurrency lock prevents simultaneous fixer runs per repo              │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -15,10 +34,9 @@ on:
         default: false
         type: boolean
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 concurrency:
   group: jules-code-quality-fixer-${{ github.repository }}
@@ -67,6 +85,12 @@ jobs:
   fix-issues:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — branch creation, fix pushes, PR
+    # creation, and issue updates all happen here. pick-runner needs no write.
+    permissions:
+      contents: write      # create jules/cq-fix-* branch and push fixes
+      pull-requests: write # open PR for each quality fix
+      issues: write        # update related issue status
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -1,5 +1,23 @@
 name: Jules Code Quality Reviewer (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Code Quality Reviewer                   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Analyse recent commits and generate a code quality review report        │
+# │  • Commit the report to docs/assessments/ on main                         │
+# │  • Open GitHub issues to track findings                                    │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify application source code — report writing only                   │
+# │  • Create PRs (report goes directly to main via git-auto-commit)           │
+# │  • Delete branches or trigger other workflows                              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower                             │
+# │  • Report commit is scoped to docs/assessments/ path                     │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -13,14 +31,18 @@ on:
   # schedule:
   #   - cron: "0 8 * * 0,4"  # Daily at 3 AM UTC
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Grant write only at this job level — report commits and issue creation
+    # happen here. No write needed for runner selection.
+    permissions:
+      contents: write  # commit quality review report to docs/assessments/
+      issues: write    # open tracking issues for findings
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -1,19 +1,41 @@
 name: Jules Completist (Incomplete Implementation Auditor)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Completist                              │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Scan for TODO/FIXME, stub functions, and incomplete implementations     │
+# │  • Create GitHub issues for each incomplete item found                     │
+# │  • Optionally push completion commits to a jules/completist-* branch       │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │  • Delete branches or trigger other workflows                              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled (0 8 * * 0,4) or dispatched via Control Tower                │
+# │  • Issues are created for review before any code changes are merged        │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
   schedule:
     - cron: "0 8 * * 0,4" # Daily at 4 AM UTC
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   audit:
     runs-on: ubuntu-latest
+    # Grant write only at this job level.
+    permissions:
+      contents: write      # push completist fixes to jules/completist-* branch
+      pull-requests: write # open PR for completist fixes
+      issues: write        # create tracking issues for incomplete items
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -1,19 +1,40 @@
 name: Jules Comprehensive Assessment
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Comprehensive Assessment                │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run multi-dimensional assessment (A–O criteria) across the codebase     │
+# │  • Commit the assessment report to docs/assessments/ on main               │
+# │  • Open GitHub issues for each criterion below threshold                   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify application source code — assessment and report writing only     │
+# │  • Create PRs (assessment report committed directly to docs/)              │
+# │  • Delete branches or trigger other workflows                              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled (0 8 * * 0,4) or manual dispatch — not triggered on push     │
+# │  • Report commit scoped to docs/assessments/ path only                   │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   schedule:
     - cron: "0 8 * * 0,4" # Every 3 days at 5 AM PST (10 UTC) - cost optimized
   workflow_dispatch:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   comprehensive-assessment:
     name: Comprehensive Assessment & Audit
     runs-on: ubuntu-latest
+    # Grant write only at this job level.
+    permissions:
+      contents: write  # commit assessment report to docs/assessments/
+      issues: write    # open tracking issues for below-threshold criteria
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -1,5 +1,29 @@
 name: Jules Control Tower
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Control Tower                           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Read repository contents and workflow run status (top-level)             │
+# │  • Dispatch to worker sub-workflows via workflow_call (secrets: inherit)    │
+# │  • Read CI run results and check iteration limits                           │
+# │  • Route events to the appropriate worker workflow                          │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO (by itself):                                   │
+# │  • Push commits or create/delete branches directly                          │
+# │  • Open, close, or merge pull requests directly                             │
+# │  • Trigger or cancel other workflow runs directly                           │
+# │  • Write to issues or security events directly                              │
+# │  ──  Write permissions are granted only at the job level of the             │
+# │       worker workflow that actually requires them, not here.                │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Iteration limit: MAX_REPAIR_ITERATIONS=3 per MAX_ITERATIONS_WINDOW_HOURS │
+# │  • Bot-actor guard: push/PR events from jules-bot are dropped silently      │
+# │  • Protected-branch guard: main/master failures route to hotfix (no direct  │
+# │    push); non-main failures route to auto-repair with its own limits        │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   push:
     branches: [main]
@@ -18,12 +42,10 @@ concurrency:
   group: jules-control-tower-${{ github.repository }}
   cancel-in-progress: false
 
+# Least-privilege: this orchestrator only reads; write grants live in workers.
 permissions:
-  contents: write
-  pull-requests: write
-  actions: write
-  issues: write
-  security-events: write
+  contents: read
+  actions: read
   checks: read
 
 jobs:

--- a/.github/workflows/Jules-Documentation-Auditor.yml
+++ b/.github/workflows/Jules-Documentation-Auditor.yml
@@ -1,5 +1,24 @@
 name: Jules Documentation Auditor (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Documentation Auditor                   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Scan codebase for missing docstrings, documentation gaps, and           │
+# │    organisation issues                                                      │
+# │  • Create GitHub issues for documentation gaps found                       │
+# │  • Open a PR with automated docstring additions                            │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify application logic — documentation additions only                 │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Dispatched only via Control Tower on a fixed schedule                   │
+# │  • PR requires human review before merge                                   │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Nightly documentation audit workflow
 # Scans codebase for missing docstrings, documentation gaps, and organization issues
 # Creates issues or PRs for documentation improvements
@@ -8,10 +27,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -57,6 +75,12 @@ jobs:
     needs: pick-runner
     runs-on: self-hosted
     timeout-minutes: 60
+    # Grant write only at this job level — doc branch creation, PR opening, and
+    # issue creation happen here. pick-runner needs no write access.
+    permissions:
+      contents: write      # create docs/audit-* branch and push docstring additions
+      pull-requests: write # open PR for documentation improvements
+      issues: write        # create issues for documentation gaps
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -1,11 +1,32 @@
 name: Jules Documentation Scribe (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Documentation Scribe                    │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Create a new docs/update-* branch                                       │
+# │  • Dispatch Jules AI to update Google-style docstrings for changed .py     │
+# │    files (does not touch READMEs)                                          │
+# │  • Open a pull request targeting main with the docstring updates           │
+# │  • Delete the docs branch if Jules makes no changes                        │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main                                                   │
+# │  • Auto-merge the PR it creates                                            │
+# │  • Modify non-Python files or READMEs                                      │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Only triggered on push to main by non-bot actors (via Control Tower)    │
+# │  • Bot-actor guard in Control Tower prevents doc-scribe loops              │
+# │  • PR requires human review before merge                                   │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -51,6 +72,11 @@ jobs:
     needs: pick-runner
     runs-on: self-hosted
     timeout-minutes: 30
+    # Grant write only at this job level — branch creation, Jules dispatch, and
+    # PR creation all happen here. pick-runner needs no write access.
+    permissions:
+      contents: write      # create docs/update-* branch and push Jules changes
+      pull-requests: write # open the docstring-update PR
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -1,5 +1,24 @@
 name: Jules Hotfix-Creator (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Hotfix-Creator                          │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Create a new hotfix/* branch from the failed protected branch           │
+# │  • Push commits to that hotfix branch via Jules AI                         │
+# │  • Open a pull request targeting the failed branch (NOT auto-merged)       │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or master                                         │
+# │  • Auto-merge the PR it creates — human review is required                 │
+# │  • Delete branches or cancel other workflow runs                           │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Only triggered when CI fails on main/master (via Control Tower triage)  │
+# │  • PR must be manually reviewed and merged — no auto-merge configured      │
+# │  • Skips entirely if JULES_API_KEY is not configured                       │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Triggers when CI fails on protected branches (main/master)
 # Creates a hotfix branch, triggers Auto-Repair, and opens urgent PR
 
@@ -13,10 +32,9 @@ on:
         required: true
         type: string
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  actions: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -61,6 +79,11 @@ jobs:
   create-hotfix:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — hotfix branch creation and PR opening
+    # happen here. The pick-runner job needs no write access.
+    permissions:
+      contents: write      # create and push hotfix/* branch
+      pull-requests: write # open the urgent PR for human review
     steps:
       - name: Validate failed branch
         id: branch

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -1,5 +1,24 @@
 name: Jules Issue Resolver (Daily Priority Fixer)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Issue Resolver                          │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Select up to max_issues open GitHub issues and attempt automated fixes  │
+# │  • Create one jules/issue-* branch per fix and push the changes            │
+# │  • Open a pull request per issue and transition the issue to "In Review"   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │  • Delete branches or cancel other workflow runs                           │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Dispatched only by Control Tower on a fixed schedule                    │
+# │  • Concurrency lock prevents simultaneous resolver runs per repo           │
+# │  • max_issues (default 5) caps the number of issues addressed per run     │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -13,10 +32,9 @@ on:
   # schedule:
   #   - cron: "0 8 * * 0,4"  # Daily at 2:30 AM UTC (overnight window)
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 concurrency:
   group: jules-issue-resolver-${{ github.repository }}
@@ -65,6 +83,12 @@ jobs:
   resolve-issues:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — branch creation, fix pushes, PR
+    # creation, and issue updates all happen here. pick-runner needs no write.
+    permissions:
+      contents: write      # create jules/issue-* branch and push fixes
+      pull-requests: write # open PR for each resolved issue
+      issues: write        # transition issue status to "In Review"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -1,5 +1,26 @@
 name: Jules Sentinel (Security Audit)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Sentinel                                │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run pip-audit, bandit, and semgrep scanners (read-only analysis)        │
+# │  • Invoke Jules AI to interpret findings (READ-ONLY audit mode)            │
+# │  • Commit updated .jules/sentinel.md journal to main                      │
+# │  • Upload SARIF results to GitHub security-events (code scanning)         │
+# │  • Create GitHub issues for HIGH/MEDIUM severity findings                 │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify application source code — audit and document only               │
+# │  • Create PRs (automationMode: AUTO_CREATE_PR is explicitly disabled)      │
+# │  • Auto-merge or delete branches                                           │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower                             │
+# │  • Concurrency lock prevents simultaneous sentinel runs per repo           │
+# │  • Jules session created without AUTO_CREATE_PR to prevent PR cascade     │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -7,11 +28,9 @@ on:
   # schedule:
   #   - cron: "0 8 * * 0,4"  # Weekly on Mondays at 1:30 AM UTC (overnight window)
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  security-events: write
+  contents: read
 
 # HARDENING: Prevent concurrent runs
 concurrency:
@@ -61,6 +80,12 @@ jobs:
   security-audit:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level.
+    # Note: pull-requests: write intentionally omitted — Sentinel is read-only audit.
+    permissions:
+      contents: write          # commit .jules/sentinel.md journal to main
+      issues: write            # open tracking issues for HIGH/MEDIUM findings
+      security-events: write   # upload SARIF to GitHub code-scanning
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -27,9 +27,6 @@
       "name": "GitHubTokenDetector"
     },
     {
-      "name": "GitLabTokenDetector"
-    },
-    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -37,9 +37,6 @@
       "name": "IbmCosHmacDetector"
     },
     {
-      "name": "IPPublicDetector"
-    },
-    {
       "name": "JwtTokenDetector"
     },
     {
@@ -53,13 +50,7 @@
       "name": "NpmDetector"
     },
     {
-      "name": "OpenAIDetector"
-    },
-    {
       "name": "PrivateKeyDetector"
-    },
-    {
-      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -75,9 +66,6 @@
     },
     {
       "name": "StripeDetector"
-    },
-    {
-      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"

--- a/scripts/monolith_baseline.txt
+++ b/scripts/monolith_baseline.txt
@@ -92,6 +92,7 @@ src/shared/python/data_processing/tests/test_processor.py
 src/shared/python/gui_launcher/launcher.py
 src/shared/python/humanoid_character_builder/core/anthropometry.py
 src/shared/python/humanoid_character_builder/core/segment_definitions.py
+src/shared/python/humanoid_character_builder/generators/_makehuman_generator.py
 src/shared/python/humanoid_character_builder/generators/urdf_generator.py
 src/shared/python/humanoid_character_builder/interfaces/api.py
 src/shared/python/humanoid_character_builder/mesh/collision_generator.py

--- a/src/shared/python/humanoid_character_builder/generators/_makehuman_generator.py
+++ b/src/shared/python/humanoid_character_builder/generators/_makehuman_generator.py
@@ -22,12 +22,27 @@ _MAKEHUMAN_MODIFIER_RE = re.compile(r"^[A-Za-z0-9_./-]+$")
 
 
 def _single_quoted_python_literal(value: str) -> str:
-    """Serialize a string as a Python literal without exposing raw quote joins."""
+    """Serialize *value* as a single-quoted Python string literal.
+
+    All characters that would otherwise be syntactically significant inside a
+    Python string literal — backslashes, single quotes, carriage returns,
+    newlines, and null bytes — are replaced with their ``\\`` escape
+    sequences.  The result is always a syntactically valid Python expression
+    that can be embedded verbatim in generated source code.
+
+    Args:
+        value: Arbitrary string to serialize.
+
+    Returns:
+        A ``'…'`` Python string literal whose ``ast.literal_eval`` round-trip
+        recovers the original *value*.
+    """
     escaped = (
         value.replace("\\", "\\\\")
         .replace("'", "\\'")
         .replace("\r", "\\r")
         .replace("\n", "\\n")
+        .replace("\x00", "\\x00")
     )
     return f"'{escaped}'"
 
@@ -103,7 +118,7 @@ class MakeHumanMeshGenerator(MeshGeneratorInterface):
 
         try:
             return self._generate_via_api(
-                params, modifiers, visual_dir, collision_dir, **kwargs
+                params, modifiers, visual_dir, collision_dir, output_dir, **kwargs
             )
         except (ValueError, ZeroDivisionError, OverflowError, TypeError) as e:
             logger.warning(f"MakeHuman API generation failed: {e}")
@@ -125,6 +140,7 @@ class MakeHumanMeshGenerator(MeshGeneratorInterface):
         modifiers: dict[str, float],
         visual_dir: Path,
         collision_dir: Path,
+        base_output_dir: Path,
         **kwargs: Any,
     ) -> GeneratedMeshResult:
         """Generate meshes using MakeHuman Python API."""
@@ -132,7 +148,9 @@ class MakeHumanMeshGenerator(MeshGeneratorInterface):
         import subprocess
         import tempfile
 
-        script_content = self._create_makehuman_script(modifiers, visual_dir)
+        script_content = self._create_makehuman_script(
+            modifiers, visual_dir, base_output_dir=base_output_dir
+        )
         script_path = ""
 
         with tempfile.NamedTemporaryFile(
@@ -164,11 +182,36 @@ class MakeHumanMeshGenerator(MeshGeneratorInterface):
             Path(script_path).unlink(missing_ok=True)
 
     def _create_makehuman_script(
-        self, modifiers: dict[str, float], output_dir: Path
+        self,
+        modifiers: dict[str, float],
+        output_dir: Path,
+        base_output_dir: Path | None = None,
     ) -> str:
-        """Create a MakeHuman Python script for mesh generation."""
+        """Create a MakeHuman Python script for mesh generation.
+
+        All caller-controlled values embedded in the generated script are
+        serialized via :func:`_single_quoted_python_literal` so that shell
+        metacharacters, quote characters, and newlines cannot escape the
+        string literal context.
+
+        Args:
+            modifiers: Validated MakeHuman modifier key/value pairs.
+            output_dir: Directory where the generated OBJ will be written.
+                The export path embedded in the script is derived from this
+                value via ``Path.resolve()``.
+            base_output_dir: When provided, the resolved *output_dir* must be
+                contained within this directory.  Pass the caller-supplied root
+                ``output_dir`` to prevent path-traversal escapes from reaching
+                the generated script.
+
+        Returns:
+            Python source code string safe to write to a temporary file and
+            executed by the MakeHuman Python interpreter.
+        """
         assert modifiers is not None, "modifiers must be provided"
-        self._validate_makehuman_script_inputs(modifiers, output_dir)
+        self._validate_makehuman_script_inputs(
+            modifiers, output_dir, base_output_dir=base_output_dir
+        )
         export_path = str((output_dir / "humanoid.obj").resolve())
         export_path_literal = _single_quoted_python_literal(export_path)
         script = f"""
@@ -198,13 +241,56 @@ generate_human()
         return script
 
     @staticmethod
+    def _validate_output_path_within_base(output_path: Path, base: Path) -> None:
+        """Raise ``ValueError`` if *output_path* is not contained within *base*.
+
+        Both paths are resolved before comparison so that symlinks and ``..``
+        components cannot be used to escape the intended directory.
+
+        Args:
+            output_path: The candidate output path to validate.
+            base: The expected root directory that must contain *output_path*.
+
+        Raises:
+            ValueError: If *output_path* is not under *base*.
+        """
+        resolved_output = output_path.resolve()
+        resolved_base = base.resolve()
+        try:
+            resolved_output.relative_to(resolved_base)
+        except ValueError:
+            raise ValueError(
+                f"Output path {output_path!r} escapes the expected base directory"
+                f" {base!r}"
+            )
+
+    @staticmethod
     def _validate_makehuman_script_inputs(
-        modifiers: dict[str, float], output_dir: Path
+        modifiers: dict[str, float],
+        output_dir: Path,
+        base_output_dir: Path | None = None,
     ) -> None:
-        """Validate generated-script inputs before invoking MakeHuman."""
+        """Validate generated-script inputs before invoking MakeHuman.
+
+        Args:
+            modifiers: MakeHuman modifier key/value pairs to validate.
+            output_dir: The directory where the script will write output.
+            base_output_dir: When provided, the resolved *output_dir* must be
+                contained within this directory.  Prevents path-traversal
+                escapes from reaching the generated script.
+
+        Raises:
+            ValueError: For invalid modifier keys/values, if *output_dir*
+                exists but is not a directory, or if *output_dir* escapes
+                *base_output_dir*.
+        """
         output_path = output_dir.resolve()
         if output_path.exists() and not output_path.is_dir():
             raise ValueError("output_dir must resolve to a directory")
+        if base_output_dir is not None:
+            MakeHumanMeshGenerator._validate_output_path_within_base(
+                output_dir, base_output_dir
+            )
         for key, value in modifiers.items():
             if not isinstance(key, str) or not _MAKEHUMAN_MODIFIER_RE.fullmatch(key):
                 raise ValueError(f"Invalid MakeHuman modifier key: {key!r}")

--- a/src/shared/python/model_generation/api/rest_api_routes.py
+++ b/src/shared/python/model_generation/api/rest_api_routes.py
@@ -16,7 +16,7 @@ from typing import Any
 from .rest_api_types import APIRequest, APIResponse, HTTPMethod, Route
 
 logger = logging.getLogger(__name__)
-MAX_MESH_UPLOAD_BYTES = 10 * 1024 * 1024
+MAX_MESH_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MiB — closes #2479
 ALLOWED_MESH_SUFFIXES = {".stl", ".obj", ".ply", ".off", ".dae", ".glb", ".gltf"}
 
 
@@ -685,13 +685,21 @@ class ModelGenerationAPI:
         except ValueError as e:
             return APIResponse.error(str(e), 413)
 
+        # Derive the correct file suffix from the filename so trimesh uses the
+        # right loader (OBJ, PLY, GLB, etc.).  Fall back to .stl for unknown types.
+        _filename = str(body.get("filename") or "")
+        _suffix = Path(_filename).suffix.lower() if _filename else ".stl"
+        if _suffix not in ALLOWED_MESH_SUFFIXES:
+            _suffix = ".stl"
+
         # Try to use trimesh for mesh-based inertia
         temp_path = ""
         try:
             import trimesh
 
-            # Save to temp file
-            with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as f:
+            # Save to temp file; delete=False so trimesh can re-open it by path.
+            # The finally block below guarantees cleanup on every exit path.
+            with tempfile.NamedTemporaryFile(suffix=_suffix, delete=False) as f:
                 f.write(mesh_content)
                 temp_path = f.name
 

--- a/src/shared/python/scripting/scripting_env.py
+++ b/src/shared/python/scripting/scripting_env.py
@@ -12,13 +12,24 @@ The usage is *controlled* for the following reasons:
 1. **Explicit consent**: The scripting environment is an opt-in interactive
    console.  Users deliberately type code into it; they are not supplying
    untrusted third-party input.
-2. **Restricted namespace**: The execution namespace is seeded only with
-   vetted scientific libraries (``numpy``, ``math``, optionally ``pandas``
-   and ``scipy``).  It does *not* expose ``os``, ``subprocess``, or
-   ``__builtins__`` in raw form beyond what Python injects by default.
+2. **Restricted namespace**: The execution namespace is seeded with a
+   restricted ``__builtins__`` dict.  Dangerous primitives (``open``,
+   ``exec``, ``eval``, ``compile``, ``breakpoint``) are removed.
+   ``__import__`` is *replaced* with a sandbox-aware wrapper that denies
+   host-process modules (``os``, ``subprocess``, ``sys``, ``socket``, …)
+   while still allowing internal C-extension sub-imports (numpy, scipy, …).
 3. **No web-facing exposure**: This class is never called from a network
    handler.  It is only instantiated by GUI widgets running in-process.
-4. **Bandit suppression**: The ``# nosec B102`` / ``# nosec B307`` markers
+4. **Execution timeout**: Each ``execute()`` call is bounded by
+   ``max_execution_time`` seconds (default 30 s).  On Linux/macOS the
+   timeout is enforced via ``signal.alarm``; on Windows a daemon thread
+   is used to interrupt the main thread.
+5. **Resource limits (Linux only)**: CPU time and virtual-memory ceilings
+   are applied via ``resource.setrlimit`` when the ``resource`` module is
+   available.  On Windows these limits cannot be applied in-process;
+   full process-level sandboxing requires running ``ConsoleEnvironment``
+   inside a subprocess (e.g. via ``multiprocessing`` with a ``Pool``).
+6. **Bandit suppression**: The ``# nosec B102`` / ``# nosec B307`` markers
    are intentional and reviewed.  Do not remove them without re-evaluating
    the threat model above.
 
@@ -27,15 +38,156 @@ If you need to evaluate *user-supplied expressions from an untrusted source*
 performs AST-level validation before execution.
 """
 
+import builtins
 import contextlib
+import ctypes
 import io
 import math
 import os
 import sys
+import threading
 import traceback
 from typing import Any
 
 import numpy as np
+
+# ---------------------------------------------------------------------------
+# Resource limits (Linux / macOS only)
+# ---------------------------------------------------------------------------
+try:
+    import resource as _resource
+
+    _HAS_RESOURCE = True
+except ImportError:  # Windows
+    _resource = None  # type: ignore[assignment]
+    _HAS_RESOURCE = False
+
+# CPU soft/hard limits in seconds applied at module import time on supported
+# platforms.  These are process-wide ceilings; the per-call timeout inside
+# execute() provides a finer-grained guard on all platforms.
+_CPU_SOFT_LIMIT_S = 5
+_CPU_HARD_LIMIT_S = 10
+# Virtual memory ceiling: 512 MiB
+_MEM_LIMIT_BYTES = 512 * 1024 * 1024
+
+if _HAS_RESOURCE and _resource is not None:
+    try:
+        _resource.setrlimit(
+            _resource.RLIMIT_CPU, (_CPU_SOFT_LIMIT_S, _CPU_HARD_LIMIT_S)
+        )
+    except (ValueError, _resource.error):
+        pass
+    try:
+        _resource.setrlimit(_resource.RLIMIT_AS, (_MEM_LIMIT_BYTES, _MEM_LIMIT_BYTES))
+    except (ValueError, _resource.error):
+        pass
+
+# ---------------------------------------------------------------------------
+# Restricted builtins
+# ---------------------------------------------------------------------------
+# The following names are *removed* from the sandbox __builtins__ dict.
+# NOTE: ``__import__`` is handled separately — it must exist so that C
+# extensions (numpy, scipy) can perform internal sub-imports, but it is
+# *replaced* with a restricted wrapper that blocks dangerous top-level
+# module names (see _make_restricted_import / _BLOCKED_IMPORT_MODULES).
+_BLOCKED_BUILTINS: frozenset[str] = frozenset(
+    {
+        "open",
+        "exec",
+        "eval",
+        "compile",
+        "breakpoint",
+    }
+)
+
+# Modules that user code must NOT be able to import from the sandbox.
+_BLOCKED_IMPORT_MODULES: frozenset[str] = frozenset(
+    {
+        "os",
+        "subprocess",
+        "sys",
+        "socket",
+        "shutil",
+        "pathlib",
+        "io",
+        "builtins",
+        "importlib",
+        "ctypes",
+        "signal",
+        "resource",
+        "threading",
+        "multiprocessing",
+        "pty",
+        "atexit",
+        "gc",
+        "code",
+        "codeop",
+        "runpy",
+        "ast",
+        "dis",
+        "marshal",
+        "pickle",
+        "shelve",
+        "dbm",
+        "sqlite3",
+        "struct",
+    }
+)
+
+
+def _make_restricted_import(
+    blocked: frozenset[str] = _BLOCKED_IMPORT_MODULES,
+) -> Any:
+    """Return a ``__import__`` wrapper that blocks host-process modules.
+
+    The wrapper delegates to the real ``builtins.__import__`` for safe
+    modules so that C extensions (numpy, scipy) can perform their internal
+    sub-imports normally.  Any attempt to import a blocked top-level module
+    raises ``ImportError``.
+
+    Args:
+        blocked: Set of top-level module names to deny.
+
+    Returns:
+        A callable with the same signature as ``builtins.__import__``.
+    """
+    _real_import = builtins.__import__
+
+    def _restricted_import(
+        name: str,
+        globals: dict[str, Any] | None = None,  # noqa: A002
+        locals: dict[str, Any] | None = None,  # noqa: A002
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        top_level = name.split(".")[0]
+        if top_level in blocked:
+            raise ImportError(f"import of '{name}' is blocked in the scripting sandbox")
+        return _real_import(name, globals, locals, fromlist, level)
+
+    return _restricted_import
+
+
+def _make_restricted_builtins() -> dict[str, Any]:
+    """Return a copy of ``builtins.__dict__`` with dangerous names removed/replaced.
+
+    Returns:
+        A dict suitable for use as the ``__builtins__`` value in an exec/eval
+        namespace.  Dangerous primitives are absent; ``__import__`` is replaced
+        with a module-blocking wrapper.
+    """
+    safe: dict[str, Any] = {
+        k: v for k, v in vars(builtins).items() if k not in _BLOCKED_BUILTINS
+    }
+    # Replace __import__ with a restricted wrapper so internal C-extension
+    # imports still work while user-initiated imports of dangerous modules
+    # are blocked.
+    safe["__import__"] = _make_restricted_import()
+    return safe
+
+
+# Default per-call execution timeout (seconds).
+_DEFAULT_MAX_EXECUTION_TIME = 30
 
 USER_CODE_ERROR_TYPES = (
     ArithmeticError,
@@ -68,6 +220,32 @@ except ImportError:
     HAS_SCIPY = False
 
 
+# ---------------------------------------------------------------------------
+# Timeout helpers
+# ---------------------------------------------------------------------------
+
+try:
+    import signal as _signal
+
+    _HAS_SIGNAL_ALARM = hasattr(_signal, "alarm")
+except ImportError:
+    _signal = None  # type: ignore[assignment]
+    _HAS_SIGNAL_ALARM = False
+
+
+def _raise_keyboard_interrupt_in_thread(thread_id: int) -> None:
+    """Raise ``KeyboardInterrupt`` in *thread_id* using the CPython C API.
+
+    This is the Windows-compatible fallback for enforcing the execution
+    timeout.  Only works with CPython; on other runtimes the call is a
+    no-op.
+    """
+    ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_ulong(thread_id),
+        ctypes.py_object(KeyboardInterrupt),
+    )
+
+
 class ConsoleEnvironment:
     """Manages the interactive Python namespace and execution for the CLI."""
 
@@ -75,24 +253,45 @@ class ConsoleEnvironment:
         self,
         default_namespace: dict[str, Any] | None = None,
         user_lib_path: str = "~/.shared_console_user_funcs.py",
+        max_execution_time: int = _DEFAULT_MAX_EXECUTION_TIME,
     ) -> None:
         """Initialize the console environment.
 
         Args:
             default_namespace: Variables/modules to inject into the namespace.
             user_lib_path: Path to the user's persistent functions file.
+            max_execution_time: Wall-clock timeout in seconds for each
+                ``execute()`` call (default 30 s).  On Linux/macOS the
+                timeout is enforced via ``signal.alarm``; on Windows a
+                daemon thread raises ``KeyboardInterrupt`` in the calling
+                thread after this many seconds.  Set to 0 to disable.
+
+        Raises:
+            ValueError: If ``max_execution_time`` is negative.
         """
+        if max_execution_time < 0:
+            raise ValueError("max_execution_time must be >= 0")
         self._initial_namespace = default_namespace or {}
         self.namespace: dict[str, Any] = {}
         self._user_lib_path = os.path.expanduser(user_lib_path)
+        self._max_execution_time = max_execution_time
         self.reset()
 
     def reset(self) -> None:
         """Reset the namespace to its initial state.
 
         Follows DbC by ensuring the namespace is clear before population.
+        The namespace is seeded with a restricted ``__builtins__`` dict that
+        removes dangerous host-process access primitives (``open``, ``exec``,
+        ``eval``, ``compile``, ``breakpoint``) and replaces ``__import__``
+        with a module-blocking wrapper.
         """
         self.namespace.clear()
+
+        # Install restricted builtins — this is the primary blast-radius guard.
+        # User code running inside exec/eval will only see this dict for name
+        # lookups on builtins, preventing access to file I/O and code injection.
+        self.namespace["__builtins__"] = _make_restricted_builtins()
 
         # Add basic dependencies
         self.namespace["np"] = np
@@ -102,7 +301,7 @@ class ConsoleEnvironment:
         if HAS_SCIPY:
             self.namespace["scipy"] = scipy
 
-        # Inject injected defaults
+        # Inject caller-supplied defaults (vetted by the embedding application)
         self.namespace.update(self._initial_namespace)
 
         # Provide specialized help function that works within the console
@@ -154,9 +353,16 @@ class ConsoleEnvironment:
     def refresh_user_functions(self) -> None:
         """Reload user functions into the namespace.
 
+        Expected user-code errors (those listed in ``USER_CODE_ERROR_TYPES``)
+        are caught, reported to stderr, and swallowed so the host application
+        keeps running.  System-level failures (``MemoryError``, etc.) are
+        **re-raised** so they are not silently hidden.
+
         Raises:
             KeyboardInterrupt: If the user interrupts execution.
             SystemExit: If the code explicitly calls sys.exit().
+            BaseException: Any non-user-code exception (e.g. ``MemoryError``)
+                is re-raised after reporting.
         """
         if not os.path.exists(self._user_lib_path):
             return
@@ -167,9 +373,55 @@ class ConsoleEnvironment:
         try:
             # Execute within current namespace so imports/functions are persistent
             exec(code, self.namespace)  # nosec B102
-        except Exception as e:  # noqa: BLE001 — user library code may raise anything; report and continue
+        except USER_CODE_ERROR_TYPES as e:  # noqa: BLE001 — user library code may raise anything; report and continue
             sys.stderr.write(f"Error loading user library: {e}\n")
             sys.stderr.flush()
+
+    # ------------------------------------------------------------------
+    # Internal timeout context managers
+    # ------------------------------------------------------------------
+
+    @contextlib.contextmanager
+    def _timeout_context(self):  # type: ignore[return]
+        """Context manager that enforces ``_max_execution_time``.
+
+        On Linux/macOS uses ``signal.alarm`` (only valid on the main thread).
+        On Windows, or when called from a non-main thread, falls back to a
+        daemon thread that raises ``KeyboardInterrupt`` via the CPython C API.
+        """
+        timeout = self._max_execution_time
+        if not timeout:
+            yield
+            return
+
+        on_main_thread = threading.current_thread() is threading.main_thread()
+
+        if _HAS_SIGNAL_ALARM and on_main_thread:
+            # Unix path — signal.alarm is precise and zero-overhead.
+            def _handler(signum: int, frame: object) -> None:  # noqa: ARG001
+                raise TimeoutError(f"Execution exceeded {timeout} s CPU time limit")
+
+            old_handler = _signal.signal(_signal.SIGALRM, _handler)  # type: ignore[attr-defined]
+            _signal.alarm(timeout)  # type: ignore[attr-defined]
+            try:
+                yield
+            finally:
+                _signal.alarm(0)  # type: ignore[attr-defined]
+                _signal.signal(_signal.SIGALRM, old_handler)  # type: ignore[attr-defined]
+        else:
+            # Windows / non-main-thread path — daemon thread fires KI.
+            caller_id = threading.get_ident()
+
+            def _fire() -> None:
+                _raise_keyboard_interrupt_in_thread(caller_id)
+
+            timer = threading.Timer(timeout, _fire)
+            timer.daemon = True
+            timer.start()
+            try:
+                yield
+            finally:
+                timer.cancel()
 
     def execute(self, source: str | None) -> tuple[str, str]:
         """Execute a block of source code, capturing stdout and stderr.
@@ -192,20 +444,23 @@ class ConsoleEnvironment:
             with (
                 contextlib.redirect_stdout(out_buf),
                 contextlib.redirect_stderr(err_buf),
+                self._timeout_context(),
             ):
                 # Try to evaluate as an expression first for REPL output behavior
                 try:
-                    code_obj = compile(source, "<console>", "eval")
-                    res = eval(code_obj, self.namespace)  # nosec B307
+                    code_obj = builtins.compile(source, "<console>", "eval")
+                    res = builtins.eval(code_obj, self.namespace)  # nosec B307
                     if res is not None:
                         sys.stdout.write(repr(res) + "\n")
                 except SyntaxError:
                     # Not an expression, try exec
-                    code_obj = compile(source, "<console>", "exec")
-                    exec(code_obj, self.namespace)  # nosec B102
+                    code_obj = builtins.compile(source, "<console>", "exec")
+                    builtins.exec(code_obj, self.namespace)  # nosec B102
 
         except (KeyboardInterrupt, SystemExit):
             raise
+        except TimeoutError as e:
+            err_buf.write(f"TimeoutError: {e}\n")
         except USER_CODE_ERROR_TYPES:
             # Expected user-code failures are formatted REPL-style so the
             # console displays them without crashing the host application.

--- a/tests/shared/python/humanoid/test_makehuman_script_hardening.py
+++ b/tests/shared/python/humanoid/test_makehuman_script_hardening.py
@@ -9,6 +9,15 @@ from humanoid_character_builder.generators._makehuman_generator import (
     MakeHumanMeshGenerator,
 )
 
+_SHELL_METACHAR_PATHS = [
+    "out;rm -rf /",
+    "out&bad",
+    "out|evil",
+    "out`cmd`",
+    "out$(cmd)",
+    "out\x00null",
+]
+
 
 def test_makehuman_script_serializes_quoted_output_path(tmp_path: Path) -> None:
     generator = MakeHumanMeshGenerator(makehuman_path=tmp_path)
@@ -39,3 +48,78 @@ def test_makehuman_script_rejects_nonfinite_modifier_value(tmp_path: Path) -> No
 
     with pytest.raises(ValueError, match="Invalid MakeHuman modifier value"):
         generator._create_makehuman_script({"macrodetails/Gender": math.nan}, tmp_path)
+
+
+@pytest.mark.parametrize("suffix", _SHELL_METACHAR_PATHS)
+def test_makehuman_script_shell_metacharacters_are_safely_serialized(
+    tmp_path: Path, suffix: str
+) -> None:
+    """Paths containing shell metacharacters must either be safely serialized
+    in the generated script (so the metacharacters cannot cause shell injection
+    when the script file is later executed by MakeHuman's Python interpreter)
+    or be rejected outright.
+
+    The generated script must remain syntactically valid Python regardless of
+    what characters appear in the path, and the embedded path value must
+    round-trip correctly via ``ast.literal_eval``.
+    """
+    generator = MakeHumanMeshGenerator(makehuman_path=tmp_path)
+    output_dir = tmp_path / suffix
+    modifiers = {"macrodetails/Gender": 0.5}
+
+    try:
+        script = generator._create_makehuman_script(modifiers, output_dir)
+    except ValueError:
+        # Rejection is an acceptable defence — the path never reaches the script.
+        return
+
+    # If the path was accepted it must be safely serialized: the generated
+    # Python must parse without errors and the exported path must survive a
+    # literal_eval round-trip (no injected tokens).
+    compile(script, "<makehuman_script>", "exec")
+    export_line = next(line for line in script.splitlines() if "export_path =" in line)
+    rhs = export_line.split("=", 1)[1].strip()
+    recovered = ast.literal_eval(rhs)
+    expected = str((output_dir / "humanoid.obj").resolve())
+    assert recovered == expected, (
+        f"Path with metacharacters was not faithfully round-tripped.\n"
+        f"  suffix={suffix!r}\n"
+        f"  expected={expected!r}\n"
+        f"  got={recovered!r}"
+    )
+
+
+def test_makehuman_validate_output_path_within_base_rejects_traversal(
+    tmp_path: Path,
+) -> None:
+    """A path that escapes the base directory via ``..`` must be rejected."""
+    base = tmp_path / "output"
+    base.mkdir()
+    escaped = base / ".." / ".." / "etc" / "passwd"
+
+    with pytest.raises(ValueError, match="escapes the expected base directory"):
+        MakeHumanMeshGenerator._validate_output_path_within_base(escaped, base)
+
+
+def test_makehuman_validate_output_path_within_base_accepts_child(
+    tmp_path: Path,
+) -> None:
+    """A path that is genuinely inside the base directory must not raise."""
+    base = tmp_path / "output"
+    child = base / "visual" / "humanoid.obj"
+    # Should not raise
+    MakeHumanMeshGenerator._validate_output_path_within_base(child, base)
+
+
+def test_makehuman_script_rejects_output_dir_escaping_base(tmp_path: Path) -> None:
+    """_create_makehuman_script must raise when output_dir escapes base_output_dir."""
+    generator = MakeHumanMeshGenerator(makehuman_path=tmp_path)
+    base = tmp_path / "allowed"
+    escaped_output = tmp_path / "not_allowed" / "visual"
+
+    with pytest.raises(ValueError, match="escapes the expected base directory"):
+        generator._create_makehuman_script(
+            {"macrodetails/Gender": 0.5},
+            escaped_output,
+            base_output_dir=base,
+        )

--- a/tests/shared/python/model_generation/test_mesh_upload_hardening.py
+++ b/tests/shared/python/model_generation/test_mesh_upload_hardening.py
@@ -4,8 +4,15 @@ import sys
 import types
 from pathlib import Path
 
-from model_generation.api.rest_api_routes import ModelGenerationAPI
+import pytest
+from model_generation.api.rest_api_routes import (
+    ALLOWED_MESH_SUFFIXES,
+    MAX_MESH_UPLOAD_BYTES,
+    ModelGenerationAPI,
+)
 from model_generation.api.rest_api_types import APIRequest, HTTPMethod
+
+_ASCII_STL = b"solid mesh\nendsolid mesh\n"
 
 
 def _mesh_request(mesh: bytes, **body: object) -> APIRequest:
@@ -17,29 +24,53 @@ def _mesh_request(mesh: bytes, **body: object) -> APIRequest:
     )
 
 
+def test_max_upload_bytes_is_50_mib() -> None:
+    """Constant must equal exactly 50 MiB (issue #2479 requirement)."""
+    assert MAX_MESH_UPLOAD_BYTES == 50 * 1024 * 1024
+
+
 def test_mesh_upload_rejects_oversized_payload() -> None:
+    """Payloads exceeding MAX_MESH_UPLOAD_BYTES must return HTTP 413."""
     api = ModelGenerationAPI()
 
-    response = api.inertia_from_mesh(_mesh_request(b"0" * (10 * 1024 * 1024 + 1)))
+    response = api.inertia_from_mesh(_mesh_request(b"0" * (MAX_MESH_UPLOAD_BYTES + 1)))
 
     assert response.status_code == 413
     assert "exceeds" in response.body["error"]
 
 
+def test_mesh_upload_accepts_payload_at_size_limit() -> None:
+    """Payload exactly at the limit must NOT be rejected by the size check."""
+    api = ModelGenerationAPI()
+
+    response = api.inertia_from_mesh(_mesh_request(b"0" * MAX_MESH_UPLOAD_BYTES))
+
+    assert response.status_code != 413
+
+
 def test_mesh_upload_rejects_unsupported_filename() -> None:
     api = ModelGenerationAPI()
 
-    response = api.inertia_from_mesh(
-        _mesh_request(b"solid mesh\nendsolid mesh\n", filename="mesh.exe")
-    )
+    response = api.inertia_from_mesh(_mesh_request(_ASCII_STL, filename="mesh.exe"))
 
     assert response.status_code == 413
     assert "Unsupported mesh file type" in response.body["error"]
 
 
-def test_mesh_upload_cleans_temp_file_on_parser_failure(
-    monkeypatch,
-) -> None:
+@pytest.mark.parametrize("suffix", sorted(ALLOWED_MESH_SUFFIXES))
+def test_mesh_upload_allows_all_supported_extensions(suffix: str) -> None:
+    """Every extension in ALLOWED_MESH_SUFFIXES must pass the filename check."""
+    api = ModelGenerationAPI()
+
+    response = api.inertia_from_mesh(
+        _mesh_request(_ASCII_STL, filename=f"mesh{suffix}")
+    )
+
+    assert response.status_code != 413
+
+
+def test_mesh_upload_cleans_temp_file_on_parser_failure(monkeypatch) -> None:
+    """Temp file must be deleted even when the parser raises ValueError."""
     captured_path: dict[str, Path] = {}
 
     def load(path: str | Path) -> object:
@@ -49,8 +80,91 @@ def test_mesh_upload_cleans_temp_file_on_parser_failure(
     monkeypatch.setitem(sys.modules, "trimesh", types.SimpleNamespace(load=load))
     api = ModelGenerationAPI()
 
-    response = api.inertia_from_mesh(_mesh_request(b"solid mesh\nendsolid mesh\n"))
+    response = api.inertia_from_mesh(_mesh_request(_ASCII_STL))
 
     assert response.status_code == 400
     assert "Mesh processing failed" in response.body["error"]
     assert captured_path["path"].exists() is False
+
+
+def test_mesh_upload_cleans_temp_file_on_unexpected_exception(monkeypatch) -> None:
+    """Temp file must be deleted when trimesh raises an unexpected RuntimeError."""
+    captured_path: dict[str, Path] = {}
+
+    def load(path: str | Path) -> object:
+        captured_path["path"] = Path(path)
+        raise RuntimeError("unexpected crash")
+
+    monkeypatch.setitem(sys.modules, "trimesh", types.SimpleNamespace(load=load))
+    api = ModelGenerationAPI()
+
+    response = api.inertia_from_mesh(_mesh_request(_ASCII_STL))
+
+    assert response.status_code == 400
+    assert captured_path["path"].exists() is False
+
+
+def test_mesh_upload_uses_correct_suffix_for_ply_file(monkeypatch) -> None:
+    """Temp file suffix must match the uploaded filename extension (.ply)."""
+    captured_path: dict[str, Path] = {}
+
+    def load(path: str | Path) -> object:
+        captured_path["path"] = Path(path)
+        raise ValueError("stop early")
+
+    monkeypatch.setitem(sys.modules, "trimesh", types.SimpleNamespace(load=load))
+    api = ModelGenerationAPI()
+
+    api.inertia_from_mesh(_mesh_request(b"ply\n", filename="model.ply"))
+
+    assert captured_path["path"].suffix == ".ply"
+
+
+def test_mesh_upload_no_trimesh_returns_501() -> None:
+    """When trimesh is not installed the route must return HTTP 501."""
+    api = ModelGenerationAPI()
+
+    original = sys.modules.pop("trimesh", None)
+    try:
+        response = api.inertia_from_mesh(_mesh_request(_ASCII_STL))
+    finally:
+        if original is not None:
+            sys.modules["trimesh"] = original
+
+    assert response.status_code == 501
+    assert "trimesh" in response.body["error"]
+
+
+def test_mesh_upload_missing_file_returns_error() -> None:
+    """Request without a mesh file must return an error response."""
+    api = ModelGenerationAPI()
+
+    request = APIRequest(
+        method=HTTPMethod.POST,
+        path="/api/v1/inertia/from-mesh",
+        body={"mass": 1.0},
+        files={},
+    )
+    response = api.inertia_from_mesh(request)
+
+    assert response.status_code == 400
+    assert "Missing mesh file" in response.body["error"]
+
+
+def test_mesh_upload_requires_mass_or_density() -> None:
+    """Request without mass or density must return an error response."""
+    api = ModelGenerationAPI()
+
+    request = APIRequest(
+        method=HTTPMethod.POST,
+        path="/api/v1/inertia/from-mesh",
+        body={"filename": "mesh.stl"},
+        files={"mesh": _ASCII_STL},
+    )
+    response = api.inertia_from_mesh(request)
+
+    assert response.status_code == 400
+    assert (
+        "mass" in response.body["error"].lower()
+        or "density" in response.body["error"].lower()
+    )

--- a/tests/shared/python/scripting/test_scripting_env.py
+++ b/tests/shared/python/scripting/test_scripting_env.py
@@ -6,7 +6,146 @@ from pathlib import Path
 
 import pytest
 
-from shared.python.scripting.scripting_env import ConsoleEnvironment
+from shared.python.scripting.scripting_env import (
+    _BLOCKED_BUILTINS,
+    _BLOCKED_IMPORT_MODULES,
+    ConsoleEnvironment,
+)
+
+# ---------------------------------------------------------------------------
+# Sandbox / security tests (issue #2471)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_blocked_builtins_not_present_in_namespace() -> None:
+    """Restricted builtins must not appear in the sandbox __builtins__ dict."""
+    env = ConsoleEnvironment()
+    sandbox_builtins = env.namespace["__builtins__"]
+    assert isinstance(sandbox_builtins, dict), "__builtins__ must be a restricted dict"
+    for name in _BLOCKED_BUILTINS:
+        assert name not in sandbox_builtins, (
+            f"Blocked builtin '{name}' leaked into sandbox"
+        )
+
+
+@pytest.mark.unit
+def test_import_is_replaced_not_removed() -> None:
+    """``__import__`` must be present in __builtins__ but be a restricted wrapper."""
+    env = ConsoleEnvironment()
+    sandbox_builtins = env.namespace["__builtins__"]
+    assert "__import__" in sandbox_builtins, (
+        "__import__ must exist for C-extension sub-imports"
+    )
+    # The wrapper must not be the real builtins.__import__
+    import builtins as _builtins
+
+    assert sandbox_builtins["__import__"] is not _builtins.__import__, (
+        "__import__ must be the restricted wrapper, not the real one"
+    )
+
+
+@pytest.mark.unit
+def test_open_is_blocked_in_sandbox(tmp_path: Path) -> None:
+    """User code must not be able to call ``open()`` directly."""
+    env = ConsoleEnvironment()
+    _, err = env.execute("open('/etc/passwd', 'r')")
+    assert err, "Expected an error when calling open() in the sandbox"
+    assert "NameError" in err or "open" in err.lower()
+
+
+@pytest.mark.unit
+def test_os_system_is_blocked_via_import_restriction(tmp_path: Path) -> None:
+    """``import os; os.system(...)`` must be blocked — os is in the deny-list.
+
+    Regression test for issue #2471: arbitrary host-process commands must not
+    be executable from the scripting sandbox.
+    """
+    env = ConsoleEnvironment()
+    _, err = env.execute("import os; os.system('echo pwned')")
+    # The restricted __import__ wrapper raises ImportError for os.
+    assert err, "Expected an error when attempting os.system() via import"
+    assert "ImportError" in err or "blocked" in err.lower(), (
+        f"Unexpected error message: {err!r}"
+    )
+
+
+@pytest.mark.unit
+def test_blocked_import_modules_are_denied() -> None:
+    """Every module in _BLOCKED_IMPORT_MODULES must raise ImportError in the sandbox."""
+    env = ConsoleEnvironment()
+    # Spot-check a representative subset to keep the test fast.
+    spot_check = {"os", "subprocess", "sys", "socket"}
+    assert spot_check.issubset(_BLOCKED_IMPORT_MODULES), (
+        "spot-check set must be a subset"
+    )
+    for module_name in spot_check:
+        _, err = env.execute(f"import {module_name}")
+        assert err, f"Expected ImportError when importing '{module_name}'"
+        assert "ImportError" in err or "blocked" in err.lower(), (
+            f"import of '{module_name}' did not produce expected error: {err!r}"
+        )
+
+
+@pytest.mark.unit
+def test_exec_builtin_is_blocked_in_sandbox() -> None:
+    """``exec`` must not be callable from within user code."""
+    env = ConsoleEnvironment()
+    _, err = env.execute("exec('x = 1')")
+    assert err, "Expected an error when calling exec() in the sandbox"
+    assert "NameError" in err
+
+
+@pytest.mark.unit
+def test_eval_builtin_is_blocked_in_sandbox() -> None:
+    """``eval`` must not be callable from within user code."""
+    env = ConsoleEnvironment()
+    _, err = env.execute("eval('1+1')")
+    assert err, "Expected an error when calling eval() in the sandbox"
+    assert "NameError" in err
+
+
+@pytest.mark.unit
+def test_compile_builtin_is_blocked_in_sandbox() -> None:
+    """``compile`` must not be callable from within user code."""
+    env = ConsoleEnvironment()
+    _, err = env.execute("compile('x=1', '<s>', 'exec')")
+    assert err, "Expected an error when calling compile() in the sandbox"
+    assert "NameError" in err
+
+
+@pytest.mark.unit
+def test_max_execution_time_negative_raises() -> None:
+    """Negative max_execution_time must be rejected at construction time."""
+    with pytest.raises(ValueError, match="max_execution_time"):
+        ConsoleEnvironment(max_execution_time=-1)
+
+
+@pytest.mark.unit
+def test_legitimate_code_still_executes_in_sandbox() -> None:
+    """Basic numpy/math operations must remain functional after sandboxing."""
+    env = ConsoleEnvironment()
+    out, err = env.execute("np.array([1, 2, 3]).sum()")
+    assert not err, f"Unexpected error: {err}"
+    assert "6" in out
+
+
+@pytest.mark.unit
+def test_reset_reinstalls_restricted_builtins() -> None:
+    """``reset()`` must reinstall the restricted __builtins__ dict."""
+    env = ConsoleEnvironment()
+    # Manually corrupt the namespace
+    env.namespace["__builtins__"] = __builtins__
+    env.reset()
+    sandbox_builtins = env.namespace["__builtins__"]
+    assert isinstance(sandbox_builtins, dict)
+    for name in _BLOCKED_BUILTINS:
+        assert name not in sandbox_builtins
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing tests
+# ---------------------------------------------------------------------------
 
 
 def test_refresh_user_functions_propagates_system_level_errors(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #2479

## Changes

- **50 MiB upload cap** — `MAX_MESH_UPLOAD_BYTES` raised from 10 MiB to 50 MiB to match the issue requirement; enforced before any temp file is written via `_validate_mesh_upload()`
- **Correct temp file suffix** — temp file now uses the uploaded file's extension (`.ply`, `.obj`, `.glb`, etc.) instead of always `.stl`, so trimesh selects the right loader
- **Guaranteed cleanup** — the existing `try/finally` block covers all paths including `ValueError`, `RuntimeError`, `OSError`, and bare `Exception`; `ImportError` fires before temp file creation so cleanup is not needed there

## Tests added (17 total, all pass)

| Test | Coverage |
|---|---|
| `test_max_upload_bytes_is_50_mib` | constant value regression |
| `test_mesh_upload_rejects_oversized_payload` | 413 on > 50 MiB |
| `test_mesh_upload_accepts_payload_at_size_limit` | no 413 at exact limit |
| `test_mesh_upload_rejects_unsupported_filename` | 413 on `.exe` |
| `test_mesh_upload_allows_all_supported_extensions[*]` | 7 parametrized cases |
| `test_mesh_upload_cleans_temp_file_on_parser_failure` | cleanup on `ValueError` |
| `test_mesh_upload_cleans_temp_file_on_unexpected_exception` | cleanup on `RuntimeError` |
| `test_mesh_upload_uses_correct_suffix_for_ply_file` | `.ply` suffix propagation |
| `test_mesh_upload_no_trimesh_returns_501` | `ImportError` → 501 |
| `test_mesh_upload_missing_file_returns_error` | missing file → 400 |
| `test_mesh_upload_requires_mass_or_density` | missing params → 400 |