### PR TITLE
fix(ci): narrow autonomous workflow permissions to least privilege

### DIFF
--- a/.github/workflows/Jules-Archivist.yml
+++ b/.github/workflows/Jules-Archivist.yml
@@ -1,11 +1,29 @@
 name: Jules Archivist
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Archivist                               │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Delete remote branches prefixed with "jules/" after they are merged     │
+# │    (git push origin --delete <branch>)                                     │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Delete main, master, or any non-jules/* branch                          │
+# │  • Close or merge pull requests                                             │
+# │  • Commit new code or modify file contents                                 │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Only triggered on pull_request.closed+merged (via Control Tower)        │
+# │  • Only targets branches matching "jules/" prefix — other branches ignored │
+# │  • Gracefully skips on API rate-limit errors                               │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
 
-# Grants access to delete remote branches.
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   # Dispatcher: route to self-hosted if available.
@@ -50,6 +68,10 @@ jobs:
   archive-tasks:
     needs: pick-runner
     runs-on: ${{ needs.pick-runner.outputs.runner }}
+    # Grant write only at this job level — branch deletion requires contents: write.
+    # pick-runner needs no write access.
+    permissions:
+      contents: write  # delete merged jules/* branches
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -1,5 +1,23 @@
 name: Jules Assessment Generator (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Assessment Generator                    │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run code quality / assessment tools and write reports to docs/           │
+# │  • Commit assessment markdown files to main (via git-auto-commit)          │
+# │  • Open issues to track findings                                           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify source code — reports only                                       │
+# │  • Merge PRs or delete branches                                            │
+# │  • Trigger other autonomous workflows                                      │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower — not triggered on push     │
+# │  • Commits are limited to docs/assessments/ path                          │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -7,14 +25,18 @@ on:
   # schedule:
   #   - cron: "0 8 * * 0,4"  # Daily at midnight UTC (overnight window)
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   generate-assessments:
     runs-on: ubuntu-latest
+    # Grant write only at this job level — assessment commits and issue creation
+    # happen here.
+    permissions:
+      contents: write  # commit assessment reports to docs/assessments/
+      issues: write    # open tracking issues for findings
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -1,5 +1,25 @@
 name: Jules Assessment Remediator (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Assessment Remediator                   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Pick the top N assessment findings and create one PR per fix            │
+# │  • Push code changes to a new remediation/* branch                        │
+# │  • Close GitHub issues that are resolved by the automated fixes            │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │  • Exceed MAX_ISSUES_PER_RUN (10) fixes per execution                     │
+# │  • Delete branches other than merged remediation/* branches                │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Manual dispatch or scheduled (0 8 * * 0,4) — not triggered on push     │
+# │  • dry_run input available to preview without creating PRs                 │
+# │  • Concurrency lock prevents simultaneous remediation runs                 │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Automated issue remediation workflow for assessment-identified issues
 # Creates PRs with automated fixes for the top N most impactful issues
 
@@ -40,10 +60,9 @@ on:
     # Daily at 5 AM PST (13:00 UTC) - runs after overnight assessments complete
     - cron: "0 8 * * 0,4"
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 # Prevent multiple remediation runs simultaneously
 concurrency:
@@ -58,6 +77,12 @@ jobs:
   remediate:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Grant write only at this job level — remediation creates branches, pushes
+    # fixes, opens PRs, and closes resolved issues.
+    permissions:
+      contents: write      # create remediation branch and push fixes
+      pull-requests: write # open PR with automated fixes
+      issues: write        # close issues that are resolved by the fixes
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/Jules-Auto-Rebase.yml
+++ b/.github/workflows/Jules-Auto-Rebase.yml
@@ -1,5 +1,22 @@
 name: Jules Auto-Rebase (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Auto-Rebase                             │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Rebase open PRs that are behind main (force-push to feature branch)     │
+# │  • Apply the "needs-rebase" label to PRs with unresolvable merge conflicts │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Touch main or any protected branch                                       │
+# │  • Merge PRs or create new branches                                         │
+# │  • Delete branches, manage issues, or trigger other workflows               │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Dispatched only by Control Tower on a fixed schedule                    │
+# │  • Conflicts are labelled, not resolved — human author must resolve        │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Replaces Jules-Conflict-Fix workflow
 # Automatically rebases PRs that are behind main
 # Labels PRs that have actual merge conflicts for manual resolution
@@ -8,9 +25,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -55,6 +72,11 @@ jobs:
   auto-rebase-prs:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — rebasing pushes to feature branches
+    # and may add labels. pick-runner needs no write access.
+    permissions:
+      contents: write      # force-push rebased feature branch
+      pull-requests: write # apply labels to conflicted PRs
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Jules-Auto-Refactor.yml
+++ b/.github/workflows/Jules-Auto-Refactor.yml
@@ -1,5 +1,23 @@
 name: Jules Auto-Refactor (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Auto-Refactor                           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run ruff/isort/autoflake on files with the most linting issues          │
+# │  • Create a new jules/auto-refactor/* branch and push the fixes            │
+# │  • Open a pull request with the automated improvements                     │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge the PR it creates                                            │
+# │  • Delete branches, manage issues, or trigger other workflows              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower — not triggered on push     │
+# │  • PR requires human review before merge                                   │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Replaces Jules-Tech-Custodian workflow
 # Finds files with the most linting issues and auto-fixes them
 # Creates a PR with the automated improvements
@@ -8,9 +26,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -55,6 +73,11 @@ jobs:
   auto-refactor:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — branch creation, fix pushes, and PR
+    # opening happen here. pick-runner needs no write access.
+    permissions:
+      contents: write      # create jules/auto-refactor-* branch and push fixes
+      pull-requests: write # open PR with automated refactor improvements
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -1,5 +1,26 @@
 name: Jules Auto-Repair (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Auto-Repair                             │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Push commits directly to the failing feature branch (not main/master)   │
+# │  • Run ruff, autoflake, and mypy to apply automated lint/type fixes        │
+# │  • Comment on the associated PR with repair status                         │
+# │  • Optionally invoke the Jules AI API to generate targeted fixes           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push to main or master (protected-branch guard enforced in script)      │
+# │  • Open, close, or merge pull requests                                     │
+# │  • Create or delete branches beyond the target repair branch               │
+# │  • Exceed MAX_REPAIR_ATTEMPTS commits within REPAIR_WINDOW_HOURS           │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Max repair commits per branch per 72-hour window (MAX_REPAIR_ATTEMPTS)  │
+# │  • Protected-branch guard: refuses to touch main/master                    │
+# │  • Loop-prevention: concurrency group prevents parallel repairs per branch │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Re-enabled with proper safeguards against PR explosion.
 # This workflow uses the Jules API for intelligent fixes when simple linting isn't enough.
 #
@@ -35,9 +56,9 @@ on:
         default: "5"
         type: string
 
+# Least-privilege top level: no write access until the job that needs it.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
   actions: read
   checks: read
 
@@ -90,6 +111,11 @@ jobs:
   intelligent-repair:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — this is the only job that pushes commits
+    # or comments on PRs. pick-runner needs no write access.
+    permissions:
+      contents: write      # push repair commits to the target branch
+      pull-requests: write # post repair-status comment on the associated PR
     # Prevent multiple repairs on same branch simultaneously
     concurrency:
       group: auto-repair-${{ inputs.branch || github.event.workflow_run.head_branch }}

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -1,5 +1,24 @@
 name: Jules Code Quality Fixer (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Code Quality Fixer                      │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Parse the latest Code Quality Review assessment and select top findings │
+# │  • Create jules/cq-fix-* branches and push automated fixes                 │
+# │  • Open PRs and update related GitHub issues                               │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │  • Delete branches or trigger other workflows                              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower                             │
+# │  • dry_run input available to preview without creating branches/PRs        │
+# │  • Concurrency lock prevents simultaneous fixer runs per repo              │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -15,10 +34,9 @@ on:
         default: false
         type: boolean
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 concurrency:
   group: jules-code-quality-fixer-${{ github.repository }}
@@ -67,6 +85,12 @@ jobs:
   fix-issues:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — branch creation, fix pushes, PR
+    # creation, and issue updates all happen here. pick-runner needs no write.
+    permissions:
+      contents: write      # create jules/cq-fix-* branch and push fixes
+      pull-requests: write # open PR for each quality fix
+      issues: write        # update related issue status
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -1,5 +1,23 @@
 name: Jules Code Quality Reviewer (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Code Quality Reviewer                   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Analyse recent commits and generate a code quality review report        │
+# │  • Commit the report to docs/assessments/ on main                         │
+# │  • Open GitHub issues to track findings                                    │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify application source code — report writing only                   │
+# │  • Create PRs (report goes directly to main via git-auto-commit)           │
+# │  • Delete branches or trigger other workflows                              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower                             │
+# │  • Report commit is scoped to docs/assessments/ path                     │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -13,14 +31,18 @@ on:
   # schedule:
   #   - cron: "0 8 * * 0,4"  # Daily at 3 AM UTC
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Grant write only at this job level — report commits and issue creation
+    # happen here. No write needed for runner selection.
+    permissions:
+      contents: write  # commit quality review report to docs/assessments/
+      issues: write    # open tracking issues for findings
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -1,19 +1,41 @@
 name: Jules Completist (Incomplete Implementation Auditor)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Completist                              │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Scan for TODO/FIXME, stub functions, and incomplete implementations     │
+# │  • Create GitHub issues for each incomplete item found                     │
+# │  • Optionally push completion commits to a jules/completist-* branch       │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │  • Delete branches or trigger other workflows                              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled (0 8 * * 0,4) or dispatched via Control Tower                │
+# │  • Issues are created for review before any code changes are merged        │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
   schedule:
     - cron: "0 8 * * 0,4" # Daily at 4 AM UTC
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   audit:
     runs-on: ubuntu-latest
+    # Grant write only at this job level.
+    permissions:
+      contents: write      # push completist fixes to jules/completist-* branch
+      pull-requests: write # open PR for completist fixes
+      issues: write        # create tracking issues for incomplete items
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -1,19 +1,40 @@
 name: Jules Comprehensive Assessment
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Comprehensive Assessment                │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run multi-dimensional assessment (A–O criteria) across the codebase     │
+# │  • Commit the assessment report to docs/assessments/ on main               │
+# │  • Open GitHub issues for each criterion below threshold                   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify application source code — assessment and report writing only     │
+# │  • Create PRs (assessment report committed directly to docs/)              │
+# │  • Delete branches or trigger other workflows                              │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled (0 8 * * 0,4) or manual dispatch — not triggered on push     │
+# │  • Report commit scoped to docs/assessments/ path only                   │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   schedule:
     - cron: "0 8 * * 0,4" # Every 3 days at 5 AM PST (10 UTC) - cost optimized
   workflow_dispatch:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   comprehensive-assessment:
     name: Comprehensive Assessment & Audit
     runs-on: ubuntu-latest
+    # Grant write only at this job level.
+    permissions:
+      contents: write  # commit assessment report to docs/assessments/
+      issues: write    # open tracking issues for below-threshold criteria
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -1,5 +1,29 @@
 name: Jules Control Tower
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Control Tower                           │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Read repository contents and workflow run status (top-level)             │
+# │  • Dispatch to worker sub-workflows via workflow_call (secrets: inherit)    │
+# │  • Read CI run results and check iteration limits                           │
+# │  • Route events to the appropriate worker workflow                          │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO (by itself):                                   │
+# │  • Push commits or create/delete branches directly                          │
+# │  • Open, close, or merge pull requests directly                             │
+# │  • Trigger or cancel other workflow runs directly                           │
+# │  • Write to issues or security events directly                              │
+# │  ──  Write permissions are granted only at the job level of the             │
+# │       worker workflow that actually requires them, not here.                │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Iteration limit: MAX_REPAIR_ITERATIONS=3 per MAX_ITERATIONS_WINDOW_HOURS │
+# │  • Bot-actor guard: push/PR events from jules-bot are dropped silently      │
+# │  • Protected-branch guard: main/master failures route to hotfix (no direct  │
+# │    push); non-main failures route to auto-repair with its own limits        │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   push:
     branches: [main]
@@ -18,12 +42,10 @@ concurrency:
   group: jules-control-tower-${{ github.repository }}
   cancel-in-progress: false
 
+# Least-privilege: this orchestrator only reads; write grants live in workers.
 permissions:
-  contents: write
-  pull-requests: write
-  actions: write
-  issues: write
-  security-events: write
+  contents: read
+  actions: read
   checks: read
 
 jobs:

--- a/.github/workflows/Jules-Documentation-Auditor.yml
+++ b/.github/workflows/Jules-Documentation-Auditor.yml
@@ -1,5 +1,24 @@
 name: Jules Documentation Auditor (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Documentation Auditor                   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Scan codebase for missing docstrings, documentation gaps, and           │
+# │    organisation issues                                                      │
+# │  • Create GitHub issues for documentation gaps found                       │
+# │  • Open a PR with automated docstring additions                            │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify application logic — documentation additions only                 │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Dispatched only via Control Tower on a fixed schedule                   │
+# │  • PR requires human review before merge                                   │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Nightly documentation audit workflow
 # Scans codebase for missing docstrings, documentation gaps, and organization issues
 # Creates issues or PRs for documentation improvements
@@ -8,10 +27,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -57,6 +75,12 @@ jobs:
     needs: pick-runner
     runs-on: self-hosted
     timeout-minutes: 60
+    # Grant write only at this job level — doc branch creation, PR opening, and
+    # issue creation happen here. pick-runner needs no write access.
+    permissions:
+      contents: write      # create docs/audit-* branch and push docstring additions
+      pull-requests: write # open PR for documentation improvements
+      issues: write        # create issues for documentation gaps
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -1,11 +1,32 @@
 name: Jules Documentation Scribe (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Documentation Scribe                    │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Create a new docs/update-* branch                                       │
+# │  • Dispatch Jules AI to update Google-style docstrings for changed .py     │
+# │    files (does not touch READMEs)                                          │
+# │  • Open a pull request targeting main with the docstring updates           │
+# │  • Delete the docs branch if Jules makes no changes                        │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main                                                   │
+# │  • Auto-merge the PR it creates                                            │
+# │  • Modify non-Python files or READMEs                                      │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Only triggered on push to main by non-bot actors (via Control Tower)    │
+# │  • Bot-actor guard in Control Tower prevents doc-scribe loops              │
+# │  • PR requires human review before merge                                   │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -51,6 +72,11 @@ jobs:
     needs: pick-runner
     runs-on: self-hosted
     timeout-minutes: 30
+    # Grant write only at this job level — branch creation, Jules dispatch, and
+    # PR creation all happen here. pick-runner needs no write access.
+    permissions:
+      contents: write      # create docs/update-* branch and push Jules changes
+      pull-requests: write # open the docstring-update PR
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -1,5 +1,24 @@
 name: Jules Hotfix-Creator (Worker)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Hotfix-Creator                          │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Create a new hotfix/* branch from the failed protected branch           │
+# │  • Push commits to that hotfix branch via Jules AI                         │
+# │  • Open a pull request targeting the failed branch (NOT auto-merged)       │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or master                                         │
+# │  • Auto-merge the PR it creates — human review is required                 │
+# │  • Delete branches or cancel other workflow runs                           │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Only triggered when CI fails on main/master (via Control Tower triage)  │
+# │  • PR must be manually reviewed and merged — no auto-merge configured      │
+# │  • Skips entirely if JULES_API_KEY is not configured                       │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 # Triggers when CI fails on protected branches (main/master)
 # Creates a hotfix branch, triggers Auto-Repair, and opens urgent PR
 
@@ -13,10 +32,9 @@ on:
         required: true
         type: string
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  actions: write
+  contents: read
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
@@ -61,6 +79,11 @@ jobs:
   create-hotfix:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — hotfix branch creation and PR opening
+    # happen here. The pick-runner job needs no write access.
+    permissions:
+      contents: write      # create and push hotfix/* branch
+      pull-requests: write # open the urgent PR for human review
     steps:
       - name: Validate failed branch
         id: branch

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -1,5 +1,24 @@
 name: Jules Issue Resolver (Daily Priority Fixer)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Issue Resolver                          │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Select up to max_issues open GitHub issues and attempt automated fixes  │
+# │  • Create one jules/issue-* branch per fix and push the changes            │
+# │  • Open a pull request per issue and transition the issue to "In Review"   │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Push directly to main or any protected branch                           │
+# │  • Auto-merge any PR — human review required                               │
+# │  • Delete branches or cancel other workflow runs                           │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Dispatched only by Control Tower on a fixed schedule                    │
+# │  • Concurrency lock prevents simultaneous resolver runs per repo           │
+# │  • max_issues (default 5) caps the number of issues addressed per run     │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -13,10 +32,9 @@ on:
   # schedule:
   #   - cron: "0 8 * * 0,4"  # Daily at 2:30 AM UTC (overnight window)
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 concurrency:
   group: jules-issue-resolver-${{ github.repository }}
@@ -65,6 +83,12 @@ jobs:
   resolve-issues:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level — branch creation, fix pushes, PR
+    # creation, and issue updates all happen here. pick-runner needs no write.
+    permissions:
+      contents: write      # create jules/issue-* branch and push fixes
+      pull-requests: write # open PR for each resolved issue
+      issues: write        # transition issue status to "In Review"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -1,5 +1,26 @@
 name: Jules Sentinel (Security Audit)
 
+# ┌─────────────────────────────────────────────────────────────────────────────┐
+# │ BLAST RADIUS DOCUMENTATION — Jules Sentinel                                │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CAN DO:                                                  │
+# │  • Run pip-audit, bandit, and semgrep scanners (read-only analysis)        │
+# │  • Invoke Jules AI to interpret findings (READ-ONLY audit mode)            │
+# │  • Commit updated .jules/sentinel.md journal to main                      │
+# │  • Upload SARIF results to GitHub security-events (code scanning)         │
+# │  • Create GitHub issues for HIGH/MEDIUM severity findings                 │
+# │                                                                             │
+# │ WHAT THIS WORKFLOW CANNOT DO:                                               │
+# │  • Modify application source code — audit and document only               │
+# │  • Create PRs (automationMode: AUTO_CREATE_PR is explicitly disabled)      │
+# │  • Auto-merge or delete branches                                           │
+# │                                                                             │
+# │ APPROVAL GATES:                                                             │
+# │  • Scheduled/dispatched only via Control Tower                             │
+# │  • Concurrency lock prevents simultaneous sentinel runs per repo           │
+# │  • Jules session created without AUTO_CREATE_PR to prevent PR cascade     │
+# └─────────────────────────────────────────────────────────────────────────────┘
+
 on:
   workflow_call:
   workflow_dispatch:
@@ -7,11 +28,9 @@ on:
   # schedule:
   #   - cron: "0 8 * * 0,4"  # Weekly on Mondays at 1:30 AM UTC (overnight window)
 
+# Least-privilege top level: no write access by default.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  security-events: write
+  contents: read
 
 # HARDENING: Prevent concurrent runs
 concurrency:
@@ -61,6 +80,12 @@ jobs:
   security-audit:
     needs: pick-runner
     runs-on: self-hosted
+    # Grant write only at this job level.
+    # Note: pull-requests: write intentionally omitted — Sentinel is read-only audit.
+    permissions:
+      contents: write          # commit .jules/sentinel.md journal to main
+      issues: write            # open tracking issues for HIGH/MEDIUM findings
+      security-events: write   # upload SARIF to GitHub code-scanning
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Closes #2476

Moves to read-only top-level with job-level write grants only where required.

- Jules-Control-Tower.yml: top-level -> `contents/actions/checks: read` only; no write at all — workers carry their own grants.
- All 15 called worker workflows: read-only top-level permissions, write grants applied only at the specific job that needs them.
- Added `# BLAST RADIUS` comment block at the top of each workflow documenting what it can/cannot do.

Permission changes affect: Jules-Auto-Repair, Jules-Auto-Refactor, Jules-Auto-Rebase, Jules-Archivist, Jules-Assessment-Generator, Jules-Assessment-Remediator, Jules-Code-Quality-Fixer, Jules-Code-Quality-Reviewer, Jules-Completist, Jules-Comprehensive-Assessment, Jules-Documentation-Auditor, Jules-Documentation-Scribe, Jules-Hotfix-Creator, Jules-Issue-Resolver, Jules-Sentinel.