### PR TITLE
⚡ Bolt: Optimize confidence calculation in real-time pose handler

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -10,3 +10,6 @@
 ## 2024-05-19 - Optimization of Object Property Copying in Tight Loops
 **Learning:** Using a `for...in` loop combined with `Object.prototype.hasOwnProperty.call()` to copy object properties is significantly slower than using `Object.keys()` combined with a standard `for` loop, because `for...in` crawls the entire prototype chain.
 **Action:** When copying own properties of objects inside tight data processing loops, use `Object.keys()` with a standard `for` loop. It natively filters own properties and avoids the overhead of prototype chain traversal and repeated function calls.
+## 2024-05-19 - Optimization of High-Frequency Event Handlers
+**Learning:** Using array iterator methods like `.reduce()` inside event handlers that run per-frame (e.g., 30-60 times a second, like MediaPipe pose detection callbacks) introduces continuous callback allocation overhead and can hurt overall framerate.
+**Action:** Replace iterator methods like `.reduce()`, `.map()`, and `.filter()` with standard `for` loops inside high-frequency real-time event handlers to eliminate callback overhead and minimize garbage collection.

--- a/src/media_processing/video_processor/apps/web/components/golf/SwingAnalysisDashboard.tsx
+++ b/src/media_processing/video_processor/apps/web/components/golf/SwingAnalysisDashboard.tsx
@@ -36,11 +36,18 @@ export default function SwingAnalysisDashboard({
   const handlePoseDetected = useCallback((landmarks: Landmark[]) => {
     if (!videoElement || isAnalyzing) return;
 
+    // ⚡ Bolt: Replace .reduce() with a standard for-loop to eliminate callback overhead in high-frequency event handler
+    let totalVisibility = 0;
+    const len = landmarks.length;
+    for (let i = 0; i < len; i++) {
+      totalVisibility += landmarks[i].visibility || 0;
+    }
+
     const frame: PoseFrame = {
       frameNumber: Math.floor(videoElement.currentTime * fps),
       timestamp: videoElement.currentTime * 1000,
       landmarks,
-      confidence: landmarks.reduce((acc, l) => acc + (l.visibility || 0), 0) / landmarks.length,
+      confidence: totalVisibility / len,
     };
 
     setPoseFrames((prev) => {


### PR DESCRIPTION
💡 What: Replaced the `.reduce()` call inside the `handlePoseDetected` event handler with a standard `for` loop.
🎯 Why: `handlePoseDetected` runs on a per-frame basis (e.g., 30-60 times a second) triggered by MediaPipe. Using `.reduce()` allocates a callback function and incurs overhead on every frame, which can cause garbage collection pressure and negatively impact the UI framerate. Standard `for` loops eliminate this overhead.
📊 Impact: Eliminates callback allocation on every frame, reducing garbage collection pressure and marginally improving the responsiveness of real-time pose tracking.
🔬 Measurement: Verify with `pnpm run type-check`, `pnpm test`, and `pnpm run build` in the `src/media_processing/video_processor/apps/web` directory, which all pass and compile cleanly.

---
*PR created automatically by Jules for task [11964115373579865901](https://jules.google.com/task/11964115373579865901) started by @dieterolson*