### PR TITLE
build(deps): bump pandas from 2.2.3 to 3.0.2 in requirements-lock.txt

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -6,7 +6,7 @@
 
 # Core Scientific Computing
 numpy==2.4.4
-pandas==2.2.3
+pandas==3.0.2
 scipy==1.16.0
 matplotlib==3.10.9
 sympy==1.14.0


### PR DESCRIPTION
Bump pandas from 2.2.3 to 3.0.2 in requirements-lock.txt.

Fixes #2531