### PR TITLE
chore(testing): adopt fleet testing standards Phase 1 (#2542)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,14 @@ pythonpath = [
     "src/pendulum_simulator/src",
     "src/folder_tool",
 ]
-addopts = "-ra -v --strict-markers --strict-config --tb=short --color=yes --durations=20 --benchmark-disable -n auto --dist loadscope -m \"not live_simulation\" -p no:xvfb"
+# Fleet testing standards (§2): explicit timeout + asyncio config.
+# See: Repository_Management/docs/FLEET_TESTING_STANDARDS.md
+timeout = 60
+timeout_method = "thread"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+# Default lane excludes heavy + offline-only-violating selections per §2.
+addopts = "-ra -v --strict-markers --strict-config --tb=short --color=yes --durations=20 --benchmark-disable -n auto --dist loadscope -m \"not slow and not live_simulation and not e2e and not requires_network\" -p no:xvfb"
 console_output_style = "progress"
 norecursedirs = [
     "replicants",
@@ -233,6 +240,13 @@ markers = [
     "math_regression: tests looking for unintended calculation changes",
     "flaky: tests that are known to fail intermittently",
     "tools_contracts: tests verifying shared tools libraries interfaces",
+    # ---- fleet testing standards §2 additions ----
+    "serial: must run with -n 0 (xdist parallel breaks this test)",
+    "requires_mujoco: skip when import mujoco fails",
+    "requires_drake: skip when import pydrake fails",
+    "requires_pinocchio: skip when pinocchio is the stub PyPI wheel",
+    "requires_opensim: skip when import opensim fails",
+    "requires_matlab: skip when MATLAB Engine for Python is unavailable",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-# Pre-load tkinter to prevent namespace corruption on Windows 3.13 during pytest collection
+# Pre-load tkinter to prevent namespace corruption on Windows 3.13
+# during pytest collection.
 try:
     import tkinter  # noqa: F401
     import tkinter.ttk  # noqa: F401
@@ -43,6 +44,8 @@ os.environ.setdefault("OMP_NUM_THREADS", "1")
 os.environ.setdefault("MKL_NUM_THREADS", "1")
 os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
 os.environ.setdefault("HEADLESS", "true")
+# Fleet testing standards §5: Qt headless backend for indirect PyQt/PySide imports.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
 


### PR DESCRIPTION
## Summary

Aligns this repo's pytest configuration with the fleet-wide testing
standards Phase 1 baseline:

- [Standards doc](https://github.com/D-sorganization/Repository_Management/blob/main/docs/FLEET_TESTING_STANDARDS.md) §2 (pyproject block) and §5 (`conftest.py` env vars).
- Closes the Phase 0 audit recorded on #2542.
- Issue: #2542 — EPIC: D-sorganization/Repository_Management#1140
- Repo tier: **Tooling (70% coverage gate)**.

## What changed

**`pyproject.toml [tool.pytest.ini_options]`** (additive — no existing
markers removed):

- Added explicit `timeout = 60` + `timeout_method = "thread"`.
- Added `asyncio_mode = "auto"` + `asyncio_default_fixture_loop_scope = "function"`.
- Expanded default-lane marker exclusion to the §2 set:
  `not slow and not live_simulation and not e2e and not requires_network`
  (was: `not live_simulation` only).
- Added the §2 markers that weren't already declared:
  `serial`, `requires_mujoco`, `requires_drake`, `requires_pinocchio`,
  `requires_opensim`, `requires_matlab`.

**`tests/conftest.py`**:

- Added `os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")` from §5
  (other thread-safety env vars — `OMP/OPENBLAS/MKL/NUMEXPR/MPLBACKEND` —
  were already present).
- Re-flowed the one-line tkinter comment to satisfy E501 (88-char limit).

**Intentionally NOT changed**: §5 network-blocker fixture is omitted
because this repo has no direct `httpx` / `requests` / `aiohttp` imports
under `src/` — only `types-requests` type stubs.

`--strict-markers --strict-config` were already in `addopts`, so all new
markers had to be declared before use — done here.

## Phase 0 audit numbers

| Metric                           | Value         |
| -------------------------------- | ------------- |
| `test_*.py` files under `tests/` | 274           |
| Tests collected (default lane)   | 5366 / 5390 (24 deselected) |
| Pre-existing collection errors   | 3 (PyQt6 DLL on Win — exist on `main`, not introduced by this PR) |
| Local `pytest --collect-only -q` wall-clock | ~4m 42s |
| Pre-existing `markers = [...]`   | 27 entries   |
| New markers added by this PR     | 6            |

The 3 collection errors (`tests/data_processing/data_processor/test_ui_thread_workers.py`,
`tests/ode_solver/test_main_window.py`, `tests/shared/python/theme/test_theme_manager.py`)
all stem from `PyQt6` DLL load failures on this Windows host, are
present on `main` before this PR, and are out of scope for Phase 1.

## Test plan

- [x] `pytest --collect-only -q` runs under strict-markers/strict-config with the new marker list (verified locally; only pre-existing PyQt6 DLL collection errors remain).
- [x] No existing markers removed; existing tests' `@pytest.mark.X` decorators continue to resolve.
- [ ] CI green (unit + integration + ruff + format + delta checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)