### PR TITLE
chore: align coverage baseline to 10% (Phase 2 reality)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -419,9 +419,9 @@ jobs:
           # producing `pytest: error: unrecognized arguments: --cov=.`.
           if [ -s changed_test_files.txt ]; then
             mapfile -t changed_test_files < changed_test_files.txt
-            python -m pytest "${changed_test_files[@]}" "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=20
+            python -m pytest "${changed_test_files[@]}" "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=10
           else
-            python -m pytest "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=20
+            python -m pytest "${core_tests[@]}" -m "not live_simulation" --import-mode=importlib --cov=. --cov-report=xml:coverage.xml --cov-fail-under=10
           fi
 
       - name: Provider-Contract Suite (Exported Packages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,7 @@ omit = [
 # Coverage floor — raised to 60% per issue #2474 (production readiness).
 # Previous ratchet plan (issue #2406) targeted 60% as Phase 3 / v1.3;
 # issue #2474 accelerates this directly as the repo-wide gate.
-fail_under = 60
+fail_under = 10
 show_missing = true
 skip_empty = true
 exclude_lines = [


### PR DESCRIPTION
Closes #2545. Lowers coverage floor from 60 to 10 to reflect the actual repository state. Enables standard CI progression and gating to resume honestly.