### PR TITLE
feat: implement TRC Rust computation backend primitives

### DIFF
--- a/rust_core/tools-core/src/lib.rs
+++ b/rust_core/tools-core/src/lib.rs
@@ -10,6 +10,8 @@ pub mod engineering;
 pub mod math;
 pub mod rrt;
 pub mod signal;
+pub mod thermodynamics;
+pub mod reactor;
 // Re-export primary types
 pub use math::{clamp, lerp, GRAVITY, R_GAS};
 pub use math_primitives::matrix3::Matrix3;
@@ -139,6 +141,12 @@ fn tools_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         &eng_mod
     )?)?;
     m.add_submodule(&eng_mod)?;
+
+    // Register thermodynamics classes
+    m.add_class::<thermodynamics::py_bindings::PyNasa7Species>()?;
+
+    // Register reactor classes
+    m.add_class::<reactor::py_bindings::PyTrc1DSystem>()?;
 
     Ok(())
 }

--- a/rust_core/tools-core/src/reactor.rs
+++ b/rust_core/tools-core/src/reactor.rs
@@ -1,0 +1,170 @@
+//! Numerical integration for 1D Plug Flow Reactors (TRC).
+//!
+//! Provides a standard 4th-order Runge-Kutta (RK4) integrator for generic ODE systems.
+
+pub trait OdeSystem {
+    /// Dimension of the state vector
+    fn state_dim(&self) -> usize;
+
+    /// Computes the derivatives (dy/dz) given independent variable z and state y.
+    /// `dy` must be mutated in place.
+    fn derivatives(&self, z: f64, y: &[f64], dy: &mut [f64]);
+}
+
+/// A 4th-order Runge-Kutta integrator for 1D ODE systems.
+pub struct Rk4Integrator {
+    pub step_size: f64,
+}
+
+impl Rk4Integrator {
+    pub fn new(step_size: f64) -> Self {
+        assert!(step_size > 0.0, "step size must be positive");
+        Self { step_size }
+    }
+
+    /// Integrates the ODE system from z_start to z_end with initial state y0.
+    /// Returns a vector of tuples `(z, y)` representing the solution trajectory.
+    pub fn integrate<S: OdeSystem>(
+        &self,
+        system: &S,
+        z_start: f64,
+        z_end: f64,
+        y0: &[f64],
+    ) -> Vec<(f64, Vec<f64>)> {
+        let dim = system.state_dim();
+        assert_eq!(y0.len(), dim, "Initial state length must match system dimension");
+
+        let mut trajectory = Vec::new();
+        let mut z = z_start;
+        let mut y = y0.to_vec();
+
+        let mut k1 = vec![0.0; dim];
+        let mut k2 = vec![0.0; dim];
+        let mut k3 = vec![0.0; dim];
+        let mut k4 = vec![0.0; dim];
+        let mut y_temp = vec![0.0; dim];
+
+        trajectory.push((z, y.clone()));
+
+        while z < z_end {
+            let h = if z + self.step_size > z_end {
+                z_end - z
+            } else {
+                self.step_size
+            };
+
+            // k1
+            system.derivatives(z, &y, &mut k1);
+
+            // k2
+            for i in 0..dim {
+                y_temp[i] = y[i] + 0.5 * h * k1[i];
+            }
+            system.derivatives(z + 0.5 * h, &y_temp, &mut k2);
+
+            // k3
+            for i in 0..dim {
+                y_temp[i] = y[i] + 0.5 * h * k2[i];
+            }
+            system.derivatives(z + 0.5 * h, &y_temp, &mut k3);
+
+            // k4
+            for i in 0..dim {
+                y_temp[i] = y[i] + h * k3[i];
+            }
+            system.derivatives(z + h, &y_temp, &mut k4);
+
+            // update
+            for i in 0..dim {
+                y[i] += (h / 6.0) * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]);
+            }
+            z += h;
+
+            trajectory.push((z, y.clone()));
+        }
+
+        trajectory
+    }
+}
+
+/// A simplified 1D Tubular Reactor ODE system for TRC kinetics
+pub struct Trc1DSystem {
+    pub pre_exponential: f64,
+    pub activation_energy: f64, // J/mol
+    pub heat_of_reaction: f64,  // J/mol
+    pub density: f64,           // kg/m3
+    pub cp: f64,                // J/(kg.K)
+    pub velocity: f64,          // m/s
+}
+
+impl OdeSystem for Trc1DSystem {
+    fn state_dim(&self) -> usize {
+        2 // state: [conversion, temperature]
+    }
+
+    fn derivatives(&self, _z: f64, y: &[f64], dy: &mut [f64]) {
+        let x = y[0];
+        let t = y[1];
+
+        // Arrhenius rate: k = A * exp(-E / RT)
+        let rate = self.pre_exponential
+            * (-self.activation_energy / (crate::engineering::R_UNIVERSAL * t)).exp();
+
+        // simple first order kinetics: dX/dz = (rate * (1 - X)) / velocity
+        let dx_dz = rate * (1.0 - x) / self.velocity;
+
+        // dT/dz = (-heat_of_reaction * rate * (1 - X)) / (density * Cp * velocity)
+        let dt_dz =
+            (-self.heat_of_reaction * rate * (1.0 - x)) / (self.density * self.cp * self.velocity);
+
+        dy[0] = dx_dz;
+        dy[1] = dt_dz;
+    }
+}
+
+#[cfg(feature = "python")]
+pub mod py_bindings {
+    use super::*;
+    use pyo3::prelude::*;
+
+    #[pyclass]
+    pub struct PyTrc1DSystem {
+        inner: Trc1DSystem,
+    }
+
+    #[pymethods]
+    impl PyTrc1DSystem {
+        #[new]
+        pub fn new(
+            pre_exponential: f64,
+            activation_energy: f64,
+            heat_of_reaction: f64,
+            density: f64,
+            cp: f64,
+            velocity: f64,
+        ) -> Self {
+            PyTrc1DSystem {
+                inner: Trc1DSystem {
+                    pre_exponential,
+                    activation_energy,
+                    heat_of_reaction,
+                    density,
+                    cp,
+                    velocity,
+                },
+            }
+        }
+
+        /// Integrates the TRC ODE system from z_start to z_end with given step size and initial state [conversion, temperature].
+        /// Returns a list of tuples (z, conversion, temperature).
+        pub fn integrate(&self, step_size: f64, z_start: f64, z_end: f64, y0: Vec<f64>) -> Vec<(f64, f64, f64)> {
+            let integrator = Rk4Integrator::new(step_size);
+            let trajectory = integrator.integrate(&self.inner, z_start, z_end, &y0);
+            
+            trajectory
+                .into_iter()
+                .map(|(z, y)| (z, y[0], y[1]))
+                .collect()
+        }
+    }
+}

--- a/rust_core/tools-core/src/thermodynamics.rs
+++ b/rust_core/tools-core/src/thermodynamics.rs
@@ -1,0 +1,142 @@
+//! Thermodynamics — NASA-7 polynomial evaluation and thermochemical properties.
+
+/// NASA-7 Polynomial coefficients for a specific temperature range.
+#[derive(Debug, Clone, Copy)]
+pub struct Nasa7Coefficients {
+    pub a1: f64,
+    pub a2: f64,
+    pub a3: f64,
+    pub a4: f64,
+    pub a5: f64,
+    pub a6: f64,
+    pub a7: f64,
+}
+
+impl Nasa7Coefficients {
+    /// Computes dimensionless specific heat capacity (Cp/R)
+    pub fn cp_over_r(&self, t: f64) -> f64 {
+        self.a1
+            + self.a2 * t
+            + self.a3 * t.powi(2)
+            + self.a4 * t.powi(3)
+            + self.a5 * t.powi(4)
+    }
+
+    /// Computes dimensionless enthalpy (H/RT)
+    pub fn h_over_rt(&self, t: f64) -> f64 {
+        self.a1
+            + self.a2 * t / 2.0
+            + self.a3 * t.powi(2) / 3.0
+            + self.a4 * t.powi(3) / 4.0
+            + self.a5 * t.powi(4) / 5.0
+            + self.a6 / t
+    }
+
+    /// Computes dimensionless entropy (S/R)
+    pub fn s_over_r(&self, t: f64) -> f64 {
+        self.a1 * t.ln()
+            + self.a2 * t
+            + self.a3 * t.powi(2) / 2.0
+            + self.a4 * t.powi(3) / 3.0
+            + self.a5 * t.powi(4) / 4.0
+            + self.a7
+    }
+}
+
+/// A species represented by two sets of NASA-7 polynomials (low and high temp).
+#[derive(Debug, Clone)]
+pub struct Nasa7Species {
+    pub name: String,
+    pub molar_mass: f64, // kg/mol
+    pub t_mid: f64,
+    pub low_temp: Nasa7Coefficients,
+    pub high_temp: Nasa7Coefficients,
+}
+
+impl Nasa7Species {
+    fn get_coeffs(&self, t: f64) -> &Nasa7Coefficients {
+        if t < self.t_mid {
+            &self.low_temp
+        } else {
+            &self.high_temp
+        }
+    }
+
+    /// Specific heat capacity Cp in J/(mol·K)
+    pub fn cp(&self, t: f64) -> f64 {
+        self.get_coeffs(t).cp_over_r(t) * crate::engineering::R_UNIVERSAL
+    }
+
+    /// Enthalpy H in J/mol
+    pub fn enthalpy(&self, t: f64) -> f64 {
+        self.get_coeffs(t).h_over_rt(t) * crate::engineering::R_UNIVERSAL * t
+    }
+
+    /// Entropy S in J/(mol·K)
+    pub fn entropy(&self, t: f64) -> f64 {
+        self.get_coeffs(t).s_over_r(t) * crate::engineering::R_UNIVERSAL
+    }
+}
+
+#[cfg(feature = "python")]
+pub mod py_bindings {
+    use super::*;
+    use pyo3::prelude::*;
+
+    #[pyclass]
+    #[derive(Clone)]
+    pub struct PyNasa7Species {
+        inner: Nasa7Species,
+    }
+
+    #[pymethods]
+    impl PyNasa7Species {
+        #[new]
+        #[pyo3(signature = (name, molar_mass, t_mid, low_coeffs, high_coeffs))]
+        pub fn new(
+            name: String,
+            molar_mass: f64,
+            t_mid: f64,
+            low_coeffs: [f64; 7],
+            high_coeffs: [f64; 7],
+        ) -> Self {
+            PyNasa7Species {
+                inner: Nasa7Species {
+                    name,
+                    molar_mass,
+                    t_mid,
+                    low_temp: Nasa7Coefficients {
+                        a1: low_coeffs[0],
+                        a2: low_coeffs[1],
+                        a3: low_coeffs[2],
+                        a4: low_coeffs[3],
+                        a5: low_coeffs[4],
+                        a6: low_coeffs[5],
+                        a7: low_coeffs[6],
+                    },
+                    high_temp: Nasa7Coefficients {
+                        a1: high_coeffs[0],
+                        a2: high_coeffs[1],
+                        a3: high_coeffs[2],
+                        a4: high_coeffs[3],
+                        a5: high_coeffs[4],
+                        a6: high_coeffs[5],
+                        a7: high_coeffs[6],
+                    },
+                },
+            }
+        }
+
+        pub fn cp(&self, t: f64) -> f64 {
+            self.inner.cp(t)
+        }
+
+        pub fn enthalpy(&self, t: f64) -> f64 {
+            self.inner.enthalpy(t)
+        }
+
+        pub fn entropy(&self, t: f64) -> f64 {
+            self.inner.entropy(t)
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces native Rust implementations for 1D plug flow reactor numerical integration (Rk4Integrator) and thermodynamic polynomial evaluation (Nasa7Species). 

This is part of the fleet Epic to migrate the TRC (Tubular Reactor Calculator) computations from Python into the shared ud-tools Rust kernel for superior performance during large simulations and parameter sweeps.