### PR TITLE
fix(mesh): expose public API through __init__.py exports

### DIFF
--- a/src/shared/python/model_generation/mesh/__init__.py
+++ b/src/shared/python/model_generation/mesh/__init__.py
@@ -1,18 +1,51 @@
-"""
-Mesh processing utilities for model generation.
+"""Mesh processing utilities for model generation.
 
-Re-exports mesh processing components from humanoid_character_builder.
+Re-exports mesh processing components from humanoid_character_builder.mesh.
 """
 
 try:
+    from humanoid_character_builder.mesh import (
+        CollisionGeometry,
+        CollisionGeometryGenerator,
+        LODGenerationResult,
+        LODGenerator,
+        LODLevel,
+        MeshExportConfig,
+        MeshInertiaCalculator,
+        MeshProcessor,
+        MeshSegmentResult,
+        PrimitiveInertiaCalculator,
+        PrimitiveMeshGenerator,
+        PrimitiveShape,
+    )
+    from humanoid_character_builder.mesh.lod import (
+        LODGenerationResult,
+        LODGenerator,
+        LODLevel,
+    )
+    from humanoid_character_builder.mesh.mesh_inertia import (
+        InertiaMode,
+        InertiaResult,
+        MeshInertiaCalculator,
+        PrimitiveInertiaCalculator,
+        PrimitiveShape,
+    )
+except ImportError:  # pragma: no cover
     pass
 
-    __all__ = [
-        "MeshProcessor",
-        "MeshExportConfig",
-        "MeshSegmentResult",
-        "PrimitiveMeshGenerator",
-        "MeshInertiaCalculator",
-    ]
-except ImportError:
-    __all__ = []
+__all__: list[str] = [
+    "CollisionGeometry",
+    "CollisionGeometryGenerator",
+    "InertiaMode",
+    "InertiaResult",
+    "LODGenerationResult",
+    "LODGenerator",
+    "LODLevel",
+    "MeshExportConfig",
+    "MeshInertiaCalculator",
+    "MeshProcessor",
+    "MeshSegmentResult",
+    "PrimitiveInertiaCalculator",
+    "PrimitiveMeshGenerator",
+    "PrimitiveShape",
+]


### PR DESCRIPTION
Previously `src/shared/python/model_generation/mesh/__init__.py` exported nothing, forcing consumers to reach into `humanoid_character_builder.mesh` directly.

This PR re-exports the stable public API: MeshProcessor, MeshSegmentResult, MeshExportConfig, PrimitiveMeshGenerator, PrimitiveShape, LODGenerator, LODLevel, LODGenerationResult, CollisionGeometry, CollisionGeometryGenerator, MeshInertiaCalculator, PrimitiveInertiaCalculator, InertiaMode, and InertiaResult.

Non-breaking change — existing deep imports continue to work.