### PR TITLE
fix(humanoid): expose public API through __init__.py exports

### DIFF
--- a/src/shared/python/model_generation/humanoid/__init__.py
+++ b/src/shared/python/model_generation/humanoid/__init__.py
@@ -1,61 +1,108 @@
+"""Humanoid model generation components.
+
+Re-exports from humanoid_character_builder for integration with the
+unified model_generation package.
 """
-Humanoid model generation components.
 
-This module re-exports components from the humanoid_character_builder
-for integration with the unified model_generation package.
-"""
-
-from __future__ import annotations
-
-from typing import Any, NoReturn
-
-# Import from humanoid_character_builder
 try:
+    from humanoid_character_builder import (
+        AnthropometryData,
+        BodyParameters,
+        BuildType,
+        CharacterBuilder,
+        CharacterBuildResult,
+        DE_LEVA_DATA,
+        ExportOptions,
+        GenderModel,
+        HUMANOID_JOINTS,
+        HUMANOID_SEGMENTS,
+        JointDefinition,
+        PRESET_NAMES,
+        SegmentDefinition,
+        SegmentMeshInfo,
+        quick_build,
+        quick_urdf,
+    )
+    from humanoid_character_builder.appearance import AppearanceParameters
+    from humanoid_character_builder.builder import (
+        CharacterBuilder,
+        CharacterBuildResult,
+        ExportOptions,
+        quick_build,
+        quick_urdf,
+    )
     from humanoid_character_builder.core.body_parameters import (
         BodyParameters,
         BuildType,
         GenderModel,
+        SegmentParameters,
     )
     from humanoid_character_builder.presets.loader import (
+        get_preset_info,
+        list_available_presets,
         load_body_preset,
     )
+    from humanoid_character_builder.segments import (
+        HUMANOID_JOINTS,
+        HUMANOID_SEGMENTS,
+        JointDefinition,
+        SegmentDefinition,
+    )
+    from humanoid_character_builder.urdf import (
+        HumanoidURDFGenerator,
+        URDFGeneratorConfig,
+    )
+    from humanoid_character_builder.mesh import (
+        InertiaMode,
+        InertiaResult,
+        MeshInertiaCalculator,
+        PrimitiveInertiaCalculator,
+        PrimitiveShape,
+    )
+except ImportError:  # pragma: no cover
+    pass
 
-    __all__ = [
-        # Body parameters
-        "BodyParameters",
-        "BuildType",
-        "GenderModel",
-        "AppearanceParameters",
-        "SegmentParameters",
-        # Anthropometry
-        "DE_LEVA_DATA",
-        "estimate_segment_masses",
-        "estimate_segment_dimensions",
-        "estimate_segment_inertia_from_gyration",
-        "get_segment_mass_ratio",
-        "get_segment_length_ratio",
-        "get_com_location",
-        # Segments
-        "HUMANOID_SEGMENTS",
-        "SegmentDefinition",
-        # Presets
-        "PRESET_NAMES",
-        "load_body_preset",
-        "list_available_presets",
-        "get_preset_info",
-    ]
-
-except ImportError:
-    # humanoid_character_builder not available
-    __all__ = []
-
-    def _not_available(*args: Any, **kwargs: Any) -> NoReturn:
-        raise ImportError(
-            "humanoid_character_builder not available. Ensure it is in the Python path."
-        )
-
-    # Create stubs
-    BodyParameters = _not_available
-    BuildType = _not_available
-    GenderModel = _not_available
-    load_body_preset = _not_available
+__all__: list[str] = [
+    # Body parameters & appearance
+    "AppearanceParameters",
+    "BodyParameters",
+    "BuildType",
+    "GenderModel",
+    "SegmentParameters",
+    # Anthropometry
+    "AnthropometryData",
+    "DE_LEVA_DATA",
+    "estimate_segment_masses",
+    "estimate_segment_dimensions",
+    "estimate_segment_inertia_from_gyration",
+    "get_segment_mass_ratio",
+    "get_segment_length_ratio",
+    "get_com_location",
+    # Segments & joints
+    "HUMANOID_SEGMENTS",
+    "HUMANOID_JOINTS",
+    "SegmentDefinition",
+    "JointDefinition",
+    # Presets
+    "PRESET_NAMES",
+    "load_body_preset",
+    "list_available_presets",
+    "get_preset_info",
+    # Builder
+    "CharacterBuilder",
+    "CharacterBuildResult",
+    "ExportOptions",
+    "SegmentMeshInfo",
+    # URDF
+    "HumanoidURDFGenerator",
+    "URDFGeneratorConfig",
+    # Convenience
+    "quick_build",
+    "quick_urdf",
+    # Mesh/inertia
+    "InertiaMode",
+    "InertiaResult",
+    "MeshInertiaCalculator",
+    "PrimitiveInertiaCalculator",
+    "PrimitiveShape",
+]


### PR DESCRIPTION
Previously `src/shared/python/model_generation/humanoid/__init__.py` exported nothing, forcing consumers to reach into `humanoid_character_builder` directly.

This PR re-exports the stable public API: BodyParameters, BuildType, GenderModel, AppearanceParameters, SegmentParameters, AnthropometryData, DE_LEVA_DATA, SegmentDefinition, JointDefinition, HUMANOID_SEGMENTS, HUMANOID_JOINTS, CharacterBuilder, CharacterBuildResult, ExportOptions, SegmentMeshInfo, HumanoidURDFGenerator, URDFGeneratorConfig, quick_build, quick_urdf, InertiaMode, InertiaResult, MeshInertiaCalculator, PrimitiveInertiaCalculator, PrimitiveShape.

Non-breaking change — existing deep imports continue to work.