### PR TITLE
fix(terminal): make TerminalAgentSessionInfo frozen and use model_copy (#2754)

### DIFF
--- a/src/shared/python/chat/terminal_contracts.py
+++ b/src/shared/python/chat/terminal_contracts.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 TerminalSessionState = Literal[
     "starting",
@@ -100,6 +100,8 @@ class TerminalAgentSessionRequest(BaseModel):
 
 class TerminalAgentSessionInfo(BaseModel):
     """Lifecycle state for a terminal-agent session."""
+
+    model_config = ConfigDict(frozen=True)
 
     session_id: str = Field(..., min_length=1)
     resolved_cwd: Path

--- a/src/shared/python/chat/terminal_runtime.py
+++ b/src/shared/python/chat/terminal_runtime.py
@@ -140,7 +140,7 @@ class TerminalSessionRuntime:
         """Stop the session's process and mark it stopped."""
         session = self._session_for(session_id)
         self._process_adapter.stop(session.process_id)
-        session.info.state = "stopped"
+        session.info = session.info.model_copy(update={"state": "stopped"})
         return session.info
 
     def drain_events(self, session_id: str) -> list[TerminalAgentEvent]:

--- a/tests/shared/python/chat/test_terminal_runtime.py
+++ b/tests/shared/python/chat/test_terminal_runtime.py
@@ -194,6 +194,28 @@ def test_unknown_session_operations_fail_fast() -> None:
         runtime.write("missing", "text")
 
 
+def test_stop_does_not_mutate_held_reference_to_old_info(tmp_path: Path) -> None:
+    """Stopping a session must not mutate a previously captured info reference.
+
+    TerminalAgentSessionInfo is frozen; stop() must produce a new instance via
+    model_copy so callers that stored the old reference see its original state.
+    """
+    adapter = FakeProcessAdapter()
+    runtime = TerminalSessionRuntime(_registry(), adapter)
+    runtime.start(_request(tmp_path))
+    session_id = runtime.start(_request(tmp_path)).session_id
+
+    old_info = runtime.get_session(session_id)
+    assert old_info.state == "running"
+
+    runtime.stop(session_id)
+
+    # The held reference must be unchanged (frozen model — no mutation)
+    assert old_info.state != "stopped"
+    # The registry must reflect the new state
+    assert runtime.get_session(session_id).state == "stopped"
+
+
 def test_secret_like_environment_values_are_not_overridden(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #2754.

Makes session info immutable. Mutation now produces new instances via model_copy. Tests verify a held reference to old info does NOT change after stop().

## Changes

- `terminal_contracts.py`: Added `model_config = ConfigDict(frozen=True)` to `TerminalAgentSessionInfo` (Pydantic v2 frozen model).
- `terminal_runtime.py`: Replaced `session.info.state = "stopped"` with `session.info = session.info.model_copy(update={"state": "stopped"})`. `_RuntimeSession` is a regular (non-frozen) dataclass so the reassignment is valid.

## Test plan
- [x] Regression test `test_stop_does_not_mutate_held_reference_to_old_info` — captures old info ref, calls stop(), asserts old ref unchanged and registry has new state
- [x] Existing terminal_runtime tests pass (9/9)
- [x] ruff clean (check + format, zero violations)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>