### PR TITLE
fix: markdown export writes real newlines instead of literal \n (#2750)

### DIFF
--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -855,8 +855,8 @@ class ChatDockWidget(QDockWidget):
                 widget = item.widget()
                 if isinstance(widget, ChatMessageBubble):
                     role_str = "You" if widget._role == "user" else "AI"
-                    lines.append(f"**{role_str}**:\\n\\n{widget._content}\\n")
-        return "\\n".join(lines)
+                    lines.append(f"**{role_str}**:\n\n{widget._content}\n")
+        return "\n".join(lines)
 
     def _copy_entire_thread(self) -> None:
         clipboard = QApplication.clipboard()

--- a/tests/shared/python/chat/test_chat_dock_widget.py
+++ b/tests/shared/python/chat/test_chat_dock_widget.py
@@ -361,3 +361,30 @@ class TestChatDockWidget:
         assert "test assistant message" in text
 
         widget.close()
+
+    def test_get_thread_markdown_uses_real_newlines(self, qtbot):
+        """_get_thread_markdown must use real newlines (chr(10)), not literal \\n."""
+        from chat.chat_dock_widget import ChatDockWidget
+
+        ChatDockWidget._shared_session_id = None
+        widget = ChatDockWidget(app_name="test_app")
+        _track_widget(qtbot, widget)
+
+        widget._add_bubble("user", "Hello world")
+        widget._add_bubble("assistant", "Hi there")
+        widget._add_bubble("user", "How are you?")
+
+        markdown = widget._get_thread_markdown()
+
+        # Must NOT contain the literal backslash-n sequence
+        assert "\\n" not in markdown, "Found literal \\n — newlines are escaped"
+        # Must contain real newline characters
+        assert chr(10) in markdown, "No real newline (chr(10)) found in markdown output"
+        # Content must appear correctly separated
+        assert "**You**" in markdown
+        assert "**AI**" in markdown
+        assert "Hello world" in markdown
+        assert "Hi there" in markdown
+        assert "How are you?" in markdown
+
+        widget.close()


### PR DESCRIPTION
Closes #2750.

Replaces escaped \n in _get_thread_markdown with real newlines.

## Test plan
- [x] Added unit test asserting real newline characters in export output
- [x] ruff check + format clean
- [x] Existing test_chat_dock_widget tests still pass