### PR TITLE
refactor(sidebar): inject storage_dir for calculator workspace (#2773)

### DIFF
--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/__init__.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/__init__.py
@@ -34,7 +34,9 @@ from .calculator_workspace import (
     CalculatorWorkspaceSettings,
     GlobalWorkspaceController,
     GlobalWorkspaceSettings,
+    default_calculator_workspace_controller,
     default_global_workspace_controller,
+    get_default_sidekick_dir,
     validate_calculator_workspace_path,
 )
 from .command_history import (
@@ -161,8 +163,10 @@ __all__ = [
     "WorkspaceVariable",
     "build_calculator_plot_spec",
     "create_tools_sidebar",
+    "default_calculator_workspace_controller",
     "default_global_workspace_controller",
     "default_calculator_startup_config",
+    "get_default_sidekick_dir",
     "install_tools_sidebar",
     "resolve_sidekick_theme",
     "sidekick_qss",

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/calculator_runtime.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/calculator_runtime.py
@@ -22,6 +22,7 @@ from .calculator_workspace import (
     build_calculator_workspace_controls,
     default_calculator_workspace_controller,
     evaluate_calculator_expression,
+    get_default_sidekick_dir,
 )
 from .command_history import CommandHistoryController
 from .qt_compat import QtCore, QtWidgets
@@ -72,6 +73,7 @@ class SidekickCalculatorWidget(QtWidgets.QWidget):
         )
         self._workspace_controller = default_calculator_workspace_controller(
             self._registry,
+            storage_dir=get_default_sidekick_dir("upstream_drift_tools"),
         )
         self._startup_namespace: dict[str, Any] = {}
         self._startup_result = apply_calculator_startup_imports(

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/calculator_workspace.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/calculator_workspace.py
@@ -369,27 +369,60 @@ class CalculatorWorkspaceActions:
         self._status_label.setText("Cleared calculator workspace.")
 
 
+def get_default_sidekick_dir(app_name: str | None = None) -> Path:
+    """Return the default Sidekick storage directory for an application.
+
+    Args:
+        app_name: Optional application name. When given, returns
+            ``~/.{app_name}/sidekick``; otherwise returns ``~/.sidekick``.
+
+    Returns:
+        Resolved path to the Sidekick storage directory.
+    """
+    if app_name is not None:
+        return Path.home() / f".{app_name}" / "sidekick"
+    return Path.home() / ".sidekick"
+
+
 def default_calculator_workspace_controller(
     registry: WorkspaceRegistry,
+    *,
+    storage_dir: Path | None = None,
 ) -> CalculatorWorkspaceController:
-    """Build the default Sidekick calculator-local workspace controller."""
+    """Build the default Sidekick calculator-local workspace controller.
+
+    Args:
+        registry: The calculator-local workspace registry.
+        storage_dir: Directory for workspace files. Defaults to
+            ``~/.sidekick`` when ``None``. Pass
+            ``get_default_sidekick_dir("upstream_drift_tools")`` to preserve
+            the legacy ``~/.upstream_drift_tools/sidekick`` path.
+    """
+    directory = storage_dir if storage_dir is not None else get_default_sidekick_dir()
     return CalculatorWorkspaceController(
         registry,
-        settings=CalculatorWorkspaceSettings(
-            default_directory=Path.home() / ".upstream_drift_tools" / "sidekick",
-        ),
+        settings=CalculatorWorkspaceSettings(default_directory=directory),
     )
 
 
 def default_global_workspace_controller(
     registry: WorkspaceRegistry,
+    *,
+    storage_dir: Path | None = None,
 ) -> GlobalWorkspaceController:
-    """Build the default Sidekick global workspace controller."""
+    """Build the default Sidekick global workspace controller.
+
+    Args:
+        registry: The shared global workspace registry.
+        storage_dir: Directory for workspace files. Defaults to
+            ``~/.sidekick`` when ``None``. Pass
+            ``get_default_sidekick_dir("upstream_drift_tools")`` to preserve
+            the legacy ``~/.upstream_drift_tools/sidekick`` path.
+    """
+    directory = storage_dir if storage_dir is not None else get_default_sidekick_dir()
     return GlobalWorkspaceController(
         registry,
-        settings=GlobalWorkspaceSettings(
-            default_directory=Path.home() / ".upstream_drift_tools" / "sidekick",
-        ),
+        settings=GlobalWorkspaceSettings(default_directory=directory),
     )
 
 

--- a/tests/shared/python/upstream_drift_tools/ui/test_tools_sidebar_calculator_workspace.py
+++ b/tests/shared/python/upstream_drift_tools/ui/test_tools_sidebar_calculator_workspace.py
@@ -15,6 +15,8 @@ from upstream_drift_tools.ui.tools_sidebar import (
     GlobalWorkspaceController,
     GlobalWorkspaceSettings,
     WorkspaceRegistry,
+    default_calculator_workspace_controller,
+    get_default_sidekick_dir,
     validate_calculator_workspace_path,
 )
 
@@ -264,3 +266,52 @@ def test_promote_local_variable_requires_explicit_overwrite() -> None:
     workspace.promote_to_global("result", overwrite=True)
 
     assert global_workspace.get("result") == 7
+
+
+# ---------------------------------------------------------------------------
+# Storage-dir injection tests (issue #2773)
+# ---------------------------------------------------------------------------
+
+
+def test_get_default_sidekick_dir_no_app_name() -> None:
+    """With no app_name, returns ~/.sidekick."""
+    result = get_default_sidekick_dir()
+    assert result == Path.home() / ".sidekick"
+
+
+def test_get_default_sidekick_dir_with_app_name() -> None:
+    """With app_name, returns ~/.{app_name}/sidekick."""
+    result = get_default_sidekick_dir("myapp")
+    assert result == Path.home() / ".myapp" / "sidekick"
+
+
+def test_get_default_sidekick_dir_upstream_drift_tools_compat() -> None:
+    """Calling with 'upstream_drift_tools' preserves the legacy path."""
+    result = get_default_sidekick_dir("upstream_drift_tools")
+    assert result == Path.home() / ".upstream_drift_tools" / "sidekick"
+
+
+def test_default_calculator_workspace_controller_no_args_uses_dot_sidekick() -> None:
+    """default_calculator_workspace_controller() with no storage_dir uses ~/.sidekick."""  # noqa: E501
+    registry = WorkspaceRegistry()
+    controller = default_calculator_workspace_controller(registry)
+    assert controller.settings.default_directory == Path.home() / ".sidekick"
+
+
+def test_default_calculator_workspace_controller_custom_storage_dir(
+    tmp_path: Path,
+) -> None:
+    """default_calculator_workspace_controller(storage_dir=...) uses the custom path."""
+    registry = WorkspaceRegistry()
+    controller = default_calculator_workspace_controller(registry, storage_dir=tmp_path)
+    assert controller.settings.default_directory == tmp_path
+
+
+def test_default_calculator_workspace_controller_custom_storage_dir_saves_there(
+    tmp_path: Path,
+) -> None:
+    """Controller with custom storage_dir actually writes to that directory."""
+    registry = WorkspaceRegistry({"x": 1})
+    controller = default_calculator_workspace_controller(registry, storage_dir=tmp_path)
+    saved = controller.save()
+    assert saved.parent == tmp_path


### PR DESCRIPTION
Closes #2773.

Removes hardcoded `~/.upstream_drift_tools/sidekick` from the shared library. Default is now `~/.sidekick` (brand-neutral). Hosts can inject their own `storage_dir`. UpstreamDrift call sites updated to preserve existing behavior explicitly.

## Changes

- `get_default_sidekick_dir(app_name=None)` helper added to `calculator_workspace.py` — returns `~/.sidekick` or `~/.{app_name}/sidekick`
- `default_calculator_workspace_controller(registry, *, storage_dir=None)` — new optional `storage_dir` parameter; defaults to `~/.sidekick`
- `default_global_workspace_controller(registry, *, storage_dir=None)` — same treatment for the global controller
- `calculator_runtime.py` (UpstreamDrift consumer) passes `storage_dir=get_default_sidekick_dir("upstream_drift_tools")` explicitly to preserve legacy `~/.upstream_drift_tools/sidekick` behavior
- Both `default_calculator_workspace_controller` and `get_default_sidekick_dir` exported from `__init__.py`

## Test plan
- [x] Default uses `~/.sidekick`
- [x] Custom `storage_dir` works
- [x] `get_default_sidekick_dir("myapp")` returns `~/.myapp/sidekick`
- [x] `get_default_sidekick_dir("upstream_drift_tools")` preserves legacy path
- [x] Controller with custom `storage_dir` actually writes to that directory
- [x] All 19 tests pass (`pytest tests/shared/python/upstream_drift_tools/ui/test_tools_sidebar_calculator_workspace.py`)
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>