### PR TITLE
build(rust): add ai_backend to Cargo workspace (#2775)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,14 @@ resolver = "2"
 members = [
     "rust_core/tools-core",
     "rust_core/math-primitives",
+    "rust_core/ai_backend",
 ]
 
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
 rust-version = "1.70"
+authors = ["D-sorganization Contributors"]
 license = "MIT"
 repository = "https://github.com/D-sorganization/Tools"
 


### PR DESCRIPTION
Closes #2775.

Includes ai_backend in cargo build/test/clippy workspace runs. CI can now actually exercise the AI Rust backend.

## Changes

- Added `"rust_core/ai_backend"` to `[workspace] members` in root `Cargo.toml`
- Added `authors = ["D-sorganization Contributors"]` to `[workspace.package]` — required because `rust_core/ai_backend/Cargo.toml` uses `authors.workspace = true`; without this field the workspace manifest rejects the crate

## Dependency audit

`ai_backend` uses the following direct deps not previously in the workspace:
- `tokio`, `reqwest`, `futures`, `rusqlite`, `walkdir`, `regex`, `ignore` — all declared inline (not as workspace deps), no conflict
- `pyo3`, `serde`, `serde_json` — declared as `{ workspace = true, optional = true }` or `{ workspace = true }`, already present at root — no conflict
- `ort`, `tokenizers`, `ndarray`, `sha2`, `dirs` — all behind the opt-in `local-embeddings` feature; default build does not pull them

## Test plan
- [x] cargo build --workspace succeeds
- [x] cargo test --workspace --no-run compiles
- [x] local-embeddings feature remains opt-in (no ONNX runtime required for default build)