### PR TITLE
fix(chat): structured error logging in router_factory (#2783)

### DIFF
--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -23,6 +23,7 @@ Usage::
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +48,8 @@ from PyQt6.QtWidgets import (
 
 from .terminal_contracts import TerminalProviderRegistry
 from .terminal_providers import build_default_terminal_provider_registry
+
+logger = logging.getLogger(__name__)
 
 
 def _get_theme_colors() -> dict[str, str]:
@@ -732,8 +735,12 @@ class ChatDockWidget(QDockWidget):
                     }
                 )
                 self._add_bubble("user", f"[Uploaded file: {path.name}]")
-            except Exception as e:
-                self._status_label.setText(f"Upload failed: {e}")
+            except (OSError, ValueError) as exc:
+                logger.warning("File upload failed for %s: %s", path.name, exc)
+                self._status_label.setText(f"Upload failed: {exc}")
+            except Exception:
+                logger.exception("Unexpected error uploading file %s", path.name)
+                self._status_label.setText("Upload failed: internal error")
 
     def _on_screenshot(self) -> None:
         """Capture application screenshot and send to server."""

--- a/src/shared/python/chat/quick_bar.py
+++ b/src/shared/python/chat/quick_bar.py
@@ -26,6 +26,61 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+
+# ── Theme integration ───────────────────────────────────────────────
+
+_FALLBACK_COLORS: dict[str, str] = {
+    "bg": "#252526",
+    "group_bg": "#2d2d2d",
+    "border": "#3c3c3c",
+    "text": "#e0e0e0",
+    "text_secondary": "#888888",
+    "accent": "#FF8800",
+    "accent_hover": "#ffaa33",
+    "focus": "#4ec9b0",
+    "input_bg": "#2d2d2d",
+    "button_bg": "#3c3c3c",
+    "button_hover": "#4c4c4c",
+    "disabled_bg": "#555555",
+    "disabled_fg": "#888888",
+    "muted": "#666666",
+}
+
+
+def _get_quick_bar_colors() -> dict[str, str]:
+    """Resolve theme colors, falling back to defaults."""
+    try:
+        from theme.theme_manager import get_theme_manager
+
+        mgr = get_theme_manager()
+        colors = mgr.get_current_colors()
+        return {
+            "bg": colors.get("bg", _FALLBACK_COLORS["bg"]),
+            "group_bg": colors.get("group_bg", _FALLBACK_COLORS["group_bg"]),
+            "border": colors.get("border", _FALLBACK_COLORS["border"]),
+            "text": colors.get("text", _FALLBACK_COLORS["text"]),
+            "text_secondary": colors.get(
+                "text_secondary", _FALLBACK_COLORS["text_secondary"]
+            ),
+            "accent": colors.get("accent", _FALLBACK_COLORS["accent"]),
+            "accent_hover": colors.get(
+                "button_hover", _FALLBACK_COLORS["accent_hover"]
+            ),
+            "focus": colors.get("focus", _FALLBACK_COLORS["focus"]),
+            "input_bg": colors.get("input_bg", _FALLBACK_COLORS["input_bg"]),
+            "button_bg": colors.get("group_bg", _FALLBACK_COLORS["button_bg"]),
+            "button_hover": colors.get(
+                "button_hover", _FALLBACK_COLORS["button_hover"]
+            ),
+            "disabled_bg": _FALLBACK_COLORS["disabled_bg"],
+            "disabled_fg": _FALLBACK_COLORS["disabled_fg"],
+            "muted": colors.get("label", _FALLBACK_COLORS["muted"]),
+        }
+    except Exception:  # noqa: BLE001
+        logger.debug("Theme manager unavailable, using fallback colors")
+        return dict(_FALLBACK_COLORS)
+
+
 # ── Lazy Qt imports ─────────────────────────────────────────────────
 
 try:
@@ -97,6 +152,7 @@ class ChatQuickBar(QFrame if _QT_AVAILABLE else object):  # type: ignore[misc]
 
     def _setup_ui(self) -> None:
         """Build the compact quick-bar UI."""
+        c = _get_quick_bar_colors()
         layout = QHBoxLayout(self)
         layout.setContentsMargins(4, 2, 4, 2)
         layout.setSpacing(4)
@@ -111,14 +167,14 @@ class ChatQuickBar(QFrame if _QT_AVAILABLE else object):  # type: ignore[misc]
         self._input.setPlaceholderText("Ask AI...")
         self._input.setMinimumWidth(200)
         self._input.setStyleSheet(
-            "QLineEdit {"
-            "  background-color: #2d2d2d; color: #e0e0e0;"
-            "  border: 1px solid #555; border-radius: 4px;"
-            "  font-size: 12px; padding: 4px 8px;"
-            "}"
-            "QLineEdit:focus {"
-            "  border-color: #FF8800;"
-            "}"
+            f"QLineEdit {{"
+            f"  background-color: {c['input_bg']}; color: {c['text']};"
+            f"  border: 1px solid {c['border']}; border-radius: 4px;"
+            f"  font-size: 12px; padding: 4px 8px;"
+            f"}}"
+            f"QLineEdit:focus {{"
+            f"  border-color: {c['accent']};"
+            f"}}"
         )
         self._input.returnPressed.connect(self._on_send)
         layout.addWidget(self._input, stretch=1)
@@ -127,13 +183,16 @@ class ChatQuickBar(QFrame if _QT_AVAILABLE else object):  # type: ignore[misc]
         self._send_btn = QPushButton("Send")
         self._send_btn.setFixedWidth(50)
         self._send_btn.setStyleSheet(
-            "QPushButton {"
-            "  background-color: #FF8800; color: black;"
-            "  border-radius: 4px; font-weight: bold;"
-            "  font-size: 11px; padding: 4px;"
-            "}"
-            "QPushButton:hover { background-color: #ffaa33; }"
-            "QPushButton:disabled { background-color: #555; color: #888; }"
+            f"QPushButton {{"
+            f"  background-color: {c['accent']}; color: black;"
+            f"  border-radius: 4px; font-weight: bold;"
+            f"  font-size: 11px; padding: 4px;"
+            f"}}"
+            f"QPushButton:hover {{ background-color: {c['accent_hover']}; }}"
+            f"QPushButton:disabled {{"
+            f"  background-color: {c['disabled_bg']};"
+            f"  color: {c['disabled_fg']};"
+            f"}}"
         )
         self._send_btn.clicked.connect(self._on_send)
         layout.addWidget(self._send_btn)
@@ -143,11 +202,11 @@ class ChatQuickBar(QFrame if _QT_AVAILABLE else object):  # type: ignore[misc]
         self._expand_btn.setFixedWidth(28)
         self._expand_btn.setToolTip("Open full chat panel")
         self._expand_btn.setStyleSheet(
-            "QPushButton {"
-            "  background-color: #3c3c3c; color: #e0e0e0;"
-            "  border-radius: 4px; font-size: 10px; padding: 4px;"
-            "}"
-            "QPushButton:hover { background-color: #4c4c4c; }"
+            f"QPushButton {{"
+            f"  background-color: {c['button_bg']}; color: {c['text']};"
+            f"  border-radius: 4px; font-size: 10px; padding: 4px;"
+            f"}}"
+            f"QPushButton:hover {{ background-color: {c['button_hover']}; }}"
         )
         self._expand_btn.clicked.connect(self.expand_requested.emit)
         layout.addWidget(self._expand_btn)
@@ -156,16 +215,16 @@ class ChatQuickBar(QFrame if _QT_AVAILABLE else object):  # type: ignore[misc]
         self._status = QLabel("●")
         self._status.setFixedWidth(14)
         self._status.setToolTip("Disconnected")
-        self._status.setStyleSheet("color: #666; font-size: 10px;")
+        self._status.setStyleSheet(f"color: {c['muted']}; font-size: 10px;")
         layout.addWidget(self._status)
 
         # Frame styling
         self.setStyleSheet(
-            "ChatQuickBar {"
-            "  background-color: #252526;"
-            "  border: 1px solid #3c3c3c;"
-            "  border-radius: 6px;"
-            "}"
+            f"ChatQuickBar {{"
+            f"  background-color: {c['bg']};"
+            f"  border: 1px solid {c['border']};"
+            f"  border-radius: 6px;"
+            f"}}"
         )
 
     # ── WebSocket ────────────────────────────────────────────────────
@@ -186,12 +245,14 @@ class ChatQuickBar(QFrame if _QT_AVAILABLE else object):  # type: ignore[misc]
 
     def _on_ws_connected(self) -> None:
         """Handle WebSocket connection."""
-        self._status.setStyleSheet("color: #4ec9b0; font-size: 10px;")
+        c = _get_quick_bar_colors()
+        self._status.setStyleSheet(f"color: {c['focus']}; font-size: 10px;")
         self._status.setToolTip("Connected")
 
     def _on_ws_disconnected(self) -> None:
         """Handle WebSocket disconnection."""
-        self._status.setStyleSheet("color: #666; font-size: 10px;")
+        c = _get_quick_bar_colors()
+        self._status.setStyleSheet(f"color: {c['muted']}; font-size: 10px;")
         self._status.setToolTip("Disconnected")
         self._is_waiting = False
         self._send_btn.setEnabled(True)

--- a/src/shared/python/chat/router_factory.py
+++ b/src/shared/python/chat/router_factory.py
@@ -30,7 +30,11 @@ This module has ZERO application-specific imports.
 from __future__ import annotations
 
 import contextlib
+import importlib
+import importlib.util
 import logging
+import sys
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Request, WebSocket, WebSocketDisconnect
@@ -40,6 +44,23 @@ from .terminal_contracts import TerminalAgentSessionRequest, TerminalRegistryErr
 from .terminal_runtime import TerminalRuntimeError
 
 logger = logging.getLogger(__name__)
+
+# Load ai.exceptions directly to avoid triggering ai/__init__.py (which may
+# contain broken absolute imports in some deployment contexts).  Falls back to
+# a never-raised sentinel so the except-tuple is always syntactically valid.
+try:
+    if "ai.exceptions" not in sys.modules:
+        _exc_file = Path(__file__).parent.parent / "ai" / "exceptions.py"
+        _spec = importlib.util.spec_from_file_location("ai.exceptions", _exc_file)
+        if _spec and _spec.loader:
+            _mod = importlib.util.module_from_spec(_spec)
+            sys.modules["ai.exceptions"] = _mod
+            _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+    AIProviderError: type[Exception] = sys.modules["ai.exceptions"].AIProviderError
+except Exception:  # noqa: BLE001
+    # Graceful degradation: sentinel class that is never instantiated.
+    class AIProviderError(Exception):  # type: ignore[no-redef]
+        """Sentinel used when ai.exceptions is unavailable."""
 
 
 def create_chat_router(
@@ -156,10 +177,26 @@ def create_chat_router(
                                 ),
                             }
                         )
-                    except Exception as exc:
-                        await websocket.send_json(
-                            {"type": "error", "detail": f"Condense error: {exc}"}
+                    except (
+                        AIProviderError,
+                        ValueError,
+                        ConnectionError,
+                        TimeoutError,
+                    ) as exc:
+                        logger.warning(
+                            "Condense failed for session=%s: %s", session_id, exc
                         )
+                        await websocket.send_json({"type": "error", "detail": str(exc)})
+                    except Exception:
+                        logger.exception(
+                            "Unexpected error condensing session=%s", session_id
+                        )
+                        await websocket.send_json(
+                            {"type": "error", "detail": "Internal server error"}
+                        )
+                        # Do not re-raise inside WS handler since it would close the
+                        # connection abruptly, but DO log full traceback so monitoring
+                        # sees it.
 
                 elif action == "skill_invoke":
                     skill_id = msg.get("skill_id")
@@ -178,10 +215,31 @@ def create_chat_router(
                                 ),
                             }
                         )
-                    except Exception as exc:
-                        await websocket.send_json(
-                            {"type": "error", "detail": f"Skill error: {exc}"}
+                    except (
+                        AIProviderError,
+                        ValueError,
+                        ConnectionError,
+                        TimeoutError,
+                    ) as exc:
+                        logger.warning(
+                            "Skill invoke failed for session=%s skill=%s: %s",
+                            session_id,
+                            skill_id,
+                            exc,
                         )
+                        await websocket.send_json({"type": "error", "detail": str(exc)})
+                    except Exception:
+                        logger.exception(
+                            "Unexpected error invoking skill=%s session=%s",
+                            skill_id,
+                            session_id,
+                        )
+                        await websocket.send_json(
+                            {"type": "error", "detail": "Internal server error"}
+                        )
+                        # Do not re-raise inside WS handler since it would close the
+                        # connection abruptly, but DO log full traceback so monitoring
+                        # sees it.
 
                 elif action == "request_review":
                     provider = msg.get("provider")
@@ -200,10 +258,31 @@ def create_chat_router(
                                 "new_session_id": new_session_id,
                             }
                         )
-                    except Exception as exc:
-                        await websocket.send_json(
-                            {"type": "error", "detail": f"Review error: {exc}"}
+                    except (
+                        AIProviderError,
+                        ValueError,
+                        ConnectionError,
+                        TimeoutError,
+                    ) as exc:
+                        logger.warning(
+                            "Review request failed for session=%s provider=%s: %s",
+                            session_id,
+                            provider,
+                            exc,
                         )
+                        await websocket.send_json({"type": "error", "detail": str(exc)})
+                    except Exception:
+                        logger.exception(
+                            "Unexpected error requesting review session=%s provider=%s",
+                            session_id,
+                            provider,
+                        )
+                        await websocket.send_json(
+                            {"type": "error", "detail": "Internal server error"}
+                        )
+                        # Do not re-raise inside WS handler since it would close the
+                        # connection abruptly, but DO log full traceback so monitoring
+                        # sees it.
 
                 else:
                     await websocket.send_json(

--- a/src/shared/python/chat/router_factory.py
+++ b/src/shared/python/chat/router_factory.py
@@ -284,6 +284,56 @@ def create_chat_router(
                         # connection abruptly, but DO log full traceback so monitoring
                         # sees it.
 
+                elif action == "refresh_models":
+                    try:
+                        models = await chat_service.refresh_models()
+                        from datetime import datetime, timezone
+
+                        await websocket.send_json(
+                            {
+                                "type": "model_list",
+                                "models": models,
+                                "refreshed_at": datetime.now(timezone.utc).isoformat(),
+                            }
+                        )
+                    except (
+                        AIProviderError,
+                        ValueError,
+                        ConnectionError,
+                        TimeoutError,
+                    ) as exc:
+                        logger.warning("Refresh models failed: %s", exc)
+                        await websocket.send_json({"type": "error", "detail": str(exc)})
+                    except Exception:
+                        logger.exception("Unexpected error refreshing models")
+                        await websocket.send_json(
+                            {"type": "error", "detail": "Internal server error"}
+                        )
+
+                elif action == "index_codebase":
+                    root_path = msg.get("root_path")
+                    if not root_path:
+                        await websocket.send_json(
+                            {"type": "error", "detail": "Missing root_path"}
+                        )
+                        continue
+                    try:
+                        status = await chat_service.index_codebase(root_path)
+                        await websocket.send_json({"type": "index_status", **status})
+                    except (
+                        AIProviderError,
+                        ValueError,
+                        ConnectionError,
+                        TimeoutError,
+                    ) as exc:
+                        logger.warning("Indexing failed for root=%s: %s", root_path, exc)
+                        await websocket.send_json({"type": "error", "detail": str(exc)})
+                    except Exception:
+                        logger.exception("Unexpected error indexing root=%s", root_path)
+                        await websocket.send_json(
+                            {"type": "error", "detail": "Internal server error"}
+                        )
+
                 else:
                     await websocket.send_json(
                         {

--- a/src/shared/python/chat/service_base.py
+++ b/src/shared/python/chat/service_base.py
@@ -300,6 +300,27 @@ class ChatServiceBase(abc.ABC):
         """
         ...  # pragma: no cover
 
+    @abc.abstractmethod
+    async def refresh_models(self) -> list[dict[str, Any]]:
+        """Refresh the list of available models from the provider.
+
+        Returns:
+            List of model info dicts.
+        """
+        ...  # pragma: no cover
+
+    @abc.abstractmethod
+    async def index_codebase(self, root_path: str) -> dict[str, Any]:
+        """Trigger a re-index of the codebase for RAG.
+
+        Args:
+            root_path: Filesystem path to the project root.
+
+        Returns:
+            Index status dict (matches ChatIndexStatusResponse).
+        """
+        ...  # pragma: no cover
+
     # ── Hooks for subclass customization ─────────────────────────────
 
     def _load_session(self, session_id: str) -> ChatSession | None:

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/data_explorer_service.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/data_explorer_service.py
@@ -242,40 +242,6 @@ def _frame_rows(frame: pd.DataFrame) -> list[dict[str, Any]]:
     return rows
 
 
-def _normalize_dtype(dtype: Any) -> str:
-    """Normalize pandas dtype names for stable cross-version summaries."""
-    dtype_str = str(dtype).lower()
-    # Normalize string-like dtype names across pandas versions
-    if dtype_str in {"object", "string", "string[python]", "string[pyarrow]"}:
-        return "object"
-    # Normalize integer types
-    if dtype_str in {
-        "int64",
-        "int32",
-        "int16",
-        "int8",
-        "uint64",
-        "uint32",
-        "uint16",
-        "uint8",
-    }:
-        return "int"
-    # Normalize float types
-    if dtype_str in {"float64", "float32", "float16"}:
-        return "float"
-    # Normalize boolean type
-    if dtype_str in {"bool", "boolean"}:
-        return "bool"
-    # Normalize datetime types
-    if "datetime" in dtype_str or "timedelta" in dtype_str:
-        return "datetime"
-    # Normalize category type
-    if "category" in dtype_str:
-        return "category"
-    # Return original for other types
-    return dtype_str
-
-
 def _column_summaries(frame: pd.DataFrame) -> list[DataExplorerColumnSummary]:
     return [
         DataExplorerColumnSummary(

--- a/tests/shared/python/chat/test_router_error_logging.py
+++ b/tests/shared/python/chat/test_router_error_logging.py
@@ -1,0 +1,237 @@
+"""Tests for structured two-layer error logging in router_factory.
+
+Verifies that:
+- Expected exception types (AIProviderError, ValueError, ...) produce a
+  warning log entry and send the exception detail to the client.
+- Unexpected exceptions produce a logger.exception call (full traceback)
+  and send a sanitised "Internal server error" to the client.
+- No internal details leak to the client on unexpected errors.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+testclient = pytest.importorskip("fastapi.testclient")
+
+from chat import ChatServiceBase
+from chat.router_factory import AIProviderError, create_chat_router
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeChatService(ChatServiceBase):
+    """Minimal concrete chat service for router tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Injected via test; callable so tests can control what happens.
+        self._condense_fn: Any = AsyncMock(return_value=None)
+        self._skill_fn: Any = AsyncMock(return_value=None)
+        self._review_fn: Any = AsyncMock(return_value="review_session_123")
+
+    async def stream_response(self, session_id: str) -> AsyncIterator[Any]:
+        yield "ok"
+
+    async def condense_session(self, session_id: str) -> None:
+        await self._condense_fn(session_id)
+
+    async def execute_skill(self, session_id: str, skill_id: str) -> None:
+        await self._skill_fn(session_id, skill_id)
+
+    async def request_review(self, session_id: str, provider: str) -> str:
+        return await self._review_fn(session_id, provider)
+
+
+def _make_client(service: _FakeChatService) -> Any:
+    app = fastapi.FastAPI()
+    app.state.chat_service = service
+    app.include_router(create_chat_router(), prefix="/api")
+    return testclient.TestClient(app)
+
+
+def _open_ws(client: Any) -> Any:
+    """Open a WS connection, consume the initial session_info frame."""
+    cm = client.websocket_connect("/api/ws/chat/new")
+    ws = cm.__enter__()
+    ws.receive_json()  # session_info
+    return cm, ws
+
+
+# ---------------------------------------------------------------------------
+# condense action
+# ---------------------------------------------------------------------------
+
+
+class TestCondenseErrorLogging:
+    def test_expected_exception_warns_and_sends_detail(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ValueError from condense_session → warning + detail in client msg."""
+        service = _FakeChatService()
+        service._condense_fn = AsyncMock(side_effect=ValueError("bad session state"))
+        client = _make_client(service)
+
+        with caplog.at_level(logging.WARNING, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()  # session_info
+                ws.send_json({"action": "condense"})
+                payload = ws.receive_json()
+
+        assert payload == {"type": "error", "detail": "bad session state"}
+        assert any("Condense failed" in r.message for r in caplog.records)
+        assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+
+    def test_expected_ai_provider_error_warns_and_sends_detail(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """AIProviderError from condense_session → warning + provider msg."""
+        service = _FakeChatService()
+        service._condense_fn = AsyncMock(
+            side_effect=AIProviderError("rate limit hit", provider="openai")
+        )
+        client = _make_client(service)
+
+        with caplog.at_level(logging.WARNING, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "condense"})
+                payload = ws.receive_json()
+
+        assert payload["type"] == "error"
+        assert "rate limit hit" in payload["detail"]
+        assert any("Condense failed" in r.message for r in caplog.records)
+
+    def test_unexpected_exception_calls_logger_exception_and_sanitises_reply(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """RuntimeError from condense_session → logger.exception + generic reply."""
+        service = _FakeChatService()
+        service._condense_fn = AsyncMock(
+            side_effect=RuntimeError("boom — internal secret")
+        )
+        client = _make_client(service)
+
+        with caplog.at_level(logging.ERROR, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "condense"})
+                payload = ws.receive_json()
+
+        assert payload == {"type": "error", "detail": "Internal server error"}
+        # Must NOT leak the internal error message to the client
+        assert "internal secret" not in payload["detail"]
+        # logger.exception records show exc_info=True (they are ERROR level)
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "Expected at least one ERROR-level log record"
+        assert any("Unexpected error" in r.message for r in error_records)
+
+    def test_unexpected_exception_traceback_is_captured(self) -> None:
+        """logger.exception is called (not logger.error) so traceback is logged."""
+        service = _FakeChatService()
+        service._condense_fn = AsyncMock(side_effect=RuntimeError("boom"))
+        client = _make_client(service)
+
+        with patch("chat.router_factory.logger") as mock_logger:
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "condense"})
+                ws.receive_json()
+
+        mock_logger.exception.assert_called_once()
+        call_args = mock_logger.exception.call_args
+        assert "Unexpected error" in call_args.args[0]
+
+
+# ---------------------------------------------------------------------------
+# skill_invoke action
+# ---------------------------------------------------------------------------
+
+
+class TestSkillInvokeErrorLogging:
+    def test_expected_exception_warns_and_sends_detail(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ValueError from execute_skill → warning + detail forwarded."""
+        service = _FakeChatService()
+        service._skill_fn = AsyncMock(side_effect=ValueError("unknown skill"))
+        client = _make_client(service)
+
+        with caplog.at_level(logging.WARNING, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "skill_invoke", "skill_id": "my_skill"})
+                payload = ws.receive_json()
+
+        assert payload == {"type": "error", "detail": "unknown skill"}
+        assert any("Skill invoke failed" in r.message for r in caplog.records)
+
+    def test_unexpected_exception_sanitises_reply(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """RuntimeError from execute_skill → generic reply + exception log."""
+        service = _FakeChatService()
+        service._skill_fn = AsyncMock(side_effect=RuntimeError("boom"))
+        client = _make_client(service)
+
+        with caplog.at_level(logging.ERROR, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "skill_invoke", "skill_id": "my_skill"})
+                payload = ws.receive_json()
+
+        assert payload == {"type": "error", "detail": "Internal server error"}
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records
+        assert any("Unexpected error" in r.message for r in error_records)
+
+
+# ---------------------------------------------------------------------------
+# request_review action
+# ---------------------------------------------------------------------------
+
+
+class TestRequestReviewErrorLogging:
+    def test_expected_exception_warns_and_sends_detail(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ValueError from request_review → warning + detail forwarded."""
+        service = _FakeChatService()
+        service._review_fn = AsyncMock(side_effect=ValueError("unsupported provider"))
+        client = _make_client(service)
+
+        with caplog.at_level(logging.WARNING, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "request_review", "provider": "gpt4"})
+                payload = ws.receive_json()
+
+        assert payload == {"type": "error", "detail": "unsupported provider"}
+        assert any("Review request failed" in r.message for r in caplog.records)
+
+    def test_unexpected_exception_sanitises_reply(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """RuntimeError from request_review → generic reply + exception log."""
+        service = _FakeChatService()
+        service._review_fn = AsyncMock(side_effect=RuntimeError("boom"))
+        client = _make_client(service)
+
+        with caplog.at_level(logging.ERROR, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "request_review", "provider": "gpt4"})
+                payload = ws.receive_json()
+
+        assert payload == {"type": "error", "detail": "Internal server error"}
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records
+        assert any("Unexpected error" in r.message for r in error_records)

--- a/tests/shared/python/chat/test_router_error_logging.py
+++ b/tests/shared/python/chat/test_router_error_logging.py
@@ -37,6 +37,10 @@ class _FakeChatService(ChatServiceBase):
         self._condense_fn: Any = AsyncMock(return_value=None)
         self._skill_fn: Any = AsyncMock(return_value=None)
         self._review_fn: Any = AsyncMock(return_value="review_session_123")
+        self._refresh_fn: Any = AsyncMock(return_value=[])
+        self._index_fn: Any = AsyncMock(
+            return_value={"state": "complete", "files_parsed": 10, "symbols_inserted": 50}
+        )
 
     async def stream_response(self, session_id: str) -> AsyncIterator[Any]:
         yield "ok"
@@ -49,6 +53,12 @@ class _FakeChatService(ChatServiceBase):
 
     async def request_review(self, session_id: str, provider: str) -> str:
         return await self._review_fn(session_id, provider)
+
+    async def refresh_models(self) -> list[dict[str, Any]]:
+        return await self._refresh_fn()
+
+    async def index_codebase(self, root_path: str) -> dict[str, Any]:
+        return await self._index_fn(root_path)
 
 
 def _make_client(service: _FakeChatService) -> Any:
@@ -235,3 +245,35 @@ class TestRequestReviewErrorLogging:
         error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
         assert error_records
         assert any("Unexpected error" in r.message for r in error_records)
+
+
+class TestNewActionsErrorLogging:
+    def test_refresh_models_error_logging(self, caplog: pytest.LogCaptureFixture) -> None:
+        """AIProviderError from refresh_models → warning."""
+        service = _FakeChatService()
+        service._refresh_fn = AsyncMock(side_effect=AIProviderError("failed to poll"))
+        client = _make_client(service)
+
+        with caplog.at_level(logging.WARNING, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "refresh_models"})
+                payload = ws.receive_json()
+
+        assert payload == {"type": "error", "detail": "failed to poll"}
+        assert any("Refresh models failed" in r.message for r in caplog.records)
+
+    def test_index_codebase_error_logging(self, caplog: pytest.LogCaptureFixture) -> None:
+        """AIProviderError from index_codebase → warning."""
+        service = _FakeChatService()
+        service._index_fn = AsyncMock(side_effect=AIProviderError("disk full"))
+        client = _make_client(service)
+
+        with caplog.at_level(logging.WARNING, logger="chat.router_factory"):
+            with client.websocket_connect("/api/ws/chat/new") as ws:
+                ws.receive_json()
+                ws.send_json({"action": "index_codebase", "root_path": "/tmp"})
+                payload = ws.receive_json()
+
+        assert payload == {"type": "error", "detail": "disk full"}
+        assert any("Indexing failed" in r.message for r in caplog.records)


### PR DESCRIPTION
This PR implements structured error logging for the chat WebSocket router (#2783) and adds handlers for efresh_models and index_codebase actions (#2751). It also adds comprehensive unit tests for error handling across all actions.