### PR TITLE
fix(adapters): implement AdapterFactory cache (was dead code) (#2767)

### DIFF
--- a/src/shared/python/ai/adapters/factory.py
+++ b/src/shared/python/ai/adapters/factory.py
@@ -34,6 +34,9 @@ logger = get_logger(__name__)
 _LOCAL_FIRST_ORDER = ("ollama", "bitnet", "cline", "openai", "anthropic", "gemini")
 _CLOUD_FIRST_ORDER = ("openai", "anthropic", "gemini", "ollama", "bitnet", "cline")
 
+# Type alias for the cache key tuple: (provider, api_key, model, host, timeout)
+_CacheKey = tuple[str, str | None, str | None, str | None, float | None]
+
 
 class AdapterFactory:
     """Factory for creating and managing AI provider adapters.
@@ -42,10 +45,18 @@ class AdapterFactory:
     to import individual adapter modules. Supports automatic provider
     discovery and health-checking.
 
-    All adapters are created lazily and cached per-configuration.
+    Adapters are cached per-configuration: calling ``create()`` twice with
+    identical arguments returns the **same** instance, avoiding redundant
+    HTTP client setup, auth handshakes, and capability probes.  Call
+    ``clear_cache()`` to force fresh construction (e.g. after rotating
+    credentials).
+
+    Cache key: ``(provider, api_key, model, host, timeout)`` — all
+    keyword arguments are included so that any configuration difference
+    produces a distinct cached entry.
     """
 
-    _cache: dict[str, BaseAgentAdapter] = {}
+    _cache: dict[_CacheKey, BaseAgentAdapter] = {}
 
     # Provider → (module_path, class_name, env_var_hint) for cloud providers
     _CLOUD_PROVIDERS: dict[str, tuple[str, str, str]] = {
@@ -82,6 +93,11 @@ class AdapterFactory:
     ) -> BaseAgentAdapter:
         """Create an adapter for a specific provider.
 
+        Returns a cached adapter when the same ``(provider, api_key, model,
+        host, timeout)`` combination has been requested before, avoiding
+        redundant adapter construction.  Use ``clear_cache()`` to invalidate
+        the cache (e.g. after rotating credentials).
+
         Args:
             provider: Provider name (ollama, openai, anthropic, gemini, cline).
             api_key: API key (for cloud providers).
@@ -90,7 +106,7 @@ class AdapterFactory:
             timeout: Request timeout override.
 
         Returns:
-            Configured adapter instance.
+            Configured adapter instance (may be a previously cached object).
 
         Raises:
             ValueError: If provider is unknown or empty.
@@ -104,36 +120,50 @@ class AdapterFactory:
 
         provider = provider.lower().strip()
 
+        # Check cache before constructing a new adapter
+        cache_key: _CacheKey = (provider, api_key, model, host, timeout)
+        if cache_key in cls._cache:
+            logger.debug("AdapterFactory cache hit for provider=%s", provider)
+            return cls._cache[cache_key]
+
+        # Construct adapter, then store in cache before returning
+        adapter: BaseAgentAdapter
+
         # Local adapters — no API key required
         if provider == "ollama":
             from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
 
-            return OllamaAdapter(host=host, model=model, timeout=timeout)
+            adapter = OllamaAdapter(host=host, model=model, timeout=timeout)
 
-        if provider == "cline":
+        elif provider == "cline":
             from src.shared.python.ai.adapters.cline_adapter import ClineAdapter
 
-            return ClineAdapter(host=host, timeout=timeout)
+            adapter = ClineAdapter(host=host, timeout=timeout)
 
-        if provider == "bitnet":
+        elif provider == "bitnet":
             from src.shared.python.ai.adapters.bitnet_adapter import BitnetAdapter
 
             # Bitnet uses 'host' param as bitnet_root in this context if provided
-            return BitnetAdapter(model=model, bitnet_root=host)
+            adapter = BitnetAdapter(model=model, bitnet_root=host)
 
-        # "codex" is an alias for OpenAI
-        lookup_key = "openai" if provider == "codex" else provider
+        else:
+            # "codex" is an alias for OpenAI
+            lookup_key = "openai" if provider == "codex" else provider
 
-        # Cloud adapters — DRY key resolution
-        if lookup_key in cls._CLOUD_PROVIDERS:
-            return cls._create_cloud_adapter(
-                lookup_key, api_key=api_key, model=model, timeout=timeout
-            )
+            # Cloud adapters — DRY key resolution
+            if lookup_key in cls._CLOUD_PROVIDERS:
+                adapter = cls._create_cloud_adapter(
+                    lookup_key, api_key=api_key, model=model, timeout=timeout
+                )
+            else:
+                raise ValueError(
+                    f"Unknown provider: {provider}. "
+                    f"Supported: {', '.join(sorted(cls._SUPPORTED_PROVIDERS))}"
+                )
 
-        raise ValueError(
-            f"Unknown provider: {provider}. "
-            f"Supported: {', '.join(sorted(cls._SUPPORTED_PROVIDERS))}"
-        )
+        cls._cache[cache_key] = adapter
+        logger.debug("AdapterFactory cached new adapter for provider=%s", provider)
+        return adapter
 
     @classmethod
     def _create_cloud_adapter(
@@ -281,5 +311,10 @@ class AdapterFactory:
 
     @classmethod
     def clear_cache(cls) -> None:
-        """Clear the adapter cache."""
+        """Clear the adapter cache.
+
+        Forces the next ``create()`` call to construct a fresh adapter
+        instance even for previously seen configurations.  Use after
+        rotating API keys or changing connection settings.
+        """
         cls._cache.clear()

--- a/tests/shared/python/ai/test_adapter_factory.py
+++ b/tests/shared/python/ai/test_adapter_factory.py
@@ -1,0 +1,218 @@
+"""Tests for AdapterFactory caching behaviour.
+
+Verifies that:
+- Calling create() twice with identical arguments returns the *same* instance.
+- Calling create() with different configurations returns *different* instances.
+- clear_cache() causes subsequent create() calls to construct fresh instances.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: stub the broken src.shared.python.ai __init__ and logging_pkg so
+# that importing the factory module directly works in a plain pytest run.
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str | None]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.adapters", "src/shared/python/ai/adapters"),
+    ("src.shared.python.logging_pkg", None),
+    ("src.shared.python.logging_pkg.logging_config", None),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        if _rel_path is not None:
+            _stub.__path__ = [str(ROOT / _rel_path)]  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+# Stub logging_pkg so factory.py can import get_logger without extra deps.
+_logging_config_stub = sys.modules["src.shared.python.logging_pkg.logging_config"]
+_logging_config_stub.get_logger = logging.getLogger  # type: ignore[attr-defined]
+_logging_config_stub.setup_logging = lambda *a, **kw: None  # type: ignore[attr-defined]
+
+# Pre-register adapter sub-modules with sentinel class attrs so patch() can
+# replace them.  The factory uses lazy `from X import Cls` inside create(),
+# so the sub-modules must exist in sys.modules before patch resolves the path.
+_ADAPTER_MODULES = {
+    "src.shared.python.ai.adapters.ollama_adapter": "OllamaAdapter",
+    "src.shared.python.ai.adapters.cline_adapter": "ClineAdapter",
+    "src.shared.python.ai.adapters.bitnet_adapter": "BitnetAdapter",
+}
+for _amod_name, _cls_name in _ADAPTER_MODULES.items():
+    if _amod_name not in sys.modules:
+        _amod = types.ModuleType(_amod_name)
+        setattr(_amod, _cls_name, MagicMock)
+        sys.modules[_amod_name] = _amod
+
+# Now safe to import the factory (bypasses the broken ai/__init__.py).
+from src.shared.python.ai.adapters.factory import AdapterFactory  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_adapter() -> MagicMock:
+    """Return a fresh MagicMock that quacks like a BaseAgentAdapter."""
+    return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def clear_factory_cache() -> None:
+    """Ensure a clean cache state before and after every test."""
+    AdapterFactory.clear_cache()
+    yield  # type: ignore[misc]
+    AdapterFactory.clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# Cache hit — same instance returned for identical configuration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("provider", "kwargs"),
+    [
+        ("ollama", {"host": "http://localhost:11434", "model": "llama3"}),
+        ("cline", {"host": "http://localhost:7777"}),
+        ("bitnet", {"model": "Llama3.2-1B.gguf", "host": "/opt/bitnet"}),
+    ],
+)
+def test_create_same_config_returns_same_instance(provider: str, kwargs: dict) -> None:
+    """create() called twice with identical args returns the same object."""
+    adapter_mock = _make_mock_adapter()
+
+    adapter_class_paths = {
+        "ollama": "src.shared.python.ai.adapters.ollama_adapter.OllamaAdapter",
+        "cline": "src.shared.python.ai.adapters.cline_adapter.ClineAdapter",
+        "bitnet": "src.shared.python.ai.adapters.bitnet_adapter.BitnetAdapter",
+    }
+
+    with patch(adapter_class_paths[provider], return_value=adapter_mock):
+        first = AdapterFactory.create(provider, **kwargs)
+        second = AdapterFactory.create(provider, **kwargs)
+
+    assert first is second, (
+        f"Expected the same adapter instance on second create({provider!r}, {kwargs}), "
+        f"but got a different object."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cache miss — different configs → different instances
+# ---------------------------------------------------------------------------
+
+
+def test_create_different_configs_returns_different_instances() -> None:
+    """create() with different model overrides returns distinct instances."""
+    mock_a = _make_mock_adapter()
+    mock_b = _make_mock_adapter()
+
+    with patch(
+        "src.shared.python.ai.adapters.ollama_adapter.OllamaAdapter",
+        side_effect=[mock_a, mock_b],
+    ):
+        adapter_a = AdapterFactory.create("ollama", model="llama3")
+        adapter_b = AdapterFactory.create("ollama", model="mistral")
+
+    assert adapter_a is not adapter_b, (
+        "Different model configurations must produce distinct adapter instances."
+    )
+
+
+def test_create_different_hosts_returns_different_instances() -> None:
+    """create() with different host overrides returns distinct instances."""
+    mock_a = _make_mock_adapter()
+    mock_b = _make_mock_adapter()
+
+    with patch(
+        "src.shared.python.ai.adapters.ollama_adapter.OllamaAdapter",
+        side_effect=[mock_a, mock_b],
+    ):
+        adapter_a = AdapterFactory.create("ollama", host="http://host-a:11434")
+        adapter_b = AdapterFactory.create("ollama", host="http://host-b:11434")
+
+    assert adapter_a is not adapter_b, (
+        "Different host configurations must produce distinct adapter instances."
+    )
+
+
+# ---------------------------------------------------------------------------
+# clear_cache() causes fresh construction
+# ---------------------------------------------------------------------------
+
+
+def test_clear_cache_causes_fresh_construction() -> None:
+    """After clear_cache(), create() constructs a new adapter instance."""
+    mock_first = _make_mock_adapter()
+    mock_second = _make_mock_adapter()
+
+    with patch(
+        "src.shared.python.ai.adapters.ollama_adapter.OllamaAdapter",
+        side_effect=[mock_first, mock_second],
+    ):
+        first = AdapterFactory.create("ollama", model="llama3")
+        AdapterFactory.clear_cache()
+        second = AdapterFactory.create("ollama", model="llama3")
+
+    assert first is not second, (
+        "After clear_cache(), create() must construct a fresh adapter instance."
+    )
+
+
+def test_clear_cache_empties_internal_dict() -> None:
+    """clear_cache() leaves the internal _cache dict empty."""
+    adapter_mock = _make_mock_adapter()
+
+    with patch(
+        "src.shared.python.ai.adapters.ollama_adapter.OllamaAdapter",
+        return_value=adapter_mock,
+    ):
+        AdapterFactory.create("ollama")
+
+    assert len(AdapterFactory._cache) == 1, (
+        "Cache should have one entry after create()."
+    )
+    AdapterFactory.clear_cache()
+    assert len(AdapterFactory._cache) == 0, "Cache should be empty after clear_cache()."
+
+
+# ---------------------------------------------------------------------------
+# Constructor called exactly once per unique key
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_called_once_for_repeated_create() -> None:
+    """The underlying adapter constructor is only called once for cache hits."""
+    with patch(
+        "src.shared.python.ai.adapters.ollama_adapter.OllamaAdapter",
+    ) as mock_cls:
+        mock_cls.return_value = _make_mock_adapter()
+        AdapterFactory.create("ollama", model="llama3")
+        AdapterFactory.create("ollama", model="llama3")
+        AdapterFactory.create("ollama", model="llama3")
+
+    assert mock_cls.call_count == 1, (
+        f"OllamaAdapter constructor should be called once, got {mock_cls.call_count}."
+    )


### PR DESCRIPTION
Closes #2767.

Implements the per-configuration cache that the docstring already promised. Avoids redundant adapter construction (which includes HTTP client setup, auth handshake, capabilities probe).

## Changes

- `src/shared/python/ai/adapters/factory.py`: add `_CacheKey` type alias; update `_cache` annotation to use the typed key; `create()` now checks cache on entry and writes on miss; updated docstrings to reflect truth.
- `tests/shared/python/ai/test_adapter_factory.py`: 8 new tests covering cache hit, cache miss (different model, different host), `clear_cache()` invalidation, and constructor call-count.

## Test plan
- [x] Repeated `create()` with identical args returns the **same** adapter instance
- [x] Different `model` configs return different instances
- [x] Different `host` configs return different instances
- [x] `clear_cache()` causes subsequent `create()` to construct a fresh instance
- [x] `clear_cache()` empties `_cache` dict
- [x] Adapter constructor called exactly once for repeated cache-hit creates
- [x] ruff lint clean
- [x] ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)