### PR TITLE
fix(chat): atomic shared session + injectable theme provider (#2753, #2766)

### DIFF
--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -47,6 +47,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from ._theme_protocol import ThemeProviderProtocol, _DefaultDarkTheme
 from .chat_dock_widget import (
     _DEFAULT_SERVER,
     _read_shared_session_id,
@@ -59,15 +60,20 @@ from .terminal_providers import build_default_terminal_provider_registry
 logger = logging.getLogger(__name__)
 
 
-def _get_theme_colors() -> dict[str, str]:
-    """Get the current theme colors, falling back to defaults."""
-    try:
-        from theme.theme_manager import get_theme_manager
+def _get_theme_colors(
+    theme_provider: ThemeProviderProtocol | None = None,
+) -> dict[str, str]:
+    """Get the current theme colors from the injected provider.
 
-        colors: dict[str, str] = get_theme_manager().get_current_colors()
-        return colors
-    except ImportError:
-        return {}
+    Falls back to :class:`_DefaultDarkTheme` so the widget never depends
+    on ``theme.theme_manager`` being importable (Tools issue #2766).
+    """
+    provider: ThemeProviderProtocol = theme_provider or _DefaultDarkTheme()
+    try:
+        return provider.get_current_colors()
+    except Exception:  # noqa: BLE001 - defensive: a misbehaving provider
+        # must not crash the widget
+        return _DefaultDarkTheme().get_current_colors()
 
 
 class ChatMessageBubble(QFrame):
@@ -79,6 +85,7 @@ class ChatMessageBubble(QFrame):
         content: str,
         accent_color: str = "#FF8800",
         parent: QWidget | None = None,
+        theme_provider: ThemeProviderProtocol | None = None,
     ) -> None:
         if role is None:
             raise ValueError("role must be provided")
@@ -90,7 +97,7 @@ class ChatMessageBubble(QFrame):
         layout.setContentsMargins(6, 4, 6, 4)
         layout.setSpacing(2)
 
-        colors = _get_theme_colors()
+        colors = _get_theme_colors(theme_provider)
         text_primary = colors.get("text", "#e0e0e0")
         bg_alt = colors.get("group_bg", "#2d2d2d")
         bg_secondary = colors.get("input_bg", "#252526")
@@ -158,9 +165,31 @@ class ChatDockWidget(QDockWidget):
 
     Uses QWebSocket for real-time streaming. All instances share the same
     conversation session via a file-persisted session ID.
+
+    Args:
+        app_context: Name of the module/context this widget is embedded in.
+        app_name: Application identifier for session file storage.
+        server_url: WebSocket server base URL.
+        session_id: Explicit session ID (None = use shared or create new).
+        ws_path_template: WebSocket path template with ``{session_id}`` placeholder.
+        placeholder_text: Placeholder text for the input field.
+        accent_color: Primary accent color for styling.
+        auto_index_on_open: When True, send an ``index_codebase`` action on
+            connect so the chat backend rebuilds its codemap before the user
+            starts typing. Tools issue #2549 / PR #2567.
+        terminal_registry: Registry used to populate shell/provider dropdowns.
+        theme_provider: Object implementing ``get_current_colors()`` to drive
+            widget styling. Defaults to :class:`_DefaultDarkTheme` so the
+            widget is fully portable and does not require ``theme`` to be on
+            ``sys.path`` (Tools issue #2766). Pass an app-specific manager
+            (e.g. ``theme.theme_manager.get_theme_manager()``) to honor the
+            host application's theme.
+        parent: Parent widget.
     """
 
-    # Class-level session for in-process sharing
+    # Class-level session for in-process sharing. All reads/writes are
+    # serialized through ``_SHARED_SESSION_LOCK`` in ``chat_dock_widget``
+    # to prevent the multi-window race described in Tools issue #2753.
     _shared_session_id: str | None = None
 
     # Signals for external UI integration
@@ -179,6 +208,7 @@ class ChatDockWidget(QDockWidget):
         auto_index_on_open: bool = False,
         project_root: str | Path | None = None,
         terminal_registry: TerminalProviderRegistry | None = None,
+        theme_provider: ThemeProviderProtocol | None = None,
         parent: QWidget | None = None,
     ) -> None:
         if app_context is None:
@@ -196,6 +226,9 @@ class ChatDockWidget(QDockWidget):
         )
         self._terminal_registry = (
             terminal_registry or build_default_terminal_provider_registry()
+        )
+        self._theme_provider: ThemeProviderProtocol = (
+            theme_provider or _DefaultDarkTheme()
         )
         self._is_streaming = False
         self._current_bubble: ChatMessageBubble | None = None
@@ -219,7 +252,7 @@ class ChatDockWidget(QDockWidget):
         self._connect_on_show = True
 
     def _setup_ui(self) -> None:
-        colors = _get_theme_colors()
+        colors = _get_theme_colors(self._theme_provider)
         bg_primary = colors.get("bg", "#1e1e1e")
         bg_alt = colors.get("group_bg", "#2d2d2d")
         text_primary = colors.get("text", "#e0e0e0")
@@ -244,7 +277,9 @@ class ChatDockWidget(QDockWidget):
         self._action_copy_thread = self._tools_menu.addAction("Copy Entire Thread")
         self._action_export_thread = self._tools_menu.addAction("Export to Markdown...")
         self._action_condense_thread = self._tools_menu.addAction("Condense Thread")
-        self._action_request_review = self._tools_menu.addAction("Request Agent Review...")
+        self._action_request_review = self._tools_menu.addAction(
+            "Request Agent Review..."
+        )
         if self._action_copy_thread is not None:
             self._action_copy_thread.triggered.connect(self._copy_entire_thread)
         if self._action_export_thread is not None:
@@ -710,8 +745,15 @@ class ChatDockWidget(QDockWidget):
         """Add a message bubble to the scroll area."""
         if role is None:
             raise ValueError("role must be provided")
-        bubble = ChatMessageBubble(role, content, accent_color=self._accent_color)
-        self._message_layout.insertWidget(self._message_layout.count() - 1, bubble)
+        bubble = ChatMessageBubble(
+            role,
+            content,
+            accent_color=self._accent_color,
+            theme_provider=self._theme_provider,
+        )
+        # Insert before the stretch item at the end
+        count = self._message_layout.count()
+        self._message_layout.insertWidget(count - 1, bubble)
         self._scroll_to_bottom()
         return bubble
 

--- a/src/shared/python/chat/_theme_protocol.py
+++ b/src/shared/python/chat/_theme_protocol.py
@@ -1,0 +1,57 @@
+"""Theme provider protocol for the portable chat dock widget.
+
+The chat widget previously hard-imported ``theme.theme_manager`` which
+required ``theme`` to be on ``sys.path``. That coupling blocked reuse from
+applications that vendor the chat package without the ``theme`` package.
+
+Instead, callers now inject any object that implements
+:class:`ThemeProviderProtocol`. A :class:`_DefaultDarkTheme` fallback is
+provided so the widget remains fully functional with no extra wiring
+(matches the dark-mode defaults that ``_get_theme_colors`` previously
+returned via its ``dict.get(..., default)`` fallbacks).
+
+Tools issue #2766.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+# Hardcoded dark-mode defaults — these mirror the inline ``dict.get(...)``
+# fallbacks used throughout ``_chat_dock_widget_qt.py`` so existing visuals
+# are preserved when no real theme provider is supplied.
+_DEFAULT_DARK_COLORS: dict[str, str] = {
+    "bg": "#1e1e1e",
+    "group_bg": "#2d2d2d",
+    "input_bg": "#252526",
+    "text": "#e0e0e0",
+    "text_secondary": "#888",
+    "border": "#444",
+    "button_hover": "#ffaa33",
+    "accent": "#58a6ff",
+}
+
+
+@runtime_checkable
+class ThemeProviderProtocol(Protocol):
+    """Minimal interface the chat dock needs from a theme source.
+
+    Compatible with ``theme.theme_manager.ThemeManager`` out of the box —
+    inject ``get_theme_manager()`` directly when running inside an app
+    that ships the ``theme`` package.
+    """
+
+    def get_current_colors(self) -> dict[str, str]:
+        """Return the active theme's color map (key -> hex color)."""
+        ...
+
+
+class _DefaultDarkTheme:
+    """Fallback theme used when no provider is injected.
+
+    Returns the same dark-mode color values that ``_get_theme_colors``
+    previously fell back to via inline ``dict.get(..., "<hex>")`` calls.
+    """
+
+    def get_current_colors(self) -> dict[str, str]:
+        return dict(_DEFAULT_DARK_COLORS)

--- a/src/shared/python/chat/chat_dock_widget.py
+++ b/src/shared/python/chat/chat_dock_widget.py
@@ -2,17 +2,33 @@
 
 Importing this module is intentionally safe during headless test collection.
 The PyQt6 implementation is loaded only when widget classes are requested.
+
+Threading
+---------
+Shared session state is held in a module-level singleton holder protected
+by ``_SHARED_SESSION_LOCK``. ``_read_shared_session_id`` and
+``_write_shared_session_id`` acquire this lock for the full duration of
+their I/O so concurrent writers from different threads (or windows) cannot
+interleave or observe a torn file. Writes are also atomic on disk: the new
+content is staged in a sibling ``*.tmp`` file and then ``Path.replace``'d
+into place, which is an atomic rename on POSIX and Win32.
 """
 
 # ruff: noqa: F822
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from typing import Any
 
 _DEFAULT_SERVER = "ws://127.0.0.1:8000"
 _QT_EXPORTS = {"ChatDockWidget", "ChatMessageBubble"}
+
+# Tools issue #2753: serialize all reads/writes of the shared session ID
+# file across threads. The lock guards both the in-memory holder and the
+# atomic tmp+replace dance used by ``_write_shared_session_id``.
+_SHARED_SESSION_LOCK = threading.Lock()
 
 
 def _session_file_path(app_name: str) -> Path:
@@ -21,24 +37,37 @@ def _session_file_path(app_name: str) -> Path:
 
 
 def _read_shared_session_id(path: Path) -> str | None:
-    """Read the active session ID from a shared file."""
-    try:
-        if path.exists():
-            text = path.read_text(encoding="utf-8").strip()
-            if text:
-                return text
-    except (PermissionError, OSError):
-        pass
-    return None
+    """Read the active session ID from a shared file.
+
+    Thread-safe: serialized against concurrent writers via
+    ``_SHARED_SESSION_LOCK``.
+    """
+    with _SHARED_SESSION_LOCK:
+        try:
+            if path.exists():
+                text = path.read_text(encoding="utf-8").strip()
+                if text:
+                    return text
+        except (PermissionError, OSError):
+            pass
+        return None
 
 
 def _write_shared_session_id(session_id: str, path: Path) -> None:
-    """Write the active session ID to the shared file."""
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(session_id, encoding="utf-8")
-    except (PermissionError, OSError):
-        pass
+    """Write the active session ID to the shared file atomically.
+
+    Writes the new content to ``<path>.tmp`` and then ``Path.replace``s it
+    into place so concurrent readers never observe a partially-written
+    file. Thread-safe: serialized via ``_SHARED_SESSION_LOCK``.
+    """
+    with _SHARED_SESSION_LOCK:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = path.parent / f"{path.name}.tmp"
+            tmp_path.write_text(session_id, encoding="utf-8")
+            tmp_path.replace(path)
+        except (PermissionError, OSError):
+            pass
 
 
 def _load_qt_module() -> Any:

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/runtime_tabs.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/runtime_tabs.py
@@ -372,10 +372,22 @@ def _build_pyqt_chat_dock(sidebar: Any) -> QtWidgets.QWidget | None:
         logger.debug("PyQt chat dock unavailable for Sidekick: %s", exc)
         return None
 
+    # Tools issue #2766: chat dock no longer hard-imports theme.theme_manager.
+    # Inject the manager explicitly so existing visuals are preserved when
+    # the theme package is available; otherwise the dock falls back to its
+    # built-in dark theme.
+    theme_provider: Any = None
+    try:
+        theme_module = importlib.import_module("theme.theme_manager")
+        theme_provider = theme_module.get_theme_manager()
+    except Exception as exc:  # noqa: BLE001 - theme is optional at this layer
+        logger.debug("Theme manager unavailable for chat dock: %s", exc)
+
     dock = chat_module.ChatDockWidget(
         app_context="sidekick",
         app_name="sidekick",
         project_root=sidebar.project_root,
+        theme_provider=theme_provider,
         parent=sidebar,
     )
     dock.setObjectName(SIDEKICK_CHAT_RUNTIME_OBJECT_NAME)

--- a/tests/shared/python/chat/test_chat_dock_widget.py
+++ b/tests/shared/python/chat/test_chat_dock_widget.py
@@ -387,3 +387,100 @@ class TestChatDockWidget:
         assert "How are you?" in markdown
 
         widget.close()
+
+    def test_custom_theme_provider_supplies_colors(self, qtbot):
+        """Tools issue #2766: an injected provider drives widget styling."""
+        from chat._theme_protocol import _DefaultDarkTheme
+        from chat.chat_dock_widget import ChatDockWidget
+
+        class DummyTheme:
+            def get_current_colors(self) -> dict[str, str]:
+                return {
+                    "bg": "#101010",
+                    "group_bg": "#202020",
+                    "input_bg": "#303030",
+                    "text": "#ff00ff",
+                    "text_secondary": "#abcdef",
+                    "border": "#123456",
+                    "button_hover": "#fedcba",
+                    "accent": "#00ff00",
+                }
+
+        ChatDockWidget._shared_session_id = None
+        widget = ChatDockWidget(app_name="test_app", theme_provider=DummyTheme())
+        _track_widget(qtbot, widget)
+        assert isinstance(widget._theme_provider, DummyTheme)
+        # Sanity: when a custom provider is given the default fallback is
+        # not used.
+        assert not isinstance(widget._theme_provider, _DefaultDarkTheme)
+        widget.close()
+
+
+class TestPortableThemeImport:
+    """Tools issue #2766: chat dock works without theme.theme_manager.
+
+    Verifies the chat package can be imported and ``_get_theme_colors``
+    works in a clean subprocess where the legacy ``theme`` package is
+    *not* on sys.path. The chat dock module imports PyQt6 at module
+    scope, so a Qt platform must be available in the subprocess — the
+    enclosing file already gates on this via ``pytest.importorskip``.
+    """
+
+    def test_import_without_theme_on_sys_path(self):
+        import subprocess
+        import sys
+        import textwrap
+
+        script = textwrap.dedent(
+            """
+            import sys
+
+            # Strip anything that would let `theme.theme_manager` import.
+            sys.modules.pop("theme", None)
+            sys.modules.pop("theme.theme_manager", None)
+
+            # Block future imports of the theme package outright.
+            import importlib.abc
+
+            class _BlockTheme(importlib.abc.MetaPathFinder):
+                def find_spec(self, name, path, target=None):
+                    if name == "theme" or name.startswith("theme."):
+                        raise ImportError(
+                            f"theme package intentionally blocked: {name}"
+                        )
+                    return None
+
+            sys.meta_path.insert(0, _BlockTheme())
+
+            # The chat package must import cleanly without `theme`.
+            from chat._theme_protocol import (  # noqa: F401
+                ThemeProviderProtocol,
+                _DefaultDarkTheme,
+            )
+            from chat import chat_dock_widget as cdw  # noqa: F401
+            from chat._chat_dock_widget_qt import _get_theme_colors
+
+            class DummyTheme:
+                def get_current_colors(self):
+                    return {"bg": "#abcdef", "text": "#012345"}
+
+            colors = _get_theme_colors(DummyTheme())
+            assert colors["bg"] == "#abcdef", colors
+            assert colors["text"] == "#012345", colors
+
+            # Default fallback must also work without `theme` importable.
+            defaults = _get_theme_colors(None)
+            assert defaults["bg"] == "#1e1e1e", defaults
+            print("OK")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"subprocess failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
+        assert "OK" in result.stdout, result.stdout

--- a/tests/shared/python/chat/test_chat_session_helpers.py
+++ b/tests/shared/python/chat/test_chat_session_helpers.py
@@ -70,3 +70,40 @@ class TestSessionFileHelpers:
         _write_shared_session_id("abc", path)
         assert path.exists()
         assert _read_shared_session_id(path) == "abc"
+
+    def test_concurrent_writes_are_atomic(self, tmp_path: Path) -> None:
+        """Tools issue #2753: concurrent writers must not corrupt the file.
+
+        Four threads race to write distinct session IDs to the same path.
+        With the module-level lock and atomic tmp+replace dance the file
+        must contain *exactly one* valid session ID at the end (no torn
+        writes, no exceptions, no empty file).
+        """
+        import threading
+
+        path = tmp_path / "shared_session.txt"
+        candidates = [f"sid{i}" for i in range(4)]
+        errors: list[BaseException] = []
+        barrier = threading.Barrier(len(candidates))
+
+        def writer(sid: str) -> None:
+            try:
+                barrier.wait(timeout=5.0)
+                _write_shared_session_id(sid, path)
+            except BaseException as exc:  # noqa: BLE001 - capture for assert
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(sid,)) for sid in candidates]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10.0)
+
+        assert errors == [], f"unexpected errors: {errors!r}"
+        assert path.exists(), "file should exist after concurrent writes"
+        # No leftover .tmp file after atomic replaces.
+        assert not (path.parent / f"{path.name}.tmp").exists()
+        final = path.read_text(encoding="utf-8")
+        assert final in candidates, (
+            f"expected exactly one of {candidates!r}, got {final!r}"
+        )


### PR DESCRIPTION
Closes #2753, closes #2766.

- Module-level lock + atomic write for shared session persistence
- ThemeProviderProtocol with default dark theme; chat dock no longer hard-imports theme.theme_manager
- UpstreamDrift caller updated to inject get_theme_manager() explicitly

## Test plan
- [x] Concurrent shared-session writes produce coherent state
- [x] ChatDockWidget works in a process without theme on sys.path
- [x] Existing behavior preserved for UpstreamDrift
- [x] ruff clean