### PR TITLE
refactor(ai): decouple system prompts from golf branding (#2765)

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -4,3 +4,13 @@
 ## 2024-05-01 - Optimization of Results Iteration in ODESolverCalculator
 **Learning:** Using `results.map` followed by `Math.min(...values)` and `Math.max(...values)` on large dataset arrays in JS causes excessive memory allocation (the intermediate mapped array) and throws "Maximum call stack size exceeded" errors if the array size exceeds the stack limit.
 **Action:** Replace `map` and spread operations for min/max calculations with a single-pass `for` loop tracking min and max manually.
+## 2024-05-14 - Optimization of Gas Composition Object Iteration in PressureDropCalculator
+**Learning:** Using `Object.values().reduce()` and `Object.entries().map()` inside hot rendering loops causes O(N) intermediate array allocations and excessive garbage collection overhead.
+**Action:** Replace these operations with a single-pass standard `for` loop over `Object.keys()` to prevent intermediate object allocations and minimize garbage collection.
+## 2024-05-19 - Object vs Array access in numerical hot paths
+**Learning:** Tight numerical integration loops (like RK4 solvers in JS/TS) that use Object lookup for variables (`currentState[varName]`) are significantly slower due to property hashing overhead in JavaScript engines.
+**Action:** Replace Object states with contiguous Arrays (`new Array<number>(len)`) and use positional index mapping in tight loops. This avoids the hashing overhead and massively improves execution speed.
+
+## 2026-05-15 - Optimize RK4 Expression Compilation Array Destructuring
+**Learning:** When compiling mathematical expressions dynamically using `new Function(...)` to evaluate inside tight integration loops like RK4, spreading parameters (e.g. `(...args)` and calling with `f(...args)`) introduces significant and continuous garbage collection overhead and prevents JavaScript engines from optimizing function calls due to dynamic arity.
+**Action:** When dynamically generating expressions, define the function signature to accept a single arguments array (`args: number[]`) and generate static declarations from the array based on positional indices within the function body itself (e.g. `const x = args[0];`). This avoids spread allocation entirely while keeping the invocation simple.

--- a/src/shared/python/ai/adapters/anthropic_adapter.py
+++ b/src/shared/python/ai/adapters/anthropic_adapter.py
@@ -37,6 +37,7 @@ from src.shared.python.ai.exceptions import (
     AIRateLimitError,
     AITimeoutError,
 )
+from src.shared.python.ai.system_prompts import get_prompt
 from src.shared.python.ai.types import (
     AgentChunk,
     AgentResponse,
@@ -431,7 +432,7 @@ class AnthropicAdapter(BaseAgentAdapter):
         return result
 
     def _build_system_message(self, context: ConversationContext) -> str:
-        """Build Anthropic-optimized system message.
+        """Build application-context-aware system message.
 
         Args:
             context: Current conversation context.
@@ -445,26 +446,13 @@ class AnthropicAdapter(BaseAgentAdapter):
             raise ValueError("context must be provided")
         expertise = context.user_expertise.name.lower()
         context_instructions = self.build_context_instruction_section(context)
+        app_context = context.metadata.get("app_context") if context.metadata else None
+        base_prompt = get_prompt(app_context if isinstance(app_context, str) else None)
 
         return (
-            f"You are Claude, an AI assistant for the Golf Modeling Suite, a "
-            f"research-grade biomechanics simulation platform for analyzing "
-            f"golf swings.\n\n"
+            f"{base_prompt}\n\n"
             f"Current user expertise level: {expertise}\n\n"
-            f"Your capabilities include:\n"
-            f"- Analyzing C3D motion capture data\n"
-            f"- Running physics simulations (MuJoCo, Drake, Pinocchio)\n"
-            f"- Computing inverse dynamics and joint torques\n"
-            f"- Performing drift-control decomposition\n"
-            f"- Generating visualizations and reports\n\n"
-            f"{context_instructions}\n\n"
-            f"Guidelines:\n"
-            f"1. Use tools to perform analyses - never fabricate numerical results\n"
-            f"2. Explain concepts at the {expertise} level\n"
-            f"3. Validate scientific claims before presenting them\n"
-            f"4. Guide users through workflows step by step\n"
-            f"5. Acknowledge uncertainty and cite limitations\n"
-            f"6. Be precise about physical units (SI: m, kg, s, rad, N, N·m)"
+            f"{context_instructions}"
         )
 
     def _parse_response(self, response: Any) -> AgentResponse:

--- a/src/shared/python/ai/adapters/base.py
+++ b/src/shared/python/ai/adapters/base.py
@@ -22,6 +22,7 @@ from src.shared.python.ai.memory_manager import (
     build_memory_prompt_section,
     load_agents_md,
 )
+from src.shared.python.ai.system_prompts import get_prompt
 from src.shared.python.ai.types import (
     AgentChunk,
     AgentResponse,
@@ -234,6 +235,7 @@ class BaseAgentAdapter(ABC):
         tools: list[ToolDeclaration],
         expertise_level: str = "beginner",
         context: ConversationContext | None = None,
+        app_context: str | None = None,
     ) -> str:
         """Build a system prompt including tool context.
 
@@ -257,6 +259,7 @@ class BaseAgentAdapter(ABC):
             f"- {tool.name}: {tool.description}" for tool in tools
         )
         memory_section = self.build_context_instruction_section(context)
+        base_prompt = get_prompt(app_context)
 
         # Response style instructions (Tools #2750)
         style = (context.response_style if context else "standard").lower()
@@ -278,20 +281,10 @@ class BaseAgentAdapter(ABC):
             )
 
         return (
-            f"You are an AI assistant for the Golf Modeling Suite, a research-grade "
-            f"biomechanics simulation platform.\n\n"
-            f"Your role is to help users analyze golf swings using advanced physics "
-            f"simulations across multiple engines (MuJoCo, Drake, Pinocchio).\n\n"
-            f"User expertise level: {expertise_level}\n"
+            f"{base_prompt}\n\n"
             f"Response style: {style_instructions}\n\n"
             f"{memory_section}\n\n"
-            f"Available tools:\n{tool_descriptions}\n\n"
-            f"Guidelines:\n"
-            f"1. Always validate scientific claims before presenting them\n"
-            f"2. Explain concepts at the user's expertise level\n"
-            f"3. Use tools to perform analyses rather than making up results\n"
-            f"4. Cite sources and acknowledge uncertainty\n"
-            f"5. Guide users through workflows step by step"
+            f"Available tools:\n{tool_descriptions}"
         )
 
     def build_context_instruction_section(

--- a/src/shared/python/ai/adapters/openai_adapter.py
+++ b/src/shared/python/ai/adapters/openai_adapter.py
@@ -38,6 +38,7 @@ from src.shared.python.ai.exceptions import (
     AIRateLimitError,
     AITimeoutError,
 )
+from src.shared.python.ai.system_prompts import get_prompt
 from src.shared.python.ai.types import (
     AgentChunk,
     AgentResponse,
@@ -400,7 +401,7 @@ class OpenAIAdapter(BaseAgentAdapter):
         return messages
 
     def _build_system_message(self, context: ConversationContext) -> str:
-        """Build OpenAI-optimized system message.
+        """Build application-context-aware system message.
 
         Args:
             context: Current conversation context.
@@ -414,29 +415,13 @@ class OpenAIAdapter(BaseAgentAdapter):
             raise ValueError("context must be provided")
         expertise = context.user_expertise.name.lower()
         context_instructions = self.build_context_instruction_section(context)
+        app_context = context.metadata.get("app_context") if context.metadata else None
+        base_prompt = get_prompt(app_context if isinstance(app_context, str) else None)
 
         return (
-            f"You are an AI assistant for the Golf Modeling Suite, a research-grade "
-            f"biomechanics simulation platform for analyzing golf swings.\n\n"
+            f"{base_prompt}\n\n"
             f"Current user expertise level: {expertise}\n\n"
-            f"Your capabilities include:\n"
-            f"- Analyzing C3D motion capture data\n"
-            f"- Running physics simulations (MuJoCo, Drake, Pinocchio)\n"
-            f"- Computing inverse dynamics and joint torques\n"
-            f"- Performing drift-control decomposition\n"
-            f"- Generating visualizations and reports\n\n"
-            f"{context_instructions}\n\n"
-            f"Guidelines:\n"
-            f"1. Use tools to perform analyses - never make up numerical results\n"
-            f"2. Explain concepts at the {expertise} level\n"
-            f"3. Validate scientific claims before presenting them\n"
-            f"4. Guide users through workflows step by step\n"
-            f"5. Acknowledge uncertainty and cite limitations\n\n"
-            f"When the user asks about analysis:\n"
-            f"1. First, understand what data they have\n"
-            f"2. Suggest appropriate analyses for their goals\n"
-            f"3. Execute using available tools\n"
-            f"4. Interpret results with scientific rigor"
+            f"{context_instructions}"
         )
 
     def _parse_response(self, response: Any) -> AgentResponse:

--- a/src/shared/python/ai/system_prompts.py
+++ b/src/shared/python/ai/system_prompts.py
@@ -20,6 +20,53 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+GENERIC_SYSTEM_PROMPT = (
+    "You are a helpful AI assistant integrated into a desktop application.\n\n"
+    "Guidelines:\n"
+    "1. Use available tools to perform analyses — never fabricate numerical results\n"
+    "2. Explain concepts clearly at the user's level\n"
+    "3. Validate claims before presenting them\n"
+    "4. Guide users through workflows step by step\n"
+    "5. Acknowledge uncertainty and cite limitations"
+)
+
+GOLF_MODELING_SYSTEM_PROMPT = (
+    "You are an AI assistant for the Golf Modeling Suite, a research-grade "
+    "biomechanics simulation platform.\n\n"
+    "Your role is to help users analyze golf swings using advanced physics "
+    "simulations across multiple engines (MuJoCo, Drake, Pinocchio).\n\n"
+    "Guidelines:\n"
+    "1. Use tools to perform analyses — never fabricate numerical results\n"
+    "2. Explain concepts at the user's expertise level\n"
+    "3. Validate scientific claims before presenting them\n"
+    "4. Guide users through workflows step by step\n"
+    "5. Acknowledge uncertainty and cite limitations\n"
+    "6. Be precise about physical units (SI: m, kg, s, rad, N, N·m)"
+)
+
+SYSTEM_PROMPTS: dict[str | None, str] = {
+    "upstream_drift": GOLF_MODELING_SYSTEM_PROMPT,
+    "tools": GENERIC_SYSTEM_PROMPT,
+    None: GENERIC_SYSTEM_PROMPT,
+    "": GENERIC_SYSTEM_PROMPT,
+}
+
+
+def get_prompt(app_context: str | None) -> str:
+    """Return the system prompt string for the given application context.
+
+    Falls back to the generic, brand-neutral prompt for unknown contexts.
+
+    Args:
+        app_context: Application context key (e.g., ``"upstream_drift"``).
+            ``None`` and ``""`` both return the generic prompt.
+
+    Returns:
+        System prompt string appropriate for the application context.
+    """
+    return SYSTEM_PROMPTS.get(app_context or "", GENERIC_SYSTEM_PROMPT)
+
+
 # ── Application context registry ────────────────────────────────────
 
 _APP_CONTEXTS: dict[str, dict[str, Any]] = {

--- a/tests/shared/python/ai/test_system_prompts.py
+++ b/tests/shared/python/ai/test_system_prompts.py
@@ -1,0 +1,188 @@
+"""Tests for src.shared.python.ai.system_prompts.
+
+Verifies the prompt registry is brand-neutral by default and preserves
+golf-themed branding only when ``app_context="upstream_drift"`` is used.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: ensure the package chain is importable in a plain pytest run.
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str | None]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.adapters", "src/shared/python/ai/adapters"),
+    ("src.shared.python.logging_pkg", None),
+    ("src.shared.python.logging_pkg.logging_config", None),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        if _rel_path is not None:
+            _stub.__path__ = [str(ROOT / _rel_path)]  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+# Stub logging_pkg so adapter modules can import get_logger.
+_logging_config_stub = sys.modules["src.shared.python.logging_pkg.logging_config"]
+_logging_config_stub.get_logger = logging.getLogger  # type: ignore[attr-defined]
+
+# Stub contracts used by base adapter.
+if "src.shared.python.contracts" not in sys.modules:
+    _contracts_stub = types.ModuleType("src.shared.python.contracts")
+
+    def _precondition(predicate, message="precondition failed"):  # type: ignore[misc]
+        """No-op precondition decorator stub."""
+
+        def decorator(func):  # type: ignore[misc]
+            return func
+
+        return decorator
+
+    _contracts_stub.precondition = _precondition  # type: ignore[attr-defined]
+    sys.modules["src.shared.python.contracts"] = _contracts_stub
+
+# Stub memory_manager used by base adapter.
+if "src.shared.python.ai.memory_manager" not in sys.modules:
+    _mem_stub = types.ModuleType("src.shared.python.ai.memory_manager")
+    _mem_stub.build_memory_prompt_section = lambda **_: ""  # type: ignore[attr-defined]
+    _mem_stub.load_agents_md = lambda _root=None: None  # type: ignore[attr-defined]
+    sys.modules["src.shared.python.ai.memory_manager"] = _mem_stub
+
+# ---------------------------------------------------------------------------
+# Now import the modules under test.
+# ---------------------------------------------------------------------------
+
+from src.shared.python.ai.system_prompts import (  # noqa: E402
+    GENERIC_SYSTEM_PROMPT,
+    GOLF_MODELING_SYSTEM_PROMPT,
+    get_prompt,
+)
+
+# ── GENERIC_SYSTEM_PROMPT contract ───────────────────────────────────
+
+
+def test_generic_prompt_contains_no_golf_mentions() -> None:
+    assert "Golf" not in GENERIC_SYSTEM_PROMPT
+    assert "golf" not in GENERIC_SYSTEM_PROMPT
+
+
+def test_generic_prompt_contains_no_mujoco() -> None:
+    assert "MuJoCo" not in GENERIC_SYSTEM_PROMPT
+    assert "Drake" not in GENERIC_SYSTEM_PROMPT
+    assert "Pinocchio" not in GENERIC_SYSTEM_PROMPT
+
+
+def test_generic_prompt_is_non_empty() -> None:
+    assert len(GENERIC_SYSTEM_PROMPT.strip()) > 20
+
+
+# ── GOLF_MODELING_SYSTEM_PROMPT contract ─────────────────────────────
+
+
+def test_golf_prompt_mentions_golf_modeling_suite() -> None:
+    assert "Golf Modeling Suite" in GOLF_MODELING_SYSTEM_PROMPT
+
+
+def test_golf_prompt_mentions_physics_engines() -> None:
+    assert "MuJoCo" in GOLF_MODELING_SYSTEM_PROMPT
+    assert "Drake" in GOLF_MODELING_SYSTEM_PROMPT
+    assert "Pinocchio" in GOLF_MODELING_SYSTEM_PROMPT
+
+
+# ── get_prompt() registry ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "app_context",
+    [None, ""],
+    ids=["none", "empty_string"],
+)
+def test_get_prompt_default_is_generic(app_context: str | None) -> None:
+    prompt = get_prompt(app_context)
+    assert "Golf" not in prompt
+    assert "MuJoCo" not in prompt
+    assert prompt == GENERIC_SYSTEM_PROMPT
+
+
+def test_get_prompt_upstream_drift_returns_golf_prompt() -> None:
+    prompt = get_prompt("upstream_drift")
+    assert "Golf Modeling Suite" in prompt
+    assert "MuJoCo" in prompt
+
+
+def test_get_prompt_unknown_app_returns_generic_not_error() -> None:
+    prompt = get_prompt("unknown_app_xyz")
+    assert "Golf" not in prompt
+    assert prompt == GENERIC_SYSTEM_PROMPT
+
+
+def test_get_prompt_tools_returns_generic() -> None:
+    prompt = get_prompt("tools")
+    assert "Golf" not in prompt
+    assert "MuJoCo" not in prompt
+
+
+# ── BaseAgentAdapter.build_system_prompt smoke test ──────────────────
+
+
+def _make_adapter():  # type: ignore[misc]
+    """Construct a minimal concrete BaseAgentAdapter for smoke testing."""
+    from src.shared.python.ai.adapters.base import BaseAgentAdapter, ToolDeclaration
+
+    class ConcreteAdapter(BaseAgentAdapter):
+        def send_message(self, message, context, tools):  # type: ignore[override]
+            raise NotImplementedError
+
+        def stream_response(self, message, context, tools):  # type: ignore[override]
+            raise NotImplementedError
+
+        @property
+        def capabilities(self):  # type: ignore[override]
+            raise NotImplementedError
+
+        def validate_connection(self):  # type: ignore[override]
+            raise NotImplementedError
+
+    return ConcreteAdapter(), ToolDeclaration
+
+
+def test_build_system_prompt_default_no_golf() -> None:
+    adapter, ToolDeclaration = _make_adapter()
+    tools = [ToolDeclaration(name="ping", description="Check connectivity")]
+    prompt = adapter.build_system_prompt(tools, app_context=None)
+    assert "Golf" not in prompt
+    assert "MuJoCo" not in prompt
+
+
+def test_build_system_prompt_upstream_drift_has_golf() -> None:
+    adapter, ToolDeclaration = _make_adapter()
+    tools = [ToolDeclaration(name="ping", description="Check connectivity")]
+    prompt = adapter.build_system_prompt(tools, app_context="upstream_drift")
+    assert "Golf Modeling Suite" in prompt
+    assert "MuJoCo" in prompt
+
+
+def test_build_system_prompt_includes_tool_names() -> None:
+    adapter, ToolDeclaration = _make_adapter()
+    tools = [
+        ToolDeclaration(name="run_sim", description="Run simulation"),
+        ToolDeclaration(name="export_csv", description="Export to CSV"),
+    ]
+    prompt = adapter.build_system_prompt(tools, app_context=None)
+    assert "run_sim" in prompt
+    assert "export_csv" in prompt


### PR DESCRIPTION
## Summary

- Adds `GENERIC_SYSTEM_PROMPT`, `GOLF_MODELING_SYSTEM_PROMPT`, `SYSTEM_PROMPTS` dict, and `get_prompt(app_context)` to `system_prompts.py`
- Updates `BaseAgentAdapter.build_system_prompt()` to accept `app_context` parameter and delegate to `get_prompt()`
- Updates `AnthropicAdapter._build_system_message()` and `OpenAIAdapter._build_system_message()` to read `app_context` from `context.metadata` and use `get_prompt()`
- Default prompt is now brand-neutral (no golf/MuJoCo/Drake/Pinocchio references); golf branding only activates when `app_context="upstream_drift"`
- Adds 13 tests in `tests/shared/python/ai/test_system_prompts.py` covering prompt constants, registry lookup, and adapter integration

Closes #2765

## Test plan

- [ ] `python3 -m pytest tests/shared/python/ai/test_system_prompts.py -v` — all 13 tests pass
- [ ] `python3 -m ruff check src/shared/python/ai/` — zero violations
- [ ] `python3 -m ruff format --check src/shared/python/ai/` — zero diffs
- [ ] Verify `get_prompt(None)` and `get_prompt("")` return `GENERIC_SYSTEM_PROMPT`
- [ ] Verify `get_prompt("upstream_drift")` returns `GOLF_MODELING_SYSTEM_PROMPT`
- [ ] Verify `get_prompt("unknown_xyz")` returns `GENERIC_SYSTEM_PROMPT` (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)