### PR TITLE
fix(chat): wire refresh_models and index_codebase router handlers (#2751)

### DIFF
--- a/src/shared/python/chat/router_factory.py
+++ b/src/shared/python/chat/router_factory.py
@@ -297,6 +297,16 @@ def create_chat_router(
                                 "refreshed_at": datetime.now(UTC).isoformat(),
                             }
                         )
+                    except NotImplementedError as exc:
+                        logger.warning("refresh_models not implemented: %s", exc)
+                        await websocket.send_json(
+                            {
+                                "type": "error",
+                                "detail": (
+                                    "refresh_models not supported by this service"
+                                ),
+                            }
+                        )
                     except (
                         AIProviderError,
                         ValueError,
@@ -312,15 +322,26 @@ def create_chat_router(
                         )
 
                 elif action == "index_codebase":
-                    root_path = msg.get("root_path")
-                    if not root_path:
-                        await websocket.send_json(
-                            {"type": "error", "detail": "Missing root_path"}
-                        )
-                        continue
+                    # Tools issue #2751: the dock widget sends this action
+                    # without a root_path (it expects the server to use the
+                    # process cwd).  Fall back to os.getcwd() so the action
+                    # works out of the box.
+                    import os as _os
+
+                    root_path = msg.get("root_path") or _os.getcwd()
                     try:
                         status = await chat_service.index_codebase(root_path)
                         await websocket.send_json({"type": "index_status", **status})
+                    except NotImplementedError as exc:
+                        logger.warning("index_codebase not implemented: %s", exc)
+                        await websocket.send_json(
+                            {
+                                "type": "error",
+                                "detail": (
+                                    "index_codebase not supported by this service"
+                                ),
+                            }
+                        )
                     except (
                         AIProviderError,
                         ValueError,

--- a/src/shared/python/chat/service_base.py
+++ b/src/shared/python/chat/service_base.py
@@ -315,26 +315,36 @@ class ChatServiceBase(abc.ABC):
         )
         return session_id
 
-    @abc.abstractmethod
     async def refresh_models(self) -> list[dict[str, Any]]:
         """Refresh the list of available models from the provider.
 
-        Returns:
-            List of model info dicts.
-        """
-        ...  # pragma: no cover
+        Default implementation raises ``NotImplementedError``.  Subclasses
+        that wire a provider with a model-listing API (e.g. Ollama)
+        should override.  The router converts this exception into a clear
+        ``"refresh_models not supported by this service"`` error reply
+        instead of leaving the action silently broken (Tools issue #2751).
 
-    @abc.abstractmethod
+        Returns:
+            List of model info dicts (matches ``ChatModelInfo``).
+        """
+        raise NotImplementedError("refresh_models must be implemented by subclass")
+
     async def index_codebase(self, root_path: str) -> dict[str, Any]:
         """Trigger a re-index of the codebase for RAG.
+
+        Default implementation raises ``NotImplementedError``.  Subclasses
+        that bundle an embedding/codemap pipeline should override.  The
+        router converts this exception into a clear
+        ``"index_codebase not supported by this service"`` error reply
+        instead of leaving the action silently broken (Tools issue #2751).
 
         Args:
             root_path: Filesystem path to the project root.
 
         Returns:
-            Index status dict (matches ChatIndexStatusResponse).
+            Index status dict (matches ``ChatIndexStatusResponse``).
         """
-        ...  # pragma: no cover
+        raise NotImplementedError("index_codebase must be implemented by subclass")
 
     # ── Hooks for subclass customization ─────────────────────────────
 

--- a/tests/shared/python/chat/test_router_action_coverage.py
+++ b/tests/shared/python/chat/test_router_action_coverage.py
@@ -1,0 +1,105 @@
+"""AST contract guard: every chat action a widget sends must be handled
+by the router (Tools issue #2751).
+
+The dock widget and quick bar send WebSocket actions to the shared chat
+router.  When a sender adds a new action without a matching ``elif
+action == "..."`` branch in ``router_factory.py`` the server returns
+``"Unknown action: ..."`` and the feature is silently broken.
+
+This test walks the AST of the sender modules, collects every literal
+action string, and asserts that ``router_factory.py`` has a handler
+branch for it.  Actions that the router knowingly does not yet handle
+can be listed in ``KNOWN_UNHANDLED`` with a tracking issue.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+CHAT_DIR = Path(__file__).resolve().parents[4] / "src" / "shared" / "python" / "chat"
+SENDERS = [CHAT_DIR / "_chat_dock_widget_qt.py", CHAT_DIR / "quick_bar.py"]
+ROUTER = CHAT_DIR / "router_factory.py"
+
+# Actions that senders emit but the router intentionally does not handle
+# yet.  Each entry must reference a tracking issue.
+KNOWN_UNHANDLED: dict[str, str] = {
+    # file_upload: tracked separately (not part of #2751 scope)
+    "file_upload": "tracked separately",
+}
+
+
+def _collect_sent_actions(path: Path) -> set[str]:
+    """Return the set of literal action strings sent from a sender module."""
+    if not path.exists():
+        return set()
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    actions: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        for key, value in zip(node.keys, node.values, strict=False):
+            if (
+                isinstance(key, ast.Constant)
+                and key.value == "action"
+                and isinstance(value, ast.Constant)
+                and isinstance(value.value, str)
+            ):
+                actions.add(value.value)
+    return actions
+
+
+def _collect_router_branches(path: Path) -> set[str]:
+    """Return the set of action strings handled by elif branches in router."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    branches: set[str] = set()
+    for node in ast.walk(tree):
+        # Match: ``action == "..."`` and ``"..." == action``
+        if not isinstance(node, ast.Compare):
+            continue
+        if len(node.ops) != 1 or not isinstance(node.ops[0], ast.Eq):
+            continue
+        left, right = node.left, node.comparators[0]
+        for a, b in ((left, right), (right, left)):
+            if (
+                isinstance(a, ast.Name)
+                and a.id == "action"
+                and isinstance(b, ast.Constant)
+                and isinstance(b.value, str)
+            ):
+                branches.add(b.value)
+    return branches
+
+
+def test_every_sent_action_has_router_branch() -> None:
+    """Guard against sender/router drift (Tools issue #2751)."""
+    sent: set[str] = set()
+    for sender in SENDERS:
+        sent |= _collect_sent_actions(sender)
+
+    handled = _collect_router_branches(ROUTER)
+    missing = sent - handled - set(KNOWN_UNHANDLED)
+
+    assert not missing, (
+        f"Widget(s) send action(s) {sorted(missing)} but "
+        f"router_factory.py has no matching ``elif action == '...'`` "
+        f"branch. Either add a handler or list the action in "
+        f"KNOWN_UNHANDLED with a tracking issue."
+    )
+
+
+def test_known_unhandled_actions_are_actually_sent() -> None:
+    """KNOWN_UNHANDLED entries should not bit-rot — every listed action
+    must still be sent by some widget. Otherwise the entry is stale."""
+    sent: set[str] = set()
+    for sender in SENDERS:
+        sent |= _collect_sent_actions(sender)
+
+    stale = set(KNOWN_UNHANDLED) - sent
+    if stale:
+        pytest.fail(
+            f"KNOWN_UNHANDLED lists action(s) {sorted(stale)} that no "
+            f"widget sends. Remove the stale entries."
+        )

--- a/tests/shared/python/chat/test_terminal_protocol.py
+++ b/tests/shared/python/chat/test_terminal_protocol.py
@@ -182,3 +182,129 @@ def test_terminal_start_validation_error_is_structured() -> None:
 
     assert payload["type"] == "error"
     assert "project_root" in payload["detail"]
+
+
+# ── refresh_models / index_codebase (Tools issue #2751) ──────────────
+
+
+class _ModelListService(ChatServiceBase):
+    """Service double that returns a fixed model list."""
+
+    async def stream_response(self, session_id: str) -> AsyncIterator[Any]:
+        yield "ok"
+
+    async def refresh_models(self) -> list[dict[str, Any]]:
+        return [
+            {"id": "model-a", "name": "model-a", "provider": "fake"},
+            {"id": "model-b", "name": "model-b", "provider": "fake"},
+        ]
+
+
+class _IndexService(ChatServiceBase):
+    """Service double that records the index_codebase root_path it received."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.received_root: str | None = None
+
+    async def stream_response(self, session_id: str) -> AsyncIterator[Any]:
+        yield "ok"
+
+    async def index_codebase(self, root_path: str) -> dict[str, Any]:
+        self.received_root = root_path
+        return {
+            "state": "complete",
+            "files_parsed": 42,
+            "symbols_inserted": 100,
+            "duration_seconds": 1.5,
+        }
+
+
+def _client_with(service: ChatServiceBase) -> Any:
+    app = fastapi.FastAPI()
+    app.state.chat_service = service
+    app.include_router(create_chat_router(), prefix="/api")
+    return testclient.TestClient(app)
+
+
+def test_refresh_models_returns_model_list_payload() -> None:
+    """refresh_models action returns a model_list response with models."""
+    client = _client_with(_ModelListService())
+
+    with client.websocket_connect("/api/ws/chat/new") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "refresh_models"})
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "model_list"
+    assert payload["models"] == [
+        {"id": "model-a", "name": "model-a", "provider": "fake"},
+        {"id": "model-b", "name": "model-b", "provider": "fake"},
+    ]
+    assert "refreshed_at" in payload
+
+
+def test_index_codebase_returns_index_status_payload(tmp_path: Path) -> None:
+    """index_codebase action returns an index_status response with totals."""
+    service = _IndexService()
+    client = _client_with(service)
+
+    with client.websocket_connect("/api/ws/chat/new") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "index_codebase", "root_path": str(tmp_path)})
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "index_status"
+    assert payload["state"] == "complete"
+    assert payload["files_parsed"] == 42
+    assert payload["symbols_inserted"] == 100
+    assert service.received_root == str(tmp_path)
+
+
+def test_index_codebase_defaults_root_path_when_missing() -> None:
+    """index_codebase falls back to cwd when no root_path is supplied.
+
+    The dock widget sends ``{"action": "index_codebase"}`` with no
+    ``root_path`` (Tools issue #2751).
+    """
+    service = _IndexService()
+    client = _client_with(service)
+
+    with client.websocket_connect("/api/ws/chat/new") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "index_codebase"})
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "index_status"
+    assert service.received_root is not None
+    assert service.received_root != ""
+
+
+def test_refresh_models_not_implemented_returns_clear_error() -> None:
+    """A service that does not override refresh_models gets a clear error
+    message — NOT a generic 'Unknown action' reply (Tools issue #2751)."""
+    client = _client_with(FakeChatService())
+
+    with client.websocket_connect("/api/ws/chat/new") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "refresh_models"})
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "error"
+    assert "not supported" in payload["detail"]
+    assert "Unknown action" not in payload["detail"]
+
+
+def test_index_codebase_not_implemented_returns_clear_error(tmp_path: Path) -> None:
+    """A service that does not override index_codebase gets a clear error
+    message — NOT a generic 'Unknown action' reply (Tools issue #2751)."""
+    client = _client_with(FakeChatService())
+
+    with client.websocket_connect("/api/ws/chat/new") as websocket:
+        websocket.receive_json()
+        websocket.send_json({"action": "index_codebase", "root_path": str(tmp_path)})
+        payload = websocket.receive_json()
+
+    assert payload["type"] == "error"
+    assert "not supported" in payload["detail"]
+    assert "Unknown action" not in payload["detail"]


### PR DESCRIPTION
Closes #2751.

Adds proper router handling for `refresh_models` and `index_codebase` actions. Makes the corresponding methods on `ChatServiceBase` concrete (raise `NotImplementedError` by default; subclasses override). Adds an AST-based regression test that guarantees every action a widget sends has a matching router branch.

## Changes
- `service_base.py`: `refresh_models` and `index_codebase` are no longer `@abstractmethod` — they raise `NotImplementedError` so apps that do not need them are not forced to stub them out.
- `router_factory.py`:
  - Catch `NotImplementedError` and reply `"<action> not supported by this service"` instead of leaking the exception.
  - `index_codebase` falls back to `os.getcwd()` when the widget omits `root_path` (the widget actually does omit it).
- `tests/shared/python/chat/test_terminal_protocol.py`: 5 new tests covering both happy and `NotImplementedError` paths.
- `tests/shared/python/chat/test_router_action_coverage.py` (new): AST guard — walks `_chat_dock_widget_qt.py` and `quick_bar.py`, collects every `{"action": "..."}` literal, and asserts the router has a matching `elif action == "..."` branch.

## Test plan
- [x] `refresh_models` returns model_list-shaped reply
- [x] `index_codebase` returns index_status-shaped reply
- [x] `index_codebase` defaults `root_path` to cwd when widget omits it
- [x] `NotImplementedError` surfaces a clear "not supported" error (not "Unknown action")
- [x] AST guard prevents future sender/router drift
- [x] ruff check + format clean
- [x] 21/21 tests pass locally

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>