### PR TITLE
test(sidekick): cover router REST + ollama + rust adapter (#2781)

### DIFF
--- a/tests/shared/python/ai/test_ollama_adapter_extended.py
+++ b/tests/shared/python/ai/test_ollama_adapter_extended.py
@@ -1,0 +1,443 @@
+"""Extended unit tests for OllamaAdapter.
+
+Covers the previously untested happy-path, error-path, and capability
+contracts. The existing test_ollama_adapter.py only tests _format_messages
+behavior introduced in PR #2750; this file covers the remaining surface:
+
+  - send_message happy path
+  - send_message → AIConnectionError on ConnectError
+  - send_message → AITimeoutError on TimeoutException
+  - send_message → AIProviderError on HTTP error
+  - validate_connection success and failure cases
+  - list_available_models happy path and connection failure
+  - capabilities report STREAMING + SYSTEM_MESSAGE; FUNCTION_CALLING for llama3
+  - stream_response yields ordered AgentChunk instances
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: mirror the approach in test_ollama_adapter.py
+# ---------------------------------------------------------------------------
+
+ROOT = __import__("pathlib").Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str | None]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.config", "src/shared/python/config"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.adapters", "src/shared/python/ai/adapters"),
+    ("src.shared.python.logging_pkg", None),
+    ("src.shared.python.logging_pkg.logging_config", None),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        if _rel_path is not None:
+            _stub.__path__ = [str(ROOT / _rel_path)]  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+_logging_config_stub = sys.modules["src.shared.python.logging_pkg.logging_config"]
+_logging_config_stub.get_logger = MagicMock()  # type: ignore[attr-defined]
+
+_config_stub = types.ModuleType("src.shared.python.ai.config")
+_config_stub.get_ollama_host = MagicMock(return_value="http://localhost:11434")
+_config_stub.get_ollama_model = MagicMock(return_value="llama3.1:8b")
+_config_stub.get_ollama_timeout = MagicMock(return_value=120.0)
+_config_stub.DEFAULT_OLLAMA_HOST = "http://localhost:11434"
+_config_stub.DEFAULT_OLLAMA_MODEL = "llama3.1:8b"
+_config_stub.DEFAULT_OLLAMA_TIMEOUT = 120.0
+sys.modules["src.shared.python.ai.config"] = _config_stub
+
+from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter  # noqa: E402
+from src.shared.python.ai.exceptions import (  # noqa: E402
+    AIConnectionError,
+    AIProviderError,
+    AITimeoutError,
+)
+from src.shared.python.ai.types import (  # noqa: E402
+    ConversationContext,
+    ExpertiseLevel,
+    ProviderCapability,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def adapter() -> OllamaAdapter:
+    return OllamaAdapter(host="http://localhost:11434", model="llama3.1:8b")
+
+
+@pytest.fixture()
+def context() -> ConversationContext:
+    return ConversationContext(
+        session_id="test-session",
+        user_expertise=ExpertiseLevel.INTERMEDIATE,
+    )
+
+
+def _make_mock_response(body: dict[str, Any], status_code: int = 200) -> MagicMock:
+    """Return a fake httpx response with .json() and .raise_for_status()."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = _httpx_status_error(status_code)
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _httpx_status_error(status_code: int) -> Exception:
+    import httpx
+
+    request = httpx.Request("POST", "http://localhost:11434/api/chat")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+# ---------------------------------------------------------------------------
+# send_message
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageHappyPath:
+    def test_returns_agent_response_with_content(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """send_message returns an AgentResponse containing the model reply."""
+        fake_body = {
+            "model": "llama3.1:8b",
+            "message": {"role": "assistant", "content": "Hello, world!"},
+            "done": True,
+        }
+        mock_client = MagicMock()
+        mock_client.post.return_value = _make_mock_response(fake_body)
+        adapter._client = mock_client
+
+        response = adapter.send_message("hi", context, [])
+
+        assert response.content == "Hello, world!"
+        assert response.finish_reason == "stop"
+        assert response.tool_calls == []
+
+    def test_finish_reason_is_length_when_not_done(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """finish_reason is 'length' when the model did not finish naturally."""
+        fake_body = {
+            "message": {"content": "partial..."},
+            "done": False,
+        }
+        mock_client = MagicMock()
+        mock_client.post.return_value = _make_mock_response(fake_body)
+        adapter._client = mock_client
+
+        response = adapter.send_message("hi", context, [])
+
+        assert response.finish_reason == "length"
+
+    def test_usage_fields_are_populated_from_eval_counts(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """prompt_eval_count and eval_count map to usage dict."""
+        fake_body = {
+            "message": {"content": "ok"},
+            "done": True,
+            "prompt_eval_count": 42,
+            "eval_count": 17,
+        }
+        mock_client = MagicMock()
+        mock_client.post.return_value = _make_mock_response(fake_body)
+        adapter._client = mock_client
+
+        response = adapter.send_message("hi", context, [])
+
+        assert response.usage["prompt_tokens"] == 42
+        assert response.usage["completion_tokens"] == 17
+
+    def test_tool_calls_are_parsed_from_response(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """Tool calls in the model response are extracted."""
+        fake_body = {
+            "message": {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "tc_0",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"city": "London"},
+                        },
+                    }
+                ],
+            },
+            "done": True,
+        }
+        mock_client = MagicMock()
+        mock_client.post.return_value = _make_mock_response(fake_body)
+        adapter._client = mock_client
+
+        response = adapter.send_message("hi", context, [])
+
+        assert len(response.tool_calls) == 1
+        assert response.tool_calls[0].name == "get_weather"
+        assert response.tool_calls[0].arguments == {"city": "London"}
+
+
+class TestSendMessageErrors:
+    def test_connect_error_raises_ai_connection_error(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """httpx.ConnectError is translated to AIConnectionError."""
+        import httpx
+
+        mock_client = MagicMock()
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+        adapter._client = mock_client
+
+        with pytest.raises(AIConnectionError, match="ollama"):
+            adapter.send_message("hi", context, [])
+
+    def test_timeout_raises_ai_timeout_error(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """httpx.TimeoutException is translated to AITimeoutError."""
+        import httpx
+
+        mock_client = MagicMock()
+        mock_client.post.side_effect = httpx.TimeoutException("timed out")
+        adapter._client = mock_client
+
+        with pytest.raises(AITimeoutError):
+            adapter.send_message("hi", context, [])
+
+    def test_http_error_raises_ai_provider_error(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """Non-connect HTTP errors wrap as AIProviderError."""
+        import httpx
+
+        mock_client = MagicMock()
+        request = httpx.Request("POST", "http://localhost/api/chat")
+        response = httpx.Response(500, request=request)
+        mock_client.post.side_effect = httpx.HTTPStatusError(
+            "server error", request=request, response=response
+        )
+        adapter._client = mock_client
+
+        with pytest.raises(AIProviderError):
+            adapter.send_message("hi", context, [])
+
+
+# ---------------------------------------------------------------------------
+# validate_connection
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConnection:
+    def test_success_when_model_is_available(self, adapter: OllamaAdapter) -> None:
+        """Returns (True, message) when model appears in /api/tags."""
+        fake_body = {"models": [{"name": "llama3.1:8b"}]}
+        mock_client = MagicMock()
+        mock_client.get.return_value = _make_mock_response(fake_body)
+        adapter._client = mock_client
+
+        ok, msg = adapter.validate_connection()
+
+        assert ok is True
+        assert "llama3.1" in msg
+
+    def test_failure_when_no_models_installed(self, adapter: OllamaAdapter) -> None:
+        """Returns (False, message) when model list is empty."""
+        fake_body: dict[str, Any] = {"models": []}
+        mock_client = MagicMock()
+        mock_client.get.return_value = _make_mock_response(fake_body)
+        adapter._client = mock_client
+
+        ok, msg = adapter.validate_connection()
+
+        assert ok is False
+        assert "No models" in msg or "ollama pull" in msg
+
+    def test_failure_when_model_not_in_list(self, adapter: OllamaAdapter) -> None:
+        """Returns (False, message) when model is not among available models."""
+        fake_body = {"models": [{"name": "mistral"}, {"name": "codellama"}]}
+        mock_client = MagicMock()
+        mock_client.get.return_value = _make_mock_response(fake_body)
+        adapter._client = mock_client
+
+        ok, msg = adapter.validate_connection()
+
+        assert ok is False
+        assert "llama3.1" in msg or "not found" in msg
+
+    def test_failure_on_connect_error(self, adapter: OllamaAdapter) -> None:
+        """Returns (False, message) when Ollama server is unreachable."""
+        import httpx
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = httpx.ConnectError("refused")
+        adapter._client = mock_client
+
+        ok, msg = adapter.validate_connection()
+
+        assert ok is False
+        assert "connect" in msg.lower() or "running" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
+# list_available_models
+# ---------------------------------------------------------------------------
+
+
+class TestListAvailableModels:
+    def test_returns_model_names(self, adapter: OllamaAdapter) -> None:
+        """Returns a list of model name strings."""
+        fake_body = {
+            "models": [
+                {"name": "llama3.1:8b"},
+                {"name": "mistral:latest"},
+            ]
+        }
+        mock_client = MagicMock()
+        mock_client.get.return_value = _make_mock_response(fake_body)
+        adapter._client = mock_client
+
+        names = adapter.list_available_models()
+
+        assert names == ["llama3.1:8b", "mistral:latest"]
+
+    def test_raises_ai_connection_error_on_failure(
+        self, adapter: OllamaAdapter
+    ) -> None:
+        """Network failure wraps as AIConnectionError."""
+        import httpx
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = httpx.ConnectError("refused")
+        adapter._client = mock_client
+
+        with pytest.raises(AIConnectionError):
+            adapter.list_available_models()
+
+
+# ---------------------------------------------------------------------------
+# capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    @pytest.mark.parametrize(
+        "model",
+        ["llama3.1:8b", "llama3:latest", "mistral:7b"],
+    )
+    def test_llama3_and_mistral_support_function_calling(self, model: str) -> None:
+        """Models matching 'llama3' or 'mistral' advertise FUNCTION_CALLING."""
+        adapter = OllamaAdapter(model=model)
+        caps = adapter.capabilities
+        assert ProviderCapability.FUNCTION_CALLING in caps.supported
+
+    def test_generic_model_does_not_advertise_function_calling(self) -> None:
+        """Unknown models do not claim function calling support."""
+        adapter = OllamaAdapter(model="phi2")
+        caps = adapter.capabilities
+        assert ProviderCapability.FUNCTION_CALLING not in caps.supported
+
+    def test_streaming_and_system_message_always_supported(self) -> None:
+        """STREAMING and SYSTEM_MESSAGE are always in capabilities."""
+        adapter = OllamaAdapter(model="phi2")
+        caps = adapter.capabilities
+        assert ProviderCapability.STREAMING in caps.supported
+        assert ProviderCapability.SYSTEM_MESSAGE in caps.supported
+
+    def test_capabilities_provider_name_is_ollama(self) -> None:
+        """provider_name is always 'ollama'."""
+        adapter = OllamaAdapter(model="llama3.1:8b")
+        assert adapter.capabilities.provider_name == "ollama"
+
+
+# ---------------------------------------------------------------------------
+# stream_response
+# ---------------------------------------------------------------------------
+
+
+class TestStreamResponse:
+    def test_yields_agent_chunks_in_order(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """stream_response yields AgentChunk for each SSE line."""
+        lines = [
+            json.dumps({"message": {"content": "hel"}, "done": False}),
+            json.dumps({"message": {"content": "lo"}, "done": False}),
+            json.dumps({"message": {"content": "!"}, "done": True}),
+        ]
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.iter_lines.return_value = iter(lines)
+
+        mock_client = MagicMock()
+        enter = MagicMock(return_value=mock_response)
+        mock_client.stream.return_value.__enter__ = enter
+        mock_client.stream.return_value.__exit__ = MagicMock(return_value=False)
+        adapter._client = mock_client
+
+        chunks = list(adapter.stream_response("hi", context, []))
+
+        assert [c.content for c in chunks] == ["hel", "lo", "!"]
+
+    def test_final_chunk_has_is_final_true(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """The chunk with done=True has is_final=True."""
+        lines = [
+            json.dumps({"message": {"content": "part1"}, "done": False}),
+            json.dumps({"message": {"content": "part2"}, "done": True}),
+        ]
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.iter_lines.return_value = iter(lines)
+
+        mock_client = MagicMock()
+        enter = MagicMock(return_value=mock_response)
+        mock_client.stream.return_value.__enter__ = enter
+        mock_client.stream.return_value.__exit__ = MagicMock(return_value=False)
+        adapter._client = mock_client
+
+        chunks = list(adapter.stream_response("hi", context, []))
+
+        assert chunks[0].is_final is False
+        assert chunks[1].is_final is True
+
+    def test_malformed_json_raises_ai_provider_error(
+        self, adapter: OllamaAdapter, context: ConversationContext
+    ) -> None:
+        """A non-JSON line in the stream raises AIProviderError."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.iter_lines.return_value = iter(["not-json"])
+
+        mock_client = MagicMock()
+        enter = MagicMock(return_value=mock_response)
+        mock_client.stream.return_value.__enter__ = enter
+        mock_client.stream.return_value.__exit__ = MagicMock(return_value=False)
+        adapter._client = mock_client
+
+        with pytest.raises(AIProviderError):
+            list(adapter.stream_response("hi", context, []))

--- a/tests/shared/python/ai/test_rust_adapter_extended.py
+++ b/tests/shared/python/ai/test_rust_adapter_extended.py
@@ -1,0 +1,349 @@
+"""Extended unit tests for RustAgentAdapter.
+
+Supplements test_rust_adapter.py (which covers stream_response generator
+behavior from #2752) with:
+
+  - send_message happy path
+  - send_message exception swallowing → error AgentResponse
+  - index_codebase delegates to rag.index_codebase
+  - retrieve_context returns list[str]
+  - retrieve_context converts non-str items to str
+  - validate_connection always returns True
+  - capabilities advertise STREAMING and SYSTEM_MESSAGE
+  - constructor builds config / engine / memory correctly
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap (identical to test_rust_adapter.py)
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str | None]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.adapters", "src/shared/python/ai/adapters"),
+    ("src.shared.python.logging_pkg", None),
+    ("src.shared.python.logging_pkg.logging_config", None),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        if _rel_path is not None:
+            _stub.__path__ = [str(ROOT / _rel_path)]  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+_logging_config_stub = sys.modules["src.shared.python.logging_pkg.logging_config"]
+_logging_config_stub.get_logger = logging.getLogger  # type: ignore[attr-defined]
+
+
+def _install_ai_backend_stub() -> types.ModuleType:
+    """Install minimal ai_backend stub (matches test_rust_adapter.py pattern)."""
+    stub = types.ModuleType("ai_backend")
+
+    class _AIConfig:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self.model = "stub-model"
+
+    class _AIEngine:
+        def __init__(self, _config: object) -> None:
+            self._response = "default-response"
+
+        def generate_response(self, _prompt: str) -> str:
+            return self._response
+
+        def stream_response(self, _prompt: str) -> list[str]:
+            return [self._response]
+
+    class _MemoryManager:
+        def __init__(self, _path: str) -> None:
+            self.initialized = False
+
+        def initialize(self) -> None:
+            self.initialized = True
+
+    class _RagPipeline:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self._indexed_path: str = ""
+            self._context: list[str] = []
+
+        def index_codebase(self, root: str) -> int:
+            self._indexed_path = root
+            return len(root)
+
+        def retrieve_context(self, _prompt: str, top_k: int) -> list[str]:
+            return self._context[:top_k]
+
+    stub.AIConfig = _AIConfig  # type: ignore[attr-defined]
+    stub.AIEngine = _AIEngine  # type: ignore[attr-defined]
+    stub.MemoryManager = _MemoryManager  # type: ignore[attr-defined]
+    stub.RagPipeline = _RagPipeline  # type: ignore[attr-defined]
+    sys.modules["ai_backend"] = stub
+    return stub
+
+
+_install_ai_backend_stub()
+
+from src.shared.python.ai.adapters.rust_adapter import RustAgentAdapter  # noqa: E402
+from src.shared.python.ai.types import (  # noqa: E402
+    ConversationContext,
+    ExpertiseLevel,
+    ProviderCapability,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(**kwargs: object) -> RustAgentAdapter:
+    return RustAgentAdapter(
+        api_key="test-key",
+        base_url="https://example.invalid/v1",
+        model="stub-model",
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def _make_context() -> ConversationContext:
+    return ConversationContext(
+        messages=[],
+        user_expertise=ExpertiseLevel.INTERMEDIATE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# send_message
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessage:
+    def test_happy_path_returns_engine_response(self) -> None:
+        """send_message returns the Rust engine's generate_response as content."""
+        adapter = _make_adapter()
+        adapter.engine._response = "Rust says hello"  # type: ignore[attr-defined]
+
+        response = adapter.send_message("prompt", _make_context(), [])
+
+        assert response.content == "Rust says hello"
+        assert response.finish_reason != "error"
+
+    def test_context_messages_are_prepended_to_prompt(self) -> None:
+        """History messages are concatenated before the new prompt."""
+        from src.shared.python.ai.types import Message
+
+        adapter = _make_adapter()
+        captured: list[str] = []
+
+        original_gen = adapter.engine.generate_response
+
+        def _capture(prompt: str) -> str:
+            captured.append(prompt)
+            return original_gen(prompt)
+
+        adapter.engine.generate_response = _capture  # type: ignore[method-assign]
+
+        ctx = _make_context()
+        ctx.messages = [
+            Message(role="user", content="first"),
+            Message(role="assistant", content="second"),
+        ]
+
+        adapter.send_message("third", ctx, [])
+
+        assert len(captured) == 1
+        full_prompt = captured[0]
+        assert "first" in full_prompt
+        assert "second" in full_prompt
+        assert "third" in full_prompt
+
+    def test_engine_exception_returns_error_response(self) -> None:
+        """When the Rust engine raises, send_message returns an error AgentResponse."""
+        adapter = _make_adapter()
+        adapter.engine.generate_response = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("backend crash")
+        )
+
+        response = adapter.send_message("hi", _make_context(), [])
+
+        assert "Error" in response.content or "error" in response.content.lower()
+        assert response.finish_reason == "error"
+
+    def test_tools_parameter_is_ignored_without_raising(self) -> None:
+        """The Rust adapter does not use tools; passing them must not raise."""
+        from src.shared.python.ai.adapters.base import ToolDeclaration
+
+        adapter = _make_adapter()
+        tools = [ToolDeclaration(name="noop", description="no-op")]
+
+        # Should not raise
+        response = adapter.send_message("hi", _make_context(), tools)
+        assert response.content  # some content returned
+
+
+# ---------------------------------------------------------------------------
+# index_codebase
+# ---------------------------------------------------------------------------
+
+
+class TestIndexCodebase:
+    def test_delegates_to_rag_pipeline(self) -> None:
+        """index_codebase calls rag.index_codebase with the given path."""
+        adapter = _make_adapter()
+        result = adapter.index_codebase("/tmp/project")
+
+        assert isinstance(result, int)
+        # The stub returns len(root_path); non-zero confirms delegation
+        assert result > 0
+        assert adapter.rag._indexed_path == "/tmp/project"  # type: ignore[attr-defined]
+
+    def test_return_value_is_int(self) -> None:
+        """index_codebase always returns an int (document count)."""
+        adapter = _make_adapter()
+        result = adapter.index_codebase("/some/path")
+        assert isinstance(result, int)
+
+    @pytest.mark.parametrize("root", ["/a", "/var/tmp/project", "C:\\project"])
+    def test_various_root_paths_are_forwarded(self, root: str) -> None:
+        """Arbitrary root path strings are forwarded unchanged."""
+        adapter = _make_adapter()
+        adapter.index_codebase(root)
+        assert adapter.rag._indexed_path == root  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# retrieve_context
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieveContext:
+    def test_returns_list_of_strings(self) -> None:
+        """retrieve_context always returns list[str]."""
+        adapter = _make_adapter()
+        adapter.rag._context = ["ctx_a", "ctx_b", "ctx_c"]  # type: ignore[attr-defined]
+
+        result = adapter.retrieve_context("query", top_k=3)
+
+        assert isinstance(result, list)
+        assert all(isinstance(item, str) for item in result)
+
+    def test_top_k_limits_results(self) -> None:
+        """top_k caps the number of returned context chunks."""
+        adapter = _make_adapter()
+        adapter.rag._context = ["a", "b", "c", "d", "e"]  # type: ignore[attr-defined]
+
+        result = adapter.retrieve_context("query", top_k=2)
+
+        assert len(result) <= 2
+
+    def test_non_string_items_are_converted_to_str(self) -> None:
+        """Non-string items returned by the Rust layer are coerced to str."""
+        adapter = _make_adapter()
+        # Simulate Rust returning mixed types via the stub
+        adapter.rag.retrieve_context = MagicMock(  # type: ignore[method-assign]
+            return_value=[42, None, b"bytes"]
+        )
+
+        result = adapter.retrieve_context("query", top_k=5)
+
+        assert all(isinstance(item, str) for item in result)
+
+    def test_empty_context_returns_empty_list(self) -> None:
+        """No context chunks → empty list."""
+        adapter = _make_adapter()
+        adapter.rag._context = []  # type: ignore[attr-defined]
+
+        result = adapter.retrieve_context("query")
+
+        assert result == []
+
+    def test_default_top_k_is_five(self) -> None:
+        """Default top_k value is 5 (implicit signature contract)."""
+        import inspect
+
+        sig = inspect.signature(RustAgentAdapter.retrieve_context)
+        top_k_param = sig.parameters.get("top_k")
+        assert top_k_param is not None
+        assert top_k_param.default == 5
+
+
+# ---------------------------------------------------------------------------
+# validate_connection
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConnection:
+    def test_returns_true_when_engine_is_initialized(self) -> None:
+        """validate_connection returns (True, message) unconditionally."""
+        adapter = _make_adapter()
+        ok, msg = adapter.validate_connection()
+        assert ok is True
+        assert isinstance(msg, str)
+        assert len(msg) > 0
+
+
+# ---------------------------------------------------------------------------
+# capabilities
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilities:
+    def test_streaming_is_advertised(self) -> None:
+        """STREAMING capability is always present."""
+        adapter = _make_adapter()
+        assert ProviderCapability.STREAMING in adapter.capabilities.supported
+
+    def test_system_message_is_advertised(self) -> None:
+        """SYSTEM_MESSAGE capability is always present."""
+        adapter = _make_adapter()
+        assert ProviderCapability.SYSTEM_MESSAGE in adapter.capabilities.supported
+
+    def test_provider_name_is_rust(self) -> None:
+        """provider_name identifies the backend."""
+        adapter = _make_adapter()
+        assert adapter.capabilities.provider_name == "rust"
+
+    def test_model_name_comes_from_config(self) -> None:
+        """model_name in capabilities reflects the config model."""
+        adapter = _make_adapter()
+        assert adapter.capabilities.model_name == "stub-model"
+
+    def test_max_tokens_is_positive(self) -> None:
+        """max_tokens must be a positive integer."""
+        adapter = _make_adapter()
+        assert adapter.capabilities.max_tokens > 0
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    def test_initializes_memory_manager(self) -> None:
+        """MemoryManager.initialize() is called during construction."""
+        adapter = _make_adapter()
+        assert adapter.memory.initialized is True  # type: ignore[attr-defined]
+
+    def test_db_path_defaults_to_memory_db(self) -> None:
+        """Default db_path is './memory.db'."""
+        import inspect
+
+        sig = inspect.signature(RustAgentAdapter.__init__)
+        db_path_param = sig.parameters.get("db_path")
+        assert db_path_param is not None
+        assert db_path_param.default == "./memory.db"

--- a/tests/shared/python/chat/test_router_rest.py
+++ b/tests/shared/python/chat/test_router_rest.py
@@ -1,0 +1,244 @@
+"""Tests for router_factory REST endpoints.
+
+Covers the HTTP (non-WebSocket) surface of ``create_chat_router``:
+  - GET  /chat/sessions          → list sessions
+  - GET  /chat/sessions/{id}/history → per-session history
+
+These paths were previously untested (only the WebSocket path had coverage).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+testclient = pytest.importorskip("fastapi.testclient")
+
+from chat import ChatServiceBase
+from chat.router_factory import create_chat_router
+
+# ---------------------------------------------------------------------------
+# Minimal concrete service
+# ---------------------------------------------------------------------------
+
+
+class _MinimalService(ChatServiceBase):
+    """Concrete service stub with controllable state."""
+
+    async def stream_response(self, session_id: str) -> AsyncIterator[Any]:  # type: ignore[override]
+        yield "ok"
+
+    async def refresh_models(self) -> list[dict[str, Any]]:
+        return []
+
+    async def index_codebase(self, root_path: str) -> dict[str, Any]:
+        return {"state": "complete", "files_parsed": 0, "symbols_inserted": 0}
+
+
+def _make_app(service: ChatServiceBase | None = None) -> Any:
+    """Create a FastAPI test app with the chat router mounted."""
+    app = fastapi.FastAPI()
+    app.state.chat_service = service or _MinimalService()
+    app.include_router(create_chat_router(), prefix="/api")
+    return app
+
+
+# ---------------------------------------------------------------------------
+# GET /api/chat/sessions
+# ---------------------------------------------------------------------------
+
+
+class TestListSessions:
+    def test_returns_empty_list_when_no_sessions_exist(self) -> None:
+        """Fresh service has no sessions → endpoint returns []."""
+        client = testclient.TestClient(_make_app())
+        resp = client.get("/api/chat/sessions")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_returns_list_after_session_is_created(self) -> None:
+        """Creating a session via the service layer shows up in GET."""
+        service = _MinimalService()
+        session = service.get_or_create_session(None)
+        client = testclient.TestClient(_make_app(service))
+
+        resp = client.get("/api/chat/sessions")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["session_id"] == session.session_id
+
+    def test_returns_all_sessions_when_multiple_exist(self) -> None:
+        """Multiple sessions are all represented in the list."""
+        service = _MinimalService()
+        s1 = service.get_or_create_session(None)
+        s2 = service.get_or_create_session(None)
+        s3 = service.get_or_create_session(None)
+        client = testclient.TestClient(_make_app(service))
+
+        resp = client.get("/api/chat/sessions")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        ids = {item["session_id"] for item in data}
+        assert ids == {s1.session_id, s2.session_id, s3.session_id}
+
+    def test_each_session_has_expected_fields(self) -> None:
+        """Each entry in the list has the standard session summary shape."""
+        service = _MinimalService()
+        service.get_or_create_session(None)
+        client = testclient.TestClient(_make_app(service))
+
+        resp = client.get("/api/chat/sessions")
+        data = resp.json()
+
+        entry = data[0]
+        for key in ("session_id", "message_count", "created_at", "last_active"):
+            assert key in entry, f"Missing field: {key}"
+
+    def test_message_count_increments_after_adding_messages(self) -> None:
+        """message_count reflects actual message history."""
+        service = _MinimalService()
+        session = service.get_or_create_session(None)
+        service.add_user_message(session.session_id, "hello")
+        service.add_user_message(session.session_id, "world")
+        client = testclient.TestClient(_make_app(service))
+
+        resp = client.get("/api/chat/sessions")
+        data = resp.json()
+
+        assert data[0]["message_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# GET /api/chat/sessions/{id}/history
+# ---------------------------------------------------------------------------
+
+
+class TestGetSessionHistory:
+    def test_returns_empty_messages_for_fresh_session(self) -> None:
+        """A session with no messages returns an empty list."""
+        service = _MinimalService()
+        session = service.get_or_create_session(None)
+        client = testclient.TestClient(_make_app(service))
+
+        resp = client.get(f"/api/chat/sessions/{session.session_id}/history")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["session_id"] == session.session_id
+        assert body["messages"] == []
+
+    def test_returns_messages_in_order(self) -> None:
+        """Messages appear in insertion order."""
+        service = _MinimalService()
+        session = service.get_or_create_session(None)
+        service.add_user_message(session.session_id, "first")
+        service.add_user_message(session.session_id, "second")
+        client = testclient.TestClient(_make_app(service))
+
+        resp = client.get(f"/api/chat/sessions/{session.session_id}/history")
+
+        assert resp.status_code == 200
+        messages = resp.json()["messages"]
+        assert len(messages) == 2
+        assert messages[0]["content"] == "first"
+        assert messages[1]["content"] == "second"
+
+    def test_each_message_has_role_content_timestamp(self) -> None:
+        """Each message dict has role, content, and timestamp keys."""
+        service = _MinimalService()
+        session = service.get_or_create_session(None)
+        service.add_user_message(session.session_id, "ping")
+        client = testclient.TestClient(_make_app(service))
+
+        resp = client.get(f"/api/chat/sessions/{session.session_id}/history")
+
+        msg = resp.json()["messages"][0]
+        for key in ("role", "content", "timestamp"):
+            assert key in msg, f"Missing key: {key}"
+        assert msg["role"] == "user"
+        assert msg["content"] == "ping"
+
+    def test_unknown_session_returns_empty_messages(self) -> None:
+        """Non-existent session_id returns an empty messages list (not 404).
+
+        The service layer returns [] for unknown sessions, so the REST
+        endpoint forwards that to the caller.
+        """
+        client = testclient.TestClient(_make_app())
+
+        resp = client.get("/api/chat/sessions/nonexistent-session-id/history")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["session_id"] == "nonexistent-session-id"
+        assert body["messages"] == []
+
+    def test_whitespace_only_session_id_returns_empty_messages(self) -> None:
+        """Whitespace-only session_id is treated as empty and returns []."""
+        client = testclient.TestClient(_make_app())
+        # Path parameter must be non-empty for the route to match; use spaces
+        # as a URL-encoded string to exercise the strip guard in the handler.
+        resp = client.get("/api/chat/sessions/%20/history")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["messages"] == []
+
+    def test_session_id_is_echoed_in_response(self) -> None:
+        """The session_id from the path is always reflected in the body."""
+        service = _MinimalService()
+        session = service.get_or_create_session(None)
+        client = testclient.TestClient(_make_app(service))
+
+        resp = client.get(f"/api/chat/sessions/{session.session_id}/history")
+
+        assert resp.json()["session_id"] == session.session_id
+
+
+# ---------------------------------------------------------------------------
+# Integration: REST endpoints share same service state as WebSocket
+# ---------------------------------------------------------------------------
+
+
+class TestRestAndWebSocketShareState:
+    def test_session_created_via_ws_appears_in_rest_list(self) -> None:
+        """A session opened via WebSocket is visible in GET /chat/sessions."""
+        service = _MinimalService()
+        client = testclient.TestClient(_make_app(service))
+
+        with client.websocket_connect("/api/ws/chat/new") as ws:
+            info = ws.receive_json()
+            assert info["type"] == "session_info"
+            ws_session_id = info["session_id"]
+
+        resp = client.get("/api/chat/sessions")
+        assert resp.status_code == 200
+        ids = {item["session_id"] for item in resp.json()}
+        assert ws_session_id in ids
+
+    def test_message_sent_via_ws_appears_in_rest_history(self) -> None:
+        """A message sent over WebSocket shows up in GET history endpoint."""
+        service = _MinimalService()
+        client = testclient.TestClient(_make_app(service))
+
+        with client.websocket_connect("/api/ws/chat/new") as ws:
+            info = ws.receive_json()
+            ws_session_id = info["session_id"]
+            ws.send_json({"action": "send", "message": "hello from ws"})
+            # Drain all responses until "complete"
+            for _ in range(10):
+                reply = ws.receive_json()
+                if reply.get("type") == "complete":
+                    break
+
+        resp = client.get(f"/api/chat/sessions/{ws_session_id}/history")
+        assert resp.status_code == 200
+        contents = [m["content"] for m in resp.json()["messages"]]
+        assert "hello from ws" in contents


### PR DESCRIPTION
Closes #2781 (substantial portion — router REST, Ollama adapter, Rust adapter).

`file_navigation` and `project_file_explorer` gaps are already covered by existing tests in `tests/shared/python/upstream_drift_tools/ui/`.

## What's added

### `tests/shared/python/chat/test_router_rest.py` (NEW — 13 tests)
Covers the HTTP (non-WebSocket) surface of `create_chat_router` that had zero coverage:
- `GET /chat/sessions` → empty list, session list, all sessions, field shape, message count
- `GET /chat/sessions/{id}/history` → empty, ordered, field shape, unknown session (empty not 404), whitespace guard, session_id echo
- Integration: session created via WS appears in REST list; message sent via WS appears in REST history

### `tests/shared/python/ai/test_ollama_adapter_extended.py` (NEW — 22 tests)
Covers the full `OllamaAdapter` surface (existing test only covered `_format_messages`):
- `send_message`: content, finish_reason, usage fields, tool call parsing, ConnectError → AIConnectionError, TimeoutException → AITimeoutError, HTTP error → AIProviderError
- `validate_connection`: success, no models, model not found, ConnectError
- `list_available_models`: names list, AIConnectionError on failure
- `capabilities`: STREAMING + SYSTEM_MESSAGE always; FUNCTION_CALLING for llama3/mistral; provider_name
- `stream_response`: ordered chunks, is_final flag, malformed JSON → AIProviderError

### `tests/shared/python/ai/test_rust_adapter_extended.py` (NEW — 22 tests)
Supplements `test_rust_adapter.py` (which only covered `stream_response` generator from #2752):
- `send_message`: happy path, context messages prepended, exception swallowing → error response, tools parameter ignored
- `index_codebase`: delegates to rag, returns int, parametrized path forwarding
- `retrieve_context`: list[str] contract, top_k cap, non-str coercion, empty list, default top_k=5 signature check
- `validate_connection`: always True
- `capabilities`: STREAMING, SYSTEM_MESSAGE, provider_name="rust", model_name from config, max_tokens > 0
- `__init__`: MemoryManager.initialize() called, db_path default="./memory.db"

## Test plan
- [x] All 57 new tests pass locally
- [x] ruff check + ruff format — clean
- [x] Pre-commit hooks pass (no --no-verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>