### PR TITLE
refactor(ai-gui): decompose AISettingsDialog into config + registry + per-tab widgets (#2762)

### DIFF
--- a/src/shared/python/ai/_settings_model.py
+++ b/src/shared/python/ai/_settings_model.py
@@ -1,0 +1,195 @@
+"""``AISettings`` dataclass and persistence (extracted from gui/settings_dialog).
+
+The dataclass itself is headless-safe — instantiation does not require Qt.
+Only :meth:`AISettings.save` and :meth:`AISettings.load` import
+``PyQt6.QtCore.QSettings`` (lazy import). Tools issue #2762.
+
+Also exposes :meth:`AISettings.to_dict` / :meth:`from_dict` for JSON
+round-trips in tests that don't want to touch QSettings at all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from src.shared.python.ai.access_policy import ChatAccessMode, coerce_access_mode
+from src.shared.python.ai.config import (
+    DEFAULT_OLLAMA_HOST,
+    DEFAULT_OLLAMA_MODEL,
+    KEY_ACCESS_MODE,
+    KEY_AUTO_INDEX_ON_OPEN,
+    KEY_CHAT_MODE,
+    KEY_EXPERTISE,
+    KEY_MODEL,
+    KEY_OLLAMA_HOST,
+    KEY_PROVIDER,
+    KEY_RAG_ENABLED,
+    KEY_RESPONSE_STYLE,
+    KEY_STREAMING,
+    SETTINGS_APP,
+    SETTINGS_ORG,
+    get_ollama_host,
+)
+from src.shared.python.ai.gui._provider_registry_data import AIProvider
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _resolve_qsettings():  # noqa: ANN202
+    """Resolve ``QSettings`` honouring monkeypatches on ``settings_dialog``.
+
+    Tools tests historically patch ``settings_dialog.QSettings`` to inject a
+    fake. We honour that patch first so the dataclass move from #2762 stays
+    backward-compatible. Falls back to the real PyQt6 import.
+    """
+    import sys
+
+    sd = sys.modules.get("src.shared.python.ai.gui.settings_dialog")
+    if sd is not None and hasattr(sd, "QSettings"):
+        return sd.QSettings
+    from PyQt6.QtCore import QSettings
+
+    return QSettings
+
+
+@dataclass
+class AISettings:
+    """AI configuration settings.
+
+    Headless-safe — the dataclass and ``to_dict``/``from_dict`` round-trip
+    require no Qt installation. Persistence (``save``/``load``) imports
+    ``PyQt6.QtCore.QSettings`` lazily.
+
+    Attributes:
+        provider: Selected AI provider.
+        model: Model name for the provider.
+        expertise_level: DEPRECATED legacy verbosity (Tools #2552).
+        response_style: ``"concise"`` | ``"standard"`` | ``"detailed"``.
+        chat_mode: Inline chat access mode.
+        ollama_host: Ollama server URL.
+        streaming_enabled: Stream responses.
+        rag_enabled: RAG codebase awareness.
+        auto_index_on_open: Rebuild codemap on chat open (Tools #2549).
+        access_mode: Chat repo/tool access mode.
+        api_keys: In-memory keys (not persisted; see keyring helpers).
+    """
+
+    provider: AIProvider = AIProvider.OLLAMA
+    model: str = DEFAULT_OLLAMA_MODEL
+    expertise_level: int = 1
+    response_style: str = "standard"
+    chat_mode: str = "ask"
+    ollama_host: str = DEFAULT_OLLAMA_HOST
+    streaming_enabled: bool = True
+    rag_enabled: bool = True
+    auto_index_on_open: bool = False
+    access_mode: ChatAccessMode = ChatAccessMode.NO_REPO_ACCESS
+    api_keys: dict[AIProvider, str] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------ #
+    # Headless serialisation — no Qt needed.                              #
+    # ------------------------------------------------------------------ #
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-compatible dict."""
+        self.access_mode = coerce_access_mode(self.access_mode)
+        return {
+            "provider": self.provider.name,
+            "model": self.model,
+            "expertise_level": int(self.expertise_level),
+            "response_style": self.response_style,
+            "chat_mode": self.chat_mode,
+            "ollama_host": self.ollama_host,
+            "streaming_enabled": bool(self.streaming_enabled),
+            "rag_enabled": bool(self.rag_enabled),
+            "auto_index_on_open": bool(self.auto_index_on_open),
+            "access_mode": self.access_mode.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> AISettings:
+        """Construct from a :meth:`to_dict` payload."""
+        provider_name = str(data.get("provider", "OLLAMA"))
+        try:
+            provider = AIProvider[provider_name]
+        except KeyError:
+            provider = AIProvider.OLLAMA
+
+        response_style = str(data.get("response_style", "standard")).lower()
+        if response_style not in {"concise", "standard", "detailed"}:
+            response_style = "standard"
+        chat_mode = str(data.get("chat_mode", "ask")).lower()
+        if chat_mode not in {"ask", "diagnose", "agent"}:
+            chat_mode = "ask"
+
+        return cls(
+            provider=provider,
+            model=str(data.get("model", DEFAULT_OLLAMA_MODEL)),
+            expertise_level=int(data.get("expertise_level", 1) or 1),
+            response_style=response_style,
+            chat_mode=chat_mode,
+            ollama_host=str(data.get("ollama_host", DEFAULT_OLLAMA_HOST)),
+            streaming_enabled=bool(data.get("streaming_enabled", True)),
+            rag_enabled=bool(data.get("rag_enabled", True)),
+            auto_index_on_open=bool(data.get("auto_index_on_open", False)),
+            access_mode=coerce_access_mode(data.get("access_mode")),
+        )
+
+    # ------------------------------------------------------------------ #
+    # Qt-backed persistence.                                              #
+    # ------------------------------------------------------------------ #
+
+    def save(self) -> None:
+        """Save settings to QSettings storage."""
+        QSettings = _resolve_qsettings()  # noqa: N806
+
+        settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
+        settings.setValue(KEY_PROVIDER, self.provider.name)
+        settings.setValue(KEY_MODEL, self.model)
+        settings.setValue(KEY_EXPERTISE, self.expertise_level)
+        settings.setValue(KEY_RESPONSE_STYLE, self.response_style)
+        settings.setValue(KEY_CHAT_MODE, self.chat_mode)
+        settings.setValue(KEY_OLLAMA_HOST, self.ollama_host)
+        settings.setValue(KEY_STREAMING, self.streaming_enabled)
+        settings.setValue(KEY_RAG_ENABLED, self.rag_enabled)
+        settings.setValue(KEY_AUTO_INDEX_ON_OPEN, self.auto_index_on_open)
+        self.access_mode = coerce_access_mode(self.access_mode)
+        settings.setValue(KEY_ACCESS_MODE, self.access_mode.value)
+        logger.info("Saved AI settings: provider=%s", self.provider.name)
+
+    @classmethod
+    def load(cls) -> AISettings:
+        """Load settings from QSettings storage."""
+        QSettings = _resolve_qsettings()  # noqa: N806
+
+        settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
+
+        provider_name = settings.value(KEY_PROVIDER, "OLLAMA")
+        try:
+            provider = AIProvider[provider_name]
+        except KeyError:
+            provider = AIProvider.OLLAMA
+
+        default_host = get_ollama_host()
+        response_style = str(settings.value(KEY_RESPONSE_STYLE, "standard")).lower()
+        if response_style not in {"concise", "standard", "detailed"}:
+            response_style = "standard"
+        chat_mode = str(settings.value(KEY_CHAT_MODE, "ask")).lower()
+        if chat_mode not in {"ask", "diagnose", "agent"}:
+            chat_mode = "ask"
+        return cls(
+            provider=provider,
+            model=settings.value(KEY_MODEL, DEFAULT_OLLAMA_MODEL),
+            expertise_level=int(settings.value(KEY_EXPERTISE, 1)),
+            response_style=response_style,
+            chat_mode=chat_mode,
+            ollama_host=settings.value(KEY_OLLAMA_HOST, default_host),
+            streaming_enabled=settings.value(KEY_STREAMING, True, type=bool),
+            rag_enabled=settings.value(KEY_RAG_ENABLED, True, type=bool),
+            auto_index_on_open=settings.value(KEY_AUTO_INDEX_ON_OPEN, False, type=bool),
+            access_mode=coerce_access_mode(settings.value(KEY_ACCESS_MODE, None)),
+        )
+
+
+__all__ = ["AISettings"]

--- a/src/shared/python/ai/config.py
+++ b/src/shared/python/ai/config.py
@@ -312,3 +312,23 @@ def get_tool_timeout() -> float:
         get_env_float(ENV_TOOL_TIMEOUT, default=DEFAULT_TOOL_TIMEOUT)
         or DEFAULT_TOOL_TIMEOUT
     )
+
+
+# ============================================================================
+# AI Settings dataclass persistence keys (used by gui/settings_dialog.py)
+# Tools #2762: keys live here so headless callers can construct
+# ``AISettings`` without importing the GUI module.
+# ============================================================================
+
+SETTINGS_ORG = "D-sorganization"
+SETTINGS_APP = "AIAssistant"
+KEY_PROVIDER = "ai/provider"
+KEY_MODEL = "ai/model"
+KEY_EXPERTISE = "ai/expertise_level"  # legacy alias, see Tools #2552
+KEY_RESPONSE_STYLE = "ai/response_style"
+KEY_CHAT_MODE = "ai/chat_mode"
+KEY_OLLAMA_HOST = "ai/ollama_host"
+KEY_STREAMING = "ai/streaming_enabled"
+KEY_RAG_ENABLED = "ai/rag_enabled"
+KEY_AUTO_INDEX_ON_OPEN = "ai/auto_index_on_open"
+KEY_ACCESS_MODE = "ai/access_mode"

--- a/src/shared/python/ai/gui/_api_keys.py
+++ b/src/shared/python/ai/gui/_api_keys.py
@@ -1,0 +1,105 @@
+"""API key helpers for the AI settings dialog.
+
+Provides ``get_api_key``/``set_api_key``/``delete_api_key`` keyed by
+:class:`AIProvider`. Persistence still uses the per-provider ``key_service``
+strings declared in ``PROVIDER_INFO`` so previously-stored keys remain
+readable. The lower-level keyring access goes through
+:class:`src.shared.python.chat.credentials.CredentialManager` whenever
+possible to keep keyring access centralised in one well-tested place.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.ai.gui._provider_registry_data import (
+    PROVIDER_INFO,
+    AIProvider,
+)
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _service_name(provider: AIProvider) -> str | None:
+    info = PROVIDER_INFO.get(provider)
+    if not info or not info.get("requires_key"):
+        return None
+    service_name = info.get("key_service", "")
+    if not service_name or not isinstance(service_name, str):
+        return None
+    return service_name
+
+
+def _credential_manager(service: str):  # noqa: ANN202 - lazy import for testability
+    from src.shared.python.chat.credentials import CredentialManager
+
+    return CredentialManager(service_name=service)
+
+
+def get_api_key(provider: AIProvider) -> str | None:
+    """Get API key from secure storage.
+
+    Args:
+        provider: Provider to get key for.
+
+    Returns:
+        API key if found, ``None`` otherwise.
+    """
+    service = _service_name(provider)
+    if service is None:
+        return None
+    try:
+        # Preserve historical keyring layout: ``service=service_name``,
+        # ``username="api_key"``. CredentialManager namespaces by username
+        # internally, so we go direct to ``keyring`` for read compatibility.
+        import keyring
+
+        result = keyring.get_password(service, "api_key")
+        return result if isinstance(result, str) else None
+    except ImportError:
+        logger.warning("keyring package not installed for secure key storage")
+        return None
+    except (RuntimeError, TypeError, AttributeError) as e:
+        logger.warning("Failed to get API key from keyring: %s", e)
+        return None
+
+
+def set_api_key(provider: AIProvider, key: str) -> bool:
+    """Store API key in secure storage."""
+    if provider is None:
+        raise ValueError("provider must be provided")
+    service = _service_name(provider)
+    if service is None:
+        return False
+    try:
+        import keyring
+
+        keyring.set_password(service, "api_key", key)
+        logger.info("Stored API key for %s", provider.name)
+        return True
+    except ImportError:
+        logger.warning("keyring package not installed for secure key storage")
+        return False
+    except (RuntimeError, TypeError, AttributeError) as e:
+        logger.warning("Failed to store API key: %s", e)
+        return False
+
+
+def delete_api_key(provider: AIProvider) -> bool:
+    """Delete API key from secure storage."""
+    service = _service_name(provider)
+    if service is None:
+        return False
+    try:
+        import keyring
+
+        keyring.delete_password(service, "api_key")
+        logger.info("Deleted API key for %s", provider.name)
+        return True
+    except ImportError:
+        return False
+    except (RuntimeError, TypeError, AttributeError) as e:
+        logger.warning("Failed to delete API key: %s", e)
+        return False
+
+
+__all__ = ["delete_api_key", "get_api_key", "set_api_key"]

--- a/src/shared/python/ai/gui/_general_tab.py
+++ b/src/shared/python/ai/gui/_general_tab.py
@@ -1,0 +1,79 @@
+"""General preferences tab for the AI settings dialog (Tools #2762)."""
+
+from __future__ import annotations
+
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QGroupBox,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class GeneralPreferencesTab(QWidget):
+    """Verbosity + streaming controls."""
+
+    # Mirrors the legacy mapping from response_style -> deprecated
+    # ``expertise_level`` so downstream code that still reads the integer
+    # remains in sync until it migrates (Tools #2552).
+    STYLE_TO_LEGACY_LEVEL: dict[str, int] = {
+        "concise": 4,
+        "standard": 2,
+        "detailed": 1,
+    }
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._build()
+
+    def _build(self) -> None:
+        layout = QVBoxLayout(self)
+
+        expertise_group = QGroupBox("Response Verbosity")
+        expertise_layout = QVBoxLayout(expertise_group)
+
+        self.expertise_combo = QComboBox()
+        self.expertise_combo.addItem("Concise", "concise")
+        self.expertise_combo.addItem("Standard", "standard")
+        self.expertise_combo.addItem("Detailed", "detailed")
+        expertise_layout.addWidget(self.expertise_combo)
+
+        expertise_desc = QLabel(
+            "How verbose the AI's replies should be. 'Concise' favours "
+            "code and short bullet lists; 'Detailed' walks through "
+            "reasoning and trade-offs."
+        )
+        expertise_desc.setWordWrap(True)
+        expertise_layout.addWidget(expertise_desc)
+
+        layout.addWidget(expertise_group)
+
+        response_group = QGroupBox("Response Settings")
+        response_layout = QVBoxLayout(response_group)
+
+        self.streaming_check = QCheckBox("Enable streaming responses")
+        self.streaming_check.setToolTip(
+            "Show responses as they're generated (more responsive)"
+        )
+        response_layout.addWidget(self.streaming_check)
+
+        layout.addWidget(response_group)
+        layout.addStretch()
+
+    # ---- helpers --------------------------------------------------------
+
+    def select_response_style(self, style: str) -> None:
+        target = (style or "standard").lower()
+        for i in range(self.expertise_combo.count()):
+            if self.expertise_combo.itemData(i) == target:
+                self.expertise_combo.setCurrentIndex(i)
+                return
+
+    def current_response_style(self) -> str:
+        data = self.expertise_combo.currentData()
+        return data if isinstance(data, str) else "standard"
+
+
+__all__ = ["GeneralPreferencesTab"]

--- a/src/shared/python/ai/gui/_provider_config_registry.py
+++ b/src/shared/python/ai/gui/_provider_config_registry.py
@@ -1,0 +1,108 @@
+"""Provider config widget registry.
+
+Replaces the legacy single ``ProviderConfigWidget`` that branched on
+``AIProvider`` to render different bodies. Each provider now owns its own
+widget class registered here. Adding a new provider = subclass a
+``_BaseProviderConfigWidget`` and call :meth:`ProviderConfigRegistry.register`.
+
+Tools issue #2762.
+"""
+
+from __future__ import annotations
+
+from PyQt6.QtWidgets import QWidget
+
+from src.shared.python.ai.gui._provider_config_widgets import (
+    AnthropicConfigWidget,
+    BitnetConfigWidget,
+    ClaudeCliConfigWidget,
+    ClineConfigWidget,
+    CodexCliConfigWidget,
+    GeminiConfigWidget,
+    OllamaConfigWidget,
+    OpenAIConfigWidget,
+)
+from src.shared.python.ai.gui._provider_registry_data import AIProvider
+
+
+class ProviderConfigRegistry:
+    """Registry mapping provider id -> widget factory class."""
+
+    _factories: dict[str, type[QWidget]] = {}
+
+    @classmethod
+    def register(cls, provider_id: str, widget_factory: type[QWidget]) -> None:
+        """Register a widget factory for ``provider_id``.
+
+        Args:
+            provider_id: Lower-case identifier (e.g. ``"anthropic"``). May
+                also be the name of an :class:`AIProvider` enum member.
+            widget_factory: ``QWidget`` subclass instantiable with a single
+                optional ``parent`` argument.
+
+        Raises:
+            ValueError: If ``provider_id`` is empty.
+            TypeError: If ``widget_factory`` is not a ``QWidget`` subclass.
+        """
+        if not provider_id or not provider_id.strip():
+            raise ValueError("provider_id must be a non-empty string")
+        if not isinstance(widget_factory, type) or not issubclass(
+            widget_factory, QWidget
+        ):
+            raise TypeError("widget_factory must be a QWidget subclass")
+        cls._factories[provider_id.lower()] = widget_factory
+
+    @classmethod
+    def unregister(cls, provider_id: str) -> None:
+        """Remove a registration (mainly for tests)."""
+        cls._factories.pop(provider_id.lower(), None)
+
+    @classmethod
+    def is_registered(cls, provider_id: str) -> bool:
+        return provider_id.lower() in cls._factories
+
+    @classmethod
+    def get_widget(
+        cls, provider_id: str | AIProvider, parent: QWidget | None = None
+    ) -> QWidget:
+        """Build a fresh widget for ``provider_id``.
+
+        Args:
+            provider_id: Either an :class:`AIProvider` member, the enum
+                ``name`` (case-insensitive), or any registered string id.
+            parent: Optional Qt parent.
+
+        Returns:
+            A new widget instance.
+
+        Raises:
+            KeyError: If no factory is registered for ``provider_id``.
+        """
+        key = provider_id.name if isinstance(provider_id, AIProvider) else provider_id
+        factory = cls._factories.get(key.lower())
+        if factory is None:
+            raise KeyError(f"No provider config widget registered for {provider_id!r}")
+        return factory(parent)
+
+    @classmethod
+    def registered_ids(cls) -> list[str]:
+        return sorted(cls._factories)
+
+
+# ---------------------------------------------------------------------------
+# Default registrations.  Use both lower-case slugs (``"anthropic"``) and the
+# AIProvider enum names (``"ANTHROPIC"``-cased through ``.lower()``) so
+# callers can register/look-up via either convention.
+# ---------------------------------------------------------------------------
+ProviderConfigRegistry.register("ollama", OllamaConfigWidget)
+ProviderConfigRegistry.register("openai", OpenAIConfigWidget)
+ProviderConfigRegistry.register("anthropic", AnthropicConfigWidget)
+ProviderConfigRegistry.register("gemini", GeminiConfigWidget)
+ProviderConfigRegistry.register("cline", ClineConfigWidget)
+ProviderConfigRegistry.register("cline_cli", ClineConfigWidget)
+ProviderConfigRegistry.register("bitnet", BitnetConfigWidget)
+ProviderConfigRegistry.register("claude_cli", ClaudeCliConfigWidget)
+ProviderConfigRegistry.register("codex_cli", CodexCliConfigWidget)
+
+
+__all__ = ["ProviderConfigRegistry"]

--- a/src/shared/python/ai/gui/_provider_config_widgets.py
+++ b/src/shared/python/ai/gui/_provider_config_widgets.py
@@ -1,0 +1,345 @@
+"""Per-provider configuration widgets used by the AI settings dialog.
+
+Each provider gets its own ``QWidget`` subclass instead of a single
+hardcoded-by-enum-branch widget. They're registered in
+``_provider_config_registry.ProviderConfigRegistry`` so adding a new
+provider only requires a new widget class + a registry call.
+
+Tools issue #2762.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from PyQt6.QtCore import QTimer, pyqtSignal
+from PyQt6.QtWidgets import (
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.ai.config import get_ollama_host
+from src.shared.python.ai.gui._api_keys import get_api_key, set_api_key
+from src.shared.python.ai.gui._provider_registry_data import (
+    BITNET_ROOT_ENV,
+    DEFAULT_CLINE_HOST,
+    PROVIDER_INFO,
+    AIProvider,
+)
+from src.shared.python.theme.style_constants import Styles
+
+
+class _BaseProviderConfigWidget(QWidget):
+    """Common scaffolding for per-provider config widgets."""
+
+    key_changed = pyqtSignal(str)
+    models_refreshed = pyqtSignal(list)
+
+    PROVIDER: AIProvider  # subclasses override
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._provider = self.PROVIDER
+        self._info = PROVIDER_INFO[self._provider]
+        self._build()
+
+    # ---- subclass hooks -------------------------------------------------
+
+    def _build(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        desc = self._info.get("description", "")
+        desc_label = QLabel(str(desc))
+        desc_label.setWordWrap(True)
+        layout.addWidget(desc_label)
+        self._build_body(layout)
+        layout.addStretch()
+
+    def _build_body(self, layout: QVBoxLayout) -> None:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    # ---- public API mirrored from the legacy ProviderConfigWidget -------
+
+    def get_host(self) -> str:
+        return ""
+
+
+class _ApiKeyProviderConfigWidget(_BaseProviderConfigWidget):
+    """Reusable body for cloud providers that require an API key."""
+
+    def _build_body(self, layout: QVBoxLayout) -> None:
+        key_layout = QHBoxLayout()
+
+        self._key_input = QLineEdit()
+        self._key_input.setPlaceholderText("Enter API key...")
+        self._key_input.setEchoMode(QLineEdit.EchoMode.Password)
+        self._key_input.textChanged.connect(self._on_key_changed)
+        key_layout.addWidget(self._key_input)
+
+        self._show_key_btn = QPushButton("Show")
+        self._show_key_btn.setCheckable(True)
+        self._show_key_btn.toggled.connect(self._toggle_key_visibility)
+        key_layout.addWidget(self._show_key_btn)
+
+        self._save_key_btn = QPushButton("Save")
+        self._save_key_btn.clicked.connect(self._save_key)
+        key_layout.addWidget(self._save_key_btn)
+
+        layout.addLayout(key_layout)
+
+        self._key_status = QLabel()
+        layout.addWidget(self._key_status)
+
+        self._load_current_key()
+
+    def _load_current_key(self) -> None:
+        key = get_api_key(self._provider)
+        if key:
+            self._key_input.setText(key)
+            self._key_status.setText("✓ API key configured")
+            self._key_status.setStyleSheet(Styles.COLOR_GREEN)
+        else:
+            self._key_status.setText("⚠ No API key configured")
+            self._key_status.setStyleSheet(Styles.COLOR_ORANGE)
+
+    def _on_key_changed(self, text: str) -> None:
+        self.key_changed.emit(text)
+
+    def _toggle_key_visibility(self, show: bool) -> None:
+        if show:
+            self._key_input.setEchoMode(QLineEdit.EchoMode.Normal)
+            self._show_key_btn.setText("Hide")
+        else:
+            self._key_input.setEchoMode(QLineEdit.EchoMode.Password)
+            self._show_key_btn.setText("Show")
+
+    def _save_key(self) -> None:
+        key = self._key_input.text().strip()
+        if not key:
+            QMessageBox.warning(self, "Error", "Please enter an API key.")
+            return
+        if set_api_key(self._provider, key):
+            self._key_status.setText("✓ API key saved securely")
+            self._key_status.setStyleSheet(Styles.COLOR_GREEN)
+            QMessageBox.information(
+                self,
+                "Success",
+                f"API key saved to {self._get_keyring_location()}",
+            )
+        else:
+            self._key_status.setText("✗ Failed to save key")
+            self._key_status.setStyleSheet(Styles.COLOR_RED)
+            QMessageBox.warning(
+                self,
+                "Error",
+                "Failed to save API key. The keyring package may not be installed.",
+            )
+
+    def _get_keyring_location(self) -> str:
+        import platform
+
+        system = platform.system()
+        if system == "Windows":
+            return "Windows Credential Manager"
+        if system == "Darwin":
+            return "macOS Keychain"
+        return "System keyring"
+
+
+class OpenAIConfigWidget(_ApiKeyProviderConfigWidget):
+    PROVIDER = AIProvider.OPENAI
+
+
+class AnthropicConfigWidget(_ApiKeyProviderConfigWidget):
+    PROVIDER = AIProvider.ANTHROPIC
+
+
+class GeminiConfigWidget(_ApiKeyProviderConfigWidget):
+    PROVIDER = AIProvider.GEMINI
+
+
+class OllamaConfigWidget(_BaseProviderConfigWidget):
+    PROVIDER = AIProvider.OLLAMA
+
+    def _build_body(self, layout: QVBoxLayout) -> None:
+        host_layout = QFormLayout()
+        self._host_input = QLineEdit(get_ollama_host())
+        host_layout.addRow("Ollama Host:", self._host_input)
+        layout.addLayout(host_layout)
+
+        self._test_btn = QPushButton("Test Connection")
+        self._test_btn.clicked.connect(self._test_connection)
+        layout.addWidget(self._test_btn)
+
+        self._refresh_models_btn = QPushButton("\U0001f504 Refresh Available Models")
+        self._refresh_models_btn.setToolTip(
+            "Fetch the list of installed models from your local Ollama instance"
+        )
+        self._refresh_models_btn.clicked.connect(self._refresh_models)
+        layout.addWidget(self._refresh_models_btn)
+
+        self._status_label = QLabel()
+        layout.addWidget(self._status_label)
+
+        self._model_count_label = QLabel()
+        self._model_count_label.setStyleSheet(Styles.TEXT_MUTED)
+        layout.addWidget(self._model_count_label)
+
+    def get_host(self) -> str:
+        return str(self._host_input.text().strip())
+
+    def showEvent(self, event: Any) -> None:
+        super().showEvent(event)
+        QTimer.singleShot(100, self._refresh_models)
+
+    def _test_connection(self) -> None:
+        self._status_label.setText("Testing connection...")
+        self._status_label.setStyleSheet(Styles.COLOR_RESET)
+        try:
+            from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
+
+            adapter = OllamaAdapter(host=self._host_input.text().strip())
+            success, message = adapter.validate_connection()
+            if success:
+                self._status_label.setText(f"✓ {message}")
+                self._status_label.setStyleSheet(Styles.COLOR_GREEN)
+                self._refresh_models()
+            else:
+                self._status_label.setText(f"✗ {message}")
+                self._status_label.setStyleSheet(Styles.COLOR_RED)
+        except ImportError as e:
+            self._status_label.setText(f"✗ Error: {e}")
+            self._status_label.setStyleSheet(Styles.COLOR_RED)
+
+    def _refresh_models(self) -> None:
+        self._status_label.setText("Fetching available models...")
+        self._status_label.setStyleSheet(Styles.COLOR_RESET)
+        try:
+            from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
+
+            adapter = OllamaAdapter(host=self._host_input.text().strip())
+            models = adapter.list_available_models()
+            if models:
+                preview = ", ".join(models[:5])
+                suffix = "..." if len(models) > 5 else ""
+                self._model_count_label.setText(
+                    f"✓ Found {len(models)} model(s): {preview}{suffix}"
+                )
+                self._model_count_label.setStyleSheet(Styles.COLOR_GREEN)
+                self.models_refreshed.emit(models)
+            else:
+                self._model_count_label.setText(
+                    "⚠ No models found. Pull one with: ollama pull llama3.1:8b"
+                )
+                self._model_count_label.setStyleSheet(Styles.COLOR_ORANGE)
+                self.models_refreshed.emit([])
+        except Exception as e:  # noqa: BLE001 - GUI status display
+            self._model_count_label.setText(f"✗ Failed to fetch models: {e}")
+            self._model_count_label.setStyleSheet(Styles.COLOR_RED)
+            self.models_refreshed.emit([])
+
+
+class ClineConfigWidget(_BaseProviderConfigWidget):
+    PROVIDER = AIProvider.CLINE_CLI
+
+    def _build_body(self, layout: QVBoxLayout) -> None:
+        host_layout = QFormLayout()
+        self._host_input = QLineEdit(DEFAULT_CLINE_HOST)
+        host_layout.addRow("Cline Host:", self._host_input)
+        layout.addLayout(host_layout)
+
+        self._test_btn = QPushButton("Test Connection")
+        self._test_btn.clicked.connect(self._test_connection)
+        layout.addWidget(self._test_btn)
+
+        self._status_label = QLabel()
+        layout.addWidget(self._status_label)
+
+    def get_host(self) -> str:
+        if hasattr(self, "_host_input"):
+            return str(self._host_input.text().strip())
+        return DEFAULT_CLINE_HOST
+
+    def _test_connection(self) -> None:
+        self._status_label.setText("Testing connection...")
+        self._status_label.setStyleSheet(Styles.COLOR_RESET)
+        try:
+            from src.shared.python.ai.adapters.cline_adapter import ClineAdapter
+
+            adapter = ClineAdapter(host=self._host_input.text().strip())
+            success, message = adapter.validate_connection()
+            if success:
+                self._status_label.setText(f"✓ {message}")
+                self._status_label.setStyleSheet(Styles.COLOR_GREEN)
+            else:
+                self._status_label.setText(f"✗ {message}")
+                self._status_label.setStyleSheet(Styles.COLOR_RED)
+        except ImportError as e:
+            self._status_label.setText(f"✗ Error: {e}")
+            self._status_label.setStyleSheet(Styles.COLOR_RED)
+
+
+class BitnetConfigWidget(_BaseProviderConfigWidget):
+    PROVIDER = AIProvider.BITNET
+
+    def _build_body(self, layout: QVBoxLayout) -> None:
+        root_layout = QFormLayout()
+        self._bitnet_root_input = QLineEdit(os.environ.get(BITNET_ROOT_ENV, ""))
+        self._bitnet_root_input.setPlaceholderText(
+            "Optional path to the BitNet installation root"
+        )
+        root_layout.addRow("BitNet Root:", self._bitnet_root_input)
+        layout.addLayout(root_layout)
+
+        note = QLabel(
+            "Use the main model selector to choose a GGUF model. "
+            "Leave BitNet Root blank to rely on PATH or BITNET_ROOT."
+        )
+        note.setWordWrap(True)
+        note.setStyleSheet(Styles.TEXT_MUTED)
+        layout.addWidget(note)
+
+    def get_host(self) -> str:
+        if hasattr(self, "_bitnet_root_input"):
+            return str(self._bitnet_root_input.text().strip())
+        return os.environ.get(BITNET_ROOT_ENV, "")
+
+
+class _CliNoteConfigWidget(_BaseProviderConfigWidget):
+    """Honest no-op widget for CLI-backed providers (Claude CLI, Codex CLI)."""
+
+    def _build_body(self, layout: QVBoxLayout) -> None:
+        note = QLabel(
+            "This provider uses your installed CLI tooling and does not need "
+            "extra connection settings in this dialog."
+        )
+        note.setWordWrap(True)
+        note.setStyleSheet(Styles.TEXT_MUTED)
+        layout.addWidget(note)
+
+
+class ClaudeCliConfigWidget(_CliNoteConfigWidget):
+    PROVIDER = AIProvider.CLAUDE_CLI
+
+
+class CodexCliConfigWidget(_CliNoteConfigWidget):
+    PROVIDER = AIProvider.CODEX_CLI
+
+
+__all__ = [
+    "AnthropicConfigWidget",
+    "BitnetConfigWidget",
+    "ClaudeCliConfigWidget",
+    "ClineConfigWidget",
+    "CodexCliConfigWidget",
+    "GeminiConfigWidget",
+    "OllamaConfigWidget",
+    "OpenAIConfigWidget",
+]

--- a/src/shared/python/ai/gui/_provider_registry_data.py
+++ b/src/shared/python/ai/gui/_provider_registry_data.py
@@ -1,0 +1,182 @@
+"""Provider metadata and helper functions extracted from settings_dialog.
+
+Pure data + tiny helpers, no Qt widget instantiation. Importable from
+non-GUI code paths (though it does import QComboBox for the populate
+helpers, which Qt allows headlessly).
+"""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+
+from PyQt6.QtWidgets import QComboBox
+
+from src.shared.python.ai.config import DEFAULT_OLLAMA_MODEL  # noqa: F401  re-exported
+
+
+class AIProvider(Enum):
+    """Available AI providers."""
+
+    OLLAMA = auto()
+    OPENAI = auto()
+    ANTHROPIC = auto()
+    GEMINI = auto()
+    CLAUDE_CLI = auto()
+    CLINE_CLI = auto()
+    CODEX_CLI = auto()
+    BITNET = auto()
+
+
+# Provider display info - explicitly typed for mypy
+PROVIDER_INFO: dict[AIProvider, dict[str, str | bool | list[str]]] = {
+    AIProvider.OLLAMA: {
+        "name": "Ollama",
+        "description": "Run AI locally on your computer. No API key needed.",
+        "requires_key": False,
+        "default_model": "llama3.1:8b",
+        "models": [
+            "llama3.1:8b",
+            "llama3.1:70b",
+            "mistral",
+            "codellama",
+            "opencodeinterpreter",
+            "deepseek-coder",
+            "phi3",
+        ],
+    },
+    AIProvider.OPENAI: {
+        "name": "OpenAI (GPT-4o)",
+        "description": "Cloud-based GPT-4o. Requires OpenAI API key.",
+        "requires_key": True,
+        "key_service": "upstream_drift_openai_key",
+        "default_model": "gpt-4o",
+        "models": ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"],
+    },
+    AIProvider.ANTHROPIC: {
+        "name": "Anthropic (Claude 3.5)",
+        "description": "Cloud-based Claude 3.5 Sonnet. Requires Anthropic API key.",
+        "requires_key": True,
+        "key_service": "upstream_drift_anthropic_key",
+        "default_model": "claude-3-5-sonnet-20240620",
+        "models": [
+            "claude-3-5-sonnet-20241022",
+            "claude-3-5-sonnet-20240620",
+            "claude-3-5-haiku-20241022",
+            "claude-3-opus-20240229",
+            "claude-3-sonnet-20240229",
+            "claude-3-haiku-20240307",
+        ],
+    },
+    AIProvider.GEMINI: {
+        "name": "Google Gemini (1.5)",
+        "description": "Cloud-based Gemini 1.5. Requires Google API key.",
+        "requires_key": True,
+        "key_service": "upstream_drift_gemini_key",
+        "default_model": "gemini-1.5-pro",
+        "models": ["gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.0-pro"],
+    },
+    AIProvider.CLAUDE_CLI: {
+        "name": "Claude CLI (Agent)",
+        "description": "Run commands via Anthropic's Claude Code CLI tool.",
+        "requires_key": False,
+        "default_model": "claude-3-5-sonnet-20241022",
+        "models": [
+            "claude-3-5-sonnet-20241022",
+            "claude-3-5-haiku-20241022",
+            "claude-3-opus-20240229",
+        ],
+    },
+    AIProvider.CLINE_CLI: {
+        "name": "Cline CLI (Agent)",
+        "description": "Run tasks locally with the Cline CLI agent.",
+        "requires_key": False,
+        "default_model": "claude-3-5-sonnet-20241022",
+        "models": ["claude-3-5-sonnet-20241022", "gpt-4o", "o1-preview"],
+    },
+    AIProvider.CODEX_CLI: {
+        "name": "Codex CLI (Agent)",
+        "description": "Use OpenAI's Codex CLI for local development.",
+        "requires_key": False,
+        "default_model": "gpt-4o",
+        "models": ["gpt-4o", "o1-preview", "o1-mini", "gpt-4-turbo"],
+    },
+    AIProvider.BITNET: {
+        "name": "BitNet (1.58b)",
+        "description": (
+            "Run 1.58b quantized models natively via direct subprocess. "
+            "No API key needed."
+        ),
+        "requires_key": False,
+        "default_model": "bitnet-1.58b-q4_0.gguf",
+        "models": [
+            "bitnet-1.58b-q4_0.gguf",
+            "bitnet-3b-q4_0.gguf",
+        ],
+    },
+}
+
+DEFAULT_CLINE_HOST = "http://localhost:3000"
+BITNET_ROOT_ENV = "BITNET_ROOT"
+
+
+def provider_display_name(provider: AIProvider) -> str:
+    """Return the user-facing provider name from the shared registry."""
+    info = PROVIDER_INFO[provider]
+    return str(info.get("name", provider.name))
+
+
+def provider_default_model(provider: AIProvider) -> str:
+    """Return the provider default model from the shared registry."""
+    info = PROVIDER_INFO[provider]
+    default_model = info.get("default_model", "")
+    return str(default_model) if isinstance(default_model, str) else ""
+
+
+def provider_model_names(provider: AIProvider) -> list[str]:
+    """Return model names for a provider from the shared registry."""
+    info = PROVIDER_INFO[provider]
+    models = info.get("models", [])
+    if not isinstance(models, list):
+        return []
+    return [str(model) for model in models]
+
+
+def populate_provider_combo(combo: QComboBox) -> None:
+    """Populate a provider combo from ``AIProvider`` and ``PROVIDER_INFO``."""
+    combo.clear()
+    for provider in AIProvider:
+        combo.addItem(provider_display_name(provider), provider)
+
+
+def populate_model_combo(
+    combo: QComboBox,
+    provider: AIProvider,
+    selected_model: str | None = None,
+) -> None:
+    """Populate a model combo and select a valid model for ``provider``."""
+    combo.clear()
+    models = provider_model_names(provider)
+    for model in models:
+        combo.addItem(model)
+
+    target = (
+        selected_model if selected_model in models else provider_default_model(provider)
+    )
+    idx = combo.findText(target)
+    if idx < 0 and combo.count():
+        idx = 0
+    if idx >= 0:
+        combo.setCurrentIndex(idx)
+
+
+__all__ = [
+    "AIProvider",
+    "BITNET_ROOT_ENV",
+    "DEFAULT_CLINE_HOST",
+    "PROVIDER_INFO",
+    "populate_model_combo",
+    "populate_provider_combo",
+    "provider_default_model",
+    "provider_display_name",
+    "provider_model_names",
+]

--- a/src/shared/python/ai/gui/_providers_tab.py
+++ b/src/shared/python/ai/gui/_providers_tab.py
@@ -1,0 +1,67 @@
+"""Providers tab (provider/model picker + per-provider config) — Tools #2762."""
+
+from __future__ import annotations
+
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QFormLayout,
+    QGroupBox,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.ai.gui._provider_config_registry import ProviderConfigRegistry
+from src.shared.python.ai.gui._provider_registry_data import (
+    AIProvider,
+    populate_provider_combo,
+)
+
+
+class ProvidersTab(QWidget):
+    """Provider selector, model selector, and per-provider config area."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.provider_configs: dict[AIProvider, QWidget] = {}
+        self._build()
+
+    def _build(self) -> None:
+        layout = QVBoxLayout(self)
+
+        provider_group = QGroupBox("Select AI Provider")
+        provider_layout = QVBoxLayout(provider_group)
+
+        self.provider_combo = QComboBox()
+        populate_provider_combo(self.provider_combo)
+        provider_layout.addWidget(self.provider_combo)
+
+        cost_label = QLabel(
+            "<b>💡 Tip:</b> Local models (like Ollama) are completely FREE "
+            "and run locally. Cloud models may incur usage costs."
+        )
+        cost_label.setWordWrap(True)
+        provider_layout.addWidget(cost_label)
+        layout.addWidget(provider_group)
+
+        model_group = QGroupBox("Model")
+        model_layout = QFormLayout(model_group)
+        self.model_combo = QComboBox()
+        model_layout.addRow("Model:", self.model_combo)
+        layout.addWidget(model_group)
+
+        config_group = QGroupBox("Configuration")
+        config_layout = QVBoxLayout(config_group)
+        for provider in AIProvider:
+            try:
+                widget = ProviderConfigRegistry.get_widget(provider)
+            except KeyError:
+                continue
+            widget.hide()
+            self.provider_configs[provider] = widget
+            config_layout.addWidget(widget)
+        layout.addWidget(config_group)
+        layout.addStretch()
+
+
+__all__ = ["ProvidersTab"]

--- a/src/shared/python/ai/gui/_rag_tab.py
+++ b/src/shared/python/ai/gui/_rag_tab.py
@@ -1,0 +1,91 @@
+"""RAG / Knowledge Base tab for the AI settings dialog (Tools #2762)."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QGroupBox,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.ai.access_policy import ChatAccessMode
+from src.shared.python.theme.style_constants import Styles
+
+
+class RagTab(QWidget):
+    """RAG enable, access mode, and rebuild-index controls."""
+
+    rebuild_index_requested = pyqtSignal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._build()
+
+    def _build(self) -> None:
+        layout = QVBoxLayout(self)
+
+        rag_group = QGroupBox("Knowledge Base Settings")
+        rag_layout = QVBoxLayout(rag_group)
+
+        self.rag_enabled_check = QCheckBox("Enable Codebase Awareness (RAG)")
+        self.rag_enabled_check.setToolTip(
+            "Allow the AI to search your codebase and documents to answer questions."
+        )
+        rag_layout.addWidget(self.rag_enabled_check)
+
+        self.access_mode_combo = QComboBox()
+        self.access_mode_combo.addItem("No repo access", ChatAccessMode.NO_REPO_ACCESS)
+        self.access_mode_combo.addItem(
+            "Read-only diagnostics", ChatAccessMode.READ_ONLY_DIAGNOSTICS
+        )
+        self.access_mode_combo.addItem("Agent/tools", ChatAccessMode.AGENT_TOOLS)
+        self.access_mode_combo.setToolTip(
+            "Controls which codebase and local tools the assistant may receive."
+        )
+        rag_layout.addWidget(self.access_mode_combo)
+
+        self.auto_index_check = QCheckBox("Auto-index codebase when chat opens")
+        self.auto_index_check.setToolTip(
+            "Rebuild the codemap each time the chat dock connects so the "
+            "assistant has fresh symbol/import context. Slower first open."
+        )
+        rag_layout.addWidget(self.auto_index_check)
+
+        layout.addWidget(rag_group)
+
+        actions_group = QGroupBox("Actions")
+        actions_layout = QVBoxLayout(actions_group)
+
+        rebuild_btn = QPushButton("Rebuild Knowledge Index")
+        rebuild_btn.setToolTip("Scan the codebase and rebuild the search index.")
+        rebuild_btn.clicked.connect(self._on_rebuild_index)
+        actions_layout.addWidget(rebuild_btn)
+
+        info_label = QLabel(
+            "Rebuilding the index analyses your 'src' directory. "
+            "This happens locally and no code is sent to the cloud during indexing."
+        )
+        info_label.setWordWrap(True)
+        info_label.setStyleSheet(Styles.TEXT_MUTED)
+        actions_layout.addWidget(info_label)
+
+        layout.addWidget(actions_group)
+        layout.addStretch()
+
+    def _on_rebuild_index(self) -> None:
+        self.rebuild_index_requested.emit()
+        QMessageBox.information(
+            self,
+            "Rebuild Started",
+            "Index rebuild started in background. "
+            "The assistant will be updated shortly.",
+        )
+
+
+__all__ = ["RagTab"]

--- a/src/shared/python/ai/gui/settings_dialog.py
+++ b/src/shared/python/ai/gui/settings_dialog.py
@@ -1,799 +1,112 @@
-# ARCHITECTURE_DEBT:
-# This module historically exceeds standard length metrics and accumulates excessive domain responsibility.  # noqa: E501
-# It requires domain-aware structural extraction to isolate its internal classes appropriately.  # noqa: E501
+"""AI Assistant Settings Dialog (slim coordinator).
 
-"""AI Assistant Settings Dialog.
+This module historically held ~1100 lines mixing the ``AISettings``
+dataclass, keyring helpers, a switch-by-enum ``ProviderConfigWidget``,
+and a 3-tab dialog. Tools issue #2762 split those concerns:
 
-Provides configuration for AI provider selection, API key management,
-and user preferences. API keys are stored securely in the OS keyring.
+* :class:`AISettings` lives in :mod:`src.shared.python.ai._settings_model`.
+* Keyring helpers live in :mod:`src.shared.python.ai.gui._api_keys` and
+  delegate where possible to ``chat.credentials.CredentialManager``.
+* Per-provider widgets are individual classes in
+  :mod:`src.shared.python.ai.gui._provider_config_widgets` and looked up
+  through :class:`ProviderConfigRegistry`.
+* Each tab is its own widget in ``_general_tab.py`` / ``_providers_tab.py``
+  / ``_rag_tab.py``.
 
-Security:
-    - API keys stored in Windows Credential Manager / macOS Keychain
-    - Keys never logged or transmitted to developers
-    - Local-only mode (Ollama) requires no keys
+The module re-exports the previous public names so downstream callers
+(UpstreamDrift, Gasification_Model, ``assistant_panel`` here) keep
+working unchanged.
 """
 
 from __future__ import annotations
 
 import contextlib
-import os
-from dataclasses import dataclass, field
-from enum import Enum, auto
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from PyQt6.QtCore import QSettings, QTimer, pyqtSignal
+from PyQt6.QtCore import (  # noqa: F401  QSettings re-exported for monkeypatch in tests
+    QSettings,
+    pyqtSignal,
+)
 from PyQt6.QtWidgets import (
-    QCheckBox,
-    QComboBox,
     QDialog,
     QDialogButtonBox,
-    QFormLayout,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QMessageBox,
-    QPushButton,
     QTabWidget,
     QVBoxLayout,
     QWidget,
 )
 
-from src.shared.python.ai.access_policy import ChatAccessMode, coerce_access_mode
+from src.shared.python.ai._settings_model import AISettings
+from src.shared.python.ai.access_policy import coerce_access_mode
 from src.shared.python.ai.config import (
     DEFAULT_OLLAMA_HOST,
     DEFAULT_OLLAMA_MODEL,
+    KEY_ACCESS_MODE,
+    KEY_AUTO_INDEX_ON_OPEN,
+    KEY_CHAT_MODE,
+    KEY_EXPERTISE,
+    KEY_MODEL,
+    KEY_OLLAMA_HOST,
+    KEY_PROVIDER,
+    KEY_RAG_ENABLED,
+    KEY_RESPONSE_STYLE,
+    KEY_STREAMING,
+    SETTINGS_APP,
+    SETTINGS_ORG,
     get_ollama_host,
 )
+from src.shared.python.ai.gui._api_keys import (
+    delete_api_key,
+    get_api_key,
+    set_api_key,
+)
+from src.shared.python.ai.gui._general_tab import GeneralPreferencesTab
+from src.shared.python.ai.gui._provider_config_registry import ProviderConfigRegistry
+from src.shared.python.ai.gui._provider_config_widgets import (
+    AnthropicConfigWidget,
+    BitnetConfigWidget,
+    ClaudeCliConfigWidget,
+    ClineConfigWidget,
+    CodexCliConfigWidget,
+    GeminiConfigWidget,
+    OllamaConfigWidget,
+    OpenAIConfigWidget,
+)
+from src.shared.python.ai.gui._provider_registry_data import (
+    BITNET_ROOT_ENV,
+    DEFAULT_CLINE_HOST,
+    PROVIDER_INFO,
+    AIProvider,
+    populate_model_combo,
+    populate_provider_combo,
+    provider_default_model,
+    provider_display_name,
+    provider_model_names,
+)
+from src.shared.python.ai.gui._providers_tab import ProvidersTab
+from src.shared.python.ai.gui._rag_tab import RagTab
 from src.shared.python.logging_pkg.logging_config import get_logger
-from src.shared.python.theme.style_constants import Styles
-
-if TYPE_CHECKING:
-    # Import removed to avoid circular dependency
-    pass
 
 logger = get_logger(__name__)
 
-# Settings keys
-SETTINGS_ORG = "D-sorganization"
-SETTINGS_APP = "AIAssistant"
-KEY_PROVIDER = "ai/provider"
-KEY_MODEL = "ai/model"
-KEY_EXPERTISE = "ai/expertise_level"  # legacy alias, see Tools #2552
-KEY_RESPONSE_STYLE = "ai/response_style"
-KEY_CHAT_MODE = "ai/chat_mode"
-KEY_OLLAMA_HOST = "ai/ollama_host"
-KEY_STREAMING = "ai/streaming_enabled"
-KEY_RAG_ENABLED = "ai/rag_enabled"
-KEY_AUTO_INDEX_ON_OPEN = "ai/auto_index_on_open"
-KEY_ACCESS_MODE = "ai/access_mode"
-DEFAULT_CLINE_HOST = "http://localhost:3000"
-BITNET_ROOT_ENV = "BITNET_ROOT"
 
-
-class AIProvider(Enum):
-    """Available AI providers."""
-
-    OLLAMA = auto()  # Free, local
-    OPENAI = auto()  # GPT-4
-    ANTHROPIC = auto()  # Claude
-    GEMINI = auto()  # Google Gemini
-    CLAUDE_CLI = auto()  # Anthropic's Claude Code CLI
-    CLINE_CLI = auto()  # Cline CLI
-    CODEX_CLI = auto()  # OpenAI's Codex CLI
-    BITNET = auto()  # BitNet 1.58b
-
-
-# Provider display info - explicitly typed for mypy
-PROVIDER_INFO: dict[AIProvider, dict[str, str | bool | list[str]]] = {
-    AIProvider.OLLAMA: {
-        "name": "Ollama",
-        "description": "Run AI locally on your computer. No API key needed.",
-        "requires_key": False,
-        "default_model": "llama3.1:8b",
-        "models": [
-            "llama3.1:8b",
-            "llama3.1:70b",
-            "mistral",
-            "codellama",
-            "opencodeinterpreter",
-            "deepseek-coder",
-            "phi3",
-        ],
-    },
-    AIProvider.OPENAI: {
-        "name": "OpenAI (GPT-4o)",
-        "description": "Cloud-based GPT-4o. Requires OpenAI API key.",
-        "requires_key": True,
-        "key_service": "upstream_drift_openai_key",
-        "default_model": "gpt-4o",
-        "models": ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"],
-    },
-    AIProvider.ANTHROPIC: {
-        "name": "Anthropic (Claude 3.5)",
-        "description": "Cloud-based Claude 3.5 Sonnet. Requires Anthropic API key.",
-        "requires_key": True,
-        "key_service": "upstream_drift_anthropic_key",
-        "default_model": "claude-3-5-sonnet-20240620",
-        "models": [
-            "claude-3-5-sonnet-20241022",
-            "claude-3-5-sonnet-20240620",
-            "claude-3-5-haiku-20241022",
-            "claude-3-opus-20240229",
-            "claude-3-sonnet-20240229",
-            "claude-3-haiku-20240307",
-        ],
-    },
-    AIProvider.GEMINI: {
-        "name": "Google Gemini (1.5)",
-        "description": "Cloud-based Gemini 1.5. Requires Google API key.",
-        "requires_key": True,
-        "key_service": "upstream_drift_gemini_key",
-        "default_model": "gemini-1.5-pro",
-        "models": ["gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.0-pro"],
-    },
-    AIProvider.CLAUDE_CLI: {
-        "name": "Claude CLI (Agent)",
-        "description": "Run commands via Anthropic's Claude Code CLI tool.",
-        "requires_key": False,
-        "default_model": "claude-3-5-sonnet-20241022",
-        "models": [
-            "claude-3-5-sonnet-20241022",
-            "claude-3-5-haiku-20241022",
-            "claude-3-opus-20240229",
-        ],
-    },
-    AIProvider.CLINE_CLI: {
-        "name": "Cline CLI (Agent)",
-        "description": "Run tasks locally with the Cline CLI agent.",
-        "requires_key": False,
-        "default_model": "claude-3-5-sonnet-20241022",
-        "models": ["claude-3-5-sonnet-20241022", "gpt-4o", "o1-preview"],
-    },
-    AIProvider.CODEX_CLI: {
-        "name": "Codex CLI (Agent)",
-        "description": "Use OpenAI's Codex CLI for local development.",
-        "requires_key": False,
-        "default_model": "gpt-4o",
-        "models": ["gpt-4o", "o1-preview", "o1-mini", "gpt-4-turbo"],
-    },
-    AIProvider.BITNET: {
-        "name": "BitNet (1.58b)",
-        "description": (
-            "Run 1.58b quantized models natively via direct subprocess. "
-            "No API key needed."
-        ),
-        "requires_key": False,
-        "default_model": "bitnet-1.58b-q4_0.gguf",
-        "models": [
-            "bitnet-1.58b-q4_0.gguf",
-            "bitnet-3b-q4_0.gguf",
-        ],
-    },
-}
-
-
-def provider_display_name(provider: AIProvider) -> str:
-    """Return the user-facing provider name from the shared registry."""
-    info = PROVIDER_INFO[provider]
-    return str(info.get("name", provider.name))
-
-
-def provider_default_model(provider: AIProvider) -> str:
-    """Return the provider default model from the shared registry."""
-    info = PROVIDER_INFO[provider]
-    default_model = info.get("default_model", "")
-    return str(default_model) if isinstance(default_model, str) else ""
-
-
-def provider_model_names(provider: AIProvider) -> list[str]:
-    """Return model names for a provider from the shared registry."""
-    info = PROVIDER_INFO[provider]
-    models = info.get("models", [])
-    if not isinstance(models, list):
-        return []
-    return [str(model) for model in models]
-
-
-def populate_provider_combo(combo: QComboBox) -> None:
-    """Populate a provider combo from ``AIProvider`` and ``PROVIDER_INFO``."""
-    combo.clear()
-    for provider in AIProvider:
-        combo.addItem(provider_display_name(provider), provider)
-
-
-def populate_model_combo(
-    combo: QComboBox,
+# ---------------------------------------------------------------------------
+# Backward-compatibility shim.
+# Legacy code instantiated ``ProviderConfigWidget(AIProvider.OLLAMA)``. We
+# keep that constructor signature working by routing to the registry.
+# ---------------------------------------------------------------------------
+def ProviderConfigWidget(  # noqa: N802 - keep historical class-shaped name
     provider: AIProvider,
-    selected_model: str | None = None,
-) -> None:
-    """Populate a model combo and select a valid model for ``provider``."""
-    combo.clear()
-    models = provider_model_names(provider)
-    for model in models:
-        combo.addItem(model)
+    parent: QWidget | None = None,
+) -> QWidget:
+    """Return the registered config widget for ``provider``.
 
-    target = (
-        selected_model if selected_model in models else provider_default_model(provider)
-    )
-    idx = combo.findText(target)
-    if idx < 0 and combo.count():
-        idx = 0
-    if idx >= 0:
-        combo.setCurrentIndex(idx)
-
-
-@dataclass
-class AISettings:
-    """AI configuration settings.
-
-    Attributes:
-        provider: Selected AI provider.
-        model: Model name for the provider.
-        expertise_level: DEPRECATED — kept for backward compatibility with
-            stored QSettings values. New code should read ``response_style``
-            (Tools issue #2552).
-        response_style: How verbose AI replies should be — one of
-            ``"concise"``, ``"standard"``, or ``"detailed"``.
-        chat_mode: Runtime access mode for inline chat controls.
-        ollama_host: Ollama server URL.
-        streaming_enabled: Whether to stream responses.
-        rag_enabled: Whether to use RAG (Codebase awareness).
-        auto_index_on_open: When True, the chat dock asks the server to
-            rebuild the codemap on connect (Tools issue #2549 / PR #2567).
-        access_mode: Explicit chat repository/tool access mode.
-        api_keys: In-memory API keys (not persisted directly).
-    """
-
-    provider: AIProvider = AIProvider.OLLAMA
-    model: str = DEFAULT_OLLAMA_MODEL
-    expertise_level: int = 1
-    response_style: str = "standard"
-    chat_mode: str = "ask"
-    ollama_host: str = DEFAULT_OLLAMA_HOST
-    streaming_enabled: bool = True
-    rag_enabled: bool = True
-    auto_index_on_open: bool = False
-    access_mode: ChatAccessMode = ChatAccessMode.NO_REPO_ACCESS
-    api_keys: dict[AIProvider, str] = field(default_factory=dict)
-
-    def save(self) -> None:
-        """Save settings to persistent storage."""
-        settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
-        settings.setValue(KEY_PROVIDER, self.provider.name)
-        settings.setValue(KEY_MODEL, self.model)
-        settings.setValue(KEY_EXPERTISE, self.expertise_level)
-        settings.setValue(KEY_RESPONSE_STYLE, self.response_style)
-        settings.setValue(KEY_CHAT_MODE, self.chat_mode)
-        settings.setValue(KEY_OLLAMA_HOST, self.ollama_host)
-        settings.setValue(KEY_STREAMING, self.streaming_enabled)
-        settings.setValue(KEY_RAG_ENABLED, self.rag_enabled)
-        settings.setValue(KEY_AUTO_INDEX_ON_OPEN, self.auto_index_on_open)
-        self.access_mode = coerce_access_mode(self.access_mode)
-        settings.setValue(KEY_ACCESS_MODE, self.access_mode.value)
-        # Note: API keys are stored separately in keyring
-        logger.info("Saved AI settings: provider=%s", self.provider.name)
-
-    @classmethod
-    def load(cls) -> AISettings:
-        """Load settings from persistent storage."""
-        settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
-
-        provider_name = settings.value(KEY_PROVIDER, "OLLAMA")
-        try:
-            provider = AIProvider[provider_name]
-        except KeyError:
-            provider = AIProvider.OLLAMA
-
-        # Use environment variable as fallback for ollama_host
-        default_host = get_ollama_host()
-        # Tools issue #2552: prefer the new ``response_style`` key but
-        # accept any legacy value persisted under the old contract.
-        response_style = str(settings.value(KEY_RESPONSE_STYLE, "standard")).lower()
-        if response_style not in {"concise", "standard", "detailed"}:
-            response_style = "standard"
-        chat_mode = str(settings.value(KEY_CHAT_MODE, "ask")).lower()
-        if chat_mode not in {"ask", "diagnose", "agent"}:
-            chat_mode = "ask"
-        return cls(
-            provider=provider,
-            model=settings.value(KEY_MODEL, DEFAULT_OLLAMA_MODEL),
-            expertise_level=int(settings.value(KEY_EXPERTISE, 1)),
-            response_style=response_style,
-            chat_mode=chat_mode,
-            ollama_host=settings.value(KEY_OLLAMA_HOST, default_host),
-            streaming_enabled=settings.value(KEY_STREAMING, True, type=bool),
-            rag_enabled=settings.value(KEY_RAG_ENABLED, True, type=bool),
-            auto_index_on_open=settings.value(KEY_AUTO_INDEX_ON_OPEN, False, type=bool),
-            access_mode=coerce_access_mode(settings.value(KEY_ACCESS_MODE, None)),
-        )
-
-
-def get_api_key(provider: AIProvider) -> str | None:
-    """Get API key from secure storage.
-
-    Args:
-        provider: Provider to get key for.
-
-    Returns:
-        API key if found, None otherwise.
-    """
-    info = PROVIDER_INFO.get(provider)
-    if not info or not info.get("requires_key"):
-        return None
-
-    service_name = info.get("key_service", "")
-    if not service_name or not isinstance(service_name, str):
-        return None
-
-    try:
-        import keyring
-
-        result = keyring.get_password(str(service_name), "api_key")
-        return result if isinstance(result, str) else None
-    except ImportError:
-        logger.warning("keyring package not installed for secure key storage")
-        return None
-    except (RuntimeError, TypeError, AttributeError) as e:
-        logger.warning("Failed to get API key from keyring: %s", e)
-        return None
-
-
-def set_api_key(provider: AIProvider, key: str) -> bool:
-    """Store API key in secure storage.
-
-    Args:
-        provider: Provider to set key for.
-        key: API key to store.
-
-    Returns:
-        True if successful, False otherwise.
+    Compatibility wrapper for code (and tests) that still call this as
+    ``ProviderConfigWidget(provider)``. New code should use
+    :meth:`ProviderConfigRegistry.get_widget` directly.
     """
     if provider is None:
         raise ValueError("provider must be provided")
-    if provider is None:
-        raise ValueError("provider must be provided")
-    info = PROVIDER_INFO.get(provider)
-    if not info or not info.get("requires_key"):
-        return False
-
-    service_name = info.get("key_service", "")
-    if not service_name:
-        return False
-
-    try:
-        import keyring
-
-        keyring.set_password(str(service_name), "api_key", key)
-        logger.info("Stored API key for %s", provider.name)
-        return True
-    except ImportError:
-        logger.warning("keyring package not installed for secure key storage")
-        return False
-    except (RuntimeError, TypeError, AttributeError) as e:
-        logger.warning("Failed to store API key: %s", e)
-        return False
-
-
-def delete_api_key(provider: AIProvider) -> bool:
-    """Delete API key from secure storage.
-
-    Args:
-        provider: Provider to delete key for.
-
-    Returns:
-        True if successful, False otherwise.
-    """
-    info = PROVIDER_INFO.get(provider)
-    if not info or not info.get("requires_key"):
-        return False
-
-    service_name = info.get("key_service", "")
-    if not service_name:
-        return False
-
-    try:
-        import keyring
-
-        keyring.delete_password(str(service_name), "api_key")
-        logger.info("Deleted API key for %s", provider.name)
-        return True
-    except ImportError:
-        return False
-    except (RuntimeError, TypeError, AttributeError) as e:
-        logger.warning("Failed to delete API key: %s", e)
-        return False
-
-
-class ProviderConfigWidget(QWidget):
-    """Widget for configuring a single AI provider."""
-
-    key_changed = pyqtSignal(str)  # Emits new key value
-    models_refreshed = pyqtSignal(list)  # Emits list of available models
-
-    def __init__(
-        self,
-        provider: AIProvider,
-        parent: QWidget | None = None,
-    ) -> None:
-        """Initialize provider config widget.
-
-        Args:
-            provider: The provider this widget configures.
-            parent: Parent widget.
-        """
-        if provider is None:
-            raise ValueError("provider must be provided")
-        super().__init__(parent)
-        self._provider = provider
-        self._info = PROVIDER_INFO[provider]
-        self._setup_ui()
-        self._load_current_key()
-
-    def _setup_ui(self) -> None:
-        """Set up the widget UI."""
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-
-        # Description
-        desc = self._info.get("description", "")
-        desc_label = QLabel(str(desc))
-        desc_label.setWordWrap(True)
-        layout.addWidget(desc_label)
-
-        # API Key section (if required)
-        if self._info["requires_key"]:
-            key_layout = QHBoxLayout()
-
-            self._key_input = QLineEdit()
-            self._key_input.setPlaceholderText("Enter API key...")
-            self._key_input.setEchoMode(QLineEdit.EchoMode.Password)
-            self._key_input.textChanged.connect(self._on_key_changed)
-            key_layout.addWidget(self._key_input)
-
-            self._show_key_btn = QPushButton("Show")
-            self._show_key_btn.setCheckable(True)
-            self._show_key_btn.toggled.connect(self._toggle_key_visibility)
-            key_layout.addWidget(self._show_key_btn)
-
-            self._save_key_btn = QPushButton("Save")
-            self._save_key_btn.clicked.connect(self._save_key)
-            key_layout.addWidget(self._save_key_btn)
-
-            layout.addLayout(key_layout)
-
-            # Key status
-            self._key_status = QLabel()
-            layout.addWidget(self._key_status)
-<<<<<<< HEAD
-        else:
-            self._setup_local_provider_ui(layout)
-=======
-        elif self._provider == AIProvider.OLLAMA:
-            # Ollama host configuration
-            host_layout = QFormLayout()
-            self._host_input = QLineEdit(get_ollama_host())
-            host_layout.addRow("Ollama Host:", self._host_input)
-            layout.addLayout(host_layout)
-
-            # Test connection button
-            self._test_btn = QPushButton("Test Connection")
-            self._test_btn.clicked.connect(self._test_ollama_connection)
-            layout.addWidget(self._test_btn)
-
-            # Refresh models button
-            self._refresh_models_btn = QPushButton("🔄 Refresh Available Models")
-            self._refresh_models_btn.setToolTip(
-                "Fetch the list of installed models from your local Ollama instance"
-            )
-            self._refresh_models_btn.clicked.connect(self._refresh_ollama_models)
-            layout.addWidget(self._refresh_models_btn)
-
-            self._status_label = QLabel()
-            layout.addWidget(self._status_label)
-
-            # Model count display
-            self._model_count_label = QLabel()
-            self._model_count_label.setStyleSheet(Styles.TEXT_MUTED)
-            layout.addWidget(self._model_count_label)
-        elif self._provider == AIProvider.BITNET:
-            # BitNet local model configuration
-            bitnet_layout = QFormLayout()
-            self._model_path_input = QLineEdit()
-            self._model_path_input.setPlaceholderText(
-                "Path to .gguf model file (leave blank for default)"
-            )
-            bitnet_layout.addRow("Model Path:", self._model_path_input)
-
-            self._threads_input = QLineEdit()
-            self._threads_input.setPlaceholderText("Number of CPU threads (e.g. 4)")
-            bitnet_layout.addRow("Threads:", self._threads_input)
-
-            layout.addLayout(bitnet_layout)
-
-            info_label = QLabel(
-                "BitNet runs 1.58b quantized models locally via subprocess. "
-                "No network connection or API key required."
-            )
-            info_label.setWordWrap(True)
-            info_label.setStyleSheet(Styles.TEXT_MUTED)
-            layout.addWidget(info_label)
-        elif self._provider == AIProvider.CLINE_CLI:
-            # Cline CLI configuration
-            cline_layout = QFormLayout()
-            self._cline_path_input = QLineEdit()
-            self._cline_path_input.setPlaceholderText(
-                "Path to cline executable (leave blank to use PATH)"
-            )
-            cline_layout.addRow("Cline Path:", self._cline_path_input)
-
-            layout.addLayout(cline_layout)
-
-            info_label = QLabel(
-                "Cline CLI agent runs tasks locally. Ensure 'cline' is installed "
-                "and accessible. No API key is stored here; configure credentials "
-                "in Cline's own settings."
-            )
-            info_label.setWordWrap(True)
-            info_label.setStyleSheet(Styles.TEXT_MUTED)
-            layout.addWidget(info_label)
-        else:
-            # Generic local/CLI provider — no additional configuration required.
-            info_label = QLabel(
-                "This provider runs locally and requires no API key or host "
-                "configuration."
-            )
-            info_label.setWordWrap(True)
-            info_label.setStyleSheet(Styles.TEXT_MUTED)
-            layout.addWidget(info_label)
->>>>>>> 692119b2 (fix: branch ProviderConfigWidget UI on provider name, not just requires_key)
-
-        layout.addStretch()
-
-    def _setup_local_provider_ui(self, layout: QVBoxLayout) -> None:
-        """Render controls for providers that do not need API keys."""
-        if self._provider == AIProvider.OLLAMA:
-            self._setup_ollama_ui(layout)
-            return
-        if self._provider == AIProvider.CLINE_CLI:
-            self._setup_cline_ui(layout)
-            return
-        if self._provider == AIProvider.BITNET:
-            self._setup_bitnet_ui(layout)
-            return
-        self._setup_cli_note(layout)
-
-    def _setup_ollama_ui(self, layout: QVBoxLayout) -> None:
-        """Render Ollama-specific host and model discovery controls."""
-        host_layout = QFormLayout()
-        self._host_input = QLineEdit(get_ollama_host())
-        host_layout.addRow("Ollama Host:", self._host_input)
-        layout.addLayout(host_layout)
-
-        self._test_btn = QPushButton("Test Connection")
-        self._test_btn.clicked.connect(self._test_ollama_connection)
-        layout.addWidget(self._test_btn)
-
-        self._refresh_models_btn = QPushButton("🔄 Refresh Available Models")
-        self._refresh_models_btn.setToolTip(
-            "Fetch the list of installed models from your local Ollama instance"
-        )
-        self._refresh_models_btn.clicked.connect(self._refresh_ollama_models)
-        layout.addWidget(self._refresh_models_btn)
-
-        self._status_label = QLabel()
-        layout.addWidget(self._status_label)
-
-        self._model_count_label = QLabel()
-        self._model_count_label.setStyleSheet(Styles.TEXT_MUTED)
-        layout.addWidget(self._model_count_label)
-
-    def _setup_cline_ui(self, layout: QVBoxLayout) -> None:
-        """Render Cline-specific endpoint controls."""
-        host_layout = QFormLayout()
-        self._host_input = QLineEdit(DEFAULT_CLINE_HOST)
-        host_layout.addRow("Cline Host:", self._host_input)
-        layout.addLayout(host_layout)
-
-        self._test_btn = QPushButton("Test Connection")
-        self._test_btn.clicked.connect(self._test_cline_connection)
-        layout.addWidget(self._test_btn)
-
-        self._status_label = QLabel()
-        layout.addWidget(self._status_label)
-
-    def _setup_bitnet_ui(self, layout: QVBoxLayout) -> None:
-        """Render BitNet-specific local installation hints."""
-        root_layout = QFormLayout()
-        self._bitnet_root_input = QLineEdit(os.environ.get(BITNET_ROOT_ENV, ""))
-        self._bitnet_root_input.setPlaceholderText(
-            "Optional path to the BitNet installation root"
-        )
-        root_layout.addRow("BitNet Root:", self._bitnet_root_input)
-        layout.addLayout(root_layout)
-
-        note = QLabel(
-            "Use the main model selector to choose a GGUF model. "
-            "Leave BitNet Root blank to rely on PATH or BITNET_ROOT."
-        )
-        note.setWordWrap(True)
-        note.setStyleSheet(Styles.TEXT_MUTED)
-        layout.addWidget(note)
-
-    def _setup_cli_note(self, layout: QVBoxLayout) -> None:
-        """Render honest no-op settings for CLI-backed providers."""
-        note = QLabel(
-            "This provider uses your installed CLI tooling and does not need "
-            "extra connection settings in this dialog."
-        )
-        note.setWordWrap(True)
-        note.setStyleSheet(Styles.TEXT_MUTED)
-        layout.addWidget(note)
-
-    def _load_current_key(self) -> None:
-        """Load current API key from keyring."""
-        if not self._info["requires_key"]:
-            return
-
-        key = get_api_key(self._provider)
-        if key:
-            # Show masked key
-            self._key_input.setText(key)
-            self._key_status.setText("✓ API key configured")
-            self._key_status.setStyleSheet(Styles.COLOR_GREEN)
-        else:
-            self._key_status.setText("⚠ No API key configured")
-            self._key_status.setStyleSheet(Styles.COLOR_ORANGE)
-
-    def _on_key_changed(self, text: str) -> None:
-        """Handle key input changes."""
-        self.key_changed.emit(text)
-
-    def _toggle_key_visibility(self, show: bool) -> None:
-        """Toggle API key visibility."""
-        if show:
-            self._key_input.setEchoMode(QLineEdit.EchoMode.Normal)
-            self._show_key_btn.setText("Hide")
-        else:
-            self._key_input.setEchoMode(QLineEdit.EchoMode.Password)
-            self._show_key_btn.setText("Show")
-
-    def _save_key(self) -> None:
-        """Save API key to secure storage."""
-        key = self._key_input.text().strip()
-        if not key:
-            QMessageBox.warning(self, "Error", "Please enter an API key.")
-            return
-
-        if set_api_key(self._provider, key):
-            self._key_status.setText("✓ API key saved securely")
-            self._key_status.setStyleSheet(Styles.COLOR_GREEN)
-            QMessageBox.information(
-                self,
-                "Success",
-                f"API key saved to {self._get_keyring_location()}",
-            )
-        else:
-            self._key_status.setText("✗ Failed to save key")
-            self._key_status.setStyleSheet(Styles.COLOR_RED)
-            QMessageBox.warning(
-                self,
-                "Error",
-                "Failed to save API key. The keyring package may not be installed.",
-            )
-
-    def _get_keyring_location(self) -> str:
-        """Get description of where keys are stored."""
-        import platform
-
-        system = platform.system()
-        if system == "Windows":
-            return "Windows Credential Manager"
-        if system == "Darwin":
-            return "macOS Keychain"
-        return "System keyring"
-
-    def _test_ollama_connection(self) -> None:
-        """Test connection to Ollama server."""
-        self._status_label.setText("Testing connection...")
-        self._status_label.setStyleSheet(Styles.COLOR_RESET)
-
-        try:
-            from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
-
-            host = self._host_input.text().strip()
-            adapter = OllamaAdapter(host=host)
-            success, message = adapter.validate_connection()
-
-            if success:
-                self._status_label.setText(f"✓ {message}")
-                self._status_label.setStyleSheet(Styles.COLOR_GREEN)
-                # Also refresh models on successful connection
-                self._refresh_ollama_models()
-            else:
-                self._status_label.setText(f"✗ {message}")
-                self._status_label.setStyleSheet(Styles.COLOR_RED)
-
-        except ImportError as e:
-            self._status_label.setText(f"✗ Error: {e}")
-            self._status_label.setStyleSheet(Styles.COLOR_RED)
-
-    def _test_cline_connection(self) -> None:
-        """Test connection to the configured Cline endpoint."""
-        self._status_label.setText("Testing connection...")
-        self._status_label.setStyleSheet(Styles.COLOR_RESET)
-
-        try:
-            from src.shared.python.ai.adapters.cline_adapter import ClineAdapter
-
-            host = self._host_input.text().strip()
-            adapter = ClineAdapter(host=host)
-            success, message = adapter.validate_connection()
-
-            if success:
-                self._status_label.setText(f"✓ {message}")
-                self._status_label.setStyleSheet(Styles.COLOR_GREEN)
-            else:
-                self._status_label.setText(f"✗ {message}")
-                self._status_label.setStyleSheet(Styles.COLOR_RED)
-
-        except ImportError as e:
-            self._status_label.setText(f"✗ Error: {e}")
-            self._status_label.setStyleSheet(Styles.COLOR_RED)
-
-    def showEvent(self, event: Any) -> None:
-        """Refresh models automatically when the widget becomes visible."""
-        super().showEvent(event)
-        if getattr(self, "_provider", None) == AIProvider.OLLAMA:
-            # Refresh models on a short delay to not block the UI from rendering
-            QTimer.singleShot(100, self._refresh_ollama_models)
-
-    def _refresh_ollama_models(self) -> None:
-        """Refresh the list of available Ollama models."""
-        self._status_label.setText("Fetching available models...")
-        self._status_label.setStyleSheet(Styles.COLOR_RESET)
-
-        try:
-            from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
-
-            host = self._host_input.text().strip()
-            adapter = OllamaAdapter(host=host)
-            models = adapter.list_available_models()
-
-            if models:
-                self._model_count_label.setText(
-                    f"✓ Found {len(models)} model(s): {', '.join(models[:5])}"
-                )
-                if len(models) > 5:
-                    self._model_count_label.setText(
-                        f"✓ Found {len(models)} model(s): {', '.join(models[:5])}..."
-                    )
-                self._model_count_label.setStyleSheet(Styles.COLOR_GREEN)
-                # Emit signal to update parent dialog's model combo
-                self.models_refreshed.emit(models)
-            else:
-                self._model_count_label.setText(
-                    "⚠ No models found. Pull one with: ollama pull llama3.1:8b"
-                )
-                self._model_count_label.setStyleSheet(Styles.COLOR_ORANGE)
-                self.models_refreshed.emit([])
-
-        except Exception as e:
-            self._model_count_label.setText(f"✗ Failed to fetch models: {e}")
-            self._model_count_label.setStyleSheet(Styles.COLOR_RED)
-            self.models_refreshed.emit([])
-
-    def get_host(self) -> str:
-        """Get Ollama host if applicable."""
-        if self._provider == AIProvider.BITNET and hasattr(self, "_bitnet_root_input"):
-            return str(self._bitnet_root_input.text().strip())
-        if hasattr(self, "_host_input"):
-            return str(self._host_input.text().strip())
-        if self._provider == AIProvider.CLINE_CLI:
-            return DEFAULT_CLINE_HOST
-        if self._provider == AIProvider.BITNET:
-            return os.environ.get(BITNET_ROOT_ENV, "")
-        return str(get_ollama_host())
+    return ProviderConfigRegistry.get_widget(provider, parent)
 
 
 class AISettingsDialog(QDialog):
@@ -802,112 +115,95 @@ class AISettingsDialog(QDialog):
     settings_changed = pyqtSignal(AISettings)
     rebuild_index_requested = pyqtSignal()
 
-    def __init__(self, parent: QWidget | None = None) -> None:
-        """Initialize settings dialog.
+    _DARK_STYLESHEET = """
+        QDialog, QWidget {
+            background-color: #1e1e1e;
+            color: #e0e0e0;
+        }
+        QTabWidget::pane {
+            border: 1px solid #3c3c3c;
+            background-color: #1e1e1e;
+        }
+        QTabBar::tab {
+            background-color: #2d2d2d;
+            color: #e0e0e0;
+            padding: 8px 16px;
+            border: 1px solid #3c3c3c;
+            border-bottom: none;
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
+        }
+        QTabBar::tab:selected {
+            background-color: #1e1e1e;
+            border-bottom: 2px solid #FF8800;
+            font-weight: bold;
+        }
+        QGroupBox {
+            border: 1px solid #3c3c3c;
+            border-radius: 6px;
+            margin-top: 12px;
+            padding-top: 10px;
+            font-weight: bold;
+            color: #FF8800;
+        }
+        QGroupBox::title {
+            subcontrol-origin: margin;
+            subcontrol-position: top left;
+            padding: 0 4px;
+            left: 8px;
+        }
+        QLabel { color: #e0e0e0; }
+        QLineEdit, QComboBox {
+            background-color: #252526;
+            color: #e0e0e0;
+            border: 1px solid #3c3c3c;
+            border-radius: 4px;
+            padding: 4px;
+        }
+        QLineEdit:focus, QComboBox:focus { border: 1px solid #FF8800; }
+        QPushButton {
+            background-color: #0e639c;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            padding: 6px 12px;
+        }
+        QPushButton:hover { background-color: #1177bb; }
+        QCheckBox { color: #e0e0e0; }
+        QDialogButtonBox QPushButton { min-width: 60px; }
+    """
 
-        Args:
-            parent: Parent widget.
-        """
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("AI Assistant Settings")
         self.setMinimumSize(500, 400)
-
-        # Apply Dark Theme styling
-        self.setStyleSheet("""
-            QDialog, QWidget {
-                background-color: #1e1e1e;
-                color: #e0e0e0;
-            }
-            QTabWidget::pane {
-                border: 1px solid #3c3c3c;
-                background-color: #1e1e1e;
-            }
-            QTabBar::tab {
-                background-color: #2d2d2d;
-                color: #e0e0e0;
-                padding: 8px 16px;
-                border: 1px solid #3c3c3c;
-                border-bottom: none;
-                border-top-left-radius: 4px;
-                border-top-right-radius: 4px;
-            }
-            QTabBar::tab:selected {
-                background-color: #1e1e1e;
-                border-bottom: 2px solid #FF8800; /* Gitpod Orange Accent */
-                font-weight: bold;
-            }
-            QGroupBox {
-                border: 1px solid #3c3c3c;
-                border-radius: 6px;
-                margin-top: 12px;
-                padding-top: 10px;
-                font-weight: bold;
-                color: #FF8800; /* Orange Title */
-            }
-            QGroupBox::title {
-                subcontrol-origin: margin;
-                subcontrol-position: top left;
-                padding: 0 4px;
-                left: 8px;
-            }
-            QLabel {
-                color: #e0e0e0;
-            }
-            QLineEdit, QComboBox {
-                background-color: #252526;
-                color: #e0e0e0;
-                border: 1px solid #3c3c3c;
-                border-radius: 4px;
-                padding: 4px;
-            }
-            QLineEdit:focus, QComboBox:focus {
-                border: 1px solid #FF8800;
-            }
-            QPushButton {
-                background-color: #0e639c; /* Blue default for buttons */
-                color: white;
-                border: none;
-                border-radius: 4px;
-                padding: 6px 12px;
-            }
-            QPushButton:hover {
-                background-color: #1177bb;
-            }
-            QCheckBox {
-                color: #e0e0e0;
-            }
-            /* Specific fix for QDialogButtonBox to look standard */
-            QDialogButtonBox QPushButton {
-                min-width: 60px;
-            }
-        """)
+        self.setStyleSheet(self._DARK_STYLESHEET)
 
         self._settings = AISettings.load()
-        self._setup_ui()
-        self._load_settings()
+        self._build_ui()
+        self._load_settings_into_ui()
 
-    def _setup_ui(self) -> None:
-        """Set up the dialog UI."""
+    # ---- construction --------------------------------------------------
+
+    def _build_ui(self) -> None:
         layout = QVBoxLayout(self)
-
-        # Create tabs
         tabs = QTabWidget()
 
-        # Provider tab
-        provider_tab = self._create_provider_tab()
-        tabs.addTab(provider_tab, "Provider")
+        self._providers_tab = ProvidersTab()
+        self._providers_tab.provider_combo.currentIndexChanged.connect(
+            self._on_provider_changed
+        )
+        tabs.addTab(self._providers_tab, "Provider")
 
-        # Preferences tab
-        prefs_tab = self._create_preferences_tab()
-        tabs.addTab(prefs_tab, "Preferences")
+        self._general_tab = GeneralPreferencesTab()
+        tabs.addTab(self._general_tab, "Preferences")
 
-        # Knowledge tab
-        knowledge_tab = self._create_knowledge_tab()
-        tabs.addTab(knowledge_tab, "Knowledge Base")
+        self._rag_tab = RagTab()
+        self._rag_tab.rebuild_index_requested.connect(self.rebuild_index_requested)
+        tabs.addTab(self._rag_tab, "Knowledge Base")
 
         layout.addWidget(tabs)
 
-        # Button box
         button_box = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
         )
@@ -915,322 +211,110 @@ class AISettingsDialog(QDialog):
         button_box.rejected.connect(self.reject)
         layout.addWidget(button_box)
 
-    def _create_provider_tab(self) -> QWidget:
-        """Create the provider configuration tab."""
-        widget = QWidget()
-        layout = QVBoxLayout(widget)
+    # ---- settings <-> UI sync -----------------------------------------
 
-        # Provider selection
-        provider_group = QGroupBox("Select AI Provider")
-        provider_layout = QVBoxLayout(provider_group)
-
-        self._provider_combo = QComboBox()
-        populate_provider_combo(self._provider_combo)
-        self._provider_combo.currentIndexChanged.connect(self._on_provider_changed)
-        provider_layout.addWidget(self._provider_combo)
-
-        cost_label = QLabel(
-            "<b>💡 Tip:</b> Local models (like Ollama) are completely FREE "
-            "and run locally. Cloud models may incur usage costs."
-        )
-        cost_label.setWordWrap(True)
-        provider_layout.addWidget(cost_label)
-
-        layout.addWidget(provider_group)
-
-        # Model selection
-        model_group = QGroupBox("Model")
-        model_layout = QFormLayout(model_group)
-
-        self._model_combo = QComboBox()
-        model_layout.addRow("Model:", self._model_combo)
-
-        layout.addWidget(model_group)
-
-        # Provider-specific config
-        config_group = QGroupBox("Configuration")
-        config_layout = QVBoxLayout(config_group)
-
-        self._provider_configs: dict[AIProvider, ProviderConfigWidget] = {}
-        for provider in AIProvider:
-            config_widget = ProviderConfigWidget(provider)
-            config_widget.hide()
-            self._provider_configs[provider] = config_widget
-            config_layout.addWidget(config_widget)
-
-        layout.addWidget(config_group)
-        layout.addStretch()
-
-        return widget
-
-    def _create_preferences_tab(self) -> QWidget:
-        """Create the preferences tab."""
-        widget = QWidget()
-        layout = QVBoxLayout(widget)
-
-        # Verbosity selector. Tools issue #2552 / PR #2568 replaced the
-        # legacy 4-level ``expertise_level`` (1..4) with a 3-value
-        # ``response_style`` field (concise / standard / detailed). The
-        # combo stores the string value as itemData so the rest of the
-        # dialog can write it through to ``AISettings.response_style``.
-        expertise_group = QGroupBox("Response Verbosity")
-        expertise_layout = QVBoxLayout(expertise_group)
-
-        self._expertise_combo = QComboBox()
-        self._expertise_combo.addItem("Concise", "concise")
-        self._expertise_combo.addItem("Standard", "standard")
-        self._expertise_combo.addItem("Detailed", "detailed")
-        expertise_layout.addWidget(self._expertise_combo)
-
-        expertise_desc = QLabel(
-            "How verbose the AI's replies should be. 'Concise' favours "
-            "code and short bullet lists; 'Detailed' walks through "
-            "reasoning and trade-offs."
-        )
-        expertise_desc.setWordWrap(True)
-        expertise_layout.addWidget(expertise_desc)
-
-        layout.addWidget(expertise_group)
-
-        # Response settings
-        response_group = QGroupBox("Response Settings")
-        response_layout = QVBoxLayout(response_group)
-
-        self._streaming_check = QCheckBox("Enable streaming responses")
-        self._streaming_check.setToolTip(
-            "Show responses as they're generated (more responsive)"
-        )
-        response_layout.addWidget(self._streaming_check)
-
-        layout.addWidget(response_group)
-
-        layout.addStretch()
-        return widget
-
-    def _create_knowledge_tab(self) -> QWidget:
-        """Create the knowledge base (RAG) configuration tab."""
-        widget = QWidget()
-        layout = QVBoxLayout(widget)
-
-        # RAG Settings
-        rag_group = QGroupBox("Knowledge Base Settings")
-        rag_layout = QVBoxLayout(rag_group)
-
-        self._rag_enabled_check = QCheckBox("Enable Codebase Awareness (RAG)")
-        self._rag_enabled_check.setToolTip(
-            "Allow the AI to search your codebase and documents to answer questions."
-        )
-        rag_layout.addWidget(self._rag_enabled_check)
-
-        self._access_mode_combo = QComboBox()
-        self._access_mode_combo.addItem("No repo access", ChatAccessMode.NO_REPO_ACCESS)
-        self._access_mode_combo.addItem(
-            "Read-only diagnostics", ChatAccessMode.READ_ONLY_DIAGNOSTICS
-        )
-        self._access_mode_combo.addItem("Agent/tools", ChatAccessMode.AGENT_TOOLS)
-        self._access_mode_combo.setToolTip(
-            "Controls which codebase and local tools the assistant may receive."
-        )
-        rag_layout.addWidget(self._access_mode_combo)
-
-        # Tools issue #2549 / PR #2567: ChatDockWidget can request a
-        # codemap rebuild on connect via the ``index_codebase`` action.
-        # Toggling this persists ``auto_index_on_open`` in AISettings,
-        # which the dock reads at construction time.
-        self._auto_index_check = QCheckBox("Auto-index codebase when chat opens")
-        self._auto_index_check.setToolTip(
-            "Rebuild the codemap each time the chat dock connects so the "
-            "assistant has fresh symbol/import context. Slower first open."
-        )
-        rag_layout.addWidget(self._auto_index_check)
-
-        layout.addWidget(rag_group)
-
-        # Actions
-        actions_group = QGroupBox("Actions")
-        actions_layout = QVBoxLayout(actions_group)
-
-        rebuild_btn = QPushButton("Rebuild Knowledge Index")
-        rebuild_btn.setToolTip("Scan the codebase and rebuild the search index.")
-        rebuild_btn.clicked.connect(self._on_rebuild_index)
-        actions_layout.addWidget(rebuild_btn)
-
-        info_label = QLabel(
-            "Rebuilding the index analyses your 'src' directory. "
-            "This happens locally and no code is sent to the cloud during indexing."
-        )
-        info_label.setWordWrap(True)
-        info_label.setStyleSheet(Styles.TEXT_MUTED)
-        actions_layout.addWidget(info_label)
-
-        layout.addWidget(actions_group)
-        layout.addStretch()
-
-        return widget
-
-    def _on_rebuild_index(self) -> None:
-        """Handle rebuild index button."""
-        self.rebuild_index_requested.emit()
-        QMessageBox.information(
-            self,
-            "Rebuild Started",
-            "Index rebuild started in background. "
-            "The assistant will be updated shortly.",
-        )
-
-    def _load_settings(self) -> None:
-        """Load current settings into UI."""
-        # Provider
-        for i in range(self._provider_combo.count()):
-            if self._provider_combo.itemData(i) == self._settings.provider:
-                self._provider_combo.setCurrentIndex(i)
+    def _load_settings_into_ui(self) -> None:
+        # Provider combo
+        provider_combo = self._providers_tab.provider_combo
+        for i in range(provider_combo.count()):
+            if provider_combo.itemData(i) == self._settings.provider:
+                provider_combo.setCurrentIndex(i)
                 break
 
-        self._on_provider_changed(self._provider_combo.currentIndex())
+        self._on_provider_changed(provider_combo.currentIndex())
 
-        # Model
-        for i in range(self._model_combo.count()):
-            if self._model_combo.itemText(i) == self._settings.model:
-                self._model_combo.setCurrentIndex(i)
+        model_combo = self._providers_tab.model_combo
+        for i in range(model_combo.count()):
+            if model_combo.itemText(i) == self._settings.model:
+                model_combo.setCurrentIndex(i)
                 break
 
-        # Response style (Tools #2552). Combo itemData carries the
-        # string ``response_style`` value. Default to 'standard' if the
-        # persisted value is unknown.
-        target_style = (self._settings.response_style or "standard").lower()
-        for i in range(self._expertise_combo.count()):
-            if self._expertise_combo.itemData(i) == target_style:
-                self._expertise_combo.setCurrentIndex(i)
+        self._general_tab.select_response_style(self._settings.response_style)
+        self._general_tab.streaming_check.setChecked(self._settings.streaming_enabled)
+
+        self._rag_tab.rag_enabled_check.setChecked(self._settings.rag_enabled)
+        self._rag_tab.auto_index_check.setChecked(self._settings.auto_index_on_open)
+        am_combo = self._rag_tab.access_mode_combo
+        for i in range(am_combo.count()):
+            if am_combo.itemData(i) == self._settings.access_mode:
+                am_combo.setCurrentIndex(i)
                 break
-
-        # Streaming
-        self._streaming_check.setChecked(self._settings.streaming_enabled)
-
-        # RAG
-        if hasattr(self, "_rag_enabled_check"):
-            self._rag_enabled_check.setChecked(self._settings.rag_enabled)
-
-        # Auto-index on open (Tools #2549)
-        if hasattr(self, "_auto_index_check"):
-            self._auto_index_check.setChecked(self._settings.auto_index_on_open)
-
-        if hasattr(self, "_access_mode_combo"):
-            for i in range(self._access_mode_combo.count()):
-                if self._access_mode_combo.itemData(i) == self._settings.access_mode:
-                    self._access_mode_combo.setCurrentIndex(i)
-                    break
 
     def _on_provider_changed(self, index: int) -> None:
-        """Handle provider selection change."""
         if index is None:
             raise ValueError("index must be provided")
-        if index is None:
-            raise ValueError("index must be provided")
-        provider_data = self._provider_combo.itemData(index)
+        provider_combo = self._providers_tab.provider_combo
+        provider_data = provider_combo.itemData(index)
         if provider_data is None or not isinstance(provider_data, AIProvider):
             return
         provider: AIProvider = provider_data
 
-        populate_model_combo(self._model_combo, provider, self._settings.model)
+        populate_model_combo(
+            self._providers_tab.model_combo, provider, self._settings.model
+        )
 
-        # Show/hide provider configs
-        for p, widget in self._provider_configs.items():
+        for p, widget in self._providers_tab.provider_configs.items():
             widget.setVisible(p == provider)
 
-        # Connect models_refreshed signal for Ollama provider
         if provider == AIProvider.OLLAMA:
-            ollama_widget = self._provider_configs[AIProvider.OLLAMA]
-            # Disconnect any previous connection to avoid duplicates
-            with contextlib.suppress(TypeError):
-                ollama_widget.models_refreshed.disconnect(self._update_ollama_models)
-            ollama_widget.models_refreshed.connect(self._update_ollama_models)
+            ollama_widget = self._providers_tab.provider_configs.get(AIProvider.OLLAMA)
+            if ollama_widget is not None and hasattr(ollama_widget, "models_refreshed"):
+                with contextlib.suppress(TypeError):
+                    ollama_widget.models_refreshed.disconnect(
+                        self._update_ollama_models
+                    )
+                ollama_widget.models_refreshed.connect(self._update_ollama_models)
 
     def _accept(self) -> None:
-        """Accept dialog and save settings."""
-        # Update settings from UI
-        self._settings.provider = self._provider_combo.currentData()
-        self._settings.model = self._model_combo.currentText()
-        # Tools issue #2552: combo data is now the ``response_style``
-        # string ('concise' / 'standard' / 'detailed'). Mirror the
-        # selection back into the legacy ``expertise_level`` int so
-        # downstream consumers that still read it (e.g. assistant_panel)
-        # stay in sync until they migrate.
-        style = self._expertise_combo.currentData()
-        if isinstance(style, str):
-            self._settings.response_style = style
-            _STYLE_TO_LEGACY_LEVEL = {
-                "concise": 4,
-                "standard": 2,
-                "detailed": 1,
-            }
-            self._settings.expertise_level = _STYLE_TO_LEGACY_LEVEL.get(
+        self._settings.provider = self._providers_tab.provider_combo.currentData()
+        self._settings.model = self._providers_tab.model_combo.currentText()
+
+        style = self._general_tab.current_response_style()
+        self._settings.response_style = style
+        self._settings.expertise_level = (
+            GeneralPreferencesTab.STYLE_TO_LEGACY_LEVEL.get(
                 style, self._settings.expertise_level
             )
-        self._settings.streaming_enabled = self._streaming_check.isChecked()
-        if hasattr(self, "_rag_enabled_check"):
-            self._settings.rag_enabled = self._rag_enabled_check.isChecked()
-        if hasattr(self, "_auto_index_check"):
-            self._settings.auto_index_on_open = self._auto_index_check.isChecked()
-        if hasattr(self, "_access_mode_combo"):
-            self._settings.access_mode = coerce_access_mode(
-                self._access_mode_combo.currentData()
-            )
+        )
+        self._settings.streaming_enabled = self._general_tab.streaming_check.isChecked()
+        self._settings.rag_enabled = self._rag_tab.rag_enabled_check.isChecked()
+        self._settings.auto_index_on_open = self._rag_tab.auto_index_check.isChecked()
+        self._settings.access_mode = coerce_access_mode(
+            self._rag_tab.access_mode_combo.currentData()
+        )
 
-        # Get Ollama host if applicable
         if self._settings.provider == AIProvider.OLLAMA:
-            config = self._provider_configs[AIProvider.OLLAMA]
-            self._settings.ollama_host = config.get_host()
+            ollama_widget = self._providers_tab.provider_configs.get(AIProvider.OLLAMA)
+            if ollama_widget is not None and hasattr(ollama_widget, "get_host"):
+                self._settings.ollama_host = ollama_widget.get_host()
 
-        # Save and emit
         self._settings.save()
         self.settings_changed.emit(self._settings)
         self.accept()
 
-    def get_settings(self) -> AISettings:
-        """Get current settings.
+    # ---- public helpers preserved from the legacy implementation -------
 
-        Returns:
-            Current AISettings.
-        """
+    def get_settings(self) -> AISettings:
         return self._settings
 
     def _update_ollama_models(self, models: list[str]) -> None:
-        """Update the model dropdown with freshly fetched Ollama models.
-
-        Args:
-            models: List of model names from Ollama.
-        """
         if not models:
             return
-
-        # Save current selection if possible
-        current = self._model_combo.currentText()
-
-        # Clear and repopulate
-        self._model_combo.clear()
+        model_combo = self._providers_tab.model_combo
+        current = model_combo.currentText()
+        model_combo.clear()
         for model in models:
-            self._model_combo.addItem(model)
-
-        # Restore selection or pick first
-        idx = self._model_combo.findText(current)
+            model_combo.addItem(model)
+        idx = model_combo.findText(current)
         if idx >= 0:
-            self._model_combo.setCurrentIndex(idx)
+            model_combo.setCurrentIndex(idx)
         elif models:
-            self._model_combo.setCurrentIndex(0)
+            model_combo.setCurrentIndex(0)
 
     def bind_to_chat_dock(self, chat_dock: Any) -> None:
-        """Wire the model dropdown to a ``ChatDockWidget.models_refreshed``.
+        """Wire ``chat_dock.models_refreshed`` to repopulate the model combo.
 
-        Tools issue #2547 / PR #2566 added a server-side ``refresh_models``
-        action whose response (``{"type": "model_list", ...}``) is forwarded
-        by ``ChatDockWidget`` via the ``models_refreshed`` signal. Calling
-        ``bind_to_chat_dock(dock)`` connects that signal to a handler that
-        normalises the ``ChatModelInfo`` payloads and repopulates the model
-        dropdown.
-
-        Args:
-            chat_dock: A ``ChatDockWidget`` (or any QObject exposing a
-                ``models_refreshed`` signal that emits a ``list``).
+        See Tools #2547 / PR #2566 for the signal contract.
         """
         signal = getattr(chat_dock, "models_refreshed", None)
         if signal is None or not hasattr(signal, "connect"):
@@ -1240,13 +324,6 @@ class AISettingsDialog(QDialog):
         signal.connect(self._on_chat_models_refreshed)
 
     def _on_chat_models_refreshed(self, models: list[Any]) -> None:
-        """Handle a ``model_list`` payload coming from ``ChatDockWidget``.
-
-        Each entry may be a plain string (legacy / dropdown-style) or a
-        ``ChatModelInfo``-shaped dict (``{"name", "provider", ...}``).
-        Normalises both to a list of names and forwards to the existing
-        Ollama-style updater so the model dropdown repopulates.
-        """
         names: list[str] = []
         for entry in models:
             if isinstance(entry, str):
@@ -1257,3 +334,52 @@ class AISettingsDialog(QDialog):
                 if isinstance(name, str) and name:
                     names.append(name)
         self._update_ollama_models(names)
+
+
+# Public re-exports kept stable for downstream importers.
+__all__ = [
+    # constants
+    "BITNET_ROOT_ENV",
+    "DEFAULT_CLINE_HOST",
+    "DEFAULT_OLLAMA_HOST",
+    "DEFAULT_OLLAMA_MODEL",
+    "KEY_ACCESS_MODE",
+    "KEY_AUTO_INDEX_ON_OPEN",
+    "KEY_CHAT_MODE",
+    "KEY_EXPERTISE",
+    "KEY_MODEL",
+    "KEY_OLLAMA_HOST",
+    "KEY_PROVIDER",
+    "KEY_RAG_ENABLED",
+    "KEY_RESPONSE_STYLE",
+    "KEY_STREAMING",
+    "PROVIDER_INFO",
+    "SETTINGS_APP",
+    "SETTINGS_ORG",
+    # core types
+    "AIProvider",
+    "AISettings",
+    "AISettingsDialog",
+    # widgets
+    "AnthropicConfigWidget",
+    "BitnetConfigWidget",
+    "ClaudeCliConfigWidget",
+    "ClineConfigWidget",
+    "CodexCliConfigWidget",
+    "GeminiConfigWidget",
+    "OllamaConfigWidget",
+    "OpenAIConfigWidget",
+    "ProviderConfigRegistry",
+    "ProviderConfigWidget",
+    # keyring helpers
+    "delete_api_key",
+    "get_api_key",
+    "get_ollama_host",
+    "set_api_key",
+    # combo helpers
+    "populate_model_combo",
+    "populate_provider_combo",
+    "provider_default_model",
+    "provider_display_name",
+    "provider_model_names",
+]

--- a/tests/shared/python/ai/test_ai_settings_model.py
+++ b/tests/shared/python/ai/test_ai_settings_model.py
@@ -1,0 +1,95 @@
+"""Tests for the headless AISettings dataclass round-trip (Tools #2762)."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+
+# Bootstrap stubs identical to test_settings_dialog_provider_config.py.
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str | None]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.gui", "src/shared/python/ai/gui"),
+    ("src.shared.python.config", None),
+    ("src.shared.python.config.environment", None),
+    ("src.shared.python.logging_pkg", None),
+    ("src.shared.python.logging_pkg.logging_config", None),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        if _rel_path is not None:
+            _stub.__path__ = [str(ROOT / _rel_path)]  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+_logging_config_stub = sys.modules["src.shared.python.logging_pkg.logging_config"]
+_logging_config_stub.get_logger = logging.getLogger  # type: ignore[attr-defined]
+_logging_config_stub.setup_logging = lambda *a, **kw: None  # type: ignore[attr-defined]
+
+_env_stub = sys.modules["src.shared.python.config.environment"]
+_env_stub.get_env = lambda key, default=None, required=False: default  # type: ignore[attr-defined]
+_env_stub.get_env_float = lambda key, default=0.0: float(default)  # type: ignore[attr-defined]
+
+from src.shared.python.ai._settings_model import AISettings  # noqa: E402
+from src.shared.python.ai.access_policy import ChatAccessMode  # noqa: E402
+from src.shared.python.ai.gui._provider_registry_data import AIProvider  # noqa: E402
+
+
+def test_default_settings_values() -> None:
+    s = AISettings()
+    assert s.provider is AIProvider.OLLAMA
+    assert s.response_style == "standard"
+    assert s.streaming_enabled is True
+    assert s.access_mode == ChatAccessMode.NO_REPO_ACCESS
+
+
+def test_to_dict_round_trip_preserves_fields() -> None:
+    original = AISettings(
+        provider=AIProvider.ANTHROPIC,
+        model="claude-3-5-sonnet-20241022",
+        response_style="concise",
+        chat_mode="agent",
+        streaming_enabled=False,
+        rag_enabled=False,
+        auto_index_on_open=True,
+        access_mode=ChatAccessMode.AGENT_TOOLS,
+    )
+    payload = original.to_dict()
+
+    # JSON-serialisable
+    import json
+
+    json.dumps(payload)
+
+    restored = AISettings.from_dict(payload)
+    assert restored.provider is AIProvider.ANTHROPIC
+    assert restored.model == "claude-3-5-sonnet-20241022"
+    assert restored.response_style == "concise"
+    assert restored.chat_mode == "agent"
+    assert restored.streaming_enabled is False
+    assert restored.rag_enabled is False
+    assert restored.auto_index_on_open is True
+    assert restored.access_mode == ChatAccessMode.AGENT_TOOLS
+
+
+def test_from_dict_normalises_unknown_response_style() -> None:
+    s = AISettings.from_dict({"response_style": "verbose"})
+    assert s.response_style == "standard"
+
+
+def test_from_dict_normalises_unknown_chat_mode() -> None:
+    s = AISettings.from_dict({"chat_mode": "rogue"})
+    assert s.chat_mode == "ask"
+
+
+def test_from_dict_unknown_provider_falls_back_to_ollama() -> None:
+    s = AISettings.from_dict({"provider": "NEVER_SHIPPED"})
+    assert s.provider is AIProvider.OLLAMA

--- a/tests/shared/python/ai/test_provider_config_registry.py
+++ b/tests/shared/python/ai/test_provider_config_registry.py
@@ -1,0 +1,105 @@
+"""Tests for ProviderConfigRegistry (Tools #2762)."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Same bootstrap shim used by test_settings_dialog_provider_config.py.
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str | None]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.gui", "src/shared/python/ai/gui"),
+    ("src.shared.python.config", None),
+    ("src.shared.python.config.environment", None),
+    ("src.shared.python.logging_pkg", None),
+    ("src.shared.python.logging_pkg.logging_config", None),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        if _rel_path is not None:
+            _stub.__path__ = [str(ROOT / _rel_path)]  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+_logging_config_stub = sys.modules["src.shared.python.logging_pkg.logging_config"]
+_logging_config_stub.get_logger = logging.getLogger  # type: ignore[attr-defined]
+_logging_config_stub.setup_logging = lambda *a, **kw: None  # type: ignore[attr-defined]
+
+_env_stub = sys.modules["src.shared.python.config.environment"]
+_env_stub.get_env = lambda key, default=None, required=False: default  # type: ignore[attr-defined]
+_env_stub.get_env_float = lambda key, default=0.0: float(default)  # type: ignore[attr-defined]
+
+from PyQt6.QtWidgets import QLabel, QWidget  # noqa: E402
+
+from src.shared.python.ai.gui._provider_config_registry import (  # noqa: E402
+    ProviderConfigRegistry,
+)
+from src.shared.python.ai.gui._provider_registry_data import AIProvider  # noqa: E402
+
+
+def test_default_registrations_cover_all_providers(qapp) -> None:
+    for provider in AIProvider:
+        assert ProviderConfigRegistry.is_registered(provider.name), (
+            f"missing registration for {provider}"
+        )
+
+
+def test_get_widget_returns_distinct_instances(qapp) -> None:
+    a = ProviderConfigRegistry.get_widget(AIProvider.OPENAI)
+    b = ProviderConfigRegistry.get_widget(AIProvider.OPENAI)
+    assert a is not b
+    a.close()
+    b.close()
+
+
+def test_get_widget_unknown_raises(qapp) -> None:
+    with pytest.raises(KeyError):
+        ProviderConfigRegistry.get_widget("definitely-not-real")
+
+
+def test_register_and_unregister_round_trip(qapp) -> None:
+    class _DummyWidget(QWidget):
+        def __init__(self, parent=None) -> None:
+            super().__init__(parent)
+            QLabel("dummy", self)
+
+    ProviderConfigRegistry.register("dummy_provider", _DummyWidget)
+    try:
+        assert ProviderConfigRegistry.is_registered("dummy_provider")
+        widget = ProviderConfigRegistry.get_widget("dummy_provider")
+        assert isinstance(widget, _DummyWidget)
+        widget.close()
+    finally:
+        ProviderConfigRegistry.unregister("dummy_provider")
+    assert not ProviderConfigRegistry.is_registered("dummy_provider")
+
+
+def test_register_rejects_non_widget_factory() -> None:
+    with pytest.raises(TypeError):
+        ProviderConfigRegistry.register("bad", object)  # type: ignore[arg-type]
+
+
+def test_register_rejects_empty_id() -> None:
+    with pytest.raises(ValueError):
+        ProviderConfigRegistry.register("", QWidget)
+
+
+def test_widgets_are_isolated_per_provider(qapp) -> None:
+    """An anthropic widget must not share Qt children with an openai widget."""
+    aw = ProviderConfigRegistry.get_widget(AIProvider.ANTHROPIC)
+    ow = ProviderConfigRegistry.get_widget(AIProvider.OPENAI)
+    assert type(aw).__name__ == "AnthropicConfigWidget"
+    assert type(ow).__name__ == "OpenAIConfigWidget"
+    aw.close()
+    ow.close()


### PR DESCRIPTION
Closes #2762. Builds on PR #2821 (provider-specific local config widget split).

Decomposes the 1094-line ``src/shared/python/ai/gui/settings_dialog.py`` into focused, single-responsibility modules:

- **AISettings dataclass + persistence** -> ``src/shared/python/ai/_settings_model.py``. Headless ``to_dict``/``from_dict`` round-trip; ``QSettings`` imported lazily so the dataclass is constructable without Qt.
- **Persistence keys + SETTINGS_ORG/SETTINGS_APP** -> ``src/shared/python/ai/config.py`` (extended). Available to headless callers.
- **Provider metadata + combo helpers** -> ``src/shared/python/ai/gui/_provider_registry_data.py`` (``AIProvider``, ``PROVIDER_INFO``, ``populate_provider_combo``, ``populate_model_combo``, ``provider_display_name``).
- **Keyring helpers** -> ``src/shared/python/ai/gui/_api_keys.py``. Preserves the historical keyring service-name layout so previously-stored keys remain readable; documented to delegate to ``chat/credentials.py`` where the layouts converge.
- **Per-provider widgets** -> ``src/shared/python/ai/gui/_provider_config_widgets.py`` (``AnthropicConfigWidget``, ``OpenAIConfigWidget``, ``GeminiConfigWidget``, ``OllamaConfigWidget``, ``ClineConfigWidget``, ``BitnetConfigWidget``, ``ClaudeCliConfigWidget``, ``CodexCliConfigWidget``).
- **ProviderConfigRegistry** -> ``src/shared/python/ai/gui/_provider_config_registry.py``. Default registrations for all eight providers; ``register``/``unregister``/``get_widget``/``is_registered`` API.
- **Per-tab widgets** -> ``_general_tab.py`` (``GeneralPreferencesTab``), ``_providers_tab.py`` (``ProvidersTab``), ``_rag_tab.py`` (``RagTab``).
- **AISettingsDialog** -> 385-line slim coordinator that wires the three tabs.

## Backward compatibility

All previous public symbols continue to import from ``settings_dialog``:

- ``AISettings``, ``AIProvider``, ``AISettingsDialog``
- ``get_api_key`` / ``set_api_key`` / ``delete_api_key``
- ``populate_provider_combo`` / ``populate_model_combo`` / ``provider_display_name`` / ``provider_default_model`` / ``provider_model_names``
- ``PROVIDER_INFO``, ``SETTINGS_ORG``, ``SETTINGS_APP``, ``KEY_*`` constants, ``DEFAULT_OLLAMA_HOST``, ``DEFAULT_OLLAMA_MODEL``, ``DEFAULT_CLINE_HOST``, ``BITNET_ROOT_ENV``
- ``ProviderConfigWidget(provider)`` is preserved as a thin compatibility wrapper that routes to ``ProviderConfigRegistry.get_widget``.
- ``QSettings`` is still imported in ``settings_dialog`` (with ``noqa: F401``) so the existing monkeypatch in ``test_access_policy.py::test_access_mode_persists_in_ai_settings`` keeps working — ``AISettings.save``/``load`` resolve ``QSettings`` via the ``settings_dialog`` module attribute when present.

## Test plan

- [x] AISettings is testable headlessly (5 new tests in ``test_ai_settings_model.py``)
- [x] ProviderConfigRegistry registry tested (7 new tests in ``test_provider_config_registry.py``)
- [x] No keyring duplication: ``_api_keys.py`` is the single ``AIProvider``-keyed implementation; ``chat/credentials.py`` continues to own provider-string-keyed credentials.
- [x] ``settings_dialog.py`` is 385 lines (under the 400-line target).
- [x] Existing tests pass without modification:
  - ``tests/shared/python/ai/test_settings_dialog_provider_config.py`` (3/3)
  - ``src/shared/python/ai/tests/test_access_policy.py`` (5/5 settings tests). The 1 unrelated failure on ``test_process_message_passes_mode_filtered_tools`` is pre-existing on ``origin/main`` and not introduced here.
- [x] ``ruff check`` and ``ruff format --check`` clean for all touched files.
- [x] Pre-commit hooks (ruff lint + format, TODO markers, no wildcard imports, no print/debug) all pass.