### PR TITLE
refactor(ai-gui): decompose AssistantPanel god class into 4 controllers (#2761)

### DIFF
--- a/src/shared/python/ai/gui/_adapter_lifecycle.py
+++ b/src/shared/python/ai/gui/_adapter_lifecycle.py
@@ -1,0 +1,125 @@
+"""Adapter lifecycle manager for the AI assistant.
+
+Owns provider/key resolution and adapter construction. Returns the new
+adapter (or ``None``) so the panel can install it; emits a
+``system_message`` signal for user-visible status text.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from src.shared.python.ai.gui.settings_dialog import AIProvider, AISettings
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class AdapterLifecycleManager(QObject):
+    """Constructs adapter instances from ``AISettings``.
+
+    Emits ``adapter_changed(adapter, adapter_id)`` with the freshly built
+    adapter (or ``None`` when construction failed). The ``system_message``
+    signal carries human-readable status the panel can display.
+    """
+
+    adapter_changed = pyqtSignal(object, str)
+    system_message = pyqtSignal(str)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def auto_load(self) -> AISettings | None:
+        """Reload settings from disk and rebuild the adapter."""
+        try:
+            settings = AISettings.load()
+        except ImportError as exc:
+            logger.warning("Failed to auto-load AI settings: %s", exc)
+            return None
+        self.build(settings)
+        return settings
+
+    def build(self, settings: AISettings) -> Any:
+        """Construct an adapter for ``settings`` and emit signals."""
+        adapter = self._construct(settings)
+        adapter_id = type(adapter).__name__ if adapter is not None else ""
+        if adapter is not None:
+            self.adapter_changed.emit(adapter, adapter_id)
+            self.system_message.emit(
+                f"✓ Connected to {settings.provider.name} ({settings.model})"
+            )
+        else:
+            self.adapter_changed.emit(None, "")
+            self.system_message.emit(
+                f"⚠️ Could not connect to {settings.provider.name}. "
+                "Please check your settings."
+            )
+        return adapter
+
+    # ------------------------------------------------------------------
+    # Provider construction
+    # ------------------------------------------------------------------
+    def _construct(self, settings: AISettings) -> Any:
+        provider = settings.provider
+        if provider == AIProvider.OLLAMA:
+            return self._build_ollama(settings)
+        if provider == AIProvider.OPENAI:
+            return self._build_openai(settings)
+        if provider == AIProvider.ANTHROPIC:
+            return self._build_anthropic(settings)
+        if provider == AIProvider.GEMINI:
+            return self._build_gemini(settings)
+        return None
+
+    def _build_ollama(self, settings: AISettings) -> Any:
+        try:
+            from src.shared.python.ai.adapters.rust_adapter import RustAgentAdapter
+
+            adapter = RustAgentAdapter(
+                api_key="ollama",
+                base_url=settings.ollama_host,
+                model=settings.model,
+                chat_path="/v1/chat/completions",
+                embed_path="/v1/embeddings",
+            )
+            self.system_message.emit("🚀 Using high-performance Rust AI backend.")
+            return adapter
+        except ImportError:
+            from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
+
+            return OllamaAdapter(host=settings.ollama_host, model=settings.model)
+
+    @staticmethod
+    def _build_openai(settings: AISettings) -> Any:
+        from src.shared.python.ai.gui.settings_dialog import get_api_key
+
+        api_key = get_api_key(AIProvider.OPENAI)
+        if not api_key:
+            return None
+        from src.shared.python.ai.adapters.openai_adapter import OpenAIAdapter
+
+        return OpenAIAdapter(api_key=api_key, model=settings.model)
+
+    @staticmethod
+    def _build_anthropic(settings: AISettings) -> Any:
+        from src.shared.python.ai.gui.settings_dialog import get_api_key
+
+        api_key = get_api_key(AIProvider.ANTHROPIC)
+        if not api_key:
+            return None
+        from src.shared.python.ai.adapters.anthropic_adapter import AnthropicAdapter
+
+        return AnthropicAdapter(api_key=api_key, model=settings.model)
+
+    @staticmethod
+    def _build_gemini(settings: AISettings) -> Any:
+        from src.shared.python.ai.gui.settings_dialog import get_api_key
+
+        api_key = get_api_key(AIProvider.GEMINI)
+        if not api_key:
+            return None
+        from src.shared.python.ai.adapters.gemini_adapter import GeminiAdapter
+
+        return GeminiAdapter(api_key=api_key, model=settings.model)

--- a/src/shared/python/ai/gui/_indexing.py
+++ b/src/shared/python/ai/gui/_indexing.py
@@ -1,0 +1,81 @@
+"""RAG indexing controller for the AI assistant.
+
+Owns the IndexerWorker lifecycle and reports status/messages back via
+Qt signals so the panel can update its UI without coupling.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtCore import QObject, pyqtSignal
+
+from src.shared.python.ai.rag.indexer_worker import IndexerWorker
+from src.shared.python.ai.rag.simple_rag import SimpleRAGStore
+from src.shared.python.logging_pkg.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _resolve_src_path() -> Path:
+    repo_root = Path(__file__).resolve().parent  # gui
+    while repo_root.name != "src" and repo_root.parent != repo_root:
+        repo_root = repo_root.parent
+    return repo_root if repo_root.name == "src" else Path("src").resolve()
+
+
+class IndexingController(QObject):
+    """Drives codebase indexing and exposes its lifecycle as signals."""
+
+    status_changed = pyqtSignal(str)
+    system_message = pyqtSignal(str)
+    finished = pyqtSignal(int)
+    failed = pyqtSignal(str)
+
+    def __init__(self, rag_store: SimpleRAGStore, parent: Any = None) -> None:
+        super().__init__(parent)
+        self._rag_store = rag_store
+        self._worker: IndexerWorker | None = None
+
+    @property
+    def is_running(self) -> bool:
+        return self._worker is not None and self._worker.isRunning()
+
+    @property
+    def worker(self) -> IndexerWorker | None:
+        return self._worker
+
+    def start(self) -> None:
+        """Kick off (or no-op if already running) a codebase index build."""
+        if self.is_running:
+            self.status_changed.emit("Indexing already in progress...")
+            return
+        self.status_changed.emit("Indexing codebase...")
+        self.system_message.emit("Indexing local codebase context...")
+
+        src_path = _resolve_src_path()
+        if not src_path.exists():
+            logger.error("Could not find src directory to index at %s", src_path)
+            self.status_changed.emit("Error: 'src' not found")
+            self.system_message.emit("Codebase indexing failed: 'src' not found.")
+            return
+
+        worker = IndexerWorker(src_path, self._rag_store)
+        worker.progress.connect(self.status_changed.emit)
+        worker.finished.connect(self._on_finished)
+        worker.error.connect(self._on_error)
+        self._worker = worker
+        worker.start()
+
+    def _on_finished(self, docs_indexed: int) -> None:
+        self.status_changed.emit(f"Index ready ({docs_indexed} docs)")
+        self.system_message.emit(f"Codebase index ready ({docs_indexed} docs indexed).")
+        self._worker = None
+        self.finished.emit(docs_indexed)
+
+    def _on_error(self, error: str) -> None:
+        self.status_changed.emit(f"Index error: {error}")
+        self.system_message.emit(f"Codebase indexing failed: {error}")
+        self._worker = None
+        self.failed.emit(error)

--- a/src/shared/python/ai/gui/_input_area.py
+++ b/src/shared/python/ai/gui/_input_area.py
@@ -1,0 +1,151 @@
+"""Input area widget for the AI assistant panel.
+
+Owns the QPlainTextEdit, expertise label, and Send button. Emits a
+``send_requested(str)`` signal whenever the user submits a non-empty
+message either by pressing Enter or clicking Send.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtGui import QKeySequence, QShortcut
+from PyQt6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from src.shared.python.ai.gui.assistant_widgets import ChatInput
+from src.shared.python.theme.style_constants import Styles
+
+
+class InputArea(QFrame):
+    """Compose box + Send button + verbosity indicator."""
+
+    send_requested = pyqtSignal(str)
+
+    def __init__(self, parent: Any = None) -> None:
+        super().__init__(parent)
+        self.setStyleSheet(
+            """
+            QFrame {
+                background-color: #1e1e1e;
+                border-top: 1px solid #3c3c3c;
+            }
+            """
+        )
+        layout = QVBoxLayout(self)
+
+        self.input_edit = ChatInput()
+        self.input_edit.setPlaceholderText(
+            "Type your message here... (Enter to send, Shift+Enter for new line)"
+        )
+        self.input_edit.setMaximumHeight(100)
+        self.input_edit.setStyleSheet(
+            """
+            QPlainTextEdit {
+                background-color: #252526;
+                color: #e0e0e0;
+                border: 1px solid #3c3c3c;
+                border-radius: 4px;
+                padding: 8px;
+            }
+            QPlainTextEdit:focus { border: 1px solid #FF8800; }
+            """
+        )
+        self.input_edit.submit_requested.connect(self._emit_send)
+        layout.addWidget(self.input_edit)
+
+        button_layout = QHBoxLayout()
+        self.expertise_label = QLabel("Verbosity: Verbose")
+        self.expertise_label.setStyleSheet(Styles.TEXT_MUTED)
+        button_layout.addWidget(self.expertise_label)
+        button_layout.addStretch()
+
+        self.send_btn = QPushButton("Send")
+        self.send_btn.clicked.connect(self._emit_send)
+        self.send_btn.setStyleSheet(
+            """
+            QPushButton {
+                background-color: #FF8800;
+                color: black;
+                border: none;
+                border-radius: 4px;
+                padding: 8px 16px;
+                font-weight: bold;
+            }
+            QPushButton:hover { background-color: #cc6d00; }
+            QPushButton:disabled {
+                background-color: #444444;
+                color: #888888;
+            }
+            """
+        )
+        button_layout.addWidget(self.send_btn)
+        layout.addLayout(button_layout)
+
+        # Ctrl+Enter to send, in addition to plain Enter from ChatInput.
+        shortcut = QShortcut(QKeySequence("Ctrl+Return"), self.input_edit)
+        shortcut.activated.connect(self._emit_send)
+
+    def _emit_send(self) -> None:
+        text = self.input_edit.toPlainText().strip()
+        if not text:
+            return
+        self.input_edit.clear()
+        self.send_requested.emit(text)
+
+    def set_busy(self, busy: bool) -> None:
+        """Disable Send while a request is in flight."""
+        self.send_btn.setEnabled(not busy)
+
+    def set_expertise_text(self, text: str) -> None:
+        self.expertise_label.setText(text)
+
+    def apply_theme(self, colors: dict) -> None:
+        bg_primary = colors["bg_primary"]
+        bg_alt = colors["bg_alt"]
+        text_primary = colors["text_primary"]
+        text_muted = colors["text_muted"]
+        border = colors["border"]
+        accent = colors["accent"]
+        button_hover = colors.get("button_hover", accent)
+
+        self.setStyleSheet(
+            f"QFrame {{ background-color: {bg_primary}; "
+            f"border-top: 1px solid {border}; }}"
+        )
+        self.input_edit.setStyleSheet(
+            f"""
+            QPlainTextEdit {{
+                background-color: {bg_alt};
+                color: {text_primary};
+                border: 1px solid {border};
+                border-radius: 4px;
+                padding: 8px;
+            }}
+            QPlainTextEdit:focus {{ border: 1px solid {accent}; }}
+            """
+        )
+        self.send_btn.setStyleSheet(
+            f"""
+            QPushButton {{
+                background-color: {accent};
+                color: black;
+                border: none;
+                border-radius: 4px;
+                padding: 8px 16px;
+                font-weight: bold;
+            }}
+            QPushButton:hover {{ background-color: {button_hover}; }}
+            QPushButton:disabled {{
+                background-color: {border};
+                color: {text_muted};
+            }}
+            """
+        )
+        self.expertise_label.setStyleSheet(f"color: {text_muted};")

--- a/src/shared/python/ai/gui/_message_display.py
+++ b/src/shared/python/ai/gui/_message_display.py
@@ -1,0 +1,157 @@
+"""Message display controller for the AI assistant.
+
+Owns the scrollable message area widget and message-widget lifecycle.
+The owning panel hands ``ConversationContext`` data in/out via simple
+calls; this controller does not know about adapters or settings.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import QScrollArea, QVBoxLayout, QWidget
+
+from src.shared.python.ai.gui.assistant_widgets import MessageWidget
+from src.shared.python.theme.style_constants import Styles
+
+
+class MessageDisplayController(QWidget):
+    """Wraps the QScrollArea + message-list QVBoxLayout used by the panel."""
+
+    message_added = pyqtSignal(object)  # MessageWidget
+
+    def __init__(self, parent: Any = None) -> None:
+        super().__init__(parent)
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+        )
+        self.scroll_area.setStyleSheet(
+            """
+            QScrollArea {
+                background-color: #1e1e1e;
+                border: none;
+            }
+            QScrollBar:vertical {
+                background: #1e1e1e;
+                width: 10px;
+                margin: 0px 0px 0px 0px;
+            }
+            QScrollBar::handle:vertical {
+                background: #424242;
+                min-height: 20px;
+                border-radius: 5px;
+            }
+            QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
+                background: none;
+            }
+            """
+        )
+
+        self.message_container = QWidget()
+        self.message_container.setStyleSheet(Styles.CONTAINER_DARK)
+        self.message_layout = QVBoxLayout(self.message_container)
+        self.message_layout.setContentsMargins(8, 8, 8, 8)
+        self.message_layout.setSpacing(8)
+        self.message_layout.addStretch()
+
+        self.scroll_area.setWidget(self.message_container)
+        outer.addWidget(self.scroll_area)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def add_message(
+        self,
+        role: str,
+        content: str,
+        timestamp: datetime | None = None,
+    ) -> MessageWidget:
+        """Append a message bubble to the conversation."""
+        if role is None:
+            raise ValueError("role must be provided")
+        idx = self.message_layout.count() - 1  # insert before stretch
+        widget = MessageWidget(role, content, timestamp)
+        self.message_layout.insertWidget(idx, widget)
+        self.scroll_to_bottom()
+        self.message_added.emit(widget)
+        return widget
+
+    def add_system_message(self, content: str) -> MessageWidget:
+        return self.add_message("system", content)
+
+    def restore_from_context(self, context: Any) -> None:
+        """Repaint message widgets from ``context.messages``."""
+        for msg in context.messages:
+            if msg.role != "system":
+                self.add_message(msg.role, msg.content, msg.timestamp)
+
+    def clear_messages(self) -> None:
+        """Remove every message widget; the trailing stretch stays."""
+        while self.message_layout.count() > 1:
+            item = self.message_layout.takeAt(0)
+            if item is None:
+                continue
+            widget = item.widget()
+            if widget is None:
+                continue
+            if isinstance(widget, MessageWidget):
+                self._safely_disconnect_message_widget(widget)
+            widget.deleteLater()
+
+    @staticmethod
+    def _safely_disconnect_message_widget(widget: MessageWidget) -> None:
+        try:
+            doc = widget._content_label.document()
+            if doc is not None:
+                doc.contentsChanged.disconnect(widget._adjust_height)
+        except (TypeError, RuntimeError, AttributeError):
+            pass
+
+    def scroll_to_bottom(self) -> None:
+        scrollbar = self.scroll_area.verticalScrollBar()
+        if scrollbar is not None:
+            scrollbar.setValue(scrollbar.maximum())
+
+    def apply_theme(self, colors: dict) -> None:
+        bg_primary = colors["bg_primary"]
+        border = colors["border"]
+        self.message_container.setStyleSheet(f"background-color: {bg_primary};")
+        self.scroll_area.setStyleSheet(
+            f"""
+            QScrollArea {{
+                background-color: {bg_primary};
+                border: none;
+            }}
+            QScrollBar:vertical {{
+                background: {bg_primary};
+                width: 10px;
+                margin: 0px 0px 0px 0px;
+            }}
+            QScrollBar::handle:vertical {{
+                background: {border};
+                min-height: 20px;
+                border-radius: 5px;
+            }}
+            QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{
+                background: none;
+            }}
+            """
+        )
+        self.refresh_theme()
+
+    def refresh_theme(self) -> None:
+        for i in range(self.message_layout.count()):
+            item = self.message_layout.itemAt(i)
+            if item is None:
+                continue
+            w = item.widget()
+            if isinstance(w, MessageWidget):
+                w.refresh_theme()

--- a/src/shared/python/ai/gui/_panel_header.py
+++ b/src/shared/python/ai/gui/_panel_header.py
@@ -1,0 +1,325 @@
+"""Panel header controller for the AI assistant.
+
+Owns the header UI subtree (provider/model/mode combos, access-mode combo,
+auto-index checkbox, action buttons) and emits Qt signals when the user
+changes any of them. The parent panel observes the signals; the controller
+holds no back-reference to the panel (LOD).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+)
+
+from src.shared.python.ai.access_policy import ChatAccessMode
+from src.shared.python.ai.gui.settings_dialog import (
+    AIProvider,
+    populate_model_combo,
+    populate_provider_combo,
+)
+
+if TYPE_CHECKING:
+    from src.shared.python.ai.gui.settings_dialog import AISettings
+
+
+_CHAT_MODES = (
+    ("Ask", "ask"),
+    ("Diagnose (read-only)", "diagnose"),
+    ("Agent", "agent"),
+)
+
+
+class PanelHeaderController(QFrame):
+    """Encapsulates the AI assistant's header strip.
+
+    Signals are emitted on user interaction. The owning panel wires them
+    to its own slots; controllers do not call methods on the panel directly.
+    """
+
+    provider_changed = pyqtSignal(object)  # AIProvider
+    model_changed = pyqtSignal(str)
+    mode_changed = pyqtSignal(str)
+    access_mode_changed = pyqtSignal(object)  # ChatAccessMode
+    auto_index_toggled = pyqtSignal(bool)
+    new_chat_requested = pyqtSignal()
+    settings_requested = pyqtSignal()
+    close_requested = pyqtSignal()
+
+    def __init__(self, initial_settings: AISettings, parent: Any = None) -> None:
+        super().__init__(parent)
+        self._syncing = False
+        self._build(initial_settings)
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+    def _build(self, settings: AISettings) -> None:
+        layout = QHBoxLayout(self)
+        self._add_title_widgets(layout, settings)
+        self._add_mode_and_status(layout, settings)
+        layout.addStretch()
+        self._add_action_buttons(layout)
+
+    def _add_title_widgets(self, layout: QHBoxLayout, settings: AISettings) -> None:
+        self.provider_icon = QLabel("\U0001f916")
+        layout.addWidget(self.provider_icon)
+
+        self.provider_combo = QComboBox()
+        self.provider_combo.setObjectName("aiProviderCombo")
+        self.provider_combo.setToolTip("Select AI provider")
+        populate_provider_combo(self.provider_combo)
+        self._set_combo_data(self.provider_combo, settings.provider)
+        self.provider_combo.currentIndexChanged.connect(self._on_provider_changed)
+        layout.addWidget(self.provider_combo)
+
+        self.model_combo = QComboBox()
+        self.model_combo.setObjectName("aiModelCombo")
+        self.model_combo.setToolTip("Select AI model")
+        populate_model_combo(self.model_combo, settings.provider, settings.model)
+        self.model_combo.currentIndexChanged.connect(self._on_model_changed)
+        layout.addWidget(self.model_combo)
+
+        self.model_label = QLabel("AI Assistant")
+        self.model_label.setVisible(False)
+
+        layout.addSpacing(10)
+
+    def _add_mode_and_status(self, layout: QHBoxLayout, settings: AISettings) -> None:
+        self.mode_combo = QComboBox()
+        self.mode_combo.setObjectName("aiModeCombo")
+        for label, value in _CHAT_MODES:
+            self.mode_combo.addItem(label, value)
+        self._set_combo_data(self.mode_combo, settings.chat_mode)
+        self.mode_combo.setToolTip(
+            "Select AI mode: Ask, Diagnose (read-only), or Agent"
+        )
+        self.mode_combo.currentIndexChanged.connect(self._on_mode_changed)
+        layout.addWidget(self.mode_combo)
+
+        self.access_mode_combo = QComboBox()
+        self.access_mode_combo.addItem("No repo access", ChatAccessMode.NO_REPO_ACCESS)
+        self.access_mode_combo.addItem(
+            "Read-only diagnostics", ChatAccessMode.READ_ONLY_DIAGNOSTICS
+        )
+        self.access_mode_combo.addItem("Agent/tools", ChatAccessMode.AGENT_TOOLS)
+        self.access_mode_combo.setToolTip(
+            "Controls which repo and local tools the assistant may receive."
+        )
+        self.access_mode_combo.currentIndexChanged.connect(self._on_access_mode_changed)
+        layout.addWidget(self.access_mode_combo)
+
+        self.status_label = QLabel("Ready")
+        layout.addWidget(self.status_label)
+
+    def _add_action_buttons(self, layout: QHBoxLayout) -> None:
+        self.auto_index_checkbox = QCheckBox("Auto-Index")
+        self.auto_index_checkbox.setToolTip(
+            "Rebuild the local codebase index when chat opens."
+        )
+        self.auto_index_checkbox.toggled.connect(self.auto_index_toggled.emit)
+        layout.addWidget(self.auto_index_checkbox)
+
+        new_chat_btn = QPushButton("New Chat")
+        new_chat_btn.clicked.connect(self.new_chat_requested.emit)
+        layout.addWidget(new_chat_btn)
+
+        settings_btn = QPushButton("⚙️")
+        settings_btn.setToolTip("Settings")
+        settings_btn.clicked.connect(self.settings_requested.emit)
+        layout.addWidget(settings_btn)
+
+        close_btn = QPushButton("✕")
+        close_btn.setToolTip("Close AI Chat")
+        close_btn.clicked.connect(self.close_requested.emit)
+        layout.addWidget(close_btn)
+
+    # ------------------------------------------------------------------
+    # Sync / public API
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _set_combo_data(combo: QComboBox, data: object) -> bool:
+        idx = combo.findData(data)
+        if idx < 0:
+            return False
+        combo.setCurrentIndex(idx)
+        return True
+
+    def sync_controls(self, settings: AISettings) -> None:
+        """Repopulate combos to reflect ``settings`` without firing signals."""
+        self._syncing = True
+        try:
+            self.provider_combo.blockSignals(True)
+            self.model_combo.blockSignals(True)
+            self.mode_combo.blockSignals(True)
+            self._set_combo_data(self.provider_combo, settings.provider)
+            populate_model_combo(self.model_combo, settings.provider, settings.model)
+            self._set_combo_data(self.mode_combo, settings.chat_mode)
+        finally:
+            self.provider_combo.blockSignals(False)
+            self.model_combo.blockSignals(False)
+            self.mode_combo.blockSignals(False)
+            self._syncing = False
+
+    def sync_access_mode(self, mode: ChatAccessMode) -> None:
+        for i in range(self.access_mode_combo.count()):
+            if self.access_mode_combo.itemData(i) == mode:
+                self.access_mode_combo.blockSignals(True)
+                self.access_mode_combo.setCurrentIndex(i)
+                self.access_mode_combo.blockSignals(False)
+                return
+
+    def set_auto_index_checked(self, checked: bool) -> None:
+        self.auto_index_checkbox.blockSignals(True)
+        self.auto_index_checkbox.setChecked(checked)
+        self.auto_index_checkbox.blockSignals(False)
+
+    def auto_index_enabled(self) -> bool:
+        return bool(self.auto_index_checkbox.isChecked())
+
+    def update_models(self, models: list[str]) -> None:
+        if not models:
+            return
+        current = self.model_combo.currentText()
+        self.model_combo.blockSignals(True)
+        try:
+            self.model_combo.clear()
+            for name in models:
+                self.model_combo.addItem(name)
+            idx = self.model_combo.findText(current)
+            if idx < 0 and self.model_combo.count():
+                idx = 0
+            if idx >= 0:
+                self.model_combo.setCurrentIndex(idx)
+        finally:
+            self.model_combo.blockSignals(False)
+
+    def set_status(self, text: str) -> None:
+        self.status_label.setText(text)
+
+    def set_provider_icon(self, icon: str) -> None:
+        self.provider_icon.setText(icon)
+
+    def set_model_label(self, text: str, tooltip: str = "") -> None:
+        self.model_label.setText(text)
+        if tooltip:
+            self.model_label.setToolTip(tooltip)
+
+    def apply_theme(self, colors: dict) -> None:
+        """Restyle every header child from a flat theme color dict."""
+        bg_primary = colors["bg_primary"]
+        bg_alt = colors["bg_alt"]
+        text_primary = colors["text_primary"]
+        text_muted = colors["text_muted"]
+        border = colors["border"]
+        accent = colors["accent"]
+        self.setStyleSheet(
+            f"""
+            QFrame {{
+                background-color: {bg_alt};
+                padding: 10px;
+                border-bottom: 1px solid {border};
+            }}
+            QLabel {{ color: {text_primary}; }}
+            QPushButton {{
+                background-color: transparent;
+                color: {text_muted};
+                border: 1px solid {border};
+                border-radius: 6px;
+                padding: 6px 12px;
+                font-weight: 500;
+            }}
+            QPushButton:hover {{
+                background-color: {accent};
+                color: #ffffff;
+                border-color: {accent};
+            }}
+            """
+        )
+        combo_qss = f"""
+            QComboBox {{
+                background-color: {bg_primary};
+                color: {text_primary};
+                border: 1px solid {border};
+                border-radius: 6px;
+                padding: 4px 12px;
+                min-width: 80px;
+            }}
+            QComboBox::drop-down {{ border: none; width: 20px; }}
+            QComboBox::down-arrow {{
+                image: none;
+                border-left: 4px solid transparent;
+                border-right: 4px solid transparent;
+                border-top: 4px solid {text_muted};
+                margin-top: 2px;
+            }}
+            QComboBox QAbstractItemView {{
+                background-color: {bg_alt};
+                color: {text_primary};
+                border: 1px solid {border};
+                border-radius: 4px;
+                selection-background-color: {accent};
+            }}
+        """
+        for combo in (self.provider_combo, self.model_combo, self.mode_combo):
+            combo.setStyleSheet(combo_qss)
+        self.status_label.setStyleSheet(
+            f"font-size: 11px; color: {text_muted}; background: transparent;"
+        )
+        self.provider_icon.setStyleSheet(
+            f"font-size: 18px; color: {text_primary}; background: transparent;"
+        )
+        self.model_label.setStyleSheet(
+            f"font-size: 14px; font-weight: bold; color: {text_primary}; "
+            "background: transparent;"
+        )
+        self.auto_index_checkbox.setStyleSheet(f"color: {text_primary};")
+
+    @property
+    def is_syncing(self) -> bool:
+        return self._syncing
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+    def _on_provider_changed(self, index: int) -> None:
+        if self._syncing:
+            return
+        provider = self.provider_combo.itemData(index)
+        if not isinstance(provider, AIProvider):
+            return
+        current_model = self.model_combo.currentText()
+        self._syncing = True
+        try:
+            self.model_combo.blockSignals(True)
+            populate_model_combo(self.model_combo, provider, current_model)
+        finally:
+            self.model_combo.blockSignals(False)
+            self._syncing = False
+        self.provider_changed.emit(provider)
+
+    def _on_model_changed(self, index: int) -> None:
+        if self._syncing or index < 0:
+            return
+        self.model_changed.emit(self.model_combo.currentText())
+
+    def _on_mode_changed(self, index: int) -> None:
+        if self._syncing or index < 0:
+            return
+        mode = self.mode_combo.currentData()
+        if isinstance(mode, str):
+            self.mode_changed.emit(mode)
+
+    def _on_access_mode_changed(self, _index: int) -> None:
+        from src.shared.python.ai.access_policy import coerce_access_mode
+
+        mode = coerce_access_mode(self.access_mode_combo.currentData())
+        self.access_mode_changed.emit(mode)

--- a/src/shared/python/ai/gui/_panel_tools.py
+++ b/src/shared/python/ai/gui/_panel_tools.py
@@ -1,0 +1,56 @@
+"""Tool registration helpers for AIAssistantPanel.
+
+Keeps the tool decorators out of the panel module so it stays focused
+on coordination.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.shared.python.ai.tool_registry import ToolCategory
+
+
+def register_panel_tools(tools_registry: Any, rag_store: Any) -> None:
+    """Register CLI shims and the RAG search tool with ``tools_registry``."""
+
+    @tools_registry.register(
+        name="claude_cli",
+        description="Use Claude CLI to control the application.",
+        category=ToolCategory.CONFIGURATION,
+    )
+    def claude_cli(command: str) -> str:
+        return f"Executed Claude CLI: {command}"
+
+    @tools_registry.register(
+        name="codex_cli",
+        description="Use Codex CLI to control the application.",
+        category=ToolCategory.CONFIGURATION,
+    )
+    def codex_cli(command: str) -> str:
+        return f"Executed Codex CLI: {command}"
+
+    @tools_registry.register(
+        name="cline_cli",
+        description="Use Cline CLI to control the application.",
+        category=ToolCategory.CONFIGURATION,
+    )
+    def cline_cli(command: str) -> str:
+        return f"Executed Cline CLI: {command}"
+
+    @tools_registry.register(
+        name="search_knowledge_base",
+        description="Search the user's resource library/codebase for information.",
+        category=ToolCategory.ANALYSIS,
+    )
+    def search_knowledge_base(query: str) -> str:
+        results = rag_store.query(query)
+        if not results:
+            return "No relevant information found."
+        output = ["Found relevant documents:"]
+        for doc, score in results:
+            output.append(f"--- Document: {doc.id} (Score: {score:.2f}) ---")
+            output.append(
+                doc.content[:500] + "..." if len(doc.content) > 500 else doc.content
+            )
+        return "\n\n".join(output)

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -1,14 +1,16 @@
-# ARCHITECTURE_DEBT:
-# This module historically exceeds standard length metrics and accumulates excessive domain responsibility.  # noqa: E501
-# It requires domain-aware structural extraction to isolate its internal classes appropriately.  # noqa: E501
-
 """Reusable AI assistant conversation panel.
 
-This module provides the main AI assistant conversation panel,
-including message display, input handling, and streaming support.
+The panel is a thin coordinator that wires together four specialised
+controllers:
 
-The panel integrates with the selected AI provider and displays
-responses with markdown rendering.
+* :class:`PanelHeaderController` — header strip (combos + buttons).
+* :class:`MessageDisplayController` — scrollable message log.
+* :class:`AdapterLifecycleManager` — provider/key resolution and adapter creation.
+* :class:`IndexingController` — RAG codebase indexing lifecycle.
+
+Public attributes used by tests (``_provider_combo``, ``_model_combo``,
+``_mode_combo``, ``_message_layout``, etc.) remain exposed as forwarding
+references for back-compatibility.
 """
 
 from __future__ import annotations
@@ -20,14 +22,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from PyQt6 import QtCore
 from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtGui import QKeySequence, QShortcut
 from PyQt6.QtWidgets import (
-    QComboBox,
-    QFrame,
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QScrollArea,
     QSplitter,
     QVBoxLayout,
     QWidget,
@@ -38,29 +33,27 @@ from src.shared.python.ai.access_policy import (
     coerce_access_mode,
     tool_declarations_for_access_mode,
 )
-from src.shared.python.ai.gui.assistant_widgets import (
-    ChatInput,
-    MessageWidget,
-    StreamWorker,
-)
+from src.shared.python.ai.gui._adapter_lifecycle import AdapterLifecycleManager
+from src.shared.python.ai.gui._indexing import IndexingController
+from src.shared.python.ai.gui._input_area import InputArea
+from src.shared.python.ai.gui._message_display import MessageDisplayController
+from src.shared.python.ai.gui._panel_header import PanelHeaderController
+from src.shared.python.ai.gui._panel_tools import register_panel_tools
+from src.shared.python.ai.gui.assistant_widgets import MessageWidget, StreamWorker
 from src.shared.python.ai.gui.history_sidebar import ChatHistorySidebar
 from src.shared.python.ai.gui.session_manager import ChatSessionManager
 from src.shared.python.ai.gui.settings_dialog import (
     AIProvider,
     AISettings,
     AISettingsDialog,
-    populate_model_combo,
-    populate_provider_combo,
     provider_display_name,
 )
 from src.shared.python.ai.memory_manager import MemoryManager
-from src.shared.python.ai.rag.indexer_worker import IndexerWorker
 from src.shared.python.ai.rag.simple_rag import SimpleRAGStore
-from src.shared.python.ai.tool_registry import ToolCategory, get_global_registry
+from src.shared.python.ai.tool_registry import get_global_registry
 from src.shared.python.ai.tools.codemap_tools import register_codemap_tools
 from src.shared.python.ai.tools.file_ops import register_file_tools
 from src.shared.python.logging_pkg.logging_config import get_logger
-from src.shared.python.theme.style_constants import Styles
 
 if TYPE_CHECKING:
     from src.shared.python.ai.adapters.base import BaseAgentAdapter
@@ -80,18 +73,12 @@ def _discover_project_root(start: Path) -> Path:
 
 
 class AIAssistantPanel(QWidget):
-    """Main AI Assistant conversation panel.
+    """Main AI Assistant conversation panel (coordinator)."""
 
-    This panel provides:
-    - Conversation history display
-    - Message input with send button
-    - Streaming response display
-    - Settings access
-    """
+    message_sent = pyqtSignal(str)
+    settings_requested = pyqtSignal()
+    close_requested = pyqtSignal()
 
-    message_sent = pyqtSignal(str)  # Emits when user sends message
-    settings_requested = pyqtSignal()  # Emits when settings button clicked
-    close_requested = pyqtSignal()  # Emits when close button clicked
     _CHAT_MODES = (
         ("Ask", "ask"),
         ("Diagnose (read-only)", "diagnose"),
@@ -104,45 +91,132 @@ class AIAssistantPanel(QWidget):
         *,
         project_root: Path | None = None,
     ) -> None:
-        """Initialize AI assistant panel.
-
-        Args:
-            parent: Parent widget.
-            project_root: Project root used for AGENTS.md prompt context.
-        """
         super().__init__(parent)
+
+        # --- Domain state -------------------------------------------------
         self._context = ConversationContext()
         self._adapter: BaseAgentAdapter | None = None
         self._current_worker: StreamWorker | None = None
         self._current_assistant_message: MessageWidget | None = None
         self._current_settings = AISettings.load()
-        self._syncing_header_controls = False
         self._access_mode = ChatAccessMode.NO_REPO_ACCESS
         self._rag_enabled = True
         self._auto_index_on_open = False
-        self._indexer_worker: IndexerWorker | None = None
         self._project_root = project_root or _discover_project_root(Path.cwd())
 
-        # Tools & RAG
+        # --- Tools / RAG / memory ----------------------------------------
         self._tools_registry = get_global_registry()
         self._rag_store = SimpleRAGStore()
         self._memory_manager = MemoryManager()
         self._refresh_prompt_memory()
 
-        # Persistence
+        # --- Session manager + history ----------------------------------
         self._session_manager = ChatSessionManager()
         self._session_manager.session_loaded.connect(self._on_session_loaded)
         self._load_history()
 
-        # Initialize Core Tools
         self._init_tools()
 
-        self._setup_ui()
-        # Restore messages to UI
-        self._restore_ui_messages()
+        # --- Controllers -------------------------------------------------
+        self._header = PanelHeaderController(self._current_settings)
+        self._messages = MessageDisplayController()
+        self._adapter_mgr = AdapterLifecycleManager(self)
+        self._indexer = IndexingController(self._rag_store, self)
+        self._input_container = InputArea()
 
+        self._wire_controllers()
+        self._setup_ui()
+        self._messages.restore_from_context(self._context)
+
+    # ------------------------------------------------------------------
+    # Back-compat attribute proxies (read by external tests & code)
+    # ------------------------------------------------------------------
+    @property
+    def _provider_combo(self) -> Any:
+        return self._header.provider_combo
+
+    @property
+    def _model_combo(self) -> Any:
+        return self._header.model_combo
+
+    @property
+    def _mode_combo(self) -> Any:
+        return self._header.mode_combo
+
+    @property
+    def _access_mode_combo(self) -> Any:
+        return self._header.access_mode_combo
+
+    @property
+    def _provider_icon(self) -> Any:
+        return self._header.provider_icon
+
+    @property
+    def _model_label(self) -> Any:
+        return self._header.model_label
+
+    @property
+    def _status_label(self) -> Any:
+        return self._header.status_label
+
+    @property
+    def chk_auto_index(self) -> Any:
+        return self._header.auto_index_checkbox
+
+    @property
+    def _message_layout(self) -> Any:
+        return self._messages.message_layout
+
+    @property
+    def _message_container(self) -> Any:
+        return self._messages.message_container
+
+    @property
+    def _message_area(self) -> Any:
+        return self._messages.scroll_area
+
+    @property
+    def _input_edit(self) -> Any:
+        return self._input_container.input_edit
+
+    @property
+    def _send_btn(self) -> Any:
+        return self._input_container.send_btn
+
+    @property
+    def _expertise_label(self) -> Any:
+        return self._input_container.expertise_label
+
+    @property
+    def _indexer_worker(self) -> Any:
+        return self._indexer.worker
+
+    # ------------------------------------------------------------------
+    # Wiring
+    # ------------------------------------------------------------------
+    def _wire_controllers(self) -> None:
+        """Connect controller signals to coordination slots on the panel."""
+        h = self._header
+        h.provider_changed.connect(self._on_header_provider_changed)
+        h.model_changed.connect(self._on_header_model_changed)
+        h.mode_changed.connect(self._on_header_mode_changed)
+        h.access_mode_changed.connect(self._on_access_mode_changed)
+        h.new_chat_requested.connect(self._on_new_chat)
+        h.settings_requested.connect(self._show_settings)
+        h.close_requested.connect(self.close_requested.emit)
+
+        self._adapter_mgr.adapter_changed.connect(self._on_adapter_changed)
+        self._adapter_mgr.system_message.connect(self._add_system_message)
+
+        self._indexer.status_changed.connect(self._set_status)
+        self._indexer.system_message.connect(self._add_system_message)
+
+        self._input_container.send_requested.connect(self._on_send)
+
+    # ------------------------------------------------------------------
+    # History / session
+    # ------------------------------------------------------------------
     def _load_history(self) -> None:
-        """Load the most recent active conversation history."""
         sessions = self._session_manager.list_sessions()
         active = [s for s in sessions if not s.get("archived", False)]
         if active:
@@ -154,598 +228,60 @@ class AIAssistantPanel(QWidget):
                 logger.info(f"Loaded chat session {latest_id}")
 
     def _save_history(self) -> None:
-        """Save conversation history via session manager."""
         try:
             self._refresh_prompt_memory()
             self._session_manager.save_session(self._context)
-        except Exception as e:
-            logger.warning(f"Failed to save chat session: {e}")
+        except Exception as exc:  # noqa: BLE001 - best-effort persistence
+            logger.warning(f"Failed to save chat session: {exc}")
 
     def _on_session_loaded(self, context: ConversationContext) -> None:
-        """Handle when a session is loaded from the sidebar."""
         self._context = context
         self._refresh_prompt_memory()
-        # Clear UI messages (keep stretch and welcome message? no, just keep stretch)
-        while self._message_layout.count() > 1:
-            item = self._message_layout.takeAt(0)
-            if item is not None:
-                widget = item.widget()
-                if widget is not None:
-                    widget.deleteLater()
-        self._restore_ui_messages()
+        self._messages.clear_messages()
+        self._messages.restore_from_context(self._context)
 
-    def _restore_ui_messages(self) -> None:
-        """Restore message widgets from context."""
-        # This must be called AFTER _setup_ui
-        for msg in self._context.messages:
-            if msg.role != "system":
-                self._add_message_to_ui(msg.role, msg.content, msg.timestamp)
-
+    # ------------------------------------------------------------------
+    # Tools registration
+    # ------------------------------------------------------------------
     def _init_tools(self) -> None:
-        """Initialize default tools."""
-        # 1. File Ops
         register_file_tools(self._tools_registry)
         register_codemap_tools(self._tools_registry)
+        register_panel_tools(self._tools_registry, self._rag_store)
 
-        # 2. System CLI Tools
-        @self._tools_registry.register(
-            name="claude_cli",
-            description="Use Claude CLI to control the application.",
-            category=ToolCategory.CONFIGURATION,
-        )
-        def claude_cli(command: str) -> str:
-            return f"Executed Claude CLI: {command}"
-
-        @self._tools_registry.register(
-            name="codex_cli",
-            description="Use Codex CLI to control the application.",
-            category=ToolCategory.CONFIGURATION,
-        )
-        def codex_cli(command: str) -> str:
-            return f"Executed Codex CLI: {command}"
-
-        @self._tools_registry.register(
-            name="cline_cli",
-            description="Use Cline CLI to control the application.",
-            category=ToolCategory.CONFIGURATION,
-        )
-        def cline_cli(command: str) -> str:
-            return f"Executed Cline CLI: {command}"
-
-        # 3. RAG Search Tool
-        @self._tools_registry.register(
-            name="search_knowledge_base",
-            description="Search the user's resource library/codebase for information.",
-            category=ToolCategory.ANALYSIS,
-        )
-        def search_knowledge_base(query: str) -> str:
-            """Search the RAG knowledge base and return matching documents."""
-            results = self._rag_store.query(query)
-            if not results:
-                return "No relevant information found."
-
-            output = ["Found relevant documents:"]
-            for doc, score in results:
-                output.append(f"--- Document: {doc.id} (Score: {score:.2f}) ---")
-                output.append(
-                    doc.content[:500] + "..." if len(doc.content) > 500 else doc.content
-                )
-            return "\n\n".join(output)
-
+    # ------------------------------------------------------------------
+    # UI assembly
+    # ------------------------------------------------------------------
     def _setup_ui(self) -> None:
-        """Set up the panel UI."""
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
-
-        # Header
-        self._header = self._create_header()
         layout.addWidget(self._header)
 
-        # Splitter for sidebar and the rest
         main_splitter = QSplitter(Qt.Orientation.Horizontal)
         main_splitter.setHandleWidth(1)
-        main_splitter.setStyleSheet("""
-            QSplitter::handle { background-color: #3c3c3c; }
-        """)
+        main_splitter.setStyleSheet("QSplitter::handle { background-color: #3c3c3c; }")
 
-        # Sidebar
         self._sidebar = ChatHistorySidebar(self._session_manager)
         self._sidebar.session_selected.connect(self._session_manager.load_session)
         self._sidebar.new_chat_requested.connect(self._on_new_chat)
         self._sidebar.memory_sync_requested.connect(self._on_memory_sync_requested)
         main_splitter.addWidget(self._sidebar)
 
-        # Splitter for messages and input
         msg_splitter = QSplitter(Qt.Orientation.Vertical)
         msg_splitter.setHandleWidth(1)
-        msg_splitter.setStyleSheet("""
-            QSplitter::handle {
-                background-color: #3c3c3c;
-            }
-        """)
-
-        # Message area
-        self._message_area = self._create_message_area()
-        msg_splitter.addWidget(self._message_area)
-
-        # Input area
-        self._input_container = self._create_input_area()
+        msg_splitter.setStyleSheet("QSplitter::handle { background-color: #3c3c3c; }")
+        msg_splitter.addWidget(self._messages)
         msg_splitter.addWidget(self._input_container)
-
-        # Set splitter sizes (80% messages, 20% input)
         msg_splitter.setSizes([400, 100])
         msg_splitter.setStretchFactor(0, 4)
         msg_splitter.setStretchFactor(1, 1)
 
         main_splitter.addWidget(msg_splitter)
-
-        # Set splitter sizes (sidebar, messages)
-        # We allow the user to resize the sidebar by NOT fixing its maximum width
         main_splitter.setSizes([250, 550])
         main_splitter.setStretchFactor(0, 0)
         main_splitter.setStretchFactor(1, 1)
-
         layout.addWidget(main_splitter)
 
-        # Attempt to load settings immediately
-        QtCore.QTimer.singleShot(100, self._auto_load_settings)
-
-        self.refresh_theme()
-
-    def showEvent(self, event: Any) -> None:
-        """Refresh models and auto-index when panel becomes visible."""
-        super().showEvent(event)
-        self._refresh_models()
-        if self._auto_index_enabled():
-            self._start_indexing()
-
-    def _refresh_models(self) -> None:
-        """Refresh available models from the backend adapter."""
-        if hasattr(self, "_adapter") and self._adapter:
-            try:
-                # Assuming adapter has a get_available_models or similar,
-                # we'll just log it for now or re-apply settings
-                self._auto_load_settings()
-            except Exception as e:
-                logger.warning(f"Failed to refresh models: {e}")
-
-    def _auto_load_settings(self) -> None:
-        """Try to load settings and init adapter on startup."""
-        try:
-            from src.shared.python.ai.gui.settings_dialog import AISettings
-
-            settings = AISettings.load()
-            self.apply_settings(settings)
-        except ImportError as e:
-            logger.warning(f"Failed to auto-load AI settings: {e}")
-
-    def refresh_theme(self) -> None:
-        """Refresh styling from ThemeManager."""
-        try:
-            from src.shared.python.theme.theme_manager import get_theme_manager
-
-            color_source: object = get_theme_manager().get_current_colors()
-
-            def _get(key: str, fallback: Any) -> Any:
-                if isinstance(color_source, dict):
-                    return color_source.get(key, fallback)
-                return getattr(color_source, key, fallback)
-
-            bg_primary = _get("bg", "#1e1e1e")
-            bg_alt = _get("bg_elevated", _get("group_bg", "#2d2d2d"))
-            text_primary = _get("text_primary", _get("text", "#e0e0e0"))
-            text_muted = _get("text_secondary", "#888888")
-            border = _get("border_default", _get("border", "#444444"))
-            accent = _get("primary", _get("accent", "#FF8800"))
-            button_hover = _get("bg_highlight", "#cc6d00")
-        except ImportError:
-            return
-
-        self.setStyleSheet(f"background-color: {bg_primary}; color: {text_primary};")
-
-        if hasattr(self, "_sidebar"):
-            self._sidebar.refresh_theme()
-
-        # Header
-        self._header.setStyleSheet(f"""
-            QFrame {{
-                background-color: {bg_alt};
-                padding: 10px;
-                border-bottom: 1px solid {border};
-            }}
-            QLabel {{
-                color: {text_primary};
-            }}
-            QPushButton {{
-                background-color: transparent;
-                color: {text_muted};
-                border: 1px solid {border};
-                border-radius: 6px;
-                padding: 6px 12px;
-                font-weight: 500;
-            }}
-            QPushButton:hover {{
-                background-color: {accent};
-                color: #ffffff;
-                border-color: {accent};
-            }}
-        """)
-
-        # Header combos
-        for combo_name in ("_provider_combo", "_model_combo", "_mode_combo"):
-            if not hasattr(self, combo_name):
-                continue
-            getattr(self, combo_name).setStyleSheet(f"""
-                QComboBox {{
-                    background-color: {bg_primary};
-                    color: {text_primary};
-                    border: 1px solid {border};
-                    border-radius: 6px;
-                    padding: 4px 12px;
-                    min-width: 80px;
-                }}
-                QComboBox::drop-down {{
-                    border: none;
-                    width: 20px;
-                }}
-                QComboBox::down-arrow {{
-                    image: none;
-                    border-left: 4px solid transparent;
-                    border-right: 4px solid transparent;
-                    border-top: 4px solid {text_muted};
-                    margin-top: 2px;
-                }}
-                QComboBox QAbstractItemView {{
-                    background-color: {bg_alt};
-                    color: {text_primary};
-                    border: 1px solid {border};
-                    border-radius: 4px;
-                    selection-background-color: {accent};
-                }}
-            """)
-
-        if hasattr(self, "_status_label"):
-            self._status_label.setStyleSheet(
-                f"font-size: 11px; color: {text_muted}; background: transparent;"
-            )
-
-        if hasattr(self, "_provider_icon"):
-            self._provider_icon.setStyleSheet(
-                f"font-size: 18px; color: {text_primary}; background: transparent;"
-            )
-
-        if hasattr(self, "_model_label"):
-            self._model_label.setStyleSheet(
-                f"font-size: 14px; font-weight: bold; color: {text_primary}; "
-                "background: transparent;"
-            )
-
-        if hasattr(self, "chk_auto_index"):
-            self.chk_auto_index.setStyleSheet(f"color: {text_primary};")
-
-        # Input Area
-        self._input_container.setStyleSheet(f"""
-            QFrame {{
-                background-color: {bg_primary};
-                border-top: 1px solid {border};
-            }}
-        """)
-
-        self._input_edit.setStyleSheet(f"""
-            QPlainTextEdit {{
-                background-color: {bg_alt};
-                color: {text_primary};
-                border: 1px solid {border};
-                border-radius: 4px;
-                padding: 8px;
-            }}
-            QPlainTextEdit:focus {{
-                border: 1px solid {accent};
-            }}
-        """)
-
-        self._send_btn.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {accent};
-                color: black;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-            }}
-            QPushButton:hover {{
-                background-color: {button_hover};
-            }}
-            QPushButton:disabled {{
-                background-color: {border};
-                color: {text_muted};
-            }}
-        """)
-
-        self._expertise_label.setStyleSheet(f"color: {text_muted};")
-
-        # Message Area
-        self._message_container.setStyleSheet(f"background-color: {bg_primary};")
-        self._message_area.setStyleSheet(f"""
-            QScrollArea {{
-                background-color: {bg_primary};
-                border: none;
-            }}
-            QScrollBar:vertical {{
-                background: {bg_primary};
-                width: 10px;
-                margin: 0px 0px 0px 0px;
-            }}
-            QScrollBar::handle:vertical {{
-                background: {border};
-                min-height: 20px;
-                border-radius: 5px;
-            }}
-            QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {{
-                background: none;
-            }}
-        """)
-
-        # Refresh all child messages
-        for i in range(self._message_layout.count()):
-            item = self._message_layout.itemAt(i)
-            if item:
-                w = item.widget()
-                if isinstance(w, MessageWidget):
-                    w.refresh_theme()
-
-    def _create_header(self) -> QWidget:
-        """Create the panel header."""
-        header = QFrame()
-        # Header styling is dynamically managed in refresh_theme
-
-        layout = QHBoxLayout(header)
-
-        self._add_header_title_widgets(layout)
-        self._add_header_mode_and_status(layout)
-        layout.addStretch()
-        self._add_header_action_buttons(layout)
-
-        return header
-
-    def _add_header_title_widgets(self, layout: Any) -> None:
-        if layout is None:
-            raise ValueError("layout must be provided")
-        if layout is None:
-            raise ValueError("layout must be provided")
-        self._provider_icon = QLabel("\U0001f916")
-        layout.addWidget(self._provider_icon)
-
-        self._provider_combo = QComboBox()
-        self._provider_combo.setObjectName("aiProviderCombo")
-        self._provider_combo.setToolTip("Select AI provider")
-        populate_provider_combo(self._provider_combo)
-        self._set_combo_data(self._provider_combo, self._current_settings.provider)
-        self._provider_combo.currentIndexChanged.connect(
-            self._on_header_provider_changed
-        )
-        layout.addWidget(self._provider_combo)
-
-        self._model_combo = QComboBox()
-        self._model_combo.setObjectName("aiModelCombo")
-        self._model_combo.setToolTip("Select AI model")
-        populate_model_combo(
-            self._model_combo,
-            self._current_settings.provider,
-            self._current_settings.model,
-        )
-        self._model_combo.currentIndexChanged.connect(self._on_header_model_changed)
-        layout.addWidget(self._model_combo)
-
-        self._model_label = QLabel("AI Assistant")
-        self._model_label.setVisible(False)
-
-        layout.addSpacing(10)
-
-    def _add_header_mode_and_status(self, layout: Any) -> None:
-        if layout is None:
-            raise ValueError("layout must be provided")
-        if layout is None:
-            raise ValueError("layout must be provided")
-        self._mode_combo = QComboBox()
-        self._mode_combo.setObjectName("aiModeCombo")
-        for label, value in self._CHAT_MODES:
-            self._mode_combo.addItem(label, value)
-        self._set_combo_data(self._mode_combo, self._current_settings.chat_mode)
-        self._mode_combo.setToolTip(
-            "Select AI mode: Ask, Diagnose (read-only), or Agent"
-        )
-        self._mode_combo.currentIndexChanged.connect(self._on_header_mode_changed)
-        layout.addWidget(self._mode_combo)
-
-        self._access_mode_combo = QComboBox()
-        self._access_mode_combo.addItem("No repo access", ChatAccessMode.NO_REPO_ACCESS)
-        self._access_mode_combo.addItem(
-            "Read-only diagnostics", ChatAccessMode.READ_ONLY_DIAGNOSTICS
-        )
-        self._access_mode_combo.addItem("Agent/tools", ChatAccessMode.AGENT_TOOLS)
-        self._access_mode_combo.setToolTip(
-            "Controls which repo and local tools the assistant may receive."
-        )
-        self._access_mode_combo.currentIndexChanged.connect(
-            self._on_access_mode_changed
-        )
-        layout.addWidget(self._access_mode_combo)
-
-        self._status_label = QLabel("Ready")
-        layout.addWidget(self._status_label)
-
-    def _set_combo_data(self, combo: QComboBox, data: object) -> bool:
-        idx = combo.findData(data)
-        if idx < 0:
-            return False
-        combo.setCurrentIndex(idx)
-        return True
-
-    def _sync_header_controls(self, settings: AISettings) -> None:
-        if not hasattr(self, "_provider_combo"):
-            return
-
-        self._syncing_header_controls = True
-        try:
-            self._provider_combo.blockSignals(True)
-            self._model_combo.blockSignals(True)
-            self._mode_combo.blockSignals(True)
-            self._set_combo_data(self._provider_combo, settings.provider)
-            populate_model_combo(self._model_combo, settings.provider, settings.model)
-            self._set_combo_data(self._mode_combo, settings.chat_mode)
-        finally:
-            self._provider_combo.blockSignals(False)
-            self._model_combo.blockSignals(False)
-            self._mode_combo.blockSignals(False)
-            self._syncing_header_controls = False
-
-    def _persist_header_selection(self, *, reconnect: bool) -> None:
-        if self._syncing_header_controls:
-            return
-
-        provider = self._provider_combo.currentData()
-        if not isinstance(provider, AIProvider):
-            return
-
-        self._current_settings.provider = provider
-        self._current_settings.model = self._model_combo.currentText()
-        mode = self._mode_combo.currentData()
-        self._current_settings.chat_mode = mode if isinstance(mode, str) else "ask"
-        self._current_settings.save()
-        if reconnect:
-            self.apply_settings(self._current_settings)
-
-    def _on_header_provider_changed(self, index: int) -> None:
-        if self._syncing_header_controls:
-            return
-        provider = self._provider_combo.itemData(index)
-        if not isinstance(provider, AIProvider):
-            return
-
-        current_model = self._current_settings.model
-        self._syncing_header_controls = True
-        try:
-            self._model_combo.blockSignals(True)
-            populate_model_combo(self._model_combo, provider, current_model)
-        finally:
-            self._model_combo.blockSignals(False)
-            self._syncing_header_controls = False
-        self._persist_header_selection(reconnect=True)
-
-    def _on_header_model_changed(self, index: int) -> None:
-        if index < 0:
-            return
-        self._persist_header_selection(reconnect=True)
-
-    def _on_header_mode_changed(self, index: int) -> None:
-        if index < 0:
-            return
-        self._persist_header_selection(reconnect=False)
-
-    def _update_header_models(self, models: list[str]) -> None:
-        if not models or not hasattr(self, "_model_combo"):
-            return
-
-        current = self._model_combo.currentText()
-        self._model_combo.blockSignals(True)
-        try:
-            self._model_combo.clear()
-            for model in models:
-                self._model_combo.addItem(model)
-            idx = self._model_combo.findText(current)
-            if idx < 0 and self._model_combo.count():
-                idx = 0
-            if idx >= 0:
-                self._model_combo.setCurrentIndex(idx)
-        finally:
-            self._model_combo.blockSignals(False)
-
-    def _on_chat_models_refreshed(self, models: list[Any]) -> None:
-        names: list[str] = []
-        for entry in models:
-            if isinstance(entry, str) and entry:
-                names.append(entry)
-            elif isinstance(entry, dict):
-                name = entry.get("name")
-                if isinstance(name, str) and name:
-                    names.append(name)
-        self._update_header_models(names)
-
-    def bind_to_chat_dock(self, chat_dock: Any) -> None:
-        """Wire inline model choices to a chat dock ``models_refreshed`` signal."""
-        signal = getattr(chat_dock, "models_refreshed", None)
-        if signal is None or not hasattr(signal, "connect"):
-            return
-        with contextlib.suppress(TypeError):
-            signal.disconnect(self._on_chat_models_refreshed)
-        signal.connect(self._on_chat_models_refreshed)
-
-    def _add_header_action_buttons(self, layout: Any) -> None:
-        if layout is None:
-            raise ValueError("layout must be provided")
-
-        from PyQt6.QtWidgets import QCheckBox
-
-        self.chk_auto_index = QCheckBox("Auto-Index")
-        self.chk_auto_index.setToolTip(
-            "Rebuild the local codebase index when chat opens."
-        )
-        layout.addWidget(self.chk_auto_index)
-
-        new_chat_btn = QPushButton("New Chat")
-        new_chat_btn.clicked.connect(self._on_new_chat)
-        layout.addWidget(new_chat_btn)
-
-        settings_btn = QPushButton("\u2699\ufe0f")
-        settings_btn.setToolTip("Settings")
-        settings_btn.clicked.connect(self._show_settings)
-        layout.addWidget(settings_btn)
-
-        close_btn = QPushButton("\u2715")
-        close_btn.setToolTip("Close AI Chat")
-        close_btn.clicked.connect(self.close_requested.emit)
-        layout.addWidget(close_btn)
-
-    def _create_message_area(self) -> QScrollArea:
-        """Create the message display area."""
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-
-        # Dark background for scroll area
-        scroll.setStyleSheet("""
-            QScrollArea {
-                background-color: #1e1e1e;
-                border: none;
-            }
-            QScrollBar:vertical {
-                background: #1e1e1e;
-                width: 10px;
-                margin: 0px 0px 0px 0px;
-            }
-            QScrollBar::handle:vertical {
-                background: #424242;
-                min-height: 20px;
-                border-radius: 5px;
-            }
-            QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
-                background: none;
-            }
-        """)
-
-        # Container for messages
-        self._message_container = QWidget()
-        self._message_container.setStyleSheet(Styles.CONTAINER_DARK)
-        self._message_layout = QVBoxLayout(self._message_container)
-        self._message_layout.setContentsMargins(8, 8, 8, 8)
-        self._message_layout.setSpacing(8)
-        self._message_layout.addStretch()
-
-        scroll.setWidget(self._message_container)
-
-        # Add welcome message
         self._add_system_message(
             "👋 Welcome to the shared Tools AI Assistant!\n\n"
             "I can help you:\n"
@@ -756,364 +292,254 @@ class AIAssistantPanel(QWidget):
             "How can I help you today?"
         )
 
-        return scroll
+        QtCore.QTimer.singleShot(100, self._auto_load_settings)
+        self.refresh_theme()
 
-    def _create_input_area(self) -> QWidget:
-        """Create the message input area."""
-        widget = QFrame()
-        widget.setStyleSheet("""
-            QFrame {
-                background-color: #1e1e1e;
-                border-top: 1px solid #3c3c3c;
-            }
-            """)
-
-        layout = QVBoxLayout(widget)
-
-        # Input text area
-        self._input_edit = ChatInput()
-        self._input_edit.setPlaceholderText(
-            "Type your message here... (Enter to send, Shift+Enter for new line)"
-        )
-        self._input_edit.setMaximumHeight(100)
-        self._input_edit.setStyleSheet("""
-            QPlainTextEdit {
-                background-color: #252526;
-                color: #e0e0e0;
-                border: 1px solid #3c3c3c;
-                border-radius: 4px;
-                padding: 8px;
-            }
-            QPlainTextEdit:focus {
-                border: 1px solid #FF8800;
-            }
-        """)
-        self._input_edit.submit_requested.connect(self._on_send)
-        layout.addWidget(self._input_edit)
-
-        # Buttons
-        button_layout = QHBoxLayout()
-
-        # Expertise level indicator
-        self._expertise_label = QLabel("Verbosity: Verbose")
-        self._expertise_label.setStyleSheet(Styles.TEXT_MUTED)
-        button_layout.addWidget(self._expertise_label)
-
-        button_layout.addStretch()
-
-        # Send button
-        self._send_btn = QPushButton("Send")
-        # No default, handled by Enter
-        self._send_btn.clicked.connect(self._on_send)
-        self._send_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #FF8800;
-                color: black;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #cc6d00;
-            }
-            QPushButton:disabled {
-                background-color: #444444;
-                color: #888888;
-            }
-            """)
-        button_layout.addWidget(self._send_btn)
-
-        layout.addLayout(button_layout)
-
-        return widget
-
-    def _connect_signals(self) -> None:
-        """Connect internal signals."""
-        # Ctrl+Enter to send
-        shortcut = QShortcut(QKeySequence("Ctrl+Return"), self._input_edit)
-        shortcut.activated.connect(self._on_send)
-
-    def _on_send(self) -> None:
-        """Handle send button click."""
-        message = self._input_edit.toPlainText().strip()
-        if not message:
-            return
-
-        # Clear input
-        self._input_edit.clear()
-
-        # Add user message
-        self._add_message("user", message)
-
-        # Add to context immediately (so it's saved even if app crashes)
-        self._context.add_user_message(message)
-        self._save_history()
-
-        # Emit signal
-        self.message_sent.emit(message)
-
-        # Process message if adapter is set
-        if self._adapter:
-            self._process_message(message)
-
-    def _process_message(self, message: str) -> None:
-        """Process a user message with the AI adapter.
-
-        Args:
-            message: User's message.
-        """
-        if message is None:
-            raise ValueError("message must be provided")
-        if message is None:
-            raise ValueError("message must be provided")
-        if not self._adapter:
-            self._add_system_message(
-                "⚠️ No AI provider configured. Click ⚙️ to set up a provider."
-            )
-            return
-
-        # Update status
-        self._refresh_prompt_memory()
-        self._set_status("Thinking...")
-        self._send_btn.setEnabled(False)
-
-        tools = self._build_tool_declarations()
-
-        # Create streaming worker
-        self._current_worker = StreamWorker(
-            self._adapter,
-            message,
-            self._context,
-            tools,
-        )
-        self._current_worker.chunk_received.connect(self._on_stream_chunk)
-        self._current_worker.finished.connect(self._on_stream_finished)
-        self._current_worker.error.connect(self._on_stream_error)
-
-        # Create assistant message with placeholder
-        self._current_assistant_message = self._add_message(
-            "assistant", "*Thinking...*"
-        )
-        self._is_first_chunk = True
-
-        # Start streaming
-        self._current_worker.start()
-
-    def _on_stream_chunk(self, content: str) -> None:
-        """Handle incoming stream chunk.
-
-        Args:
-            content: Content chunk.
-        """
-        if self._current_assistant_message:
-            if self._is_first_chunk:
-                self._current_assistant_message.set_content(content)
-                self._is_first_chunk = False
-            else:
-                self._current_assistant_message.append_content(content)
-
-            self._scroll_to_bottom()
-
-    def _on_stream_finished(self) -> None:
-        """Handle stream completion."""
-        self._set_status("Ready")
-        self._send_btn.setEnabled(True)
-
-        # Add to context
-        if self._current_assistant_message:
-            self._context.add_assistant_message(
-                self._current_assistant_message.get_content()
-            )
-            self._save_history()
-
-        self._current_assistant_message = None
-        # Disconnect signals before clearing worker reference to prevent memory leaks
-        if self._current_worker:
-            try:
-                self._current_worker.chunk_received.disconnect(self._on_stream_chunk)
-                self._current_worker.finished.disconnect(self._on_stream_finished)
-                self._current_worker.error.disconnect(self._on_stream_error)
-            except (TypeError, RuntimeError):
-                # Signals may already be disconnected
-                pass
-        self._current_worker = None
-
-    def _on_stream_error(self, error: str) -> None:
-        """Handle stream error.
-
-        Args:
-            error: Error message.
-        """
-        if error is None:
-            raise ValueError("error must be provided")
-        if error is None:
-            raise ValueError("error must be provided")
-        self._set_status("Error")
-        self._send_btn.setEnabled(True)
-
-        if self._current_assistant_message:
-            self._current_assistant_message.append_content(f"\n\n⚠️ **Error:** {error}")
-
-        self._current_assistant_message = None
-        # Disconnect signals before clearing worker reference to prevent memory leaks
-        if self._current_worker:
-            try:
-                self._current_worker.chunk_received.disconnect(self._on_stream_chunk)
-                self._current_worker.finished.disconnect(self._on_stream_finished)
-                self._current_worker.error.disconnect(self._on_stream_error)
-            except (TypeError, RuntimeError):
-                # Signals may already be disconnected
-                pass
-        self._current_worker = None
-
-    def _add_message_to_ui(
-        self,
-        role: str,
-        content: str,
-        timestamp: datetime | None = None,
-    ) -> MessageWidget:
-        """Add a message to the UI (alias for internal usage)."""
-        return self._add_message(role, content, timestamp)
-
-    def _add_message(
-        self,
-        role: str,
-        content: str,
-        timestamp: datetime | None = None,
-    ) -> MessageWidget:
-        """Add a message to the conversation UI.
-
-        Args:
-            role: Message role.
-            content: Message content.
-            timestamp: Optional timestamp.
-
-        Returns:
-            The created MessageWidget.
-        """
-        # Insert before the stretch
-        if role is None:
-            raise ValueError("role must be provided")
-        if role is None:
-            raise ValueError("role must be provided")
-        idx = self._message_layout.count() - 1
-
-        widget = MessageWidget(role, content, timestamp)
-        self._message_layout.insertWidget(idx, widget)
-
-        self._scroll_to_bottom()
-        return widget
-
-    def _add_system_message(self, content: str) -> MessageWidget:
-        """Add a system message.
-
-        Args:
-            content: Message content.
-
-        Returns:
-            The created MessageWidget.
-        """
-        # Don't save system messages to history usually, or maybe we do?
-        # Context usually stores them.
-        return self._add_message("system", content)
-
-    def _scroll_to_bottom(self) -> None:
-        """Scroll message area to bottom."""
-        # Guard against being called before _message_area is assigned
-        if not hasattr(self, "_message_area"):
-            return
-        scroll = self._message_area
-        scrollbar = scroll.verticalScrollBar()
-        if scrollbar is not None:
-            scrollbar.setValue(scrollbar.maximum())
-
-    def _set_status(self, status: str) -> None:
-        """Update status indicator.
-
-        Args:
-            status: Status text.
-        """
-        self._status_label.setText(status)
-
-    def _auto_index_enabled(self) -> bool:
-        """Return whether automatic indexing is currently enabled."""
-        if hasattr(self, "chk_auto_index"):
-            return bool(self.chk_auto_index.isChecked())
-        return self._auto_index_on_open
-
-    def _on_access_mode_changed(self, *_args: Any) -> None:
-        """Persist header access-mode changes immediately."""
-        if not hasattr(self, "_access_mode_combo"):
-            return
-        self._access_mode = coerce_access_mode(self._access_mode_combo.currentData())
+    # ------------------------------------------------------------------
+    # Theme
+    # ------------------------------------------------------------------
+    def refresh_theme(self) -> None:
         try:
-            from src.shared.python.ai.gui.settings_dialog import AISettings
+            from src.shared.python.theme.theme_manager import get_theme_manager
 
+            color_source: object = get_theme_manager().get_current_colors()
+
+            def _get(key: str, fallback: Any) -> Any:
+                if isinstance(color_source, dict):
+                    return color_source.get(key, fallback)
+                return getattr(color_source, key, fallback)
+
+            colors = {
+                "bg_primary": _get("bg", "#1e1e1e"),
+                "bg_alt": _get("bg_elevated", _get("group_bg", "#2d2d2d")),
+                "text_primary": _get("text_primary", _get("text", "#e0e0e0")),
+                "text_muted": _get("text_secondary", "#888888"),
+                "border": _get("border_default", _get("border", "#444444")),
+                "accent": _get("primary", _get("accent", "#FF8800")),
+                "button_hover": _get("bg_highlight", "#cc6d00"),
+            }
+        except ImportError:
+            return
+
+        self.setStyleSheet(
+            f"background-color: {colors['bg_primary']}; "
+            f"color: {colors['text_primary']};"
+        )
+        if hasattr(self, "_sidebar"):
+            self._sidebar.refresh_theme()
+        self._header.apply_theme(colors)
+        if hasattr(self, "_input_container"):
+            self._input_container.apply_theme(colors)
+        self._messages.apply_theme(colors)
+
+    # ------------------------------------------------------------------
+    # showEvent / lifecycle
+    # ------------------------------------------------------------------
+    def showEvent(self, event: Any) -> None:  # noqa: N802 - Qt API
+        super().showEvent(event)
+        self._refresh_models()
+        if self._auto_index_enabled():
+            self._start_indexing()
+
+    def _refresh_models(self) -> None:
+        if self._adapter is not None:
+            try:
+                self._auto_load_settings()
+            except Exception as exc:  # noqa: BLE001 - best-effort refresh
+                logger.warning(f"Failed to refresh models: {exc}")
+
+    def _auto_load_settings(self) -> None:
+        try:
+            settings = AISettings.load()
+        except ImportError as exc:
+            logger.warning("Failed to auto-load AI settings: %s", exc)
+            return
+        self.apply_settings(settings)
+
+    # ------------------------------------------------------------------
+    # Header back-compat helpers (tests touch these names)
+    # ------------------------------------------------------------------
+    def _sync_header_controls(self, settings: AISettings) -> None:
+        self._header.sync_controls(settings)
+
+    def _on_chat_models_refreshed(self, models: list[Any]) -> None:
+        names: list[str] = []
+        for entry in models:
+            if isinstance(entry, str) and entry:
+                names.append(entry)
+            elif isinstance(entry, dict):
+                name = entry.get("name")
+                if isinstance(name, str) and name:
+                    names.append(name)
+        self._header.update_models(names)
+
+    def bind_to_chat_dock(self, chat_dock: Any) -> None:
+        signal = getattr(chat_dock, "models_refreshed", None)
+        if signal is None or not hasattr(signal, "connect"):
+            return
+        with contextlib.suppress(TypeError):
+            signal.disconnect(self._on_chat_models_refreshed)
+        signal.connect(self._on_chat_models_refreshed)
+
+    # ------------------------------------------------------------------
+    # Header signal handlers
+    # ------------------------------------------------------------------
+    def _persist_header_selection(self, *, reconnect: bool) -> None:
+        provider = self._header.provider_combo.currentData()
+        if not isinstance(provider, AIProvider):
+            return
+        self._current_settings.provider = provider
+        self._current_settings.model = self._header.model_combo.currentText()
+        mode = self._header.mode_combo.currentData()
+        self._current_settings.chat_mode = mode if isinstance(mode, str) else "ask"
+        self._current_settings.save()
+        if reconnect:
+            self.apply_settings(self._current_settings)
+
+    def _on_header_provider_changed(self, _provider: AIProvider) -> None:
+        self._persist_header_selection(reconnect=True)
+
+    def _on_header_model_changed(self, _model: str) -> None:
+        self._persist_header_selection(reconnect=True)
+
+    def _on_header_mode_changed(self, _mode: str) -> None:
+        self._persist_header_selection(reconnect=False)
+
+    def _on_access_mode_changed(self, mode: ChatAccessMode) -> None:
+        self._access_mode = coerce_access_mode(mode)
+        try:
             settings = AISettings.load()
             settings.access_mode = self._access_mode
             settings.save()
         except (RuntimeError, ValueError, OSError, ImportError) as exc:
             logger.warning("Failed to persist chat access mode: %s", exc)
 
-    def _provider_tool_format(self) -> str:
-        """Infer the provider tool format expected by the current adapter."""
-        if self._adapter is None:
-            return "openai"
-        adapter_name = type(self._adapter).__name__.lower()
-        if "anthropic" in adapter_name:
-            return "anthropic"
-        return "openai"
-
-    def _build_tool_declarations(self) -> list[dict[str, Any]]:
-        """Build provider tool declarations permitted by access policy."""
-        return cast(
-            list[dict[str, Any]],
-            tool_declarations_for_access_mode(
-                self._tools_registry,
-                self._access_mode,
-                provider_format=self._provider_tool_format(),
-                rag_enabled=self._rag_enabled,
-                max_expertise=self._context.user_expertise.value,
-            ),
-        )
-
-    def _on_new_chat(self) -> None:
-        """Start a new chat session."""
-        # Clear messages (except welcome)
-        while self._message_layout.count() > 1:
-            item = self._message_layout.takeAt(0)
-            if item is not None:
-                widget = item.widget()
-                if widget is not None:
-                    # Disconnect any signals before deletion to prevent memory leaks
-                    if isinstance(widget, MessageWidget):
-                        try:
-                            doc = widget._content_label.document()
-                            if doc is not None:
-                                doc.contentsChanged.disconnect(widget._adjust_height)
-                        except (TypeError, RuntimeError, AttributeError):
-                            # Signal may not be connected or attribute missing
-                            pass
-                    widget.deleteLater()
-
-        # Reset context
-        self._context = ConversationContext()
-        self._refresh_prompt_memory()
+    # ------------------------------------------------------------------
+    # Send / streaming
+    # ------------------------------------------------------------------
+    def _on_send(self, message: str | None = None) -> None:
+        if message is None:
+            message = self._input_edit.toPlainText().strip()
+            if not message:
+                return
+            self._input_edit.clear()
+        self._add_message("user", message)
+        self._context.add_user_message(message)
         self._save_history()
+        self.message_sent.emit(message)
+        if self._adapter:
+            self._process_message(message)
 
-        # Add welcome back
-        self._add_system_message("🔄 New chat started. How can I help you?")
+    def _process_message(self, message: str) -> None:
+        if not self._adapter:
+            self._add_system_message(
+                "⚠️ No AI provider configured. Click ⚙️ to set up a provider."
+            )
+            return
+        self._refresh_prompt_memory()
+        self._set_status("Thinking...")
+        self._input_container.set_busy(True)
+        tools = self._build_tool_declarations()
+        self._current_worker = StreamWorker(
+            self._adapter, message, self._context, tools
+        )
+        self._current_worker.chunk_received.connect(self._on_stream_chunk)
+        self._current_worker.finished.connect(self._on_stream_finished)
+        self._current_worker.error.connect(self._on_stream_error)
+        self._current_assistant_message = self._add_message(
+            "assistant", "*Thinking...*"
+        )
+        self._is_first_chunk = True
+        self._current_worker.start()
+
+    def _on_stream_chunk(self, content: str) -> None:
+        if self._current_assistant_message:
+            if self._is_first_chunk:
+                self._current_assistant_message.set_content(content)
+                self._is_first_chunk = False
+            else:
+                self._current_assistant_message.append_content(content)
+            self._messages.scroll_to_bottom()
+
+    def _on_stream_finished(self) -> None:
+        self._set_status("Ready")
+        self._input_container.set_busy(False)
+        if self._current_assistant_message:
+            self._context.add_assistant_message(
+                self._current_assistant_message.get_content()
+            )
+            self._save_history()
+        self._current_assistant_message = None
+        self._disconnect_worker()
+
+    def _on_stream_error(self, error: str) -> None:
+        self._set_status("Error")
+        self._input_container.set_busy(False)
+        if self._current_assistant_message:
+            self._current_assistant_message.append_content(f"\n\n⚠️ **Error:** {error}")
+        self._current_assistant_message = None
+        self._disconnect_worker()
+
+    def _disconnect_worker(self) -> None:
+        if self._current_worker is None:
+            return
+        try:
+            self._current_worker.chunk_received.disconnect(self._on_stream_chunk)
+            self._current_worker.finished.disconnect(self._on_stream_finished)
+            self._current_worker.error.disconnect(self._on_stream_error)
+        except (TypeError, RuntimeError):
+            pass
+        self._current_worker = None
+
+    # ------------------------------------------------------------------
+    # Message helpers (delegate to MessageDisplayController)
+    # ------------------------------------------------------------------
+    def _add_message_to_ui(
+        self, role: str, content: str, timestamp: datetime | None = None
+    ) -> MessageWidget:
+        return self._messages.add_message(role, content, timestamp)
+
+    def _add_message(
+        self, role: str, content: str, timestamp: datetime | None = None
+    ) -> MessageWidget:
+        return self._messages.add_message(role, content, timestamp)
+
+    def _add_system_message(self, content: str) -> MessageWidget:
+        return self._messages.add_system_message(content)
+
+    def _restore_ui_messages(self) -> None:
+        self._messages.restore_from_context(self._context)
+
+    def _scroll_to_bottom(self) -> None:
+        self._messages.scroll_to_bottom()
+
+    def _set_status(self, status: str) -> None:
+        self._header.set_status(status)
+
+    # ------------------------------------------------------------------
+    # Indexing / memory
+    # ------------------------------------------------------------------
+    def _auto_index_enabled(self) -> bool:
+        if hasattr(self._header, "auto_index_checkbox"):
+            return self._header.auto_index_enabled()
+        return self._auto_index_on_open
+
+    def _start_indexing(self) -> None:
+        self._indexer.start()
+
+    def _on_indexing_finished(self, docs_indexed: int) -> None:
+        self._set_status(f"Index ready ({docs_indexed} docs)")
+
+    def _on_indexing_error(self, error: str) -> None:
+        self._set_status(f"Index error: {error}")
 
     def _refresh_prompt_memory(self) -> None:
-        """Attach bounded memory and project context to the active session."""
         self._context.metadata["prompt_memory"] = (
             self._memory_manager.build_prompt_memory()
         )
         self._context.metadata["project_root"] = str(self._project_root)
 
     def _on_memory_sync_requested(self) -> None:
-        """Digest archived conversations into persistent prompt memory."""
         archived_contexts: list[ConversationContext] = []
         for session in self._session_manager.list_sessions():
             if not session.get("archived", False):
@@ -1128,27 +554,54 @@ class AIAssistantPanel(QWidget):
             f"Memory sync complete. Added {inserted} archived preference(s)."
         )
 
-    def set_adapter(self, adapter: BaseAgentAdapter) -> None:
-        """Set the AI adapter to use.
+    # ------------------------------------------------------------------
+    # New chat
+    # ------------------------------------------------------------------
+    def _on_new_chat(self) -> None:
+        self._messages.clear_messages()
+        self._context = ConversationContext()
+        self._refresh_prompt_memory()
+        self._save_history()
+        self._add_system_message("🔄 New chat started. How can I help you?")
 
-        Args:
-            adapter: AI adapter instance.
-        """
-        if adapter is None:
-            raise ValueError("adapter must be provided")
+    # ------------------------------------------------------------------
+    # Tool declarations
+    # ------------------------------------------------------------------
+    def _provider_tool_format(self) -> str:
+        if self._adapter is None:
+            return "openai"
+        adapter_name = type(self._adapter).__name__.lower()
+        if "anthropic" in adapter_name:
+            return "anthropic"
+        return "openai"
+
+    def _build_tool_declarations(self) -> list[dict[str, Any]]:
+        return cast(
+            list[dict[str, Any]],
+            tool_declarations_for_access_mode(
+                self._tools_registry,
+                self._access_mode,
+                provider_format=self._provider_tool_format(),
+                rag_enabled=self._rag_enabled,
+                max_expertise=self._context.user_expertise.value,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Adapter / settings
+    # ------------------------------------------------------------------
+    def set_adapter(self, adapter: BaseAgentAdapter) -> None:
         if adapter is None:
             raise ValueError("adapter must be provided")
         self._adapter = adapter
         self._set_status("Ready")
 
-    def set_expertise_level(self, level: ExpertiseLevel) -> None:
-        """Set the user's expertise level.
+    def _on_adapter_changed(self, adapter: Any, _adapter_id: str) -> None:
+        if adapter is not None:
+            self._adapter = adapter
+            self._set_status("Ready")
 
-        Args:
-            level: Expertise level.
-        """
-        if level is None:
-            raise ValueError("level must be provided")
+    def set_expertise_level(self, level: ExpertiseLevel) -> None:
         if level is None:
             raise ValueError("level must be provided")
         self._context.user_expertise = level
@@ -1158,43 +611,28 @@ class AIAssistantPanel(QWidget):
             ExpertiseLevel.ADVANCED: "Concise",
             ExpertiseLevel.EXPERT: "Minimal",
         }
-        self._expertise_label.setText(f"Verbosity: {level_names[level]}")
+        self._input_container.set_expertise_text(f"Verbosity: {level_names[level]}")
 
-    def apply_settings(self, settings: AISettings) -> None:  # noqa: C901
-        """Apply settings from dialog.
-
-        Args:
-            settings: Settings to apply.
-        """
+    def apply_settings(self, settings: AISettings) -> None:
+        """Apply settings: sync header, update labels, build adapter."""
         if settings is None:
             raise ValueError("settings must be provided")
-        if settings is None:
-            raise ValueError("settings must be provided")
-        from src.shared.python.ai.gui.settings_dialog import get_api_key
-        from src.shared.python.ai.types import ExpertiseLevel
 
         self._current_settings = settings
-        self._sync_header_controls(settings)
+        self._header.sync_controls(settings)
 
-        # Update Header Icons
         provider_icons = {
             AIProvider.OLLAMA: "🦙",
             AIProvider.OPENAI: "🧠",
             AIProvider.ANTHROPIC: "🤖",
             AIProvider.GEMINI: "✨",
         }
-        icon = provider_icons.get(settings.provider, "🤖")
-        self._provider_icon.setText(icon)
-
-        # Update Model Label
-        self._model_label.setText(
-            f"{provider_display_name(settings.provider)} ({settings.model})"
-        )
-        self._model_label.setToolTip(
-            f"Provider: {settings.provider.name}\nModel: {settings.model}"
+        self._header.set_provider_icon(provider_icons.get(settings.provider, "🤖"))
+        self._header.set_model_label(
+            f"{provider_display_name(settings.provider)} ({settings.model})",
+            tooltip=f"Provider: {settings.provider.name}\nModel: {settings.model}",
         )
 
-        # Set expertise level
         level_map = {
             1: ExpertiseLevel.BEGINNER,
             2: ExpertiseLevel.INTERMEDIATE,
@@ -1208,127 +646,14 @@ class AIAssistantPanel(QWidget):
         self._rag_enabled = settings.rag_enabled
         self._auto_index_on_open = settings.auto_index_on_open
         self._access_mode = coerce_access_mode(settings.access_mode)
-        if hasattr(self, "chk_auto_index"):
-            self.chk_auto_index.setChecked(settings.auto_index_on_open)
-        if hasattr(self, "_access_mode_combo"):
-            for i in range(self._access_mode_combo.count()):
-                if self._access_mode_combo.itemData(i) == self._access_mode:
-                    self._access_mode_combo.blockSignals(True)
-                    self._access_mode_combo.setCurrentIndex(i)
-                    self._access_mode_combo.blockSignals(False)
-                    break
+        self._header.set_auto_index_checked(settings.auto_index_on_open)
+        self._header.sync_access_mode(self._access_mode)
 
-        # Create adapter based on provider
-        adapter: BaseAgentAdapter | None = None
-
-        if settings.provider == AIProvider.OLLAMA:
-            try:
-                from src.shared.python.ai.adapters.rust_adapter import RustAgentAdapter
-
-                adapter = RustAgentAdapter(
-                    api_key="ollama",
-                    base_url=settings.ollama_host,
-                    model=settings.model,
-                    chat_path="/v1/chat/completions",
-                    embed_path="/v1/embeddings",
-                )
-                self._add_system_message("🚀 Using high-performance Rust AI backend.")
-            except ImportError:
-                from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
-
-                adapter = OllamaAdapter(
-                    host=settings.ollama_host,
-                    model=settings.model,
-                )
-        elif settings.provider == AIProvider.OPENAI:
-            api_key = get_api_key(AIProvider.OPENAI)
-            if api_key:
-                from src.shared.python.ai.adapters.openai_adapter import OpenAIAdapter
-
-                adapter = OpenAIAdapter(
-                    api_key=api_key,
-                    model=settings.model,
-                )
-        elif settings.provider == AIProvider.ANTHROPIC:
-            api_key = get_api_key(AIProvider.ANTHROPIC)
-            if api_key:
-                from src.shared.python.ai.adapters.anthropic_adapter import (
-                    AnthropicAdapter,
-                )
-
-                adapter = AnthropicAdapter(
-                    api_key=api_key,
-                    model=settings.model,
-                )
-        elif settings.provider == AIProvider.GEMINI:
-            api_key = get_api_key(AIProvider.GEMINI)
-            if api_key:
-                from src.shared.python.ai.adapters.gemini_adapter import GeminiAdapter
-
-                adapter = GeminiAdapter(
-                    api_key=api_key,
-                    model=settings.model,
-                )
-
-        if adapter:
-            self.set_adapter(adapter)
-            self._add_system_message(
-                f"✓ Connected to {settings.provider.name} ({settings.model})"
-            )
-        else:
-            self._add_system_message(
-                f"⚠️ Could not connect to {settings.provider.name}. "
-                "Please check your settings."
-            )
+        self._adapter_mgr.build(settings)
 
     def _show_settings(self) -> None:
-        """Show the settings dialog."""
         dialog = AISettingsDialog(self)
         dialog.settings_changed.connect(self.apply_settings)
         if hasattr(dialog, "rebuild_index_requested"):
             dialog.rebuild_index_requested.connect(self._start_indexing)
         dialog.open()
-
-    def _start_indexing(self) -> None:
-        """Start the codebase indexing process."""
-        if self._indexer_worker is not None and self._indexer_worker.isRunning():
-            self._set_status("Indexing already in progress...")
-            return
-        self._set_status("Indexing codebase...")
-        self._add_system_message("Indexing local codebase context...")
-
-        # Safer: use CWD if it's the repo root, or try to find it.
-        # Prefer the active checkout root when available.
-        # and we want to index 'src'.
-
-        repo_root = Path(__file__).resolve().parent  # gui
-        while repo_root.name != "src" and repo_root.parent != repo_root:
-            repo_root = repo_root.parent
-
-        # We found src, let's index from here
-        # Fallback
-        src_path = repo_root if repo_root.name == "src" else Path("src").resolve()
-
-        if not src_path.exists():
-            logger.error(f"Could not find src directory to index at {src_path}")
-            self._set_status("Error: 'src' not found")
-            self._add_system_message("Codebase indexing failed: 'src' not found.")
-            return
-
-        self._indexer_worker = IndexerWorker(src_path, self._rag_store)
-        self._indexer_worker.progress.connect(self._set_status)
-        self._indexer_worker.finished.connect(self._on_indexing_finished)
-        self._indexer_worker.error.connect(self._on_indexing_error)
-        self._indexer_worker.start()
-
-    def _on_indexing_finished(self, docs_indexed: int) -> None:
-        """Handle successful local codebase indexing."""
-        self._set_status(f"Index ready ({docs_indexed} docs)")
-        self._add_system_message(f"Codebase index ready ({docs_indexed} docs indexed).")
-        self._indexer_worker = None
-
-    def _on_indexing_error(self, error: str) -> None:
-        """Handle local codebase indexing failure."""
-        self._set_status(f"Index error: {error}")
-        self._add_system_message(f"Codebase indexing failed: {error}")
-        self._indexer_worker = None

--- a/tests/shared/python/chat/test_adapter_lifecycle.py
+++ b/tests/shared/python/chat/test_adapter_lifecycle.py
@@ -1,0 +1,107 @@
+"""Unit tests for AdapterLifecycleManager."""
+
+from __future__ import annotations
+
+import sys
+import types
+from logging import getLogger
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+src_pkg = types.ModuleType("src")
+src_pkg.__path__ = [str(ROOT / "src")]
+sys.modules.setdefault("src", src_pkg)
+
+logging_pkg = types.ModuleType("src.shared.python.logging_pkg")
+logging_config = types.ModuleType("src.shared.python.logging_pkg.logging_config")
+logging_config.get_logger = getLogger
+logging_config.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("src.shared.python.logging_pkg", logging_pkg)
+sys.modules.setdefault("src.shared.python.logging_pkg.logging_config", logging_config)
+
+config_pkg = types.ModuleType("src.shared.python.config")
+environment = types.ModuleType("src.shared.python.config.environment")
+environment.get_env = lambda _name, default=None, **_k: default
+environment.get_env_float = lambda _name, default=None, **_k: default
+sys.modules.setdefault("src.shared.python.config", config_pkg)
+sys.modules.setdefault("src.shared.python.config.environment", environment)
+
+pytest.importorskip("PyQt6.QtCore")
+
+
+@pytest.fixture
+def qapp():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_build_emits_failure_when_no_api_key(monkeypatch, qapp):
+    from src.shared.python.ai.gui import _adapter_lifecycle
+    from src.shared.python.ai.gui._adapter_lifecycle import AdapterLifecycleManager
+    from src.shared.python.ai.gui.settings_dialog import (
+        AIProvider,
+        AISettings,
+        provider_default_model,
+    )
+
+    monkeypatch.setattr(_adapter_lifecycle, "AISettings", AISettings)
+    # stub get_api_key to None so OpenAI build returns None
+    settings_module = sys.modules["src.shared.python.ai.gui.settings_dialog"]
+    monkeypatch.setattr(settings_module, "get_api_key", lambda *_a, **_k: None)
+
+    mgr = AdapterLifecycleManager()
+    seen: list = []
+    mgr.adapter_changed.connect(lambda adapter, _id: seen.append(adapter))
+
+    settings = AISettings(
+        provider=AIProvider.OPENAI,
+        model=provider_default_model(AIProvider.OPENAI),
+        chat_mode="ask",
+    )
+    result = mgr.build(settings)
+    assert result is None
+    assert seen == [None]
+
+
+def test_build_emits_system_message_for_unknown_provider(qapp):
+    from src.shared.python.ai.gui._adapter_lifecycle import AdapterLifecycleManager
+    from src.shared.python.ai.gui.settings_dialog import AISettings
+
+    mgr = AdapterLifecycleManager()
+    msgs: list[str] = []
+    mgr.system_message.connect(msgs.append)
+
+    # Construct a minimal-shape settings object whose provider is not handled.
+    class FakeProvider:
+        name = "FAKE"
+
+    fake = AISettings.__new__(AISettings)
+    fake.provider = FakeProvider()  # type: ignore[assignment]
+    fake.model = "x"
+    fake.chat_mode = "ask"
+
+    mgr.build(fake)
+    assert any("Could not connect" in m for m in msgs)
+
+
+def test_construct_returns_none_for_unhandled_provider(qapp):
+    from src.shared.python.ai.gui._adapter_lifecycle import AdapterLifecycleManager
+
+    mgr = AdapterLifecycleManager()
+
+    class Settings:
+        class P:
+            pass
+
+        provider = P()
+        model = ""
+        chat_mode = "ask"
+
+    assert mgr._construct(Settings()) is None  # noqa: SLF001

--- a/tests/shared/python/chat/test_chat_dock_widget.py
+++ b/tests/shared/python/chat/test_chat_dock_widget.py
@@ -361,6 +361,7 @@ class TestChatDockWidget:
         assert "test assistant message" in text
 
         widget.close()
+
     def test_get_thread_markdown_uses_real_newlines(self, qtbot):
         """_get_thread_markdown must use real newlines (chr(10)), not literal \\n."""
         from chat.chat_dock_widget import ChatDockWidget

--- a/tests/shared/python/chat/test_indexing_controller.py
+++ b/tests/shared/python/chat/test_indexing_controller.py
@@ -1,0 +1,87 @@
+"""Unit tests for IndexingController."""
+
+from __future__ import annotations
+
+import sys
+import types
+from logging import getLogger
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+src_pkg = types.ModuleType("src")
+src_pkg.__path__ = [str(ROOT / "src")]
+sys.modules.setdefault("src", src_pkg)
+
+logging_pkg = types.ModuleType("src.shared.python.logging_pkg")
+logging_config = types.ModuleType("src.shared.python.logging_pkg.logging_config")
+logging_config.get_logger = getLogger
+logging_config.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("src.shared.python.logging_pkg", logging_pkg)
+sys.modules.setdefault("src.shared.python.logging_pkg.logging_config", logging_config)
+
+config_pkg = types.ModuleType("src.shared.python.config")
+environment = types.ModuleType("src.shared.python.config.environment")
+environment.get_env = lambda _name, default=None, **_k: default
+environment.get_env_float = lambda _name, default=None, **_k: default
+sys.modules.setdefault("src.shared.python.config", config_pkg)
+sys.modules.setdefault("src.shared.python.config.environment", environment)
+
+pytest.importorskip("PyQt6.QtCore")
+
+
+@pytest.fixture
+def qapp():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def _make_controller(qapp):
+    from src.shared.python.ai.gui._indexing import IndexingController
+
+    return IndexingController(MagicMock())
+
+
+def test_finished_signal_emitted_with_count(qapp):
+    ctrl = _make_controller(qapp)
+    out: list[int] = []
+    ctrl.finished.connect(out.append)
+    ctrl._on_finished(42)  # noqa: SLF001 - exercising lifecycle handler
+    assert out == [42]
+    assert ctrl.worker is None
+
+
+def test_failed_signal_emitted_with_message(qapp):
+    ctrl = _make_controller(qapp)
+    errs: list[str] = []
+    ctrl.failed.connect(errs.append)
+    ctrl._on_error("boom")  # noqa: SLF001
+    assert errs == ["boom"]
+
+
+def test_status_changed_on_completion(qapp):
+    ctrl = _make_controller(qapp)
+    statuses: list[str] = []
+    ctrl.status_changed.connect(statuses.append)
+    ctrl._on_finished(7)  # noqa: SLF001
+    assert any("Index ready" in s for s in statuses)
+
+
+def test_system_message_on_error(qapp):
+    ctrl = _make_controller(qapp)
+    msgs: list[str] = []
+    ctrl.system_message.connect(msgs.append)
+    ctrl._on_error("x")  # noqa: SLF001
+    assert any("indexing failed" in m for m in msgs)
+
+
+def test_is_running_false_when_no_worker(qapp):
+    ctrl = _make_controller(qapp)
+    assert ctrl.is_running is False

--- a/tests/shared/python/chat/test_message_display.py
+++ b/tests/shared/python/chat/test_message_display.py
@@ -1,0 +1,89 @@
+"""Unit tests for MessageDisplayController."""
+
+from __future__ import annotations
+
+import sys
+import types
+from logging import getLogger
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+src_pkg = types.ModuleType("src")
+src_pkg.__path__ = [str(ROOT / "src")]
+sys.modules.setdefault("src", src_pkg)
+
+logging_pkg = types.ModuleType("src.shared.python.logging_pkg")
+logging_config = types.ModuleType("src.shared.python.logging_pkg.logging_config")
+logging_config.get_logger = getLogger
+logging_config.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("src.shared.python.logging_pkg", logging_pkg)
+sys.modules.setdefault("src.shared.python.logging_pkg.logging_config", logging_config)
+
+config_pkg = types.ModuleType("src.shared.python.config")
+environment = types.ModuleType("src.shared.python.config.environment")
+environment.get_env = lambda _name, default=None, **_k: default
+environment.get_env_float = lambda _name, default=None, **_k: default
+sys.modules.setdefault("src.shared.python.config", config_pkg)
+sys.modules.setdefault("src.shared.python.config.environment", environment)
+
+pytest.importorskip("PyQt6.QtWidgets")
+
+
+@pytest.fixture
+def qapp():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+@pytest.fixture
+def display(qapp):
+    from src.shared.python.ai.gui._message_display import MessageDisplayController
+
+    return MessageDisplayController()
+
+
+def test_initial_layout_has_only_stretch(display):
+    # The trailing stretch is a non-widget item; count() == 1 means just stretch.
+    assert display.message_layout.count() == 1
+
+
+def test_add_message_inserts_widget(display):
+    w = display.add_message("user", "hello")
+    assert w is not None
+    # one widget + stretch
+    assert display.message_layout.count() == 2
+
+
+def test_add_system_message_emits_signal(display):
+    received: list = []
+    display.message_added.connect(received.append)
+    w = display.add_system_message("welcome")
+    assert received and received[-1] is w
+
+
+def test_clear_messages_keeps_only_stretch(display):
+    display.add_message("user", "a")
+    display.add_message("assistant", "b")
+    display.add_system_message("c")
+    assert display.message_layout.count() == 4
+
+    display.clear_messages()
+    assert display.message_layout.count() == 1
+
+
+def test_restore_from_context_skips_system(display):
+    from src.shared.python.ai.types import ConversationContext
+
+    ctx = ConversationContext()
+    ctx.add_user_message("hi")
+    ctx.add_assistant_message("hello back")
+    # add_user_message / add_assistant_message both push real (non-system) items
+    display.restore_from_context(ctx)
+    assert display.message_layout.count() == 1 + len(ctx.messages)

--- a/tests/shared/python/chat/test_panel_header.py
+++ b/tests/shared/python/chat/test_panel_header.py
@@ -1,0 +1,124 @@
+"""Unit tests for PanelHeaderController."""
+
+from __future__ import annotations
+
+import sys
+import types
+from logging import getLogger
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+src_pkg = types.ModuleType("src")
+src_pkg.__path__ = [str(ROOT / "src")]
+sys.modules.setdefault("src", src_pkg)
+
+logging_pkg = types.ModuleType("src.shared.python.logging_pkg")
+logging_config = types.ModuleType("src.shared.python.logging_pkg.logging_config")
+logging_config.get_logger = getLogger
+logging_config.setup_logging = lambda *a, **k: None
+sys.modules.setdefault("src.shared.python.logging_pkg", logging_pkg)
+sys.modules.setdefault("src.shared.python.logging_pkg.logging_config", logging_config)
+
+config_pkg = types.ModuleType("src.shared.python.config")
+environment = types.ModuleType("src.shared.python.config.environment")
+environment.get_env = lambda _name, default=None, **_k: default
+environment.get_env_float = lambda _name, default=None, **_k: default
+sys.modules.setdefault("src.shared.python.config", config_pkg)
+sys.modules.setdefault("src.shared.python.config.environment", environment)
+
+pytest.importorskip("PyQt6.QtWidgets")
+
+
+@pytest.fixture
+def header(qapp):
+    from src.shared.python.ai.gui._panel_header import PanelHeaderController
+    from src.shared.python.ai.gui.settings_dialog import (
+        AIProvider,
+        AISettings,
+        provider_default_model,
+    )
+
+    settings = AISettings(
+        provider=AIProvider.OLLAMA,
+        model=provider_default_model(AIProvider.OLLAMA),
+        chat_mode="ask",
+    )
+    return PanelHeaderController(settings)
+
+
+@pytest.fixture
+def qapp():
+    from PyQt6.QtWidgets import QApplication
+
+    app = QApplication.instance() or QApplication([])
+    return app
+
+
+def test_header_populates_combos(header):
+    from src.shared.python.ai.gui.settings_dialog import AIProvider
+
+    data = [
+        header.provider_combo.itemData(i) for i in range(header.provider_combo.count())
+    ]
+    assert data == list(AIProvider)
+    assert header.mode_combo.count() == 3
+    assert header.access_mode_combo.count() == 3
+
+
+def test_provider_change_emits_signal(header):
+    from src.shared.python.ai.gui.settings_dialog import AIProvider
+
+    received: list = []
+    header.provider_changed.connect(received.append)
+
+    idx = header.provider_combo.findData(AIProvider.OPENAI)
+    header.provider_combo.setCurrentIndex(idx)
+
+    assert received and received[-1] == AIProvider.OPENAI
+
+
+def test_update_models_replaces_options(header):
+    header.update_models(["alpha", "beta", "gamma"])
+    texts = [header.model_combo.itemText(i) for i in range(header.model_combo.count())]
+    assert texts == ["alpha", "beta", "gamma"]
+
+
+def test_set_status_updates_label(header):
+    header.set_status("Working...")
+    assert header.status_label.text() == "Working..."
+
+
+def test_auto_index_checkbox_round_trip(header):
+    received: list = []
+    header.auto_index_toggled.connect(received.append)
+    header.auto_index_checkbox.setChecked(True)
+    assert header.auto_index_enabled() is True
+    assert received and received[-1] is True
+
+
+def test_sync_controls_does_not_emit(header):
+    from src.shared.python.ai.gui.settings_dialog import (
+        AIProvider,
+        AISettings,
+        provider_default_model,
+    )
+
+    bursts: list = []
+    header.provider_changed.connect(bursts.append)
+    header.model_changed.connect(bursts.append)
+    header.mode_changed.connect(bursts.append)
+
+    header.sync_controls(
+        AISettings(
+            provider=AIProvider.ANTHROPIC,
+            model=provider_default_model(AIProvider.ANTHROPIC),
+            chat_mode="agent",
+        )
+    )
+
+    assert bursts == []

--- a/tests/shared/python/chat/test_router_error_logging.py
+++ b/tests/shared/python/chat/test_router_error_logging.py
@@ -39,7 +39,11 @@ class _FakeChatService(ChatServiceBase):
         self._review_fn: Any = AsyncMock(return_value="review_session_123")
         self._refresh_fn: Any = AsyncMock(return_value=[])
         self._index_fn: Any = AsyncMock(
-            return_value={"state": "complete", "files_parsed": 10, "symbols_inserted": 50}
+            return_value={
+                "state": "complete",
+                "files_parsed": 10,
+                "symbols_inserted": 50,
+            }
         )
 
     async def stream_response(self, session_id: str) -> AsyncIterator[Any]:
@@ -248,7 +252,9 @@ class TestRequestReviewErrorLogging:
 
 
 class TestNewActionsErrorLogging:
-    def test_refresh_models_error_logging(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_refresh_models_error_logging(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """AIProviderError from refresh_models → warning."""
         service = _FakeChatService()
         service._refresh_fn = AsyncMock(side_effect=AIProviderError("failed to poll"))
@@ -263,7 +269,9 @@ class TestNewActionsErrorLogging:
         assert payload == {"type": "error", "detail": "failed to poll"}
         assert any("Refresh models failed" in r.message for r in caplog.records)
 
-    def test_index_codebase_error_logging(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_index_codebase_error_logging(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """AIProviderError from index_codebase → warning."""
         service = _FakeChatService()
         service._index_fn = AsyncMock(side_effect=AIProviderError("disk full"))


### PR DESCRIPTION
Closes #2761.

Decomposes the 1334-line `AIAssistantPanel` god class into focused, signal-based controllers:

- **PanelHeaderController** (`_panel_header.py`) — header strip (provider/model/mode combos, access mode, auto-index, action buttons). 325 lines.
- **MessageDisplayController** (`_message_display.py`) — scrollable message log (`QScrollArea` + `MessageWidget` lifecycle). 157 lines.
- **AdapterLifecycleManager** (`_adapter_lifecycle.py`) — provider/key resolution and adapter construction including the silent Rust-fallback for Ollama. 125 lines.
- **IndexingController** (`_indexing.py`) — RAG codebase index lifecycle. 81 lines.
- **InputArea** (`_input_area.py`) — compose box + Send button + verbosity indicator. Extracted opportunistically because it kept the panel above 700 lines. 151 lines.
- **register_panel_tools** (`_panel_tools.py`) — module-level tool registration helper. 56 lines.

`AIAssistantPanel` (`assistant_panel.py`) is now a coordinator wiring the controllers via `pyqtSignal` slots — controllers do not hold back-references to the panel.

### API stability

Public API is unchanged. Back-compat property proxies (`_provider_combo`, `_model_combo`, `_mode_combo`, `_message_layout`, `_input_edit`, `chk_auto_index`, `_indexer_worker`, etc.) keep external callers and existing tests working without modification.

### Final size

| Module | Lines |
|---|---|
| `assistant_panel.py` | 659 (down from 1334, **-50%**) |
| `_panel_header.py` | 325 |
| `_message_display.py` | 157 |
| `_input_area.py` | 151 |
| `_adapter_lifecycle.py` | 125 |
| `_indexing.py` | 81 |
| `_panel_tools.py` | 56 |

The panel is above the 400-line target — most of the residue is the back-compat property block (~14 properties), the four header signal handlers that route persistence + reconnect, the streaming worker plumbing, and `apply_settings`. Further extraction (e.g., a dedicated `StreamSession` controller) is sensible follow-up work but not strictly required by #2761's bucket list.

## Test plan
- [x] Each controller has its own test file (5 tests for PanelHeader, 5 for MessageDisplay, 5 for IndexingController, 3 for AdapterLifecycle = 18 new tests).
- [x] Existing `test_assistant_panel_memory_sync.py` passes unchanged.
- [x] `test_assistant_panel_inline_controls.py` has a pre-existing PyQt6/PySide6 environment failure on `qtbot.addWidget` — verified to fail identically on `origin/main` before this change. Not caused by this refactor.
- [x] No new module exceeds 500 lines.
- [x] `ruff check` clean on all touched files.
- [x] `ruff format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)