### PR TITLE
fix(security): refuse fake OAuth login (Phase 1 of #2757)

### DIFF
--- a/src/shared/python/ai/auth/authentication.py
+++ b/src/shared/python/ai/auth/authentication.py
@@ -4,10 +4,18 @@ This module provides user authentication and subscription management
 for AI-powered features in the UpstreamDrift application.
 
 Features:
-    - User authentication via API keys or OAuth
+    - User authentication via API keys
     - Subscription tier management (Free, Pro, Enterprise)
     - Feature gating based on subscription level
     - Secure token storage and refresh
+
+Note:
+    OAuth and email/password authentication methods are NOT implemented.
+    ``login_with_oauth`` and ``login_with_email_password`` raise
+    ``NotImplementedError`` unconditionally (Phase 1 of issue #2757).
+    Real OAuth (PKCE + token exchange + refresh tokens) is tracked in the
+    Phase 2 follow-up issue.  Until then, ``is_authenticated`` will always
+    return False unless a valid API key is supplied via ``login_with_api_key``.
 
 Example:
     >>> from src.shared.python.ai.auth.authentication import AuthManager
@@ -313,23 +321,53 @@ class AuthManager:
             auth_code: Authorization code from OAuth flow.
 
         Returns:
-            True if login successful, False otherwise.
+            Never returns — always raises ``NotImplementedError``.
+
+        Raises:
+            NotImplementedError: Always. Real OAuth (PKCE + token exchange +
+                refresh-token handling) is deferred to Phase 2 (issue #5227).
+                To use authenticated features, configure provider credentials
+                directly via the keyring (chat/credentials.py) and supply an
+                API key via ``login_with_api_key`` instead.
 
         Note:
-            This is a placeholder for OAuth implementation.
-            In production, exchange auth_code for tokens with the provider.
+            Phase 1 of issue #2757 removes the previously fabricated
+            ``UserProfile`` that this method used to return so that callers
+            can no longer be misled into trusting a fake identity.
         """
-        logger.info("OAuth login with provider: %s", provider)
-        # TODO(#5227): Implement OAuth token exchange
-        # For now, create a demo user
-        self._current_user = UserProfile(
-            user_id=f"oauth_{provider}_{secrets.token_hex(8)}",
-            email=f"user@{provider}.com",
-            subscription_tier=SubscriptionTier.FREE,
-            features_enabled=["ollama_chat", "basic_tools"],
+        raise NotImplementedError(
+            f"OAuth login for provider {provider!r} is not implemented (TODO #5227). "
+            "To use authenticated features, configure provider credentials directly "
+            "via the keyring (chat/credentials.py) and skip the OAuth flow."
         )
-        self._save_credentials()
-        return True
+
+    def login_with_email_password(self, email: str, password: str) -> bool:
+        """Login using email and password.
+
+        Args:
+            email: User email address.
+            password: User password.
+
+        Returns:
+            Never returns — always raises ``NotImplementedError``.
+
+        Raises:
+            NotImplementedError: Always. Email/password authentication requires
+                a backend service (e.g. Supabase, Auth0) that has not yet been
+                selected or configured (Phase 2, issue #5227).
+                To use authenticated features, supply an API key via
+                ``login_with_api_key`` instead.
+
+        Note:
+            Phase 1 of issue #2757 removes the previously fabricated
+            ``UserProfile`` that this method used to return so that callers
+            can no longer be misled into trusting a fake identity.
+        """
+        raise NotImplementedError(
+            f"Email/password login for {email!r} is not implemented (TODO #5227). "
+            "To use authenticated features, supply an API key via login_with_api_key. "
+            "Email/password auth requires a backend service — see Phase 2 of #2757."
+        )
 
     def logout(self) -> None:
         """Logout and clear credentials."""
@@ -349,7 +387,15 @@ class AuthManager:
 
     @property
     def is_authenticated(self) -> bool:
-        """Check if user is authenticated."""
+        """Check if user is authenticated.
+
+        Returns:
+            True only when a ``UserProfile`` is present and its subscription
+            is active.  After a refused login attempt (``login_with_oauth`` or
+            ``login_with_email_password`` raising ``NotImplementedError``) no
+            profile is set, so this property returns False.  Callers must check
+            this explicitly before consuming gated features.
+        """
         return self._current_user is not None and self._current_user.is_active()
 
     @property

--- a/tests/shared/python/ai/test_authentication.py
+++ b/tests/shared/python/ai/test_authentication.py
@@ -1,0 +1,209 @@
+"""Tests for authentication.py — Phase 1 of issue #2757.
+
+Verifies that fake OAuth / email-password login methods refuse to fabricate
+a UserProfile, and that ``is_authenticated`` defaults to False in the absence
+of a real login.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: add repo root to sys.path and stub logging_pkg so that importing
+# authentication.py works in a plain pytest run (mirrors pattern in
+# test_adapter_factory.py).
+# ---------------------------------------------------------------------------
+
+_ROOT = Path(__file__).resolve().parents[4]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str | None]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.auth", "src/shared/python/ai/auth"),
+    ("src.shared.python.logging_pkg", None),
+    ("src.shared.python.logging_pkg.logging_config", None),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        if _rel_path is not None:
+            _stub.__path__ = [str(_ROOT / _rel_path)]  # type: ignore[attr-defined]
+        sys.modules[_mod_name] = _stub
+
+_logging_config_stub = sys.modules["src.shared.python.logging_pkg.logging_config"]
+_logging_config_stub.get_logger = logging.getLogger  # type: ignore[attr-defined]
+
+from src.shared.python.ai.auth.authentication import (  # noqa: E402
+    AuthManager,
+    UserProfile,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_auth(tmp_path: Path) -> AuthManager:
+    """Return an ``AuthManager`` that writes credentials to *tmp_path*."""
+    creds_file = tmp_path / "auth_credentials.json"
+    with patch.object(AuthManager, "CREDENTIALS_FILE", new=creds_file):
+        auth = AuthManager()
+    # Patch at the instance level so subsequent calls use the same path.
+    auth.__class__.CREDENTIALS_FILE = creds_file  # type: ignore[assignment]
+    return auth
+
+
+# ---------------------------------------------------------------------------
+# login_with_oauth
+# ---------------------------------------------------------------------------
+
+
+class TestLoginWithOauth:
+    """login_with_oauth must raise NotImplementedError unconditionally."""
+
+    def test_raises_not_implemented(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("google", "any_code")
+
+    def test_raises_for_arbitrary_provider(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("github", "abc123")
+
+    def test_error_message_mentions_provider(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError, match="google"):
+            auth.login_with_oauth("google", "any_code")
+
+    def test_error_message_mentions_issue_number(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError, match="#5227"):
+            auth.login_with_oauth("google", "any_code")
+
+    def test_credentials_file_not_created(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        creds_file = auth.CREDENTIALS_FILE
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("google", "any_code")
+        msg = "CREDENTIALS_FILE must not be written on refused login"
+        assert not creds_file.exists(), msg
+
+    def test_is_authenticated_false_after_refused_login(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("google", "any_code")
+        assert auth.is_authenticated is False
+
+    def test_current_user_none_after_refused_login(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("google", "any_code")
+        assert auth.current_user is None
+
+
+# ---------------------------------------------------------------------------
+# login_with_email_password
+# ---------------------------------------------------------------------------
+
+
+class TestLoginWithEmailPassword:
+    """login_with_email_password must raise NotImplementedError unconditionally."""
+
+    def test_raises_not_implemented(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_email_password("user@example.com", "password123")
+
+    def test_error_message_mentions_email(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError, match="user@example.com"):
+            auth.login_with_email_password("user@example.com", "password123")
+
+    def test_error_message_mentions_issue_number(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError, match="#5227"):
+            auth.login_with_email_password("user@example.com", "password123")
+
+    def test_credentials_file_not_created(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        creds_file = auth.CREDENTIALS_FILE
+        with pytest.raises(NotImplementedError):
+            auth.login_with_email_password("user@example.com", "password123")
+        msg = "CREDENTIALS_FILE must not be written on refused login"
+        assert not creds_file.exists(), msg
+
+    def test_is_authenticated_false_after_refused_login(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_email_password("user@example.com", "password123")
+        assert auth.is_authenticated is False
+
+    def test_current_user_none_after_refused_login(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_email_password("user@example.com", "password123")
+        assert auth.current_user is None
+
+
+# ---------------------------------------------------------------------------
+# is_authenticated default behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestIsAuthenticated:
+    """is_authenticated must return False when no valid auth method succeeds."""
+
+    def test_false_on_fresh_manager(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        assert auth.is_authenticated is False
+
+    def test_false_after_all_fake_methods_refused(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("google", "code")
+        with pytest.raises(NotImplementedError):
+            auth.login_with_email_password("a@b.com", "pw")
+        assert auth.is_authenticated is False
+
+
+# ---------------------------------------------------------------------------
+# No callable produces a verified UserProfile via fake methods
+# ---------------------------------------------------------------------------
+
+
+class TestNoFakeUserProfile:
+    """No auth-manager method may produce a UserProfile without real auth."""
+
+    def test_oauth_does_not_produce_user_profile(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("google", "code")
+        # current_user must remain None — no fake profile was ever set
+        assert not isinstance(auth.current_user, UserProfile)
+
+    def test_email_password_does_not_produce_user_profile(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        with pytest.raises(NotImplementedError):
+            auth.login_with_email_password("a@b.com", "pw")
+        assert not isinstance(auth.current_user, UserProfile)
+
+    def test_credentials_file_empty_after_refused_logins(self, tmp_path: Path) -> None:
+        auth = _make_auth(tmp_path)
+        creds_file = auth.CREDENTIALS_FILE
+        with pytest.raises(NotImplementedError):
+            auth.login_with_oauth("github", "code")
+        with pytest.raises(NotImplementedError):
+            auth.login_with_email_password("a@b.com", "pw")
+        assert not creds_file.exists()


### PR DESCRIPTION
Closes #2757 (Phase 1; Phase 2 tracked in #2828).

Replaces fabricated UserProfile responses in `login_with_oauth` and `login_with_email_password` with `NotImplementedError` + a helpful message. Eliminates the safety hazard where any caller could obtain a fake authenticated identity.

Real OAuth (PKCE + token exchange + refresh tokens) is a multi-day effort requiring provider sandbox credentials. See #2828 for Phase 2 scope.

## Test plan
- [x] Both fake-auth methods now raise `NotImplementedError`
- [x] `is_authenticated` returns False after refused login
- [x] `CREDENTIALS_FILE` not written on refused login
- [x] 18 new tests all passing
- [x] ruff clean