### PR TITLE
[Critical] Fix ChatDockWidget._shared_session_id race condition (#2753)

### DIFF
--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -191,6 +192,19 @@ class ChatDockWidget(QDockWidget):
     # serialized through ``_SHARED_SESSION_LOCK`` in ``chat_dock_widget``
     # to prevent the multi-window race described in Tools issue #2753.
     _shared_session_id: str | None = None
+    _session_lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def _get_shared_session_id(cls) -> str | None:
+        """Return the shared session ID under the class lock."""
+        with cls._session_lock:
+            return cls._shared_session_id
+
+    @classmethod
+    def _set_shared_session_id(cls, val: str | None) -> None:
+        """Set the shared session ID under the class lock."""
+        with cls._session_lock:
+            cls._shared_session_id = val
 
     # Signals for external UI integration
     models_refreshed = pyqtSignal(list)
@@ -242,10 +256,10 @@ class ChatDockWidget(QDockWidget):
 
         # Resolve session ID: explicit > class-level > file > "new"
         if session_id:
-            ChatDockWidget._shared_session_id = session_id
-        elif not ChatDockWidget._shared_session_id:
-            ChatDockWidget._shared_session_id = _read_shared_session_id(
-                self._session_file
+            ChatDockWidget._set_shared_session_id(session_id)
+        elif not ChatDockWidget._get_shared_session_id():
+            ChatDockWidget._set_shared_session_id(
+                _read_shared_session_id(self._session_file)
             )
 
         self._setup_ui()
@@ -434,7 +448,7 @@ class ChatDockWidget(QDockWidget):
         self._socket.disconnected.connect(self._on_disconnected)
         self._socket.textMessageReceived.connect(self._on_message)
 
-        sid = ChatDockWidget._shared_session_id or "new"
+        sid = ChatDockWidget._get_shared_session_id() or "new"
         path = self._ws_path_template.replace("{session_id}", sid)
         url = QUrl(f"{self._server_url}{path}")
         self._status_label.setText("Connecting...")
@@ -473,7 +487,7 @@ class ChatDockWidget(QDockWidget):
 
         if msg_type == "session_info":
             sid = data.get("session_id", "")
-            ChatDockWidget._shared_session_id = sid
+            ChatDockWidget._set_shared_session_id(sid)
             _write_shared_session_id(sid, self._session_file)
             self._send_ws({"action": "history"})
 
@@ -489,12 +503,12 @@ class ChatDockWidget(QDockWidget):
             self._current_bubble = None
             sid = data.get("session_id")
             if sid:
-                ChatDockWidget._shared_session_id = sid
+                ChatDockWidget._set_shared_session_id(sid)
                 _write_shared_session_id(sid, self._session_file)
 
         elif msg_type == "session_created":
             sid = data.get("session_id", "")
-            ChatDockWidget._shared_session_id = sid
+            ChatDockWidget._set_shared_session_id(sid)
             _write_shared_session_id(sid, self._session_file)
 
         elif msg_type == "history":

--- a/tests/shared/python/chat/test_chat_session_helpers.py
+++ b/tests/shared/python/chat/test_chat_session_helpers.py
@@ -6,12 +6,12 @@ imports PyQt6 at the top, so PyQt6 must be installed for the import to succeed, 
 the test logic itself needs only the standard library.
 
 If PyQt6 is not installed in the environment the entire file is skipped via
-``pytest.importorskip`` — same as the original test_chat_dock_widget.py.  The value
+``pytest.importorskip`` -- same as the original test_chat_dock_widget.py.  The value
 of keeping these tests in a separate file is:
 
 1. They are clearly labelled as headless-safe unit tests (no widget / display server
    needed at runtime).
-2. Skip debt is visible and documented — these tests SHOULD be dependency-complete
+2. Skip debt is visible and documented -- these tests SHOULD be dependency-complete
    once the session helpers are relocated to a pure-Python module (tracked separately).
 3. The widget tests in test_chat_dock_widget.py are cleanly isolated from the
    pure-logic tests.
@@ -19,6 +19,7 @@ of keeping these tests in a separate file is:
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 
 import pytest
@@ -38,7 +39,7 @@ from chat.chat_dock_widget import (  # noqa: E402
 class TestSessionFileHelpers:
     """Unit tests for session-file persistence helpers.
 
-    These tests exercise pure-Python logic — no display server, no Qt event loop.
+    These tests exercise pure-Python logic -- no display server, no Qt event loop.
     """
 
     def test_session_file_path(self) -> None:
@@ -79,8 +80,6 @@ class TestSessionFileHelpers:
         must contain *exactly one* valid session ID at the end (no torn
         writes, no exceptions, no empty file).
         """
-        import threading
-
         path = tmp_path / "shared_session.txt"
         candidates = [f"sid{i}" for i in range(4)]
         errors: list[BaseException] = []
@@ -107,3 +106,89 @@ class TestSessionFileHelpers:
         assert final in candidates, (
             f"expected exactly one of {candidates!r}, got {final!r}"
         )
+
+    def test_atomic_write_leaves_no_tmp_file(self, tmp_path: Path) -> None:
+        """Atomic write cleans up the .tmp file after replace."""
+        path = tmp_path / "session.txt"
+        _write_shared_session_id("clean-write", path)
+        tmp = Path(str(path) + ".tmp")
+        assert not tmp.exists(), ".tmp file should be gone after atomic replace"
+        assert _read_shared_session_id(path) == "clean-write"
+
+
+@pytest.mark.unit
+class TestSharedSessionIdConcurrency:
+    """Stress tests for the thread-safe _shared_session_id accessors.
+
+    These require PyQt6.QtWebSockets for ChatDockWidget -- skipped if absent.
+    """
+
+    def test_concurrent_set_get_no_exception(self) -> None:
+        """Concurrent _set_shared_session_id / _get_shared_session_id never raises."""
+        pytest.importorskip(
+            "PyQt6.QtWebSockets",
+            reason="PyQt6.QtWebSockets required for ChatDockWidget",
+            exc_type=ImportError,
+        )
+        from chat._chat_dock_widget_qt import ChatDockWidget  # noqa: PLC0415
+
+        n_threads = 50
+        errors: list[Exception] = []
+        seen_values: list[str | None] = []
+        lock = threading.Lock()
+        ChatDockWidget._set_shared_session_id(None)
+
+        def worker(idx: int) -> None:
+            try:
+                sid = f"session-{idx}"
+                ChatDockWidget._set_shared_session_id(sid)
+                val = ChatDockWidget._get_shared_session_id()
+                with lock:
+                    seen_values.append(val)
+            except Exception as exc:  # noqa: BLE001
+                with lock:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        valid = {f"session-{i}" for i in range(n_threads)}
+        for val in seen_values:
+            assert val in valid
+        final = ChatDockWidget._get_shared_session_id()
+        assert final in valid
+
+    def test_first_writer_wins_when_already_set(self) -> None:
+        """Pre-seeded session is never overwritten when already set."""
+        pytest.importorskip(
+            "PyQt6.QtWebSockets",
+            reason="PyQt6.QtWebSockets required for ChatDockWidget",
+            exc_type=ImportError,
+        )
+        from chat._chat_dock_widget_qt import ChatDockWidget  # noqa: PLC0415
+
+        n_threads = 30
+        errors: list[Exception] = []
+        barrier = threading.Barrier(n_threads)
+        ChatDockWidget._set_shared_session_id("pre-seeded-session")
+
+        def worker() -> None:
+            try:
+                barrier.wait()
+                if not ChatDockWidget._get_shared_session_id():
+                    ChatDockWidget._set_shared_session_id("should-not-be-set")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert ChatDockWidget._get_shared_session_id() == "pre-seeded-session"


### PR DESCRIPTION
## Summary

- Add `_session_lock: threading.Lock` class variable and `_get_shared_session_id` / `_set_shared_session_id` classmethods to `ChatDockWidget` so all in-process reads and writes of the shared session ID go through a lock, eliminating the data race when multiple widget instances are constructed concurrently.
- Replace direct `path.write_text()` in `_write_shared_session_id` with atomic `tmp.write_text()` + `tmp.replace(path)`, ensuring readers never see a partial write.
- Remove TOCTOU `if path.exists()` check in `_read_shared_session_id`; catch `FileNotFoundError` directly instead.

## Files changed

- `src/shared/python/chat/_chat_dock_widget_qt.py` — lock + classmethods, all direct `_shared_session_id =` writes replaced with `_set_shared_session_id()`
- `src/shared/python/chat/chat_dock_widget.py` — atomic write + FileNotFoundError handling
- `tests/shared/python/chat/test_chat_session_helpers.py` — `test_atomic_write_leaves_no_tmp_file`, `TestSharedSessionIdConcurrency` (50-thread set/get, 30-thread barrier)

## Test plan

- [x] `ruff check` — 0 violations
- [x] `ruff format --check` — 0 diffs
- [x] `pytest tests/shared/python/chat/test_chat_session_helpers.py` — 6 passed, 2 skipped (QtWebSockets DLL not present in test env; concurrency tests properly skipped via `importorskip`)
- [x] Pre-push hook ran full `pytest` suite — passed

Closes #2753

🤖 Generated with [Claude Code](https://claude.com/claude-code)