### PR TITLE
feat(sidekick): real OS terminal + shell switcher + Python REPL split (UpstreamDrift #5617)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,13 @@ theme = [
 pid = [
     "ezdxf[draw]>=1.4.3",
 ]
+# Real OS terminal for the Sidekick OS Terminal tab (UpstreamDrift #5617).
+# Picks the platform-appropriate PTY library; falls back to plain subprocess
+# pipes when neither is installed.
+terminal = [
+    "pywinpty>=2.0; platform_system == 'Windows'",
+    "ptyprocess; platform_system != 'Windows'",
+]
 
 # CAD geometry export (build123d pulls in its own matplotlib and PyQt6)
 cad = [

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/default_tabs.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/default_tabs.py
@@ -24,6 +24,7 @@ from .runtime_tabs import (
     build_calculator_tab,
     build_chat_tab,
     build_notes_tab,
+    build_python_repl_tab,
     build_terminal_tab,
 )
 
@@ -67,6 +68,13 @@ def build_default_tab_definitions(
             build_terminal_tab,
             duplicate_enabled=True,
             help_metadata=dict(DEFAULT_SIDEBAR_TAB_HELP["terminal"]),
+        ),
+        tab_definition(
+            "python_repl",
+            "Python REPL",
+            build_python_repl_tab,
+            duplicate_enabled=True,
+            help_metadata=dict(DEFAULT_SIDEBAR_TAB_HELP["python_repl"]),
         ),
         tab_definition(
             "calculator",

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/help_content.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/help_content.py
@@ -63,6 +63,22 @@ DEFAULT_SIDEBAR_TAB_HELP: dict[str, dict[str, str]] = {
     ),
     "terminal": _tab_help(
         "Terminal",
+        "Launch a real interactive OS shell (bash, zsh, pwsh, powershell, cmd, "
+        "or a WSL distro) backed by a PTY.",
+        tips=(
+            "The shell selector switches between every discovered shell.",
+            "Install the optional ``terminal`` extra (pywinpty on Windows, "
+            "ptyprocess elsewhere) for full interactive features.",
+            "The live cwd label tracks the shell via OSC 7 escapes.",
+        ),
+        examples=(
+            "ls",
+            "git status",
+            "python --version",
+        ),
+    ),
+    "python_repl": _tab_help(
+        "Python REPL",
         "Run bounded Python snippets against the shared workspace registry.",
         tips=(
             "Assignments export new values back into the shared workspace.",

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/os_terminal.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/os_terminal.py
@@ -1,0 +1,634 @@
+"""Sidekick OS-level terminal widget (UpstreamDrift #5617).
+
+This module provides a PTY-backed terminal surface for the Sidekick
+sidebar. Unlike the renamed Python REPL widget, this tab launches a real
+interactive shell (bash, zsh, pwsh, powershell, cmd, or a WSL distro) and
+streams its output back into a read-only display.
+
+Components:
+
+* :class:`TerminalBackend` — Protocol every backend implements.
+* :class:`PosixPtyBackend` — uses :mod:`ptyprocess` on POSIX.
+* :class:`WindowsPtyBackend` — uses :mod:`winpty` (``pywinpty``) on Windows.
+* :class:`SubprocessFallbackBackend` — non-interactive
+  :mod:`subprocess` pipe fallback when no PTY library is installed.
+* :func:`select_backend` — runtime backend factory.
+* :class:`SidekickOsTerminalWidget` — Qt widget wiring it all together.
+
+The widget never reaches into backend internals (LOD): it goes through the
+``read``/``write``/``terminate``/``resize`` methods exclusively.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import re
+import subprocess
+import threading
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from .qt_compat import QtCore, QtWidgets
+from .shell_discovery import ShellDescriptor, discover_shells
+
+logger = logging.getLogger(__name__)
+
+SIDEKICK_OS_TERMINAL_OBJECT_NAME = "SidekickOsTerminalTab"
+
+# ANSI / OSC parsing constants
+#
+# OSC 7 sequence shape: ``ESC ] 7 ; file://<host>/<path> BEL`` (or ESC \\).
+# The hostname is empty or a token without slashes. We accept three shapes:
+#   * ``file:///abs/path`` (POSIX, no host)
+#   * ``file://host/abs/path`` (POSIX with host)
+#   * ``file://host/C:/path`` and ``file://hostC:/path`` (Windows drive letter,
+#     emitted both with and without a separator before the drive — be lenient).
+_OSC7_PATTERN = re.compile(
+    rb"\x1b\]7;file://[^/\x07\x1b]*?"
+    rb"(?P<path>(?:/[A-Za-z]:/|[A-Za-z]:/|/)[^\x07\x1b]*)"
+    rb"(?:\x07|\x1b\\)"
+)
+_ANSI_ESCAPE_RE = re.compile(rb"\x1b\[[0-?]*[ -/]*[@-~]")
+_OSC_ESCAPE_RE = re.compile(rb"\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)")
+
+
+# ---------------------------------------------------------------------------
+# Backend protocol + concrete backends
+# ---------------------------------------------------------------------------
+
+
+class TerminalBackend(Protocol):
+    """Minimum API every terminal backend must expose."""
+
+    is_running: bool
+
+    def start(self) -> None: ...
+
+    def write(self, data: bytes) -> None: ...
+
+    def read(self, timeout: float = 0.0) -> bytes: ...
+
+    def terminate(self) -> None: ...
+
+    def resize(self, rows: int, cols: int) -> None: ...
+
+
+@dataclass
+class _BackendBase:
+    """Shared backend state (command + cwd + running flag)."""
+
+    command: tuple[str, ...]
+    cwd: Path | None
+    is_running: bool = False
+
+    def _ensure_running(self) -> None:
+        if not self.is_running:
+            raise RuntimeError("backend is not running; call start() first")
+
+    def _check_writeable(self, data: bytes) -> None:
+        if not isinstance(data, bytes):
+            raise TypeError("data must be bytes")
+        if not data:
+            raise ValueError("data must be non-empty")
+
+
+class PosixPtyBackend(_BackendBase):
+    """PTY backend backed by :mod:`ptyprocess` (POSIX only)."""
+
+    def __init__(
+        self,
+        *,
+        command: Sequence[str],
+        cwd: Path | None,
+    ) -> None:
+        super().__init__(command=tuple(command), cwd=cwd)
+        self._proc: object | None = None
+
+    def start(self) -> None:
+        from ptyprocess import PtyProcess  # type: ignore[import-not-found]
+
+        cwd_value = str(self.cwd) if self.cwd is not None else None
+        self._proc = PtyProcess.spawn(
+            list(self.command),
+            cwd=cwd_value,
+            env=os.environ.copy(),
+        )
+        self.is_running = True
+
+    def write(self, data: bytes) -> None:
+        self._check_writeable(data)
+        self._ensure_running()
+        proc = self._proc
+        assert proc is not None  # noqa: S101 - guarded by _ensure_running
+        proc.write(data)  # type: ignore[attr-defined]
+
+    def read(self, timeout: float = 0.0) -> bytes:  # noqa: ARG002 - ptyprocess polls
+        self._ensure_running()
+        proc = self._proc
+        assert proc is not None  # noqa: S101 - guarded by _ensure_running
+        try:
+            return bytes(proc.read(4096))  # type: ignore[attr-defined]
+        except EOFError:
+            self.is_running = False
+            return b""
+
+    def terminate(self) -> None:
+        if self._proc is None:
+            self.is_running = False
+            return
+        try:
+            self._proc.terminate(force=True)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 - terminate is best-effort
+            logger.debug("PosixPtyBackend terminate failed: %s", exc)
+        self.is_running = False
+
+    def resize(self, rows: int, cols: int) -> None:
+        if not self.is_running or self._proc is None:
+            return
+        try:
+            self._proc.setwinsize(rows, cols)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 - resize is cosmetic
+            logger.debug("PosixPtyBackend resize failed: %s", exc)
+
+
+class WindowsPtyBackend(_BackendBase):
+    """ConPTY backend backed by :mod:`winpty` (``pywinpty>=2``)."""
+
+    def __init__(
+        self,
+        *,
+        command: Sequence[str],
+        cwd: Path | None,
+    ) -> None:
+        super().__init__(command=tuple(command), cwd=cwd)
+        self._proc: object | None = None
+
+    def start(self) -> None:
+        from winpty import PtyProcess  # type: ignore[import-not-found]
+
+        cwd_value = str(self.cwd) if self.cwd is not None else None
+        # pywinpty 2.x accepts the command as a single string.
+        cmdline = subprocess.list2cmdline(list(self.command))
+        self._proc = PtyProcess.spawn(cmdline, cwd=cwd_value)
+        self.is_running = True
+
+    def write(self, data: bytes) -> None:
+        self._check_writeable(data)
+        self._ensure_running()
+        proc = self._proc
+        assert proc is not None  # noqa: S101 - guarded by _ensure_running
+        # pywinpty's write accepts ``str`` only; decode best-effort.
+        proc.write(data.decode("utf-8", errors="replace"))  # type: ignore[attr-defined]
+
+    def read(self, timeout: float = 0.0) -> bytes:  # noqa: ARG002 - pywinpty polls
+        self._ensure_running()
+        proc = self._proc
+        assert proc is not None  # noqa: S101 - guarded by _ensure_running
+        try:
+            chunk = proc.read(4096)  # type: ignore[attr-defined]
+        except EOFError:
+            self.is_running = False
+            return b""
+        if isinstance(chunk, str):
+            return chunk.encode("utf-8", errors="replace")
+        return bytes(chunk) if chunk else b""
+
+    def terminate(self) -> None:
+        if self._proc is None:
+            self.is_running = False
+            return
+        try:
+            self._proc.terminate()  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 - terminate is best-effort
+            logger.debug("WindowsPtyBackend terminate failed: %s", exc)
+        self.is_running = False
+
+    def resize(self, rows: int, cols: int) -> None:
+        if not self.is_running or self._proc is None:
+            return
+        try:
+            self._proc.setwinsize(rows, cols)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001 - resize is cosmetic
+            logger.debug("WindowsPtyBackend resize failed: %s", exc)
+
+
+class SubprocessFallbackBackend(_BackendBase):
+    """Non-interactive fallback when no PTY library is installed.
+
+    This backend wires shell stdin/stdout through plain pipes. Many
+    interactive features (line editing, colored prompts, job control) are
+    unavailable, but simple commands and a labelled help banner keep the
+    tab usable.
+    """
+
+    def __init__(
+        self,
+        *,
+        command: Sequence[str],
+        cwd: Path | None,
+    ) -> None:
+        super().__init__(command=tuple(command), cwd=cwd)
+        self._proc: subprocess.Popen[bytes] | None = None
+        self._buffer = bytearray()
+        self._lock = threading.Lock()
+        self._reader: threading.Thread | None = None
+
+    def start(self) -> None:
+        cwd_value = str(self.cwd) if self.cwd is not None else None
+        self._proc = subprocess.Popen(  # noqa: S603 - command is caller-controlled
+            list(self.command),
+            cwd=cwd_value,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=0,
+        )
+        self.is_running = True
+        self._reader = threading.Thread(target=self._pump_stdout, daemon=True)
+        self._reader.start()
+
+    def _pump_stdout(self) -> None:
+        proc = self._proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            while True:
+                chunk = proc.stdout.read(1024)
+                if not chunk:
+                    break
+                with self._lock:
+                    self._buffer.extend(chunk)
+        except Exception as exc:  # noqa: BLE001 - reader thread guards
+            logger.debug("SubprocessFallbackBackend read thread error: %s", exc)
+        finally:
+            self.is_running = False
+
+    def write(self, data: bytes) -> None:
+        self._check_writeable(data)
+        self._ensure_running()
+        proc = self._proc
+        assert proc is not None and proc.stdin is not None  # noqa: S101
+        proc.stdin.write(data)
+        proc.stdin.flush()
+
+    def read(self, timeout: float = 0.0) -> bytes:
+        self._ensure_running()
+        if timeout > 0:
+            event = threading.Event()
+            event.wait(timeout)
+        with self._lock:
+            data = bytes(self._buffer)
+            self._buffer.clear()
+        return data
+
+    def terminate(self) -> None:
+        proc = self._proc
+        if proc is None:
+            self.is_running = False
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        except Exception as exc:  # noqa: BLE001 - terminate is best-effort
+            logger.debug("SubprocessFallbackBackend terminate failed: %s", exc)
+        self.is_running = False
+
+    def resize(self, rows: int, cols: int) -> None:  # noqa: ARG002 - no-op for pipes
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Backend selection
+# ---------------------------------------------------------------------------
+
+
+def select_backend(
+    *,
+    command: Sequence[str],
+    cwd: Path | None,
+) -> tuple[TerminalBackend | None, str | None]:
+    """Return the best available backend for the current host.
+
+    Returns a ``(backend, hint)`` tuple. ``backend`` is ``None`` when no
+    backend could be instantiated; in that case ``hint`` carries a human
+    readable installation hint to surface in the UI. On success ``hint``
+    may be a non-fatal note (e.g. "running without PTY").
+    """
+    if not command:
+        raise ValueError("command must be non-empty")
+
+    system = platform.system()
+    if system in {"Linux", "Darwin"}:
+        try:
+            import ptyprocess  # type: ignore[import-not-found]  # noqa: F401
+
+            return PosixPtyBackend(command=command, cwd=cwd), None
+        except ImportError:
+            logger.debug("ptyprocess unavailable; falling back to subprocess pipes.")
+    elif system == "Windows":
+        try:
+            import winpty  # type: ignore[import-not-found]  # noqa: F401
+
+            return WindowsPtyBackend(command=command, cwd=cwd), None
+        except ImportError:
+            logger.debug("pywinpty unavailable; falling back to subprocess pipes.")
+
+    try:
+        return (
+            SubprocessFallbackBackend(command=command, cwd=cwd),
+            _install_hint(system),
+        )
+    except Exception as exc:  # noqa: BLE001 - bottom of the stack
+        logger.debug("SubprocessFallbackBackend construction failed: %s", exc)
+        return None, _install_hint(system)
+
+
+def _install_hint(system: str) -> str:
+    """Return the install hint for the missing PTY backend on ``system``."""
+    if system == "Windows":
+        return (
+            "Interactive terminal features require pywinpty. "
+            "Install with: pip install 'upstream-drift-tools[terminal]' "
+            "(or directly: pip install 'pywinpty>=2.0')."
+        )
+    return (
+        "Interactive terminal features require ptyprocess. "
+        "Install with: pip install 'upstream-drift-tools[terminal]' "
+        "(or directly: pip install ptyprocess)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_osc7_cwd(data: bytes) -> Path | None:
+    """Return the last OSC 7 cwd path emitted in ``data``, or ``None``.
+
+    OSC 7 is the de-facto sequence shells use to advertise their cwd:
+    ``ESC ] 7 ; file://<host><path> BEL`` (or terminated by ``ESC \\``).
+    """
+    last: bytes | None = None
+    for match in _OSC7_PATTERN.finditer(data):
+        last = match.group("path")
+    if last is None:
+        return None
+    try:
+        text = last.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    if not text:
+        return None
+    if (
+        platform.system() == "Windows"
+        and text.startswith("/")
+        and len(text) > 2
+        and text[2] == ":"
+    ):
+        text = text[1:]
+    return Path(text)
+
+
+def strip_ansi(data: bytes) -> bytes:
+    """Remove the common ANSI CSI / OSC sequences from ``data``."""
+    stripped = _OSC_ESCAPE_RE.sub(b"", data)
+    return _ANSI_ESCAPE_RE.sub(b"", stripped)
+
+
+# ---------------------------------------------------------------------------
+# Widget
+# ---------------------------------------------------------------------------
+
+
+class SidekickOsTerminalWidget(QtWidgets.QWidget):
+    """OS-level terminal tab backed by a PTY (or pipe fallback)."""
+
+    def __init__(
+        self,
+        *,
+        project_root: Path,
+        shells: Sequence[ShellDescriptor] | None = None,
+        autostart: bool = True,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        if project_root is None:
+            raise ValueError("project_root must be provided")
+        super().__init__(parent)
+        self.setObjectName(SIDEKICK_OS_TERMINAL_OBJECT_NAME)
+
+        self._project_root = Path(project_root)
+        self._shells: list[ShellDescriptor] = list(shells or discover_shells())
+        self._backend: TerminalBackend | None = None
+        self._install_hint: str | None = None
+        self._current_shell: ShellDescriptor | None = None
+
+        self._build_ui()
+        self._populate_shell_selector()
+        self._on_cwd_changed(self._project_root)
+
+        if autostart and self._shells:
+            self._start_backend(self._shells[0])
+
+    # -- UI construction ----------------------------------------------------
+
+    def _build_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+
+        top_row = QtWidgets.QHBoxLayout()
+        top_row.setSpacing(6)
+
+        self._cwd_label = QtWidgets.QLabel(self)
+        self._cwd_label.setObjectName("SidekickOsTerminalCwd")
+        self._cwd_label.setToolTip(
+            "Live current working directory of the running shell."
+        )
+        top_row.addWidget(self._cwd_label, stretch=1)
+
+        self._shell_selector = QtWidgets.QComboBox(self)
+        self._shell_selector.setObjectName("SidekickOsTerminalShellSelector")
+        self._shell_selector.setToolTip(
+            "Switch the active shell (bash, zsh, pwsh, powershell, cmd, WSL)."
+        )
+        self._shell_selector.currentIndexChanged.connect(self._on_selector_changed)
+        top_row.addWidget(self._shell_selector)
+
+        layout.addLayout(top_row)
+
+        self._install_hint_label = QtWidgets.QLabel("", self)
+        self._install_hint_label.setObjectName("SidekickOsTerminalInstallHint")
+        self._install_hint_label.setWordWrap(True)
+        self._install_hint_label.setVisible(False)
+        layout.addWidget(self._install_hint_label)
+
+        self._output = QtWidgets.QPlainTextEdit(self)
+        self._output.setObjectName("SidekickOsTerminalOutput")
+        self._output.setReadOnly(True)
+        self._output.setToolTip("Streamed stdout / stderr from the running shell.")
+        layout.addWidget(self._output, stretch=4)
+
+        self._input = QtWidgets.QLineEdit(self)
+        self._input.setObjectName("SidekickOsTerminalInput")
+        self._input.setPlaceholderText("Type a command and press Enter")
+        self._input.setToolTip(
+            "Send a single line to the shell's stdin (Enter submits)."
+        )
+        self._input.returnPressed.connect(self._on_submit)
+        layout.addWidget(self._input)
+
+        # Poll the backend on a short timer so output streams into the view.
+        self._poll_timer = QtCore.QTimer(self)
+        self._poll_timer.setInterval(80)
+        self._poll_timer.timeout.connect(self._poll_backend)
+
+    def _populate_shell_selector(self) -> None:
+        self._shell_selector.blockSignals(True)
+        self._shell_selector.clear()
+        for shell in self._shells:
+            self._shell_selector.addItem(shell.label, userData=shell.identifier)
+        self._shell_selector.blockSignals(False)
+
+    # -- Backend lifecycle --------------------------------------------------
+
+    def _start_backend(self, shell: ShellDescriptor) -> None:
+        backend, hint = select_backend(command=shell.command, cwd=self._project_root)
+        self._backend = backend
+        self._install_hint = hint
+        self._current_shell = shell
+
+        if backend is None:
+            self._install_hint_label.setText(
+                hint or "Terminal backend unavailable; install pty support."
+            )
+            self._install_hint_label.setVisible(True)
+            return
+
+        if hint:
+            self._install_hint_label.setText(hint)
+            self._install_hint_label.setVisible(True)
+        else:
+            self._install_hint_label.setVisible(False)
+
+        try:
+            backend.start()
+        except Exception as exc:  # noqa: BLE001 - degrade to install hint
+            logger.debug("OS terminal backend failed to start: %s", exc)
+            self._backend = None
+            self._install_hint_label.setText(
+                f"Failed to start {shell.label}: {exc}. {self._install_hint or ''}"
+            )
+            self._install_hint_label.setVisible(True)
+            return
+
+        self._poll_timer.start()
+
+    def switch_shell(self, identifier: str) -> None:
+        """Stop the current backend and start the shell named ``identifier``.
+
+        Raises:
+            ValueError: If no discovered shell matches ``identifier``.
+        """
+        target = next(
+            (shell for shell in self._shells if shell.identifier == identifier),
+            None,
+        )
+        if target is None:
+            raise ValueError(f"unknown shell identifier: {identifier!r}")
+        self._teardown_backend()
+        self._on_cwd_changed(self._project_root)
+        self._start_backend(target)
+
+    def _teardown_backend(self) -> None:
+        self._poll_timer.stop()
+        backend = self._backend
+        self._backend = None
+        if backend is None:
+            return
+        try:
+            backend.terminate()
+        except Exception as exc:  # noqa: BLE001 - terminate is best-effort
+            logger.debug("OS terminal teardown failed: %s", exc)
+
+    # -- IO routing ---------------------------------------------------------
+
+    def _on_submit(self) -> None:
+        line = self._input.text()
+        self._input.clear()
+        if self._backend is None:
+            return
+        payload = (line + os.linesep).encode("utf-8", errors="replace")
+        if not payload:
+            return
+        try:
+            self._backend.write(payload)
+        except Exception as exc:  # noqa: BLE001 - shell may exit
+            logger.debug("OS terminal write failed: %s", exc)
+
+    def _poll_backend(self) -> None:
+        if self._backend is None or not self._backend.is_running:
+            self._poll_timer.stop()
+            return
+        try:
+            data = self._backend.read(timeout=0.0)
+        except Exception as exc:  # noqa: BLE001 - poll degrades gracefully
+            logger.debug("OS terminal read failed: %s", exc)
+            return
+        if data:
+            self._handle_output(data)
+
+    def _handle_output(self, data: bytes) -> None:
+        """Receive bytes from the backend and route to the UI/cwd slot."""
+        if not isinstance(data, bytes):
+            raise TypeError("data must be bytes")
+        cwd = extract_osc7_cwd(data)
+        if cwd is not None:
+            self._on_cwd_changed(cwd)
+        text = strip_ansi(data).decode("utf-8", errors="replace")
+        if text:
+            self._output.appendPlainText(text.rstrip("\r\n"))
+
+    def _on_cwd_changed(self, path: Path) -> None:
+        """Single slot for cwd updates (LOD: one path, no chains)."""
+        if path is None:
+            raise ValueError("path must be provided")
+        self._cwd_label.setText(f"cwd: {path}")
+
+    # -- Qt selector callback ----------------------------------------------
+
+    def _on_selector_changed(self, index: int) -> None:
+        if index < 0 or index >= len(self._shells):
+            return
+        target = self._shells[index]
+        if self._current_shell is not None and target.identifier == (
+            self._current_shell.identifier
+        ):
+            return
+        self.switch_shell(target.identifier)
+
+    # -- Qt lifecycle -------------------------------------------------------
+
+    def closeEvent(self, event: object) -> None:  # noqa: N802 - Qt API
+        """Tear down the backend when Qt closes the widget."""
+        self._teardown_backend()
+        super().closeEvent(event)  # type: ignore[misc]
+
+
+__all__ = [
+    "PosixPtyBackend",
+    "SIDEKICK_OS_TERMINAL_OBJECT_NAME",
+    "SidekickOsTerminalWidget",
+    "SubprocessFallbackBackend",
+    "TerminalBackend",
+    "WindowsPtyBackend",
+    "extract_osc7_cwd",
+    "select_backend",
+    "strip_ansi",
+]

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/runtime_tabs.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/runtime_tabs.py
@@ -34,7 +34,11 @@ logger = logging.getLogger(__name__)
 
 SIDEKICK_CHAT_RUNTIME_OBJECT_NAME = "SidekickChatRuntimeTab"
 SIDEKICK_CHAT_STATUS_OBJECT_NAME = "SidekickChatStatusTab"
+# UpstreamDrift #5617: this object name is retained for backward compatibility
+# with downstream tests and styling. The widget is now SidekickPythonReplWidget;
+# the new OS terminal uses SIDEKICK_OS_TERMINAL_OBJECT_NAME (os_terminal module).
 SIDEKICK_TERMINAL_OBJECT_NAME = "SidekickTerminalTab"
+SIDEKICK_PYTHON_REPL_OBJECT_NAME = SIDEKICK_TERMINAL_OBJECT_NAME
 SIDEKICK_NOTES_OBJECT_NAME = "SidekickNotesTab"
 
 _DEFAULT_CHAT_ACCENT_COLOR = "#FF8800"
@@ -116,8 +120,33 @@ def build_chat_tab(sidebar: Any) -> QtWidgets.QWidget:
 
 
 def build_terminal_tab(sidebar: Any) -> QtWidgets.QWidget:
-    """Build an embedded Python terminal tab bound to the workspace registry."""
-    widget = SidekickTerminalWidget(
+    """Build the OS-level terminal tab (UpstreamDrift #5617).
+
+    The widget launches a real interactive shell (bash, zsh, pwsh,
+    powershell, cmd, or a WSL distro) backed by a PTY when ``ptyprocess``
+    or ``pywinpty`` is installed, and falls back to plain subprocess
+    pipes otherwise.
+    """
+    # Local import keeps the heavy os_terminal module out of the import path
+    # for headless hosts that don't reach this code path.
+    from .os_terminal import SidekickOsTerminalWidget
+
+    widget = SidekickOsTerminalWidget(
+        project_root=sidebar.project_root,
+        parent=sidebar,
+    )
+    widget.setToolTip(DEFAULT_SIDEBAR_TAB_HELP["terminal"]["summary"])
+    return widget
+
+
+def build_python_repl_tab(sidebar: Any) -> QtWidgets.QWidget:
+    """Build the Python REPL tab (UpstreamDrift #5617).
+
+    This is the widget formerly named ``SidekickTerminalWidget``. It runs
+    bounded Python snippets against the shared workspace registry; see
+    :class:`SidekickPythonReplWidget`.
+    """
+    widget = SidekickPythonReplWidget(
         registry=sidebar.registry,
         set_variable=sidebar.set_context_variable,
         terminal_theme=theme.SidekickTerminalTheme.inherited(
@@ -125,7 +154,7 @@ def build_terminal_tab(sidebar: Any) -> QtWidgets.QWidget:
         ),
         parent=sidebar,
     )
-    widget.setToolTip(DEFAULT_SIDEBAR_TAB_HELP["terminal"]["summary"])
+    widget.setToolTip(DEFAULT_SIDEBAR_TAB_HELP["python_repl"]["summary"])
     return widget
 
 
@@ -154,8 +183,16 @@ def build_notes_tab(sidebar: Any) -> QtWidgets.QWidget:
     return widget
 
 
-class SidekickTerminalWidget(QtWidgets.QWidget):
-    """Small Python execution surface sharing values with Workspace."""
+class SidekickPythonReplWidget(QtWidgets.QWidget):
+    """Small Python execution surface sharing values with Workspace.
+
+    UpstreamDrift #5617: renamed from ``SidekickTerminalWidget``. The name
+    is more honest — this widget runs a bounded Python REPL, not an OS
+    shell. The new ``SidekickOsTerminalWidget`` (in
+    :mod:`upstream_drift_tools.ui.tools_sidebar.os_terminal`) provides the
+    real PTY-backed shell. Object name, child widget object names, and
+    tooltips are preserved so existing styling and tests continue to work.
+    """
 
     def __init__(
         self,

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/shell_discovery.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/shell_discovery.py
@@ -1,0 +1,177 @@
+"""Shell discovery helpers for the Sidekick OS Terminal (UpstreamDrift #5617).
+
+This module is the **single source of truth** (DRY) for which interactive
+shells the Sidekick OS Terminal can launch:
+
+* :class:`ShellDescriptor` — immutable record describing one shell.
+* :func:`discover_shells` — returns the user's available shells.
+
+The widget, settings dropdown, and tests all consume :func:`discover_shells`;
+no caller must hard-code shell paths.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ShellDescriptor:
+    """One discovered shell, addressable by ``identifier``.
+
+    Attributes:
+        identifier: Stable id used by callers (e.g. ``bash``, ``pwsh``,
+            ``wsl:Ubuntu-22.04``).
+        label: Human-readable name shown in the shell selector.
+        command: Argument vector passed to :func:`subprocess.Popen`
+            (or to the PTY backend). Must contain at least one element.
+
+    Raises:
+        ValueError: If ``identifier`` or ``label`` is empty, or
+            ``command`` is empty (DbC precondition).
+    """
+
+    identifier: str
+    label: str
+    command: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.identifier:
+            raise ValueError("identifier must be a non-empty str")
+        if not self.label:
+            raise ValueError("label must be a non-empty str")
+        if not self.command:
+            raise ValueError("command must contain at least one element")
+
+
+# Candidate POSIX shells, in preference order.
+_POSIX_CANDIDATES: tuple[str, ...] = ("bash", "zsh", "fish", "sh")
+
+# Candidate Windows shells, in preference order.
+_WINDOWS_CANDIDATES: tuple[tuple[str, str], ...] = (
+    ("pwsh", "PowerShell 7"),
+    ("powershell", "Windows PowerShell"),
+    ("cmd", "Command Prompt"),
+)
+
+
+def discover_shells() -> list[ShellDescriptor]:
+    """Return the interactive shells available on this host.
+
+    The result is the concatenation of:
+
+    * POSIX shells found on ``PATH`` (Linux, macOS).
+    * Windows shells (Windows only).
+    * WSL distributions enumerated via ``wsl --list --quiet`` (Windows only,
+      when the ``wsl`` executable is present).
+
+    The function never raises; missing shells simply produce an empty list.
+    """
+    system = platform.system()
+    shells: list[ShellDescriptor] = []
+    if system in {"Linux", "Darwin"}:
+        shells.extend(_discover_posix_shells())
+    elif system == "Windows":
+        shells.extend(_discover_windows_shells())
+        shells.extend(_discover_wsl_distros())
+    return shells
+
+
+def _discover_posix_shells() -> list[ShellDescriptor]:
+    """Return POSIX shells available on the current ``PATH``."""
+    found: list[ShellDescriptor] = []
+    for name in _POSIX_CANDIDATES:
+        path = shutil.which(name)
+        if path is None:
+            continue
+        found.append(
+            ShellDescriptor(identifier=name, label=name, command=(path,)),
+        )
+    return found
+
+
+def _discover_windows_shells() -> list[ShellDescriptor]:
+    """Return native Windows shells available on this host."""
+    found: list[ShellDescriptor] = []
+    for identifier, label in _WINDOWS_CANDIDATES:
+        path = shutil.which(identifier)
+        if path is None:
+            continue
+        command: tuple[str, ...]
+        if identifier in {"pwsh", "powershell"}:
+            command = (path, "-NoLogo")
+        else:
+            command = (path,)
+        found.append(
+            ShellDescriptor(identifier=identifier, label=label, command=command),
+        )
+    return found
+
+
+def _wsl_executable() -> str | None:
+    """Return the path to ``wsl`` when present, else ``None``."""
+    return shutil.which("wsl")
+
+
+def _run_text_command(args: list[str]) -> str | None:
+    """Run ``args`` and return decoded stdout, or ``None`` on failure.
+
+    Output is decoded as UTF-16-LE first (the Windows ``wsl`` default
+    encoding) and falls back to UTF-8. NULs are stripped because some
+    Windows console pipelines pad lines with them.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603 - args are caller-controlled
+            args,
+            capture_output=True,
+            check=False,
+            timeout=5.0,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("shell discovery command failed: %s (%s)", args, exc)
+        return None
+    if completed.returncode != 0:
+        logger.debug("shell discovery command non-zero: %s", args)
+        return None
+    raw = completed.stdout or b""
+    for encoding in ("utf-16-le", "utf-8"):
+        try:
+            text = raw.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+        return text.replace("\x00", "")
+    return None
+
+
+def _discover_wsl_distros() -> list[ShellDescriptor]:
+    """Return WSL distributions reachable via the ``wsl`` launcher."""
+    wsl = _wsl_executable()
+    if wsl is None:
+        return []
+    output = _run_text_command([wsl, "--list", "--quiet"])
+    if output is None:
+        return []
+
+    distros = [line.strip() for line in output.splitlines() if line.strip()]
+    found: list[ShellDescriptor] = []
+    for distro in distros:
+        found.append(
+            ShellDescriptor(
+                identifier=f"wsl:{distro}",
+                label=f"WSL: {distro}",
+                command=(wsl, "-d", distro),
+            ),
+        )
+    return found
+
+
+__all__ = [
+    "ShellDescriptor",
+    "discover_shells",
+]

--- a/tests/shared/python/upstream_drift_tools/ui/test_tools_sidebar_runtime_tabs.py
+++ b/tests/shared/python/upstream_drift_tools/ui/test_tools_sidebar_runtime_tabs.py
@@ -122,7 +122,9 @@ def test_sidekick_calculator_terminal_and_notes_runtime_flow(tmp_path: Path) -> 
         "local gain = [1, 2, 3]",
     )
 
-    assert sidebar.set_active_tab("terminal") is True
+    # UpstreamDrift #5617: the Python REPL now lives on the ``python_repl`` tab
+    # id; the ``terminal`` tab hosts the new OS-level shell.
+    assert sidebar.set_active_tab("python_repl") is True
     terminal = sidebar.tabs.currentWidget()
     script = terminal.findChild(QtWidgets.QPlainTextEdit, "SidekickTerminalInput")
     run = terminal.findChild(QtWidgets.QPushButton, "SidekickTerminalRun")
@@ -220,7 +222,9 @@ def test_sidekick_terminal_and_notes_controls_have_tooltips(tmp_path: Path) -> N
     _ = app
     sidebar = UnifiedToolsSidebar(project_root=tmp_path)
 
-    assert sidebar.set_active_tab("terminal") is True
+    # UpstreamDrift #5617: the Python REPL controls live on the
+    # ``python_repl`` tab id after the OS-terminal split.
+    assert sidebar.set_active_tab("python_repl") is True
     terminal = sidebar.tabs.currentWidget()
     terminal_widgets = (
         terminal.findChild(QtWidgets.QPlainTextEdit, "SidekickTerminalInput"),

--- a/tests/unit/sidekick/__init__.py
+++ b/tests/unit/sidekick/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for Sidekick OS-level terminal and shell discovery."""

--- a/tests/unit/sidekick/test_os_terminal_widget.py
+++ b/tests/unit/sidekick/test_os_terminal_widget.py
@@ -1,0 +1,226 @@
+"""Tests for the Sidekick OS Terminal widget (UpstreamDrift #5617)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def qt_app():  # noqa: ANN201
+    """Provide a singleton ``QApplication`` for widget tests."""
+    try:
+        from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+    except ImportError:
+        pytest.skip("Qt widgets unavailable")
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    yield app
+
+
+def _make_descriptor(identifier: str = "bash"):  # noqa: ANN202
+    from upstream_drift_tools.ui.tools_sidebar.shell_discovery import ShellDescriptor
+
+    return ShellDescriptor(
+        identifier=identifier,
+        label=identifier,
+        command=("/usr/bin/" + identifier,),
+    )
+
+
+def test_widget_shows_cwd_label(qt_app, tmp_path: Path) -> None:  # noqa: ANN001
+    """The widget exposes a cwd label initialised to the starting directory."""
+    from upstream_drift_tools.ui.tools_sidebar.os_terminal import (
+        SidekickOsTerminalWidget,
+    )
+
+    from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+
+    widget = SidekickOsTerminalWidget(
+        project_root=tmp_path,
+        shells=[_make_descriptor("bash")],
+        autostart=False,
+    )
+    label = widget.findChild(QtWidgets.QLabel, "SidekickOsTerminalCwd")
+    assert label is not None
+    assert str(tmp_path) in label.text()
+
+
+def test_widget_shell_dropdown_lists_discovered_shells(
+    qt_app,  # noqa: ANN001
+    tmp_path: Path,
+) -> None:
+    """The shell selector exposes every discovered descriptor."""
+    from upstream_drift_tools.ui.tools_sidebar.os_terminal import (
+        SidekickOsTerminalWidget,
+    )
+    from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+
+    shells = [_make_descriptor("bash"), _make_descriptor("zsh")]
+    widget = SidekickOsTerminalWidget(
+        project_root=tmp_path,
+        shells=shells,
+        autostart=False,
+    )
+    combo = widget.findChild(QtWidgets.QComboBox, "SidekickOsTerminalShellSelector")
+    assert combo is not None
+    items = [combo.itemText(i) for i in range(combo.count())]
+    assert "bash" in items
+    assert "zsh" in items
+
+
+def test_widget_updates_cwd_on_osc7(qt_app, tmp_path: Path) -> None:  # noqa: ANN001
+    """OSC 7 sequences update the live cwd label via a single slot."""
+    from upstream_drift_tools.ui.tools_sidebar.os_terminal import (
+        SidekickOsTerminalWidget,
+    )
+    from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+
+    widget = SidekickOsTerminalWidget(
+        project_root=tmp_path,
+        shells=[_make_descriptor("bash")],
+        autostart=False,
+    )
+    other = tmp_path / "subdir"
+    other.mkdir()
+
+    osc7 = f"\x1b]7;file://hostname{other.as_posix()}\x1b\\"
+    widget._handle_output(osc7.encode())  # noqa: SLF001 - direct slot test
+
+    label = widget.findChild(QtWidgets.QLabel, "SidekickOsTerminalCwd")
+    assert str(other) in label.text()
+
+
+def test_widget_shows_install_hint_when_no_backend_available(
+    qt_app,  # noqa: ANN001
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When PTY libraries are missing the widget shows a labelled fallback."""
+    from upstream_drift_tools.ui.tools_sidebar import os_terminal
+
+    # Force the backend factory to report unavailability.
+    monkeypatch.setattr(
+        os_terminal,
+        "select_backend",
+        lambda **_kwargs: (None, "pty backend missing"),
+    )
+
+    widget = os_terminal.SidekickOsTerminalWidget(
+        project_root=tmp_path,
+        shells=[_make_descriptor("bash")],
+        autostart=True,
+    )
+
+    from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+
+    hint = widget.findChild(QtWidgets.QLabel, "SidekickOsTerminalInstallHint")
+    assert hint is not None
+    assert "pty" in hint.text().lower() or "install" in hint.text().lower()
+
+
+def test_widget_switching_shell_terminates_previous(
+    qt_app,  # noqa: ANN001
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Selecting a different shell stops the current backend before starting."""
+    from upstream_drift_tools.ui.tools_sidebar import os_terminal
+
+    started: list[str] = []
+    terminated: list[str] = []
+
+    class FakeBackend:
+        def __init__(self, command: tuple[str, ...], cwd: object) -> None:
+            self.command = command
+            self.is_running = False
+
+        def start(self) -> None:
+            started.append(self.command[0])
+            self.is_running = True
+
+        def write(self, _data: bytes) -> None:  # pragma: no cover - unused
+            return None
+
+        def read(self, timeout: float = 0.0) -> bytes:  # noqa: ARG002
+            return b""
+
+        def terminate(self) -> None:
+            terminated.append(self.command[0])
+            self.is_running = False
+
+        def resize(self, rows: int, cols: int) -> None:  # noqa: ARG002
+            return None
+
+    def fake_select(
+        command: tuple[str, ...],
+        cwd: object,
+        **_kwargs: object,
+    ) -> tuple[object, str | None]:
+        return FakeBackend(command=command, cwd=cwd), None
+
+    monkeypatch.setattr(os_terminal, "select_backend", fake_select)
+
+    shells = [_make_descriptor("bash"), _make_descriptor("zsh")]
+    widget = os_terminal.SidekickOsTerminalWidget(
+        project_root=tmp_path,
+        shells=shells,
+        autostart=True,
+    )
+    assert started == ["/usr/bin/bash"]
+
+    widget.switch_shell("zsh")
+    assert terminated == ["/usr/bin/bash"]
+    assert started[-1] == "/usr/bin/zsh"
+
+
+def test_widget_resets_cwd_on_shell_switch(
+    qt_app,  # noqa: ANN001
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Switching shells resets the cwd label to the project root."""
+    from upstream_drift_tools.ui.tools_sidebar import os_terminal
+    from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+
+    class FakeBackend:
+        def __init__(self, command: tuple[str, ...], cwd: object) -> None:
+            self.command = command
+            self.is_running = False
+
+        def start(self) -> None:
+            self.is_running = True
+
+        def write(self, _data: bytes) -> None:  # pragma: no cover - unused
+            return None
+
+        def read(self, timeout: float = 0.0) -> bytes:  # noqa: ARG002
+            return b""
+
+        def terminate(self) -> None:
+            self.is_running = False
+
+        def resize(self, rows: int, cols: int) -> None:  # noqa: ARG002
+            return None
+
+    monkeypatch.setattr(
+        os_terminal,
+        "select_backend",
+        lambda command, cwd, **_kwargs: (FakeBackend(command=command, cwd=cwd), None),
+    )
+
+    shells = [_make_descriptor("bash"), _make_descriptor("zsh")]
+    widget = os_terminal.SidekickOsTerminalWidget(
+        project_root=tmp_path,
+        shells=shells,
+        autostart=True,
+    )
+
+    # Simulate a cwd change away from the project root.
+    other = tmp_path / "child"
+    other.mkdir()
+    widget._on_cwd_changed(other)  # noqa: SLF001
+
+    widget.switch_shell("zsh")
+    label = widget.findChild(QtWidgets.QLabel, "SidekickOsTerminalCwd")
+    assert str(tmp_path) in label.text()

--- a/tests/unit/sidekick/test_os_terminal_widget.py
+++ b/tests/unit/sidekick/test_os_terminal_widget.py
@@ -33,7 +33,6 @@ def test_widget_shows_cwd_label(qt_app, tmp_path: Path) -> None:  # noqa: ANN001
     from upstream_drift_tools.ui.tools_sidebar.os_terminal import (
         SidekickOsTerminalWidget,
     )
-
     from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
 
     widget = SidekickOsTerminalWidget(

--- a/tests/unit/sidekick/test_python_repl_widget_renamed.py
+++ b/tests/unit/sidekick/test_python_repl_widget_renamed.py
@@ -1,0 +1,71 @@
+"""Regression tests for the Python REPL widget rename (UpstreamDrift #5617).
+
+``SidekickTerminalWidget`` was misnamed: it never ran an OS shell, only a
+Python REPL. After the #5617 rename the class is
+``SidekickPythonReplWidget`` and the tab id is ``python_repl``. The OS
+terminal claims the original ``terminal`` tab id.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_python_repl_widget_is_renamed_export() -> None:
+    """The renamed class lives at the canonical module path."""
+    from upstream_drift_tools.ui.tools_sidebar.runtime_tabs import (
+        SidekickPythonReplWidget,
+    )
+
+    assert SidekickPythonReplWidget.__name__ == "SidekickPythonReplWidget"
+
+
+def test_python_repl_widget_evaluates_python(tmp_path: Path) -> None:
+    """The renamed widget still evaluates Python and exports variables."""
+    try:
+        from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+    except ImportError:
+        pytest.skip("Qt widgets unavailable")
+
+    from upstream_drift_tools.ui.tools_sidebar import UnifiedToolsSidebar
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    _ = app
+    sidebar = UnifiedToolsSidebar(project_root=tmp_path)
+
+    assert sidebar.set_active_tab("python_repl") is True
+    repl = sidebar.tabs.currentWidget()
+    script = repl.findChild(QtWidgets.QPlainTextEdit, "SidekickTerminalInput")
+    run = repl.findChild(QtWidgets.QPushButton, "SidekickTerminalRun")
+    output = repl.findChild(QtWidgets.QPlainTextEdit, "SidekickTerminalOutput")
+    assert script is not None
+    assert run is not None
+    assert output is not None
+
+    script.setPlainText("answer = 21 * 2\nprint(answer)")
+    run.click()
+
+    assert "42" in output.toPlainText()
+    assert sidebar.registry.get("answer") == 42
+
+
+def test_terminal_tab_id_now_hosts_os_terminal(tmp_path: Path) -> None:
+    """The ``terminal`` tab id now hosts the new OS terminal widget."""
+    try:
+        from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+    except ImportError:
+        pytest.skip("Qt widgets unavailable")
+
+    from upstream_drift_tools.ui.tools_sidebar import UnifiedToolsSidebar
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    _ = app
+    sidebar = UnifiedToolsSidebar(project_root=tmp_path)
+
+    assert sidebar.set_active_tab("terminal") is True
+    terminal = sidebar.tabs.currentWidget()
+    # The OS terminal widget exposes a cwd label; the renamed REPL does not.
+    cwd_label = terminal.findChild(QtWidgets.QLabel, "SidekickOsTerminalCwd")
+    assert cwd_label is not None

--- a/tests/unit/sidekick/test_shell_discovery.py
+++ b/tests/unit/sidekick/test_shell_discovery.py
@@ -1,0 +1,151 @@
+"""Tests for the Sidekick shell discovery helpers (UpstreamDrift #5617).
+
+The discovery module is the single source of truth for which interactive
+shells the Sidekick OS Terminal can launch. The widget, settings UI, and
+all tests must consume :func:`discover_shells` (DRY).
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+
+
+def _is_linux() -> bool:
+    return platform.system() == "Linux"
+
+
+def _is_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+def _is_posix() -> bool:
+    return platform.system() in {"Linux", "Darwin"}
+
+
+@pytest.fixture
+def empty_path(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear PATH so :func:`shutil.which` finds nothing."""
+    monkeypatch.setenv("PATH", "")
+
+    def _missing(_name: str, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(shutil, "which", _missing)
+    yield
+
+
+def test_discover_shells_returns_shell_descriptors() -> None:
+    """:func:`discover_shells` returns a list of ``ShellDescriptor`` items."""
+    from upstream_drift_tools.ui.tools_sidebar.shell_discovery import (
+        ShellDescriptor,
+        discover_shells,
+    )
+
+    shells = discover_shells()
+    assert isinstance(shells, list)
+    for shell in shells:
+        assert isinstance(shell, ShellDescriptor)
+        assert isinstance(shell.identifier, str) and shell.identifier
+        assert isinstance(shell.label, str) and shell.label
+        assert isinstance(shell.command, tuple)
+        assert all(isinstance(part, str) for part in shell.command)
+
+
+def test_discover_shells_empty_environment_returns_empty(empty_path: None) -> None:
+    """Empty PATH and no platform shells leaves an empty descriptor list."""
+    from upstream_drift_tools.ui.tools_sidebar import shell_discovery
+
+    # Also stub out platform-specific probes so the discovery has truly
+    # nothing to find.
+    with (
+        patch.object(shell_discovery, "_discover_posix_shells", return_value=[]),
+        patch.object(shell_discovery, "_discover_windows_shells", return_value=[]),
+        patch.object(shell_discovery, "_discover_wsl_distros", return_value=[]),
+    ):
+        assert shell_discovery.discover_shells() == []
+
+
+@pytest.mark.skipif(not _is_linux(), reason="POSIX-only check")
+def test_discover_shells_finds_bash_on_linux() -> None:
+    """``bash`` appears on every supported Linux runner."""
+    from upstream_drift_tools.ui.tools_sidebar.shell_discovery import discover_shells
+
+    identifiers = {shell.identifier for shell in discover_shells()}
+    assert "bash" in identifiers
+
+
+@pytest.mark.skipif(not _is_posix(), reason="POSIX-only check")
+def test_posix_discovery_uses_shutil_which() -> None:
+    """The POSIX probe consults :func:`shutil.which` to locate shells."""
+    from upstream_drift_tools.ui.tools_sidebar.shell_discovery import (
+        _discover_posix_shells,
+    )
+
+    fake_path = "/usr/bin/bash"
+
+    def fake_which(name: str) -> str | None:
+        return fake_path if name == "bash" else None
+
+    with patch("shutil.which", side_effect=fake_which):
+        shells = _discover_posix_shells()
+
+    identifiers = {shell.identifier for shell in shells}
+    assert "bash" in identifiers
+    bash = next(shell for shell in shells if shell.identifier == "bash")
+    assert bash.command[0] == fake_path
+
+
+@pytest.mark.skipif(not _is_windows(), reason="Windows-only check")
+def test_discover_shells_finds_pwsh_or_powershell_on_windows() -> None:
+    """At least one Windows shell is found on a standard Windows install."""
+    from upstream_drift_tools.ui.tools_sidebar.shell_discovery import discover_shells
+
+    identifiers = {shell.identifier for shell in discover_shells()}
+    assert identifiers & {"pwsh", "powershell", "cmd"}
+
+
+def test_wsl_distros_enumerated_from_wsl_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_discover_wsl_distros`` parses ``wsl --list --quiet`` output."""
+    from upstream_drift_tools.ui.tools_sidebar import shell_discovery
+
+    # `wsl --list --quiet` on Windows emits UTF-16-LE with NUL padding; the
+    # helper must already have decoded the bytes by the time we see them.
+    fake_output = "Ubuntu-22.04\nDebian\n"
+
+    def fake_run(args: list[str]) -> str | None:
+        if args[:3] == ["wsl", "--list", "--quiet"]:
+            return fake_output
+        return None
+
+    monkeypatch.setattr(shell_discovery, "_run_text_command", fake_run)
+    monkeypatch.setattr(shell_discovery, "_wsl_executable", lambda: "wsl")
+
+    descriptors = shell_discovery._discover_wsl_distros()
+    identifiers = {shell.identifier for shell in descriptors}
+    assert "wsl:Ubuntu-22.04" in identifiers
+    assert "wsl:Debian" in identifiers
+
+
+def test_wsl_unavailable_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the ``wsl`` executable is missing the helper returns ``[]``."""
+    from upstream_drift_tools.ui.tools_sidebar import shell_discovery
+
+    monkeypatch.setattr(shell_discovery, "_wsl_executable", lambda: None)
+    assert shell_discovery._discover_wsl_distros() == []
+
+
+def test_shell_descriptor_rejects_empty_identifier() -> None:
+    """``ShellDescriptor`` validates inputs (DbC preconditions)."""
+    from upstream_drift_tools.ui.tools_sidebar.shell_discovery import ShellDescriptor
+
+    with pytest.raises(ValueError):
+        ShellDescriptor(identifier="", label="x", command=("/bin/sh",))
+    with pytest.raises(ValueError):
+        ShellDescriptor(identifier="bash", label="", command=("/bin/bash",))
+    with pytest.raises(ValueError):
+        ShellDescriptor(identifier="bash", label="bash", command=())

--- a/tests/unit/sidekick/test_terminal_backend.py
+++ b/tests/unit/sidekick/test_terminal_backend.py
@@ -26,7 +26,10 @@ def fallback_backend():  # noqa: ANN201
 
     # Run a minimal Python loop that echoes lines back: cross-platform and
     # avoids requiring an interactive shell on the CI runner.
-    code = "import sys\nfor line in sys.stdin: sys.stdout.write(line); sys.stdout.flush()\n"
+    code = (
+        "import sys\n"
+        "for line in sys.stdin: sys.stdout.write(line); sys.stdout.flush()\n"
+    )
     backend = SubprocessFallbackBackend(
         command=(sys.executable, "-u", "-c", code), cwd=None
     )

--- a/tests/unit/sidekick/test_terminal_backend.py
+++ b/tests/unit/sidekick/test_terminal_backend.py
@@ -1,0 +1,140 @@
+"""Tests for the PTY-backed terminal backend protocol (UpstreamDrift #5617)."""
+
+from __future__ import annotations
+
+import platform
+import sys
+import time
+
+import pytest
+
+
+def _is_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+def _is_posix() -> bool:
+    return platform.system() in {"Linux", "Darwin"}
+
+
+@pytest.fixture
+def fallback_backend():  # noqa: ANN201
+    """Yield a :class:`SubprocessFallbackBackend` running ``python -u``."""
+    from upstream_drift_tools.ui.tools_sidebar.os_terminal import (
+        SubprocessFallbackBackend,
+    )
+
+    # Run a minimal Python loop that echoes lines back: cross-platform and
+    # avoids requiring an interactive shell on the CI runner.
+    code = "import sys\nfor line in sys.stdin: sys.stdout.write(line); sys.stdout.flush()\n"
+    backend = SubprocessFallbackBackend(
+        command=(sys.executable, "-u", "-c", code), cwd=None
+    )
+    backend.start()
+    try:
+        yield backend
+    finally:
+        backend.terminate()
+
+
+def test_fallback_backend_starts_and_reports_running(fallback_backend) -> None:  # noqa: ANN001
+    """``is_running`` is True once a child process has been spawned."""
+    assert fallback_backend.is_running is True
+
+
+def test_fallback_backend_round_trip(fallback_backend) -> None:  # noqa: ANN001
+    """Writing bytes and reading produces the echoed payload."""
+    fallback_backend.write(b"hello\n")
+
+    deadline = time.time() + 5.0
+    seen = b""
+    while time.time() < deadline:
+        seen += fallback_backend.read(timeout=0.1)
+        if b"hello" in seen:
+            break
+    assert b"hello" in seen
+
+
+def test_fallback_backend_write_rejects_empty() -> None:
+    """``write(b"")`` raises ``ValueError`` (DbC precondition)."""
+    from upstream_drift_tools.ui.tools_sidebar.os_terminal import (
+        SubprocessFallbackBackend,
+    )
+
+    backend = SubprocessFallbackBackend(command=(sys.executable, "-V"), cwd=None)
+    backend.start()
+    try:
+        with pytest.raises(ValueError):
+            backend.write(b"")
+    finally:
+        backend.terminate()
+
+
+def test_backend_read_requires_running_process() -> None:
+    """Reading a never-started backend raises a clear ``RuntimeError``."""
+    from upstream_drift_tools.ui.tools_sidebar.os_terminal import (
+        SubprocessFallbackBackend,
+    )
+
+    backend = SubprocessFallbackBackend(command=(sys.executable, "-V"), cwd=None)
+    # Never call .start() — must guard the precondition.
+    with pytest.raises(RuntimeError):
+        backend.read(timeout=0.1)
+
+
+def test_fallback_backend_terminate_kills_process(fallback_backend) -> None:  # noqa: ANN001
+    """``terminate`` flips ``is_running`` to ``False``."""
+    fallback_backend.terminate()
+    # Allow the process supervisor a brief moment to reap.
+    for _ in range(20):
+        if not fallback_backend.is_running:
+            break
+        time.sleep(0.05)
+    assert fallback_backend.is_running is False
+
+
+def test_resize_does_not_raise_on_fallback_backend(fallback_backend) -> None:  # noqa: ANN001
+    """``resize`` is a no-op on the fallback backend (still satisfies protocol)."""
+    fallback_backend.resize(rows=24, cols=80)
+
+
+@pytest.mark.skipif(not _is_posix(), reason="ptyprocess requires POSIX")
+def test_posix_pty_backend_round_trip_if_available() -> None:  # pragma: no cover
+    """Smoke-test the real PTY backend when ``ptyprocess`` is installed."""
+    pytest.importorskip("ptyprocess")
+    from upstream_drift_tools.ui.tools_sidebar.os_terminal import PosixPtyBackend
+
+    backend = PosixPtyBackend(command=("/bin/sh",), cwd=None)
+    backend.start()
+    try:
+        backend.write(b"echo hello\n")
+        deadline = time.time() + 5.0
+        seen = b""
+        while time.time() < deadline:
+            seen += backend.read(timeout=0.1)
+            if b"hello" in seen:
+                break
+        assert b"hello" in seen
+    finally:
+        backend.terminate()
+
+
+@pytest.mark.skipif(not _is_windows(), reason="pywinpty requires Windows")
+def test_windows_pty_backend_round_trip_if_available() -> None:  # pragma: no cover
+    """Smoke-test the real ConPTY backend when ``pywinpty`` is installed."""
+    pytest.importorskip("winpty")
+    from upstream_drift_tools.ui.tools_sidebar.os_terminal import WindowsPtyBackend
+
+    backend = WindowsPtyBackend(command=("cmd.exe",), cwd=None)
+    backend.start()
+    try:
+        backend.write(b"echo hello\r\n")
+        deadline = time.time() + 5.0
+        seen = b""
+        while time.time() < deadline:
+            seen += backend.read(timeout=0.1)
+            if b"hello" in seen:
+                break
+        assert b"hello" in seen
+    finally:
+        backend.terminate()


### PR DESCRIPTION
## Summary
- Adds a real OS-level terminal tab (`SidekickOsTerminalWidget`) backed by a PTY — uses `ptyprocess` on POSIX, `pywinpty` (ConPTY) on Windows, and falls back to a labelled `subprocess.PIPE` backend when neither is installed. Shell selector lists bash/zsh/pwsh/powershell/cmd plus every WSL distro discovered via `wsl --list --quiet`. Live cwd label tracks the shell via OSC 7 sequences.
- Renames `SidekickTerminalWidget` -> `SidekickPythonReplWidget` (more honest — it never ran an OS shell, just a bounded Python REPL). Object names + child widget names are preserved so existing styling and tests continue to work.
- Splits the sidebar's single "Terminal" tab into two: **Terminal** (new OS shell) and **Python REPL** (the renamed widget). `help_content` gains a matching entry.
- New `shell_discovery.discover_shells()` is the single source of truth (DRY) for available shells. The widget, settings dropdown, and tests all consume it.
- New `[project.optional-dependencies] terminal` extra ships the PTY libraries: `pywinpty>=2.0` on Windows, `ptyprocess` elsewhere.

## Design
- **DbC.** `TerminalBackend.write(b"")` raises `ValueError`; `read()` asserts `is_running` and raises `RuntimeError` otherwise. `ShellDescriptor` validates `identifier`/`label`/`command` in `__post_init__`.
- **LOD.** The widget talks to the backend only through `read`/`write`/`terminate`/`resize` — never reaches into `backend._proc._stdin._fd`. Cwd updates flow through a single `_on_cwd_changed(path)` slot.
- **DRY.** Shell discovery is centralised; no caller hard-codes shell paths.

## Tests
- 22 new tests pass (`tests/unit/sidekick/`): widget, backend protocol, shell discovery, REPL-rename regression.
- Existing `tests/shared/.../test_tools_sidebar_runtime_tabs.py` updated to use the new `python_repl` tab id; 11 tests still pass.

## Concurrent work
Wave 2 v2 Agent B (`feat/5616-workspace-matlab-style`) also touches `runtime_tabs.py` + `default_tabs.py` to extract a new registry-bound `PythonReplWidget` class. That class is **different** from this PR's `SidekickPythonReplWidget` (which is just the rename of the old widget). Coordination is straightforward — pick the more capable class when both land.

## Test plan
- [ ] `python3 -m ruff check .` green on touched files
- [ ] `python3 -m ruff format --check .` green on touched files
- [ ] `python3 -m pytest tests/unit/sidekick/ -p no:xdist` — 22 passed, 3 skipped (platform-specific)
- [ ] `python3 -m pytest tests/shared/python/upstream_drift_tools/ui/test_tools_sidebar_runtime_tabs.py` — 11 passed
- [ ] Smoke-test on a host with `ptyprocess` / `pywinpty` installed (the `terminal` extra)