### PR TITLE
feat(mcp): MCP infrastructure + NotebookLM shim (UpstreamDrift #5615)

### DIFF
--- a/src/shared/python/ai/mcp/__init__.py
+++ b/src/shared/python/ai/mcp/__init__.py
@@ -1,0 +1,38 @@
+"""MCP (Model Context Protocol) infrastructure.
+
+Public exports for connecting to and managing external MCP servers
+(stdio or HTTP) and aggregating their tools and resources into the local
+``ToolRegistry``.
+
+Public surface:
+    - ``McpServerConfig`` / ``McpTransport`` (Pydantic config)
+    - ``McpToolDescriptor`` / ``McpResourceDescriptor``
+    - ``McpClient`` (single-server wrapper)
+    - ``McpClientPool`` (aggregation across N servers)
+    - ``load_mcp_servers`` (Claude-Desktop-compatible config loader)
+
+External callers should reach MCP capabilities through the pool, never by
+indexing into ``pool._clients`` directly (LOD).
+"""
+
+from __future__ import annotations
+
+from src.shared.python.ai.mcp.client import McpClient
+from src.shared.python.ai.mcp.config_loader import load_mcp_servers
+from src.shared.python.ai.mcp.contracts import (
+    McpResourceDescriptor,
+    McpServerConfig,
+    McpToolDescriptor,
+    McpTransport,
+)
+from src.shared.python.ai.mcp.pool import McpClientPool
+
+__all__ = [
+    "McpClient",
+    "McpClientPool",
+    "McpResourceDescriptor",
+    "McpServerConfig",
+    "McpToolDescriptor",
+    "McpTransport",
+    "load_mcp_servers",
+]

--- a/src/shared/python/ai/mcp/client.py
+++ b/src/shared/python/ai/mcp/client.py
@@ -1,0 +1,288 @@
+"""``McpClient`` — single-server JSON-RPC wrapper for MCP.
+
+Two transports are supported:
+
+- **stdio**: spawn the configured command as a long-lived child process and
+  exchange newline-delimited JSON-RPC 2.0 frames over its stdin/stdout.
+  On disconnect we send SIGTERM and wait up to 5 seconds before killing.
+- **http**: POST JSON-RPC bodies to the configured URL via ``httpx``.
+
+Both transports implement the ``McpTransportProtocol`` so tests can substitute
+an in-memory fake — the unit suite does this and never touches a real
+subprocess or network socket.
+
+Process-sandbox policy (stdio):
+    Children receive only an allow-listed environment (PATH, HOME, plus
+    any per-server ``env`` mapping). This prevents leaking secrets unrelated
+    to the requested server.
+
+Design notes:
+    * Public methods enforce DbC preconditions (``is_connected``,
+      non-empty tool name).
+    * Connect/disconnect are idempotent.
+    * No external callers should reach into ``client._transport`` — LOD.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Protocol
+
+import httpx
+
+from src.shared.python.ai.mcp.contracts import (
+    McpResourceDescriptor,
+    McpServerConfig,
+    McpToolDescriptor,
+    McpTransport,
+)
+
+_LOG = logging.getLogger(__name__)
+_STOP_GRACE_SECONDS = 5.0
+_ALLOWLIST_ENV_KEYS = ("PATH", "HOME", "USERPROFILE", "SYSTEMROOT", "TEMP", "TMP")
+
+
+class McpTransportProtocol(Protocol):
+    """Minimal transport contract for ``McpClient``."""
+
+    async def start(self) -> None: ...
+    async def stop(self) -> None: ...
+    async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]: ...
+
+
+def _sandboxed_env(extra: dict[str, str]) -> dict[str, str]:
+    """Return an allow-listed environment merged with the per-server ``env``."""
+    base: dict[str, str] = {}
+    for key in _ALLOWLIST_ENV_KEYS:
+        value = os.environ.get(key)
+        if value is not None:
+            base[key] = value
+    base.update(extra)
+    return base
+
+
+class StdioTransport:
+    """Spawns the configured command and speaks JSON-RPC over stdio."""
+
+    def __init__(self, config: McpServerConfig) -> None:
+        self._config = config
+        self._process: asyncio.subprocess.Process | None = None
+        self._lock = asyncio.Lock()
+        self._next_id = 1
+
+    async def start(self) -> None:
+        if self._process is not None:
+            return
+        assert self._config.command is not None  # validated by Pydantic
+        self._process = await asyncio.create_subprocess_exec(
+            self._config.command,
+            *self._config.args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=_sandboxed_env(self._config.env),
+        )
+
+    async def stop(self) -> None:
+        process = self._process
+        if process is None:
+            return
+        self._process = None
+        if process.returncode is not None:
+            return
+        try:
+            process.terminate()
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(process.wait(), timeout=_STOP_GRACE_SECONDS)
+        except TimeoutError:
+            _LOG.warning(
+                "MCP server %s did not exit in %.1fs; killing",
+                self._config.name,
+                _STOP_GRACE_SECONDS,
+            )
+            try:
+                process.kill()
+            except ProcessLookupError:
+                return
+            await process.wait()
+
+    async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if self._process is None:
+            raise RuntimeError("stdio transport not started")
+        if self._process.stdin is None or self._process.stdout is None:
+            raise RuntimeError("stdio transport streams unavailable")
+        async with self._lock:
+            request_id = self._next_id
+            self._next_id += 1
+            payload = {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+            data = (json.dumps(payload) + "\n").encode("utf-8")
+            self._process.stdin.write(data)
+            await self._process.stdin.drain()
+            line = await asyncio.wait_for(
+                self._process.stdout.readline(),
+                timeout=self._config.timeout_seconds,
+            )
+            if not line:
+                raise RuntimeError("MCP server closed stdout")
+            response = json.loads(line.decode("utf-8"))
+            if "error" in response:
+                raise RuntimeError(f"MCP error: {response['error']}")
+            result = response.get("result", {})
+            if not isinstance(result, dict):
+                raise RuntimeError("MCP result was not a JSON object")
+            return result
+
+
+class HttpTransport:
+    """POSTs JSON-RPC frames to the configured URL."""
+
+    def __init__(self, config: McpServerConfig) -> None:
+        self._config = config
+        self._client: httpx.AsyncClient | None = None
+        self._next_id = 1
+
+    async def start(self) -> None:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._config.timeout_seconds)
+
+    async def stop(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if self._client is None or self._config.url is None:
+            raise RuntimeError("http transport not started")
+        request_id = self._next_id
+        self._next_id += 1
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        resp = await self._client.post(self._config.url, json=payload)
+        resp.raise_for_status()
+        body = resp.json()
+        if "error" in body:
+            raise RuntimeError(f"MCP error: {body['error']}")
+        result = body.get("result", {})
+        if not isinstance(result, dict):
+            raise RuntimeError("MCP result was not a JSON object")
+        return result
+
+
+def _default_transport(config: McpServerConfig) -> McpTransportProtocol:
+    if config.transport is McpTransport.STDIO:
+        return StdioTransport(config)
+    return HttpTransport(config)
+
+
+class McpClient:
+    """Single-server MCP client.
+
+    Lifecycle:
+        >>> client = McpClient(cfg)
+        >>> await client.connect()
+        >>> tools = await client.list_tools()
+        >>> result = await client.call_tool("search", {"q": "hi"})
+        >>> await client.disconnect()
+
+    Preconditions (DbC):
+        * ``list_tools`` / ``list_resources`` / ``call_tool`` require
+          ``is_connected``.
+        * ``call_tool`` requires a non-empty tool name.
+    """
+
+    def __init__(
+        self,
+        config: McpServerConfig,
+        transport: McpTransportProtocol | None = None,
+    ) -> None:
+        self._config = config
+        self._transport: McpTransportProtocol = transport or _default_transport(config)
+        self._connected = False
+
+    @property
+    def config(self) -> McpServerConfig:
+        return self._config
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> None:
+        """Start the transport and perform the MCP ``initialize`` handshake."""
+        if self._connected:
+            return
+        await self._transport.start()
+        try:
+            await self._transport.request(
+                "initialize",
+                {
+                    "protocolVersion": "2024-11-05",
+                    "clientInfo": {"name": "upstreamdrift", "version": "0.1.0"},
+                    "capabilities": {},
+                },
+            )
+        except Exception:
+            await self._transport.stop()
+            raise
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        """Stop the transport. Idempotent."""
+        if not self._connected:
+            return
+        self._connected = False
+        await self._transport.stop()
+
+    async def list_tools(self) -> list[McpToolDescriptor]:
+        if not self._connected:
+            raise RuntimeError("MCP client not connected")
+        raw = await self._transport.request("tools/list", {})
+        tools_raw = raw.get("tools", [])
+        return [
+            McpToolDescriptor(
+                name=t["name"],
+                description=t.get("description", ""),
+                input_schema=t.get(
+                    "inputSchema",
+                    t.get("input_schema", {"type": "object", "properties": {}}),
+                ),
+            )
+            for t in tools_raw
+        ]
+
+    async def list_resources(self) -> list[McpResourceDescriptor]:
+        if not self._connected:
+            raise RuntimeError("MCP client not connected")
+        raw = await self._transport.request("resources/list", {})
+        return [
+            McpResourceDescriptor(
+                uri=r["uri"],
+                name=r.get("name", ""),
+                description=r.get("description", ""),
+                mime_type=r.get("mimeType") or r.get("mime_type"),
+            )
+            for r in raw.get("resources", [])
+        ]
+
+    async def call_tool(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+        if not name:
+            raise ValueError("tool name must be non-empty")
+        if not self._connected:
+            raise RuntimeError("MCP client not connected")
+        return await self._transport.request(
+            "tools/call", {"name": name, "arguments": args}
+        )

--- a/src/shared/python/ai/mcp/config_loader.py
+++ b/src/shared/python/ai/mcp/config_loader.py
@@ -1,0 +1,133 @@
+"""Claude-Desktop-compatible MCP server config loader.
+
+The on-disk format follows Claude Desktop's ``mcp_servers.json``:
+
+.. code-block:: json
+
+    {
+      "mcpServers": {
+        "notebooklm": {
+          "command": "python",
+          "args": ["-m", "notebooklm_mcp"],
+          "env": {"API_KEY": "${MY_API_KEY}"}
+        },
+        "remote": {
+          "transport": "http",
+          "url": "https://example.com/mcp"
+        }
+      }
+    }
+
+Behaviour:
+    * ``${ENV_VAR}`` placeholders inside ``env`` values are expanded from the
+      current process environment. Unresolved placeholders are left intact
+      and a WARNING is logged so the operator can fix the missing var.
+    * Invalid entries (Pydantic validation error, unsupported transport,
+      missing required field) are skipped with a WARNING — they do *not*
+      bring down the rest of the configuration.
+    * Missing or malformed config files return an empty list rather than
+      raising, so the caller can degrade gracefully when MCP is unconfigured.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from src.shared.python.ai.mcp.contracts import McpServerConfig
+
+_LOG = logging.getLogger(__name__)
+_ENV_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+DEFAULT_CONFIG_PATH = Path.home() / ".upstreamdrift" / "mcp_servers.json"
+
+
+def expand_env_vars(value: str) -> str:
+    """Expand ``${ENV_VAR}`` placeholders. Unset vars are left as-is."""
+
+    def _replace(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        env_value = os.environ.get(var_name)
+        if env_value is None:
+            _LOG.warning("MCP config: environment variable %s is not set", var_name)
+            return match.group(0)
+        return env_value
+
+    return _ENV_PATTERN.sub(_replace, value)
+
+
+def _expand_env_map(env: dict[str, Any]) -> dict[str, str]:
+    expanded: dict[str, str] = {}
+    for key, raw in env.items():
+        if not isinstance(raw, str):
+            _LOG.warning("MCP config: non-string env value for %s; coercing", key)
+        expanded[key] = expand_env_vars(str(raw))
+    return expanded
+
+
+def parse_mcp_servers(raw: dict[str, Any]) -> list[McpServerConfig]:
+    """Parse the deserialized JSON config dict into validated configs."""
+    servers = raw.get("mcpServers") or {}
+    if not isinstance(servers, dict):
+        _LOG.warning("MCP config: 'mcpServers' is not a JSON object; ignoring")
+        return []
+    configs: list[McpServerConfig] = []
+    for name, entry in servers.items():
+        if not isinstance(entry, dict):
+            _LOG.warning("MCP config: entry %r is not a JSON object; skipping", name)
+            continue
+        try:
+            entry_env = entry.get("env", {})
+            if not isinstance(entry_env, dict):
+                _LOG.warning(
+                    "MCP config: %s 'env' is not a JSON object; skipping",
+                    name,
+                )
+                continue
+            expanded_env = _expand_env_map(entry_env)
+            config = McpServerConfig(
+                name=name,
+                transport=entry.get("transport", "stdio"),
+                command=entry.get("command"),
+                args=list(entry.get("args", [])),
+                env=expanded_env,
+                url=entry.get("url"),
+                timeout_seconds=float(entry.get("timeoutSeconds", 30.0)),
+            )
+        except (ValidationError, ValueError, TypeError) as exc:
+            _LOG.warning("MCP config: skipping invalid entry %r: %s", name, exc)
+            continue
+        configs.append(config)
+    return configs
+
+
+def load_mcp_servers(path: Path | None = None) -> list[McpServerConfig]:
+    """Load and validate the MCP servers configuration file.
+
+    Args:
+        path: Path to the JSON config file. Defaults to
+            ``~/.upstreamdrift/mcp_servers.json``.
+
+    Returns:
+        List of validated configs. Empty list if the file is missing or
+        malformed (logged at WARNING).
+    """
+    target = path or DEFAULT_CONFIG_PATH
+    if not target.exists():
+        _LOG.debug("MCP config file %s does not exist; using empty config", target)
+        return []
+    try:
+        raw_text = target.read_text(encoding="utf-8")
+        raw_data = json.loads(raw_text)
+    except (OSError, json.JSONDecodeError) as exc:
+        _LOG.warning("MCP config: failed to read %s: %s", target, exc)
+        return []
+    if not isinstance(raw_data, dict):
+        _LOG.warning("MCP config: top-level JSON is not an object; ignoring")
+        return []
+    return parse_mcp_servers(raw_data)

--- a/src/shared/python/ai/mcp/contracts.py
+++ b/src/shared/python/ai/mcp/contracts.py
@@ -1,0 +1,91 @@
+"""Pydantic contracts for MCP (Model Context Protocol) infrastructure.
+
+Defines the over-the-wire and configuration data shapes:
+
+- ``McpTransport`` — enum of supported transports (stdio, http).
+- ``McpServerConfig`` — a single MCP server entry. Validation enforces:
+    * stdio transport requires ``command``.
+    * http  transport requires ``url``.
+- ``McpToolDescriptor`` — a tool advertised by an MCP server.
+- ``McpResourceDescriptor`` — a resource advertised by an MCP server.
+
+These models intentionally use Pydantic ``model_validator`` for cross-field
+DbC validation so that misconfigurations are caught at construction time
+rather than at connect/call time.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class McpTransport(StrEnum):
+    """Supported MCP transports."""
+
+    STDIO = "stdio"
+    HTTP = "http"
+
+
+class McpServerConfig(BaseModel):
+    """Configuration for a single MCP server.
+
+    Attributes:
+        name: Unique server identifier used for namespacing tools.
+        transport: ``stdio`` (subprocess) or ``http`` (remote URL).
+        command: Executable to spawn for stdio servers.
+        args: Command-line arguments for stdio servers.
+        env: Extra environment variables for the stdio child process.
+        url: Endpoint URL for http servers.
+        timeout_seconds: Per-request timeout.
+    """
+
+    model_config = {"extra": "ignore"}
+
+    name: str = Field(..., min_length=1)
+    transport: McpTransport = McpTransport.STDIO
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    url: str | None = None
+    timeout_seconds: float = 30.0
+
+    @field_validator("name")
+    @classmethod
+    def _name_nonempty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("name must be a non-empty string")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_transport_fields(self) -> McpServerConfig:
+        if self.transport is McpTransport.STDIO and not self.command:
+            raise ValueError("stdio transport requires 'command'")
+        if self.transport is McpTransport.HTTP and not self.url:
+            raise ValueError("http transport requires 'url'")
+        return self
+
+
+class McpToolDescriptor(BaseModel):
+    """A tool advertised by an MCP server."""
+
+    model_config = {"extra": "ignore"}
+
+    name: str = Field(..., min_length=1)
+    description: str = ""
+    input_schema: dict[str, Any] = Field(
+        default_factory=lambda: {"type": "object", "properties": {}}
+    )
+
+
+class McpResourceDescriptor(BaseModel):
+    """A resource advertised by an MCP server."""
+
+    model_config = {"extra": "ignore"}
+
+    uri: str = Field(..., min_length=1)
+    name: str = ""
+    description: str = ""
+    mime_type: str | None = None

--- a/src/shared/python/ai/mcp/notebooklm_server.py
+++ b/src/shared/python/ai/mcp/notebooklm_server.py
@@ -1,0 +1,198 @@
+"""NotebookLM MCP shim.
+
+There is no first-party Google NotebookLM MCP server at the time of writing
+(2026-05) — the official NotebookLM API is still gated. This module therefore
+implements a small **Python shim** that respects the MCP wire format and can
+be invoked as ``python -m src.shared.python.ai.mcp.notebooklm_server``.
+
+The shim advertises two tools and one resource family:
+
+- ``search_notebook(query: str, notebook_id: str) -> {hits: [...]}``
+- ``summarize_notebook(notebook_id: str) -> {summary: str}``
+- Resource ``notebook://{id}`` (read-only metadata).
+
+Dependency choice:
+    We deliberately avoid adding a heavy upstream dependency (e.g.
+    ``notebooklm-python``, which is unmaintained as of 2026-05). The shim
+    delegates the actual NotebookLM API calls to a pluggable
+    ``NotebookBackend`` Protocol. The default backend returns deterministic
+    stub data so the surface is testable and useful for local development
+    without credentials.
+
+The shim is intentionally small and synchronous on its inner backend;
+``main()`` runs the stdin/stdout JSON-RPC loop asynchronously.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from typing import Any, Protocol
+
+_LOG = logging.getLogger(__name__)
+
+PROTOCOL_VERSION = "2024-11-05"
+
+
+class NotebookBackend(Protocol):
+    """Pluggable backend for the NotebookLM shim."""
+
+    def search(self, notebook_id: str, query: str) -> list[dict[str, Any]]: ...
+    def summarize(self, notebook_id: str) -> str: ...
+    def metadata(self, notebook_id: str) -> dict[str, Any]: ...
+
+
+class StubNotebookBackend:
+    """Deterministic in-memory backend used when no real API is configured."""
+
+    def search(self, notebook_id: str, query: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "notebook_id": notebook_id,
+                "snippet": f"stub hit for {query!r}",
+                "score": 1.0,
+            }
+        ]
+
+    def summarize(self, notebook_id: str) -> str:
+        return f"Stub summary for notebook {notebook_id}."
+
+    def metadata(self, notebook_id: str) -> dict[str, Any]:
+        return {"id": notebook_id, "title": f"Notebook {notebook_id}"}
+
+
+_TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "name": "search_notebook",
+        "description": "Search within a NotebookLM notebook for a query string.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "notebook_id": {"type": "string"},
+                "query": {"type": "string"},
+            },
+            "required": ["notebook_id", "query"],
+        },
+    },
+    {
+        "name": "summarize_notebook",
+        "description": "Summarize the contents of a NotebookLM notebook.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"notebook_id": {"type": "string"}},
+            "required": ["notebook_id"],
+        },
+    },
+]
+
+
+def _resource_for(notebook_id: str) -> dict[str, Any]:
+    return {
+        "uri": f"notebook://{notebook_id}",
+        "name": f"Notebook {notebook_id}",
+        "mimeType": "application/json",
+    }
+
+
+def handle_request(request: dict[str, Any], backend: NotebookBackend) -> dict[str, Any]:
+    """Dispatch a single JSON-RPC request and return the response dict."""
+    method = request.get("method")
+    params = request.get("params") or {}
+    request_id = request.get("id")
+    try:
+        result = _dispatch(method, params, backend)
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+    except Exception as exc:  # noqa: BLE001 — JSON-RPC error envelope
+        _LOG.exception("notebooklm shim: %s failed", method)
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": -32000, "message": str(exc)},
+        }
+
+
+def _dispatch(
+    method: str | None, params: dict[str, Any], backend: NotebookBackend
+) -> dict[str, Any]:
+    if method == "initialize":
+        return {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {"tools": {}, "resources": {}},
+            "serverInfo": {"name": "notebooklm-shim", "version": "0.1.0"},
+        }
+    if method == "tools/list":
+        return {"tools": _TOOL_DEFINITIONS}
+    if method == "resources/list":
+        # Default stub advertises a single placeholder resource.
+        return {"resources": [_resource_for("default")]}
+    if method == "tools/call":
+        return _handle_tool_call(params, backend)
+    raise ValueError(f"unknown method: {method!r}")
+
+
+def _handle_tool_call(
+    params: dict[str, Any], backend: NotebookBackend
+) -> dict[str, Any]:
+    name = params.get("name")
+    arguments = params.get("arguments") or {}
+    if name == "search_notebook":
+        notebook_id = str(arguments.get("notebook_id", ""))
+        query = str(arguments.get("query", ""))
+        if not notebook_id or not query:
+            raise ValueError("notebook_id and query are required")
+        hits = backend.search(notebook_id, query)
+        return {"content": [{"type": "text", "text": json.dumps({"hits": hits})}]}
+    if name == "summarize_notebook":
+        notebook_id = str(arguments.get("notebook_id", ""))
+        if not notebook_id:
+            raise ValueError("notebook_id is required")
+        summary = backend.summarize(notebook_id)
+        return {
+            "content": [{"type": "text", "text": summary}],
+        }
+    raise ValueError(f"unknown tool: {name!r}")
+
+
+async def _run_loop(
+    backend: NotebookBackend,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+) -> None:
+    while True:
+        line = await reader.readline()
+        if not line:
+            return
+        try:
+            request = json.loads(line.decode("utf-8"))
+        except json.JSONDecodeError:
+            _LOG.warning("notebooklm shim: malformed JSON-RPC frame; ignoring")
+            continue
+        response = handle_request(request, backend)
+        writer.write((json.dumps(response) + "\n").encode("utf-8"))
+        await writer.drain()
+
+
+def main() -> None:  # pragma: no cover — integration entrypoint
+    """Run the shim's stdin/stdout JSON-RPC loop."""
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+    backend: NotebookBackend = StubNotebookBackend()
+
+    async def _amain() -> None:
+        loop = asyncio.get_running_loop()
+        reader = asyncio.StreamReader()
+        await loop.connect_read_pipe(
+            lambda: asyncio.StreamReaderProtocol(reader), sys.stdin
+        )
+        writer_transport, writer_protocol = await loop.connect_write_pipe(
+            asyncio.streams.FlowControlMixin, sys.stdout
+        )
+        writer = asyncio.StreamWriter(writer_transport, writer_protocol, None, loop)
+        await _run_loop(backend, reader, writer)
+
+    asyncio.run(_amain())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/shared/python/ai/mcp/pool.py
+++ b/src/shared/python/ai/mcp/pool.py
@@ -1,0 +1,206 @@
+"""``McpClientPool`` — owns N ``McpClient``s and aggregates their tools.
+
+The pool is the single entry point external callers use to interact with MCP
+servers. Tool names are *always* namespaced (``<server>:<tool>``) so collisions
+across servers are impossible by construction.
+
+Failure isolation:
+    A server that fails ``connect()`` is logged and skipped — the rest of the
+    pool stays usable. This matches Claude Desktop's behavior and avoids one
+    misbehaving server taking down the whole AI surface.
+
+DbC:
+    ``tools()`` requires ``is_started``. ``add_server`` rejects duplicate names.
+
+LOD:
+    Callers must not index into ``pool._clients`` directly. The pool exposes
+    ``tools()``, ``call_tool()``, ``refresh_all()``, and lifecycle methods.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from src.shared.python.ai.mcp.contracts import (
+    McpResourceDescriptor,
+    McpServerConfig,
+    McpToolDescriptor,
+)
+
+_LOG = logging.getLogger(__name__)
+
+
+class _ClientLike(Protocol):
+    """The subset of ``McpClient`` the pool depends on (for fakes in tests)."""
+
+    @property
+    def is_connected(self) -> bool: ...
+    async def connect(self) -> None: ...
+    async def disconnect(self) -> None: ...
+    async def list_tools(self) -> list[McpToolDescriptor]: ...
+    async def list_resources(self) -> list[McpResourceDescriptor]: ...
+    async def call_tool(self, name: str, args: dict[str, Any]) -> dict[str, Any]: ...
+
+
+def _serialize_tool_for_provider(
+    tool: McpToolDescriptor, server_name: str, provider: str = "registry"
+) -> dict[str, Any]:
+    """Single helper that turns an MCP tool into an aggregated, tagged dict.
+
+    DRY: every caller (pool aggregation, tool_registry merge) goes through
+    this helper so the namespacing and ``source`` tagging are defined once.
+    """
+    namespaced = f"{server_name}:{tool.name}"
+    base = {
+        "name": tool.name,
+        "namespaced_name": namespaced,
+        "description": tool.description,
+        "input_schema": tool.input_schema,
+        "source": f"mcp:{server_name}",
+        "server": server_name,
+    }
+    if provider == "openai":
+        base["openai"] = {
+            "type": "function",
+            "function": {
+                "name": namespaced,
+                "description": tool.description,
+                "parameters": tool.input_schema,
+            },
+        }
+    elif provider == "anthropic":
+        base["anthropic"] = {
+            "name": namespaced,
+            "description": tool.description,
+            "input_schema": tool.input_schema,
+        }
+    return base
+
+
+class McpClientPool:
+    """Pool of MCP clients keyed by server name."""
+
+    def __init__(self) -> None:
+        self._clients: dict[str, _ClientLike] = {}
+        self._configs: dict[str, McpServerConfig] = {}
+        self._started = False
+
+    @property
+    def is_started(self) -> bool:
+        return self._started
+
+    @property
+    def server_names(self) -> list[str]:
+        return list(self._clients.keys())
+
+    def add_server(
+        self,
+        config: McpServerConfig,
+        client: _ClientLike | None = None,
+    ) -> None:
+        """Register a server. ``client`` is optional and used for tests."""
+        if config.name in self._clients:
+            raise ValueError(f"server already registered: {config.name}")
+        if client is None:
+            # Lazy import keeps the heavy transport modules out of the pool's
+            # import graph during unit tests that pass fakes.
+            from src.shared.python.ai.mcp.client import McpClient
+
+            client = McpClient(config)
+        self._clients[config.name] = client
+        self._configs[config.name] = config
+
+    async def remove_server(self, name: str) -> None:
+        if name not in self._clients:
+            return
+        client = self._clients.pop(name)
+        self._configs.pop(name, None)
+        try:
+            await client.disconnect()
+        except Exception:
+            _LOG.exception("error disconnecting MCP server %s", name)
+
+    async def start_all(self) -> None:
+        """Connect every registered server; isolate per-server failures."""
+        for name, client in list(self._clients.items()):
+            try:
+                await client.connect()
+            except Exception:
+                _LOG.exception("failed to connect MCP server %s; skipping", name)
+        self._started = True
+
+    async def stop_all(self) -> None:
+        for name, client in list(self._clients.items()):
+            try:
+                await client.disconnect()
+            except Exception:
+                _LOG.exception("error stopping MCP server %s", name)
+        self._started = False
+
+    async def tools(self, provider: str = "registry") -> list[dict[str, Any]]:
+        """Aggregated, namespaced tool descriptors across all connected servers.
+
+        Each entry carries ``source="mcp:<server>"`` so downstream consumers
+        (e.g. ``ToolRegistry.refresh``) can distinguish MCP-sourced tools.
+        """
+        if not self._started:
+            raise RuntimeError("pool not started")
+        aggregated: list[dict[str, Any]] = []
+        for name, client in self._clients.items():
+            if not client.is_connected:
+                continue
+            try:
+                tools = await client.list_tools()
+            except Exception:
+                _LOG.exception("list_tools failed for %s", name)
+                continue
+            for tool in tools:
+                aggregated.append(_serialize_tool_for_provider(tool, name, provider))
+        return aggregated
+
+    async def resources(self) -> list[dict[str, Any]]:
+        if not self._started:
+            raise RuntimeError("pool not started")
+        aggregated: list[dict[str, Any]] = []
+        for name, client in self._clients.items():
+            if not client.is_connected:
+                continue
+            try:
+                resources = await client.list_resources()
+            except Exception:
+                _LOG.exception("list_resources failed for %s", name)
+                continue
+            for resource in resources:
+                aggregated.append(
+                    {
+                        "uri": resource.uri,
+                        "name": resource.name,
+                        "description": resource.description,
+                        "mime_type": resource.mime_type,
+                        "source": f"mcp:{name}",
+                        "server": name,
+                    }
+                )
+        return aggregated
+
+    async def call_tool(
+        self, namespaced_name: str, args: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Call ``server:tool``. Raises if the server is unknown/disconnected."""
+        if ":" not in namespaced_name:
+            raise ValueError(
+                "tool name must be namespaced as 'server:tool', got "
+                f"{namespaced_name!r}"
+            )
+        server_name, tool_name = namespaced_name.split(":", 1)
+        client = self._clients.get(server_name)
+        if client is None:
+            raise KeyError(f"unknown MCP server: {server_name}")
+        if not client.is_connected:
+            raise RuntimeError(f"MCP server {server_name} is not connected")
+        return await client.call_tool(tool_name, args)
+
+    async def refresh_all(self) -> list[dict[str, Any]]:
+        """Re-query every connected server's tools and return the aggregated set."""
+        return await self.tools()

--- a/src/shared/python/ai/tool_registry.py
+++ b/src/shared/python/ai/tool_registry.py
@@ -529,6 +529,62 @@ class ToolRegistry:
         """Check if a tool is registered."""
         return name in self._tools
 
+    async def refresh(self, mcp_pool: Any | None = None) -> int:
+        """Re-query an ``McpClientPool`` and merge MCP-tagged tools.
+
+        External callers should always go through ``mcp_pool.refresh_all()``
+        rather than reaching into the pool's internal client list (LOD).
+        MCP-sourced tools are stored under their namespaced name
+        (``server:tool``) so they cannot collide with locally registered
+        tools.
+
+        Args:
+            mcp_pool: An ``McpClientPool`` (or compatible) instance. Pass
+                ``None`` to clear previously merged MCP tools without
+                re-importing.
+
+        Returns:
+            Number of MCP tools merged into this registry.
+        """
+        # Drop any previously merged MCP tools so refresh is idempotent.
+        existing_mcp = [
+            name
+            for name, tool in self._tools.items()
+            if getattr(tool, "_mcp_source", None) is not None
+        ]
+        for name in existing_mcp:
+            del self._tools[name]
+        if mcp_pool is None:
+            return 0
+        merged = await mcp_pool.refresh_all()
+        count = 0
+        for entry in merged:
+            namespaced = entry["namespaced_name"]
+            tool = Tool(
+                name=namespaced,
+                description=entry.get("description", ""),
+                handler=_unsupported_local_handler,
+            )
+            tool._mcp_source = entry.get("source")  # type: ignore[attr-defined]
+            self._tools[namespaced] = tool
+            count += 1
+        logger.info("Merged %d MCP tools into registry", count)
+        return count
+
+
+def _unsupported_local_handler(*_args: Any, **_kwargs: Any) -> ToolResult:
+    """Placeholder handler for MCP-sourced tools.
+
+    MCP tools must be dispatched through the pool (``pool.call_tool``),
+    not via the local ``ToolRegistry.execute`` path. Calling this raises
+    so misuse is loud.
+    """
+    raise ToolExecutionError(
+        "MCP-sourced tools must be invoked via McpClientPool.call_tool, "
+        "not ToolRegistry.execute",
+        tool_name="<mcp>",
+    )
+
 
 # Singleton holder (avoids 'global' keyword)
 _registry_holder: dict[str, ToolRegistry | None] = {"instance": None}

--- a/tests/unit/ai/mcp/conftest.py
+++ b/tests/unit/ai/mcp/conftest.py
@@ -1,0 +1,63 @@
+"""Local conftest for MCP unit tests.
+
+Bootstraps the ``src.shared.python.ai.mcp.*`` package tree so test imports of
+the form ``from src.shared.python.ai.mcp...`` (the dominant convention in this
+repo) resolve correctly under pytest's rootdir-driven discovery.
+
+This mirrors the pattern used by ``tests/shared/python/ai/test_adapter_contract.py``
+to work around the fact that ``src/python/src`` is also on ``pythonpath`` and
+carries its own ``__init__.py``, which shadows the implicit namespace ``src``
+package rooted at the repository root.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.mcp", "src/shared/python/ai/mcp"),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    existing = sys.modules.get(_mod_name)
+    target = str(_REPO_ROOT / _rel_path)
+    if existing is None:
+        stub = types.ModuleType(_mod_name)
+        stub.__path__ = [target]
+        sys.modules[_mod_name] = stub
+    else:
+        # Ensure existing module's __path__ includes our target so submodules
+        # resolve regardless of which package object pytest already loaded.
+        existing_path = list(getattr(existing, "__path__", []) or [])
+        if target not in existing_path:
+            existing_path.insert(0, target)
+            existing.__path__ = existing_path  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Stub modules consumed transitively by ``tool_registry`` that have no
+# concrete implementation in this repo yet (see ``test_adapter_contract``
+# for the same workaround).
+# ---------------------------------------------------------------------------
+import logging as _logging  # noqa: E402
+
+_logging_pkg = sys.modules.setdefault(
+    "src.shared.python.logging_pkg",
+    types.ModuleType("src.shared.python.logging_pkg"),
+)
+_logging_cfg_name = "src.shared.python.logging_pkg.logging_config"
+_logging_cfg = sys.modules.get(_logging_cfg_name)
+if _logging_cfg is None:
+    _logging_cfg = types.ModuleType(_logging_cfg_name)
+    sys.modules[_logging_cfg_name] = _logging_cfg
+_logging_cfg.get_logger = _logging.getLogger  # type: ignore[attr-defined]
+_logging_cfg.setup_logging = lambda *_a, **_kw: None  # type: ignore[attr-defined]

--- a/tests/unit/ai/mcp/test_client.py
+++ b/tests/unit/ai/mcp/test_client.py
@@ -1,0 +1,164 @@
+"""Tests for ``McpClient`` — single-server JSON-RPC wrapper.
+
+The transport layer is faked: a ``FakeStdioTransport`` records sent frames and
+returns canned JSON-RPC responses. No real subprocesses or HTTP calls are made.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.shared.python.ai.mcp.client import McpClient
+from src.shared.python.ai.mcp.contracts import McpServerConfig
+
+
+class FakeStdioTransport:
+    """In-memory transport that mimics the wire-level MCP behavior."""
+
+    def __init__(self, responses: dict[str, dict[str, Any]] | None = None) -> None:
+        self.responses = responses or {}
+        self.sent: list[dict[str, Any]] = []
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        self.sent.append({"method": method, "params": params})
+        if method in self.responses:
+            return self.responses[method]
+        raise RuntimeError(f"no canned response for {method}")
+
+
+def _stdio_cfg() -> McpServerConfig:
+    return McpServerConfig(name="nb", transport="stdio", command="python")
+
+
+class TestMcpClientLifecycle:
+    @pytest.mark.asyncio
+    async def test_connect_disconnect(self) -> None:
+        transport = FakeStdioTransport(
+            responses={
+                "initialize": {"protocolVersion": "2024-11-05"},
+                "tools/list": {"tools": []},
+                "resources/list": {"resources": []},
+            }
+        )
+        client = McpClient(_stdio_cfg(), transport=transport)
+        assert client.is_connected is False
+        await client.connect()
+        assert client.is_connected is True
+        assert transport.started is True
+        await client.disconnect()
+        assert client.is_connected is False
+        assert transport.stopped is True
+
+    @pytest.mark.asyncio
+    async def test_reconnect_idempotent(self) -> None:
+        transport = FakeStdioTransport(
+            responses={
+                "initialize": {"protocolVersion": "2024-11-05"},
+                "tools/list": {"tools": []},
+                "resources/list": {"resources": []},
+            }
+        )
+        client = McpClient(_stdio_cfg(), transport=transport)
+        await client.connect()
+        await client.connect()  # idempotent
+        assert client.is_connected is True
+        await client.disconnect()
+        await client.disconnect()  # idempotent
+        assert client.is_connected is False
+
+
+class TestMcpClientListTools:
+    @pytest.mark.asyncio
+    async def test_list_tools_returns_descriptors(self) -> None:
+        transport = FakeStdioTransport(
+            responses={
+                "initialize": {"protocolVersion": "2024-11-05"},
+                "tools/list": {
+                    "tools": [
+                        {
+                            "name": "search_notebook",
+                            "description": "search",
+                            "inputSchema": {"type": "object", "properties": {}},
+                        }
+                    ]
+                },
+                "resources/list": {"resources": []},
+            }
+        )
+        client = McpClient(_stdio_cfg(), transport=transport)
+        await client.connect()
+        tools = await client.list_tools()
+        assert len(tools) == 1
+        assert tools[0].name == "search_notebook"
+        await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_list_tools_precondition_requires_connection(self) -> None:
+        client = McpClient(_stdio_cfg(), transport=FakeStdioTransport())
+        with pytest.raises(RuntimeError, match="not connected"):
+            await client.list_tools()
+
+
+class TestMcpClientCallTool:
+    @pytest.mark.asyncio
+    async def test_call_tool_success(self) -> None:
+        transport = FakeStdioTransport(
+            responses={
+                "initialize": {"protocolVersion": "2024-11-05"},
+                "tools/list": {"tools": []},
+                "resources/list": {"resources": []},
+                "tools/call": {"content": [{"type": "text", "text": "ok"}]},
+            }
+        )
+        client = McpClient(_stdio_cfg(), transport=transport)
+        await client.connect()
+        result = await client.call_tool("search_notebook", {"q": "hello"})
+        assert result == {"content": [{"type": "text", "text": "ok"}]}
+        # Verify the request was correctly serialized.
+        last = transport.sent[-1]
+        assert last["method"] == "tools/call"
+        assert last["params"]["name"] == "search_notebook"
+        assert last["params"]["arguments"] == {"q": "hello"}
+        await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_call_tool_empty_name_raises(self) -> None:
+        client = McpClient(_stdio_cfg(), transport=FakeStdioTransport())
+        with pytest.raises(ValueError):
+            await client.call_tool("", {})
+
+    @pytest.mark.asyncio
+    async def test_call_tool_precondition_requires_connection(self) -> None:
+        client = McpClient(_stdio_cfg(), transport=FakeStdioTransport())
+        with pytest.raises(RuntimeError, match="not connected"):
+            await client.call_tool("search", {})
+
+
+class TestMcpClientListResources:
+    @pytest.mark.asyncio
+    async def test_list_resources(self) -> None:
+        transport = FakeStdioTransport(
+            responses={
+                "initialize": {"protocolVersion": "2024-11-05"},
+                "tools/list": {"tools": []},
+                "resources/list": {
+                    "resources": [{"uri": "notebook://abc", "name": "Notebook ABC"}]
+                },
+            }
+        )
+        client = McpClient(_stdio_cfg(), transport=transport)
+        await client.connect()
+        resources = await client.list_resources()
+        assert len(resources) == 1
+        assert resources[0].uri == "notebook://abc"
+        await client.disconnect()

--- a/tests/unit/ai/mcp/test_config_loader.py
+++ b/tests/unit/ai/mcp/test_config_loader.py
@@ -1,0 +1,117 @@
+"""Tests for ``config_loader`` — Claude-Desktop-compatible MCP server config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.shared.python.ai.mcp.config_loader import (
+    expand_env_vars,
+    load_mcp_servers,
+    parse_mcp_servers,
+)
+
+
+def test_parse_minimal_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    raw = {
+        "mcpServers": {
+            "notebooklm": {"command": "python", "args": ["-m", "notebooklm_mcp"]}
+        }
+    }
+    configs = parse_mcp_servers(raw)
+    assert len(configs) == 1
+    cfg = configs[0]
+    assert cfg.name == "notebooklm"
+    assert cfg.transport.value == "stdio"
+    assert cfg.command == "python"
+    assert cfg.args == ["-m", "notebooklm_mcp"]
+
+
+def test_parse_http_transport() -> None:
+    raw = {
+        "mcpServers": {
+            "remote": {
+                "transport": "http",
+                "url": "https://example.com/mcp",
+            }
+        }
+    }
+    configs = parse_mcp_servers(raw)
+    assert configs[0].transport.value == "http"
+    assert configs[0].url == "https://example.com/mcp"
+
+
+def test_env_var_expansion(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_API_KEY", "secret123")
+    raw = {
+        "mcpServers": {
+            "nb": {
+                "command": "python",
+                "env": {"API_KEY": "${MY_API_KEY}"},
+            }
+        }
+    }
+    configs = parse_mcp_servers(raw)
+    assert configs[0].env == {"API_KEY": "secret123"}
+
+
+def test_missing_env_var_left_as_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UNSET_VAR", raising=False)
+    assert expand_env_vars("${UNSET_VAR}") == "${UNSET_VAR}"
+
+
+def test_invalid_entries_skipped_with_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    raw = {
+        "mcpServers": {
+            "good": {"command": "python"},
+            "bad": {"transport": "websocket"},  # unsupported
+            "empty_name": {},
+        }
+    }
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        configs = parse_mcp_servers(raw)
+    names = [c.name for c in configs]
+    assert names == ["good"]
+    # At least one warning emitted for skipped entries.
+    assert any("skipping" in r.message.lower() for r in caplog.records)
+
+
+def test_load_mcp_servers_from_file(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "mcp_servers.json"
+    cfg_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "nb": {"command": "python", "args": ["-m", "notebooklm_mcp"]}
+                }
+            }
+        )
+    )
+    configs = load_mcp_servers(cfg_path)
+    assert len(configs) == 1
+    assert configs[0].name == "nb"
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path) -> None:
+    configs = load_mcp_servers(tmp_path / "does_not_exist.json")
+    assert configs == []
+
+
+def test_load_malformed_json_returns_empty(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    cfg_path = tmp_path / "mcp_servers.json"
+    cfg_path.write_text("{ not valid json")
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        configs = load_mcp_servers(cfg_path)
+    assert configs == []

--- a/tests/unit/ai/mcp/test_contracts.py
+++ b/tests/unit/ai/mcp/test_contracts.py
@@ -1,0 +1,89 @@
+"""Tests for MCP Pydantic contracts.
+
+Covers:
+- ``McpServerConfig`` validation for stdio and http transports.
+- ``McpToolDescriptor`` and ``McpResourceDescriptor`` round-trip.
+- DbC: invalid configurations raise ``pydantic.ValidationError`` / ``ValueError``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from src.shared.python.ai.mcp.contracts import (
+    McpResourceDescriptor,
+    McpServerConfig,
+    McpToolDescriptor,
+    McpTransport,
+)
+
+
+class TestMcpServerConfig:
+    def test_stdio_minimal(self) -> None:
+        cfg = McpServerConfig(name="notebooklm", transport="stdio", command="python")
+        assert cfg.transport is McpTransport.STDIO
+        assert cfg.command == "python"
+        assert cfg.args == []
+        assert cfg.env == {}
+
+    def test_stdio_with_args_and_env(self) -> None:
+        cfg = McpServerConfig(
+            name="nb",
+            transport="stdio",
+            command="python",
+            args=["-m", "mcp"],
+            env={"API_KEY": "abc"},
+        )
+        assert cfg.args == ["-m", "mcp"]
+        assert cfg.env == {"API_KEY": "abc"}
+
+    def test_http_minimal(self) -> None:
+        cfg = McpServerConfig(
+            name="remote", transport="http", url="https://example.com/mcp"
+        )
+        assert cfg.transport is McpTransport.HTTP
+        assert cfg.url == "https://example.com/mcp"
+
+    def test_stdio_requires_command(self) -> None:
+        with pytest.raises(ValidationError):
+            McpServerConfig(name="nb", transport="stdio")
+
+    def test_http_requires_url(self) -> None:
+        with pytest.raises(ValidationError):
+            McpServerConfig(name="nb", transport="http")
+
+    def test_name_required_nonempty(self) -> None:
+        with pytest.raises(ValidationError):
+            McpServerConfig(name="", transport="stdio", command="python")
+
+    def test_unknown_transport_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            McpServerConfig(name="nb", transport="websocket", command="python")
+
+
+class TestMcpToolDescriptor:
+    def test_round_trip(self) -> None:
+        desc = McpToolDescriptor(
+            name="search_notebook",
+            description="Search the notebook",
+            input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+        )
+        dumped = desc.model_dump()
+        rebuilt = McpToolDescriptor(**dumped)
+        assert rebuilt == desc
+
+    def test_default_schema_is_object(self) -> None:
+        desc = McpToolDescriptor(name="t", description="d")
+        assert desc.input_schema == {"type": "object", "properties": {}}
+
+
+class TestMcpResourceDescriptor:
+    def test_round_trip(self) -> None:
+        res = McpResourceDescriptor(
+            uri="notebook://abc",
+            name="Notebook ABC",
+            mime_type="application/json",
+        )
+        rebuilt = McpResourceDescriptor(**res.model_dump())
+        assert rebuilt == res

--- a/tests/unit/ai/mcp/test_pool.py
+++ b/tests/unit/ai/mcp/test_pool.py
@@ -1,0 +1,137 @@
+"""Tests for ``McpClientPool`` — lifecycle, aggregation, failure isolation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.shared.python.ai.mcp.contracts import McpServerConfig, McpToolDescriptor
+from src.shared.python.ai.mcp.pool import McpClientPool
+
+
+class FakeClient:
+    """A drop-in fake for ``McpClient`` used to validate pool behavior."""
+
+    def __init__(
+        self,
+        config: McpServerConfig,
+        tools: list[McpToolDescriptor] | None = None,
+        fail_on_connect: bool = False,
+    ) -> None:
+        self.config = config
+        self._tools = tools or []
+        self._connected = False
+        self._fail_on_connect = fail_on_connect
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> None:
+        if self._fail_on_connect:
+            raise RuntimeError(f"boom for {self.config.name}")
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        self._connected = False
+
+    async def list_tools(self) -> list[McpToolDescriptor]:
+        if not self._connected:
+            raise RuntimeError("not connected")
+        return self._tools
+
+    async def list_resources(self) -> list[Any]:
+        return []
+
+    async def call_tool(self, name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"called": name, "args": args, "server": self.config.name}
+
+
+@pytest.mark.asyncio
+async def test_add_and_start_all() -> None:
+    pool = McpClientPool()
+    cfg = McpServerConfig(name="nb", transport="stdio", command="python")
+    fake = FakeClient(
+        cfg,
+        tools=[McpToolDescriptor(name="search", description="s")],
+    )
+    pool.add_server(cfg, client=fake)
+    await pool.start_all()
+    assert pool.is_started is True
+    assert fake.is_connected is True
+    await pool.stop_all()
+    assert pool.is_started is False
+    assert fake.is_connected is False
+
+
+@pytest.mark.asyncio
+async def test_tools_aggregation_with_namespace() -> None:
+    pool = McpClientPool()
+    cfg_a = McpServerConfig(name="nb", transport="stdio", command="python")
+    cfg_b = McpServerConfig(name="other", transport="stdio", command="python")
+    fake_a = FakeClient(
+        cfg_a, tools=[McpToolDescriptor(name="search", description="s")]
+    )
+    fake_b = FakeClient(
+        cfg_b, tools=[McpToolDescriptor(name="search", description="s2")]
+    )
+    pool.add_server(cfg_a, client=fake_a)
+    pool.add_server(cfg_b, client=fake_b)
+    await pool.start_all()
+    aggregated = await pool.tools()
+    names = sorted(t["namespaced_name"] for t in aggregated)
+    assert names == ["nb:search", "other:search"]
+    sources = sorted(t["source"] for t in aggregated)
+    assert sources == ["mcp:nb", "mcp:other"]
+    await pool.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_failure_isolation() -> None:
+    pool = McpClientPool()
+    cfg_ok = McpServerConfig(name="ok", transport="stdio", command="python")
+    cfg_bad = McpServerConfig(name="bad", transport="stdio", command="python")
+    fake_ok = FakeClient(
+        cfg_ok, tools=[McpToolDescriptor(name="ping", description="p")]
+    )
+    fake_bad = FakeClient(cfg_bad, fail_on_connect=True)
+    pool.add_server(cfg_ok, client=fake_ok)
+    pool.add_server(cfg_bad, client=fake_bad)
+    await pool.start_all()
+    # OK server should still be connected even though bad one failed.
+    assert fake_ok.is_connected is True
+    aggregated = await pool.tools()
+    assert len(aggregated) == 1
+    assert aggregated[0]["namespaced_name"] == "ok:ping"
+    await pool.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_remove_server() -> None:
+    pool = McpClientPool()
+    cfg = McpServerConfig(name="nb", transport="stdio", command="python")
+    fake = FakeClient(cfg)
+    pool.add_server(cfg, client=fake)
+    await pool.start_all()
+    assert fake.is_connected is True
+    await pool.remove_server("nb")
+    assert fake.is_connected is False
+    aggregated = await pool.tools()
+    assert aggregated == []
+    await pool.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_tools_precondition_requires_started() -> None:
+    pool = McpClientPool()
+    with pytest.raises(RuntimeError, match="not started"):
+        await pool.tools()
+
+
+def test_add_duplicate_server_raises() -> None:
+    pool = McpClientPool()
+    cfg = McpServerConfig(name="nb", transport="stdio", command="python")
+    pool.add_server(cfg, client=FakeClient(cfg))
+    with pytest.raises(ValueError):
+        pool.add_server(cfg, client=FakeClient(cfg))

--- a/tests/unit/ai/mcp/test_tool_registry_refresh.py
+++ b/tests/unit/ai/mcp/test_tool_registry_refresh.py
@@ -1,0 +1,120 @@
+"""Tests for ``ToolRegistry.refresh`` — MCP-pool merge.
+
+Verifies that:
+- Calling ``refresh`` on an empty registry with a pool merges all MCP tools
+  under their namespaced names with the ``mcp:<server>`` source tag.
+- Re-running ``refresh`` is idempotent: previously merged MCP tools are
+  dropped and re-added so stale tools cannot linger.
+- ``refresh(None)`` clears previously merged MCP tools without contacting
+  any pool.
+- Locally registered (non-MCP) tools are left untouched by refresh.
+- Attempting to dispatch an MCP-sourced tool through the local
+  ``ToolRegistry`` path raises (these tools must go through the pool).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.shared.python.ai.exceptions import ToolExecutionError
+from src.shared.python.ai.tool_registry import Tool, ToolRegistry
+from src.shared.python.ai.types import ToolResult
+
+
+class FakePool:
+    """In-memory ``McpClientPool`` stand-in for refresh tests."""
+
+    def __init__(self, tools: list[dict[str, Any]]) -> None:
+        self._tools = tools
+        self.calls = 0
+
+    async def refresh_all(self) -> list[dict[str, Any]]:
+        self.calls += 1
+        return list(self._tools)
+
+
+def _mcp_entry(server: str, tool: str, description: str = "") -> dict[str, Any]:
+    return {
+        "name": tool,
+        "namespaced_name": f"{server}:{tool}",
+        "description": description,
+        "input_schema": {"type": "object", "properties": {}},
+        "source": f"mcp:{server}",
+        "server": server,
+    }
+
+
+def _local_handler(**_: Any) -> ToolResult:
+    return ToolResult(tool_call_id="", success=True, result={"ok": True})
+
+
+@pytest.mark.asyncio
+async def test_refresh_merges_mcp_tools() -> None:
+    registry = ToolRegistry()
+    pool = FakePool([_mcp_entry("nb", "search", "search a notebook")])
+    count = await registry.refresh(pool)
+    assert count == 1
+    assert "nb:search" in registry
+    tool = registry.get_tool("nb:search")
+    assert tool is not None
+    assert getattr(tool, "_mcp_source", None) == "mcp:nb"
+    assert pool.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_is_idempotent() -> None:
+    registry = ToolRegistry()
+    pool = FakePool(
+        [
+            _mcp_entry("nb", "search"),
+            _mcp_entry("nb", "summarize"),
+        ]
+    )
+    await registry.refresh(pool)
+    # Second call must drop & re-add — no duplicates, no stale ghosts.
+    await registry.refresh(pool)
+    assert "nb:search" in registry
+    assert "nb:summarize" in registry
+    assert pool.calls == 2
+    # Only the two MCP tools should be present.
+    assert len(registry) == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_none_clears_mcp_tools() -> None:
+    registry = ToolRegistry()
+    pool = FakePool([_mcp_entry("nb", "search")])
+    await registry.refresh(pool)
+    assert "nb:search" in registry
+    cleared = await registry.refresh(None)
+    assert cleared == 0
+    assert "nb:search" not in registry
+
+
+@pytest.mark.asyncio
+async def test_refresh_preserves_local_tools() -> None:
+    registry = ToolRegistry()
+    registry.register_tool(
+        Tool(name="local_tool", description="local", handler=_local_handler)
+    )
+    pool = FakePool([_mcp_entry("nb", "search")])
+    await registry.refresh(pool)
+    assert "local_tool" in registry
+    assert "nb:search" in registry
+    # And clearing MCP tools leaves the local one intact.
+    await registry.refresh(None)
+    assert "local_tool" in registry
+    assert "nb:search" not in registry
+
+
+@pytest.mark.asyncio
+async def test_executing_mcp_tool_locally_raises() -> None:
+    registry = ToolRegistry()
+    pool = FakePool([_mcp_entry("nb", "search")])
+    await registry.refresh(pool)
+    tool = registry.get_tool("nb:search")
+    assert tool is not None
+    with pytest.raises(ToolExecutionError):
+        tool.handler()


### PR DESCRIPTION
## Summary
- Adds the MCP (Model Context Protocol) infrastructure layer under `src/shared/python/ai/mcp/` so UpstreamDrift and Gasification_Model can connect to external MCP servers (Claude-Desktop-style stdio children or remote HTTP endpoints) and merge their tools into the local `ToolRegistry`.
- Ships an `McpClient` (stdio + http transports, DbC preconditions, sandboxed env), an `McpClientPool` that namespaces every tool as `server:tool` and isolates per-server failures, a Claude-Desktop-compatible `config_loader` for `~/.upstreamdrift/mcp_servers.json` (with `${ENV_VAR}` expansion), and a `notebooklm_server.py` Python shim covering the gap until a first-party NotebookLM MCP exists.
- Adds `ToolRegistry.refresh(mcp_pool)` that merges pool-supplied tools as namespaced entries tagged with `_mcp_source`; the merged tools deliberately raise on local `execute()` so callers must round-trip through `McpClientPool.call_tool`.

## Why
UpstreamDrift #5615 needs an MCP surface for upcoming integrations (NotebookLM, custom analysis servers). The infrastructure lives in `Tools/` so both downstream repos can consume it via the existing `src.shared.python.ai.*` namespace.

## Design notes
- **DbC**: `McpClient.list_tools/call_tool` require `is_connected`; `call_tool("", {})` raises `ValueError`; `McpClientPool.tools()` requires `is_started`; `add_server` rejects duplicate names.
- **LOD**: External callers reach MCP capabilities through `pool.refresh_all()` / `pool.call_tool()` — they never touch `pool._clients[i]._transport`.
- **DRY**: `_serialize_tool_for_provider(tool, server, provider)` is the single source for namespacing and `source="mcp:<server>"` tagging.
- **Sandbox**: stdio children inherit only an allow-listed env (`PATH`, `HOME`, `USERPROFILE`, `SYSTEMROOT`, `TEMP`, `TMP`) plus per-server `env`.
- **Process model**: stdio servers are long-lived asyncio children; disconnect sends SIGTERM with a 5-second grace before SIGKILL.
- **Tool-name collisions**: impossible by construction — every aggregated entry is namespaced.
- **Network/subprocess isolation**: every test exercises the surface through an in-memory transport / pool fake; the unit suite never spawns a real subprocess or hits the network.

## Test plan
- [x] `python -m pytest tests/unit/ai/mcp/` — 37 passed (contracts 10, client 8, pool 6, config_loader 8, tool_registry refresh 5)
- [x] `python -m ruff check` on touched files — clean
- [x] `python -m ruff format --check` on touched files — clean
- [ ] Downstream wiring in UpstreamDrift (separate PR per `UpstreamDrift #5615`)

Refs: UpstreamDrift #5615