### PR TITLE
ci: operationalize ai_backend via Maturin CI pipeline

### DIFF
--- a/.github/workflows/maturin-ai-backend.yml
+++ b/.github/workflows/maturin-ai-backend.yml
@@ -1,0 +1,175 @@
+# Maturin CI — ai_backend Python wheels
+#
+# Builds and publishes Python extension wheels for the `ai_backend` Rust crate
+# across all supported platforms and Python versions.
+#
+# Triggered on:
+#   - push to main (when ai_backend sources change)
+#   - pull_request touching ai_backend sources
+#   - workflow_dispatch (manual trigger / release)
+#
+# Acceptance criteria (issue #2870):
+#   1. Matrix: os × [ubuntu-latest, windows-latest, macos-latest]
+#   2. Python versions: 3.10, 3.11, 3.12, 3.13
+#   3. maturin build --release --features python
+#   4. Upload wheel artifacts per platform/python combination
+
+name: Maturin — ai_backend Wheels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rust_core/ai_backend/**"
+      - "Cargo.toml"
+      - "rust-toolchain.toml"
+  pull_request:
+    paths:
+      - "rust_core/ai_backend/**"
+      - "Cargo.toml"
+      - "rust-toolchain.toml"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish wheels to PyPI after build"
+        required: false
+        default: "false"
+
+concurrency:
+  group: maturin-ai-backend-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-wheels:
+    name: Build wheel (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust_core/ai_backend/target
+          key: maturin-${{ matrix.os }}-py${{ matrix.python-version }}-${{ hashFiles('rust_core/ai_backend/Cargo.toml', 'Cargo.toml') }}
+          restore-keys: |
+            maturin-${{ matrix.os }}-py${{ matrix.python-version }}-
+            maturin-${{ matrix.os }}-
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Clippy — ai_backend (python feature)
+        working-directory: rust_core/ai_backend
+        run: cargo clippy --features python -- -D warnings
+
+      - name: Build wheel
+        working-directory: rust_core/ai_backend
+        run: |
+          maturin build \
+            --release \
+            --features python \
+            --out ../../dist/${{ matrix.os }}/py${{ matrix.python-version }}
+
+      - name: Smoke-test wheel import
+        shell: bash
+        run: |
+          WHEEL=$(ls dist/${{ matrix.os }}/py${{ matrix.python-version }}/*.whl | head -1)
+          pip install "$WHEEL"
+          python -c "import ai_backend; print('ai_backend import OK:', dir(ai_backend))"
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: dist/${{ matrix.os }}/py${{ matrix.python-version }}/*.whl
+          retention-days: 14
+
+  # ── Optional: build with local-embeddings feature (Linux only, heavy) ────────
+  build-local-embeddings:
+    name: Build wheel with local-embeddings (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Only on workflow_dispatch to keep PR feedback fast
+    if: github.event_name == 'workflow_dispatch'
+
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Install ONNX Runtime (sets ORT_DYLIB_PATH)
+        run: |
+          pip install onnxruntime
+          ORT_LIB=$(python -c "import onnxruntime, pathlib; print(next(pathlib.Path(onnxruntime.__file__).parent.rglob('libonnxruntime*.so*'), ''))")
+          echo "ORT_DYLIB_PATH=$ORT_LIB" >> $GITHUB_ENV
+          echo "Located onnxruntime shared library: $ORT_LIB"
+
+      - name: Build wheel (local-embeddings)
+        working-directory: rust_core/ai_backend
+        run: |
+          maturin build \
+            --release \
+            --features "python,local-embeddings" \
+            --out ../../dist/local-embeddings/py${{ matrix.python-version }}
+
+      - name: Upload wheel artifact (local-embeddings)
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-local-embeddings-ubuntu-py${{ matrix.python-version }}
+          path: dist/local-embeddings/py${{ matrix.python-version }}/*.whl
+          retention-days: 14
+
+  # ── Summary ───────────────────────────────────────────────────────────────────
+  summary:
+    name: Wheel build summary
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Report results
+        run: |
+          echo "## Maturin ai_backend Wheel Build" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Platform | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|----------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| ubuntu-latest | ${{ needs.build-wheels.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| windows-latest | ${{ needs.build-wheels.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| macos-latest | ${{ needs.build-wheels.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Python versions: 3.10, 3.11, 3.12, 3.13" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,81 @@ Key markers:
 - **No upstream fleet dependencies.** Tools is a leaf dependency.
 - When modifying public APIs: open Issues in UpstreamDrift and Gasification_Model tracking the migration. Link them in your PR description.
 
+## Rust Crates and Maturin (ai_backend)
+
+The `rust_core/ai_backend/` crate provides Python bindings via
+[PyO3](https://pyo3.rs) and is built into a wheel using
+[maturin](https://www.maturin.rs).
+
+### Workspace membership
+
+`ai_backend` is listed in the root `Cargo.toml` workspace `members` list.
+All workspace-level dependency pins apply (see `[workspace.dependencies]`).
+
+### Feature flags
+
+| Feature | Purpose |
+|---|---|
+| `python` | Activates PyO3 `extension-module` linkage required for maturin builds. Must be enabled when building a wheel. |
+| `local-embeddings` | Opt-in ONNX-based local embeddings via `ort` + `tokenizers`. Requires a system ONNX Runtime library (see below). |
+
+### Building a wheel locally
+
+```bash
+# Install maturin
+pip install maturin
+
+# Build wheel (python bindings only — no local embeddings)
+cd rust_core/ai_backend
+maturin build --release --features python
+
+# Build wheel with local embeddings enabled
+maturin build --release --features "python,local-embeddings"
+
+# Install the built wheel into the active venv
+pip install ../../target/wheels/*.whl
+```
+
+### ORT_DYLIB_PATH — required for local-embeddings
+
+The `local-embeddings` feature uses `ort` (ONNX Runtime Rust bindings) in
+`load-dynamic` mode. This means the native `onnxruntime` shared library is
+**not bundled** at compile time. You must point `ort` at a system-installed
+copy at runtime via the `ORT_DYLIB_PATH` environment variable.
+
+```bash
+# Example (Linux/macOS) — use the onnxruntime installed by pip
+ORT_LIB=$(python -c "import onnxruntime, pathlib; \
+  print(next(pathlib.Path(onnxruntime.__file__).parent.rglob('libonnxruntime*.so*'), ''))")
+export ORT_DYLIB_PATH="$ORT_LIB"
+
+# Example (Windows) — find onnxruntime.dll
+$OrtLib = (python -c "import onnxruntime, pathlib; print(next(pathlib.Path(onnxruntime.__file__).parent.rglob('onnxruntime*.dll'), ''))")
+$env:ORT_DYLIB_PATH = $OrtLib
+```
+
+If `ORT_DYLIB_PATH` is not set the `ai_backend` module will raise an
+`OrtError` on first use of any embedding API.
+
+**Do NOT set `ORT_LIB_DIR` or rely on the `download-binaries` ort feature** —
+those paths are disabled in this project (see comment in
+`rust_core/ai_backend/Cargo.toml`).
+
+### CI — Maturin Wheel Build
+
+The workflow `.github/workflows/maturin-ai-backend.yml` builds wheels for:
+
+- **Platforms:** `ubuntu-latest`, `windows-latest`, `macos-latest`
+- **Python versions:** 3.10, 3.11, 3.12, 3.13
+- **Features:** `python` (standard) and optionally `python,local-embeddings`
+  (manual dispatch only, Linux only due to build time)
+
+The workflow triggers on push/PR to `main` whenever files under
+`rust_core/ai_backend/**` or `Cargo.toml` change.
+
+Each built wheel is uploaded as a GitHub Actions artifact
+(`wheel-<os>-py<version>`) with a 14-day retention window.
+
 ## Slash Commands
 
 - `/gaai-deliver` — Run Delivery Loop for next ready backlog item

--- a/tests/unit/rust/test_ai_backend_workspace.py
+++ b/tests/unit/rust/test_ai_backend_workspace.py
@@ -1,0 +1,141 @@
+"""
+TDD validation tests for issue #2870:
+[Sidekick] Operationalize Rust ai_backend via Maturin CI Pipeline
+
+These tests assert the acceptance criteria BEFORE implementation so that
+the green phase proves the pipeline is correctly wired up.
+
+Run with:
+    pytest tests/unit/rust/test_ai_backend_workspace.py -v
+"""
+
+import pathlib
+
+import pytest
+
+# Resolve repo root relative to this test file (tests/unit/rust/ -> repo root)
+REPO_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
+
+
+@pytest.mark.unit
+def test_ai_backend_in_cargo_workspace():
+    """ai_backend must be a declared workspace member in the root Cargo.toml."""
+    cargo_toml = (REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    assert "ai_backend" in cargo_toml, (
+        "rust_core/ai_backend is not listed in the root workspace Cargo.toml members"
+    )
+
+
+@pytest.mark.unit
+def test_ai_backend_cargo_toml_exists():
+    """The ai_backend crate must have its own Cargo.toml."""
+    crate_toml = REPO_ROOT / "rust_core" / "ai_backend" / "Cargo.toml"
+    assert crate_toml.exists(), f"Missing crate manifest: {crate_toml}"
+
+
+@pytest.mark.unit
+def test_maturin_ci_workflow_exists():
+    """A CI workflow file for maturin / ai_backend builds must exist."""
+    workflows_dir = REPO_ROOT / ".github" / "workflows"
+    candidates = (
+        list(workflows_dir.glob("*maturin*"))
+        + list(workflows_dir.glob("*ai_backend*"))
+        + list(workflows_dir.glob("*ai-backend*"))
+    )
+    assert len(candidates) > 0, (
+        f"No maturin/ai_backend CI workflow found under {workflows_dir}. "
+        "Expected a file matching *maturin* or *ai_backend* or *ai-backend*."
+    )
+
+
+@pytest.mark.unit
+def test_maturin_ci_covers_all_platforms():
+    """CI workflow must target Windows, macOS, and Linux runners."""
+    workflows_dir = REPO_ROOT / ".github" / "workflows"
+    candidates = (
+        list(workflows_dir.glob("*maturin*"))
+        + list(workflows_dir.glob("*ai_backend*"))
+        + list(workflows_dir.glob("*ai-backend*"))
+    )
+    assert candidates, "No maturin CI workflow found — cannot check platform coverage."
+
+    for wf_path in candidates:
+        content = wf_path.read_text(encoding="utf-8").lower()
+        assert "windows" in content, f"{wf_path.name}: missing Windows runner"
+        assert "ubuntu" in content or "linux" in content, (
+            f"{wf_path.name}: missing Ubuntu/Linux runner"
+        )
+        assert "macos" in content or "mac" in content, (
+            f"{wf_path.name}: missing macOS runner"
+        )
+
+
+@pytest.mark.unit
+def test_maturin_ci_covers_python_versions():
+    """CI must target Python 3.10, 3.11, 3.12, and 3.13."""
+    workflows_dir = REPO_ROOT / ".github" / "workflows"
+    candidates = (
+        list(workflows_dir.glob("*maturin*"))
+        + list(workflows_dir.glob("*ai_backend*"))
+        + list(workflows_dir.glob("*ai-backend*"))
+    )
+    assert candidates, (
+        "No maturin CI workflow found — cannot check Python version coverage."
+    )
+
+    for wf_path in candidates:
+        content = wf_path.read_text(encoding="utf-8")
+        for version in ["3.10", "3.11", "3.12", "3.13"]:
+            assert version in content, f"Python {version} not listed in {wf_path.name}"
+
+
+@pytest.mark.unit
+def test_ort_dylib_documented_in_claude_md():
+    """CLAUDE.md must document ORT_DYLIB_PATH for local-embeddings consumers."""
+    claude_md = (REPO_ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "ORT_DYLIB_PATH" in claude_md, (
+        "CLAUDE.md does not mention ORT_DYLIB_PATH. "
+        "Add a section describing how to point ort at the system ONNX Runtime library."
+    )
+
+
+@pytest.mark.unit
+def test_ai_backend_cargo_toml_declares_python_feature():
+    """ai_backend Cargo.toml must declare a 'python' feature gating PyO3 bindings."""
+    crate_toml = (REPO_ROOT / "rust_core" / "ai_backend" / "Cargo.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "python" in crate_toml, (
+        "rust_core/ai_backend/Cargo.toml does not declare a 'python' feature. "
+        "Maturin needs this feature to activate pyo3/extension-module linkage."
+    )
+
+
+@pytest.mark.unit
+def test_ai_backend_cargo_toml_declares_local_embeddings_feature():
+    """ai_backend Cargo.toml must declare a 'local-embeddings' feature."""
+    crate_toml = (REPO_ROOT / "rust_core" / "ai_backend" / "Cargo.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "local-embeddings" in crate_toml, (
+        "rust_core/ai_backend/Cargo.toml does not declare 'local-embeddings' feature."
+    )
+
+
+@pytest.mark.unit
+def test_maturin_workflow_references_maturin_action_or_command():
+    """CI workflow must actually invoke maturin (action or CLI command)."""
+    workflows_dir = REPO_ROOT / ".github" / "workflows"
+    candidates = (
+        list(workflows_dir.glob("*maturin*"))
+        + list(workflows_dir.glob("*ai_backend*"))
+        + list(workflows_dir.glob("*ai-backend*"))
+    )
+    assert candidates, "No maturin CI workflow found."
+
+    for wf_path in candidates:
+        content = wf_path.read_text(encoding="utf-8").lower()
+        assert "maturin" in content, (
+            f"{wf_path.name}: the workflow does not reference 'maturin' — "
+            "it must call maturin build or use PyO3/maturin-action."
+        )


### PR DESCRIPTION
## Summary

Closes #2870 -- [Sidekick] Operationalize Rust ai_backend via Maturin CI Pipeline

### What changed

- **.github/workflows/maturin-ai-backend.yml** -- new CI workflow that builds Python wheels for rust_core/ai_backend using maturin across a full platform x Python version matrix:
  - Platforms: ubuntu-latest, windows-latest, macos-latest
  - Python versions: 3.10, 3.11, 3.12, 3.13
  - Features: python (standard wheel), python,local-embeddings (opt-in via workflow_dispatch)
  - Each matrix cell runs Clippy, maturin build --release, a smoke-test (import ai_backend), and uploads the wheel as a GitHub Actions artifact

- **tests/unit/rust/test_ai_backend_workspace.py** -- TDD validation suite (9 tests) written before implementation to verify workspace membership, Cargo.toml feature flags, workflow existence, platform/Python coverage, maturin invocation, and ORT_DYLIB_PATH documentation. All 9 pass.

- **CLAUDE.md** -- new section "Rust Crates and Maturin (ai_backend)" documenting maturin install and local wheel build commands, python vs local-embeddings feature flags, and the ORT_DYLIB_PATH requirement for the local-embeddings feature (ort uses load-dynamic; must point at a system onnxruntime shared library at runtime).

### Acceptance criteria

| Criterion | Status |
|---|---|
| ai_backend in workspace Cargo.toml members | Already present |
| Maturin CI for Windows, macOS, Linux x Python 3.10-3.13 | New workflow |
| ORT_DYLIB_PATH documented in CLAUDE.md | New section |

### TDD evidence

Red phase: 5 of 9 tests failed (workflow not yet created, CLAUDE.md missing ORT_DYLIB_PATH).
Green phase: all 9 tests pass after implementation.

## Test plan

- [ ] Review .github/workflows/maturin-ai-backend.yml matrix entries
- [ ] Confirm CI triggers on changes under rust_core/ai_backend/**
- [ ] Verify smoke-test step runs import ai_backend successfully in CI
- [ ] Confirm CLAUDE.md ORT_DYLIB_PATH section is accurate for local dev
- [ ] Run pytest tests/unit/rust/test_ai_backend_workspace.py -v locally

Generated with [Claude Code](https://claude.com/claude-code)