### PR TITLE
feat(sidekick): add NotebookTab with graceful Jupyter degradation (Phase 1) — closes #2875

### DIFF
--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/default_tabs.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/default_tabs.py
@@ -17,6 +17,7 @@ from .data_explorer_tab import (
 )
 from .data_processor_tab import DATA_PROCESSOR_TAB_ID, build_data_processor_tab
 from .help_content import DEFAULT_SIDEBAR_TAB_HELP
+from .notebook_tab import NOTEBOOK_TAB_ID, build_notebook_tab
 from .project_file_explorer import ProjectFileExplorer
 from .qt_compat import QT_API, QtWidgets
 from .reporting_tab import build_reporting_tab
@@ -133,6 +134,14 @@ def build_default_tab_definitions(
             build_reporting_tab,
             duplicate_enabled=False,
             help_metadata=dict(DEFAULT_SIDEBAR_TAB_HELP["reporting"]),
+        ),
+        tab_definition(
+            NOTEBOOK_TAB_ID,
+            "Notebook",
+            build_notebook_tab,
+            visible=False,
+            duplicate_enabled=True,
+            help_metadata=dict(DEFAULT_SIDEBAR_TAB_HELP[NOTEBOOK_TAB_ID]),
         ),
     ]
 

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/help_content.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/help_content.py
@@ -165,6 +165,15 @@ DEFAULT_SIDEBAR_TAB_HELP: dict[str, dict[str, str]] = {
         ),
         source="upstream_drift_tools.ui.tools_sidebar.reporting_tab",
     ),
+    "notebook": _tab_help(
+        "Notebook",
+        "Open and interact with Jupyter notebooks when jupyter_client is installed.",
+        tips=(
+            "When Jupyter is not installed the tab shows an actionable install prompt.",
+            "Notebook path and kernel environment are tracked per tab instance.",
+        ),
+        source="upstream_drift_tools.ui.tools_sidebar.notebook_tab",
+    ),
 }
 
 

--- a/src/shared/python/upstream_drift_tools/ui/tools_sidebar/notebook_tab.py
+++ b/src/shared/python/upstream_drift_tools/ui/tools_sidebar/notebook_tab.py
@@ -1,0 +1,210 @@
+"""Sidekick Jupyter Notebook tab — Phase 1.
+
+Issue #2875: [Jupyter Sidekick Phase 1] Notebook UI Tab and Dependency Management.
+
+Provides :func:`build_notebook_tab` (the Sidekick factory) and
+:class:`SidekickNotebookWidget` (the underlying QWidget).
+
+When ``jupyter_client`` and ``nbformat`` are not installed the widget degrades
+gracefully: it shows an actionable install prompt instead of crashing.
+When they are installed it renders a Phase-1 placeholder ready for Phase 2/3
+kernel integration.
+
+Design-by-contract: public methods validate inputs and raise ``TypeError`` for
+wrong types, following the project-wide DbC convention.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from .help_content import DEFAULT_SIDEBAR_TAB_HELP
+from .qt_compat import QtWidgets
+
+logger = logging.getLogger(__name__)
+
+NOTEBOOK_TAB_ID = "notebook"
+
+_JUPYTER_INSTALL_HINT = (
+    "Jupyter is not installed.\n"
+    "Run: pip install jupyter_client nbformat\n"
+    "or: pip install jupyter"
+)
+
+# ---------------------------------------------------------------------------
+# Public factory (matches the Sidekick tab factory signature)
+# ---------------------------------------------------------------------------
+
+
+def build_notebook_tab(sidebar: Any) -> QtWidgets.QWidget:
+    """Build the Jupyter Notebook tab for a Sidekick sidebar.
+
+    Returns a :class:`SidekickNotebookWidget` when the optional Jupyter
+    dependencies are available, or a lightweight install-prompt widget when
+    they are absent.
+
+    Args:
+        sidebar: The host :class:`UnifiedToolsSidebar` instance (or any object
+            exposing ``project_root``).
+
+    Returns:
+        A :class:`QtWidgets.QWidget` suitable for embedding in the sidebar tab strip.
+    """
+    project_root = getattr(sidebar, "project_root", Path("."))
+    widget = SidekickNotebookWidget(project_root=project_root, parent=sidebar)
+    tooltip = DEFAULT_SIDEBAR_TAB_HELP.get(NOTEBOOK_TAB_ID, {}).get("summary", "")
+    if tooltip:
+        widget.setToolTip(tooltip)
+    return widget
+
+
+# ---------------------------------------------------------------------------
+# Widget implementation
+# ---------------------------------------------------------------------------
+
+
+class SidekickNotebookWidget(QtWidgets.QWidget):
+    """Sidekick tab widget for Jupyter notebook interaction.
+
+    Phase 1 scope:
+    - Graceful degradation when ``jupyter_client`` / ``nbformat`` are absent.
+    - Session metadata (``notebook_path``, ``kernel_env``) isolated per instance.
+    - Actionable install prompt surfaced as a ``QLabel`` when Jupyter is missing.
+    - Stub ready for Phase 2 kernel connection and notebook rendering.
+    """
+
+    OBJECT_NAME = "SidekickNotebookTab"
+
+    def __init__(
+        self,
+        *,
+        project_root: Path,
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        if project_root is None:
+            raise ValueError("project_root must be provided")
+        super().__init__(parent)
+        self.setObjectName(self.OBJECT_NAME)
+        self._project_root = project_root
+        # Session metadata — independent per instance (no class-level mutable state).
+        self.session_metadata: dict[str, str | None] = {
+            "notebook_path": None,
+            "kernel_env": None,
+        }
+        self._jupyter_available = _check_jupyter_available()
+        self._build_ui()
+
+    # ------------------------------------------------------------------
+    # Public session-management API
+    # ------------------------------------------------------------------
+
+    def open_notebook(self, path: str) -> None:
+        """Record the notebook file path in session metadata.
+
+        Args:
+            path: Absolute or project-relative path to the ``.ipynb`` file.
+
+        Raises:
+            TypeError: If ``path`` is not a :class:`str`.
+        """
+        if not isinstance(path, str):
+            raise TypeError(f"path must be a str, got {type(path).__name__!r}")
+        self.session_metadata["notebook_path"] = path
+        logger.debug("NotebookTab: notebook_path set to %r", path)
+
+    def set_kernel_environment(self, env: str) -> None:
+        """Record the kernel environment name in session metadata.
+
+        Args:
+            env: Name of the Python environment or kernel spec (e.g. ``"my-venv"``).
+
+        Raises:
+            TypeError: If ``env`` is not a :class:`str`.
+        """
+        if not isinstance(env, str):
+            raise TypeError(f"env must be a str, got {type(env).__name__!r}")
+        self.session_metadata["kernel_env"] = env
+        logger.debug("NotebookTab: kernel_env set to %r", env)
+
+    # ------------------------------------------------------------------
+    # Internal UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(8)
+
+        if self._jupyter_available:
+            self._build_available_ui(layout)
+        else:
+            self._build_install_prompt_ui(layout)
+
+    def _build_available_ui(self, layout: QtWidgets.QVBoxLayout) -> None:
+        """Phase-1 placeholder shown when Jupyter deps are present."""
+        heading = QtWidgets.QLabel("Jupyter Notebook", self)
+        heading.setObjectName("SidekickNotebookHeading")
+        heading.setWordWrap(True)
+        heading.setToolTip("Jupyter Notebook tab — Phase 1 stub.")
+        layout.addWidget(heading)
+
+        info = QtWidgets.QLabel(
+            "Jupyter is installed. Notebook kernel integration coming in Phase 2.",
+            self,
+        )
+        info.setObjectName("SidekickNotebookInfo")
+        info.setWordWrap(True)
+        layout.addWidget(info)
+        layout.addStretch(1)
+
+    def _build_install_prompt_ui(self, layout: QtWidgets.QVBoxLayout) -> None:
+        """Actionable install prompt shown when Jupyter deps are absent."""
+        heading = QtWidgets.QLabel("Jupyter Notebook", self)
+        heading.setObjectName("SidekickNotebookHeading")
+        heading.setWordWrap(True)
+        heading.setToolTip("Jupyter Notebook tab — dependencies not installed.")
+        layout.addWidget(heading)
+
+        message = QtWidgets.QLabel(_JUPYTER_INSTALL_HINT, self)
+        message.setObjectName("SidekickNotebookInstallHint")
+        message.setWordWrap(True)
+        message.setToolTip("Run this command to enable the Jupyter Notebook tab.")
+        layout.addWidget(message)
+
+        copy_btn = QtWidgets.QPushButton("Copy install command", self)
+        copy_btn.setObjectName("SidekickNotebookCopyInstall")
+        copy_btn.setToolTip("Copy the pip install command to the clipboard.")
+        copy_btn.clicked.connect(self._copy_install_command)
+        layout.addWidget(copy_btn)
+
+        layout.addStretch(1)
+
+    def _copy_install_command(self) -> None:
+        """Copy the pip install command to the system clipboard."""
+        clipboard = QtWidgets.QApplication.clipboard()
+        if clipboard is not None:
+            clipboard.setText("pip install jupyter_client nbformat")
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_jupyter_available() -> bool:
+    """Return True when both ``jupyter_client`` and ``nbformat`` are importable.
+
+    When either package is blocked via ``sys.modules[name] = None`` (the standard
+    monkeypatching technique) ``importlib.import_module`` raises ``ImportError``,
+    so the ``except`` branch handles that case correctly.
+    """
+    import importlib
+
+    for pkg in ("jupyter_client", "nbformat"):
+        try:
+            importlib.import_module(pkg)
+        except ImportError:
+            return False
+    return True

--- a/tests/shared/python/upstream_drift_tools/ui/test_notebook_tab.py
+++ b/tests/shared/python/upstream_drift_tools/ui/test_notebook_tab.py
@@ -1,0 +1,297 @@
+"""Tests for NotebookTab — Sidekick Jupyter integration Phase 1.
+
+Issue #2875: [Jupyter Sidekick Phase 1] Notebook UI Tab and Dependency Management.
+
+Test order follows TDD red-green: tests were written before the implementation
+so each test drove a specific design decision in notebook_tab.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_qt_widgets() -> Any:
+    """Return QtWidgets or skip if Qt is not available."""
+    try:
+        from upstream_drift_tools.ui.tools_sidebar.qt_compat import QtWidgets
+    except ImportError:
+        pytest.skip("Qt widgets unavailable")
+    return QtWidgets
+
+
+_QT_APP_REF: list[Any] = []
+
+
+def _get_app(QtWidgets: Any) -> Any:
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    if not _QT_APP_REF:
+        _QT_APP_REF.append(app)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookTabRegistration:
+    """NotebookTab must be registered in the default Sidekick tab definitions."""
+
+    def test_notebook_tab_id_constant_is_defined(self) -> None:
+        """NOTEBOOK_TAB_ID must be exported from the notebook_tab module."""
+        from upstream_drift_tools.ui.tools_sidebar import notebook_tab
+
+        assert hasattr(notebook_tab, "NOTEBOOK_TAB_ID")
+        assert isinstance(notebook_tab.NOTEBOOK_TAB_ID, str)
+        assert notebook_tab.NOTEBOOK_TAB_ID == "notebook"
+
+    def test_build_notebook_tab_factory_is_callable(self) -> None:
+        """build_notebook_tab must be a callable factory."""
+        from upstream_drift_tools.ui.tools_sidebar import notebook_tab
+
+        assert callable(notebook_tab.build_notebook_tab)
+
+    def test_notebook_tab_appears_in_default_tab_definitions(
+        self, tmp_path: Path
+    ) -> None:
+        """'notebook' tab_id must appear in build_default_tab_definitions output."""
+        QtWidgets = _ensure_qt_widgets()
+        _get_app(QtWidgets)
+        from upstream_drift_tools.ui.tools_sidebar.default_tabs import (
+            build_default_tab_definitions,
+        )
+        from upstream_drift_tools.ui.tools_sidebar.tab_definition import (
+            SidebarTabDefinition,
+        )
+
+        tabs = build_default_tab_definitions(None, SidebarTabDefinition)
+        tab_ids = [t.tab_id for t in tabs]
+        assert "notebook" in tab_ids
+
+    def test_notebook_tab_definition_has_correct_title(self, tmp_path: Path) -> None:
+        """The registered notebook tab must have a human-readable title."""
+        QtWidgets = _ensure_qt_widgets()
+        _get_app(QtWidgets)
+        from upstream_drift_tools.ui.tools_sidebar.default_tabs import (
+            build_default_tab_definitions,
+        )
+        from upstream_drift_tools.ui.tools_sidebar.tab_definition import (
+            SidebarTabDefinition,
+        )
+
+        tabs = build_default_tab_definitions(None, SidebarTabDefinition)
+        notebook = next((t for t in tabs if t.tab_id == "notebook"), None)
+        assert notebook is not None
+        title_lower = notebook.title.lower()
+        assert "notebook" in title_lower or "jupyter" in title_lower
+
+    def test_notebook_tab_help_metadata_exists(self) -> None:
+        """help_content must include a 'notebook' entry."""
+        from upstream_drift_tools.ui.tools_sidebar.help_content import (
+            DEFAULT_SIDEBAR_TAB_HELP,
+        )
+
+        assert "notebook" in DEFAULT_SIDEBAR_TAB_HELP
+        assert "summary" in DEFAULT_SIDEBAR_TAB_HELP["notebook"]
+
+
+# ---------------------------------------------------------------------------
+# Graceful degradation tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookTabGracefulDegradation:
+    """When Jupyter deps are absent the tab must degrade, not crash."""
+
+    def test_no_crash_when_jupyter_client_absent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """build_notebook_tab must not raise ImportError when jupyter_client is None."""
+        QtWidgets = _ensure_qt_widgets()
+        _get_app(QtWidgets)
+
+        # Block jupyter_client at the sys.modules level.
+        monkeypatch.setitem(sys.modules, "jupyter_client", None)
+        monkeypatch.setitem(sys.modules, "nbformat", None)
+
+        from upstream_drift_tools.ui.tools_sidebar import notebook_tab
+
+        fake_sidebar = QtWidgets.QWidget()
+        fake_sidebar.project_root = tmp_path  # type: ignore[attr-defined]
+        try:
+            widget = notebook_tab.build_notebook_tab(fake_sidebar)
+            assert widget is not None
+        finally:
+            fake_sidebar.deleteLater()
+
+    def test_shows_install_message_when_jupyter_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """When jupyter_client is absent the widget must mention 'pip install'."""
+        QtWidgets = _ensure_qt_widgets()
+        _get_app(QtWidgets)
+
+        monkeypatch.setitem(sys.modules, "jupyter_client", None)
+        monkeypatch.setitem(sys.modules, "nbformat", None)
+
+        # Force the module to be re-evaluated with the patched sys.modules.
+        import importlib
+
+        import upstream_drift_tools.ui.tools_sidebar.notebook_tab as nt_mod
+
+        importlib.reload(nt_mod)
+
+        fake_sidebar = QtWidgets.QWidget()
+        fake_sidebar.project_root = tmp_path  # type: ignore[attr-defined]
+        try:
+            widget = nt_mod.build_notebook_tab(fake_sidebar)
+            # Collect all QLabel text in the widget hierarchy.
+            labels = widget.findChildren(QtWidgets.QLabel)
+            combined = " ".join(lbl.text() for lbl in labels).lower()
+            assert "pip install" in combined or "install jupyter" in combined
+        finally:
+            fake_sidebar.deleteLater()
+
+    def test_widget_is_qwidget_when_jupyter_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Even without Jupyter the factory must return a QWidget."""
+        QtWidgets = _ensure_qt_widgets()
+        _get_app(QtWidgets)
+
+        monkeypatch.setitem(sys.modules, "jupyter_client", None)
+
+        from upstream_drift_tools.ui.tools_sidebar import notebook_tab
+
+        fake_sidebar = QtWidgets.QWidget()
+        fake_sidebar.project_root = tmp_path  # type: ignore[attr-defined]
+        try:
+            widget = notebook_tab.build_notebook_tab(fake_sidebar)
+            assert isinstance(widget, QtWidgets.QWidget)
+        finally:
+            fake_sidebar.deleteLater()
+
+    def test_no_crash_when_jupyter_installed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Normal (Jupyter present) path must also produce a QWidget."""
+        QtWidgets = _ensure_qt_widgets()
+        _get_app(QtWidgets)
+
+        from upstream_drift_tools.ui.tools_sidebar import notebook_tab
+
+        fake_sidebar = QtWidgets.QWidget()
+        fake_sidebar.project_root = tmp_path  # type: ignore[attr-defined]
+        try:
+            widget = notebook_tab.build_notebook_tab(fake_sidebar)
+            assert isinstance(widget, QtWidgets.QWidget)
+        finally:
+            fake_sidebar.deleteLater()
+
+
+# ---------------------------------------------------------------------------
+# Session metadata tests
+# ---------------------------------------------------------------------------
+
+
+class TestNotebookSessionMetadata:
+    """NotebookTab must track per-instance notebook path and kernel env."""
+
+    def _make_widget(self, tmp_path: Path) -> Any:
+        QtWidgets = _ensure_qt_widgets()
+        _get_app(QtWidgets)
+        from upstream_drift_tools.ui.tools_sidebar.notebook_tab import (
+            SidekickNotebookWidget,
+        )
+
+        return SidekickNotebookWidget(project_root=tmp_path, parent=None)
+
+    def test_initial_session_metadata_has_none_path(self, tmp_path: Path) -> None:
+        """Freshly constructed widget must have notebook_path == None."""
+        widget = self._make_widget(tmp_path)
+        try:
+            assert widget.session_metadata["notebook_path"] is None
+        finally:
+            widget.deleteLater()
+
+    def test_initial_session_metadata_has_none_kernel_env(self, tmp_path: Path) -> None:
+        """Freshly constructed widget must have kernel_env == None."""
+        widget = self._make_widget(tmp_path)
+        try:
+            assert widget.session_metadata["kernel_env"] is None
+        finally:
+            widget.deleteLater()
+
+    def test_tab_tracks_notebook_path(self, tmp_path: Path) -> None:
+        """open_notebook must update session_metadata['notebook_path']."""
+        widget = self._make_widget(tmp_path)
+        try:
+            widget.open_notebook("/path/to/notebook.ipynb")
+            assert widget.session_metadata["notebook_path"] == "/path/to/notebook.ipynb"
+        finally:
+            widget.deleteLater()
+
+    def test_tab_tracks_kernel_environment(self, tmp_path: Path) -> None:
+        """set_kernel_environment must update session_metadata['kernel_env']."""
+        widget = self._make_widget(tmp_path)
+        try:
+            widget.set_kernel_environment("my-venv")
+            assert widget.session_metadata["kernel_env"] == "my-venv"
+        finally:
+            widget.deleteLater()
+
+    def test_metadata_isolated_per_tab_instance(self, tmp_path: Path) -> None:
+        """Two widget instances must have independent session metadata dicts."""
+        widget1 = self._make_widget(tmp_path)
+        widget2 = self._make_widget(tmp_path)
+        try:
+            widget1.open_notebook("/a.ipynb")
+            widget2.open_notebook("/b.ipynb")
+            assert widget1.session_metadata["notebook_path"] == "/a.ipynb"
+            assert widget2.session_metadata["notebook_path"] == "/b.ipynb"
+        finally:
+            widget1.deleteLater()
+            widget2.deleteLater()
+
+    def test_open_notebook_requires_string_path(self, tmp_path: Path) -> None:
+        """open_notebook must raise TypeError for non-string input (DbC)."""
+        widget = self._make_widget(tmp_path)
+        try:
+            with pytest.raises(TypeError):
+                widget.open_notebook(123)  # type: ignore[arg-type]
+        finally:
+            widget.deleteLater()
+
+    def test_set_kernel_environment_requires_string(self, tmp_path: Path) -> None:
+        """set_kernel_environment must raise TypeError for non-string input (DbC)."""
+        widget = self._make_widget(tmp_path)
+        try:
+            with pytest.raises(TypeError):
+                widget.set_kernel_environment(None)  # type: ignore[arg-type]
+        finally:
+            widget.deleteLater()
+
+    def test_session_metadata_keys_are_stable(self, tmp_path: Path) -> None:
+        """session_metadata must always expose exactly the two documented keys."""
+        widget = self._make_widget(tmp_path)
+        try:
+            keys = set(widget.session_metadata.keys())
+            assert keys == {"notebook_path", "kernel_env"}
+        finally:
+            widget.deleteLater()


### PR DESCRIPTION
## Summary

Implements issue #2875 — Jupyter Sidekick Phase 1: Notebook UI Tab and Dependency Management.

- **`notebook_tab.py`** — new `SidekickNotebookWidget` + `build_notebook_tab` factory. When `jupyter_client`/`nbformat` are absent the widget shows an actionable install prompt (`pip install jupyter_client nbformat`) with a copy-to-clipboard button. When Jupyter is installed a Phase-1 stub is rendered, ready for Phase 2/3 kernel integration. Per-instance `session_metadata` dict tracks `notebook_path` and `kernel_env` (DbC-validated; `TypeError` on bad input).
- **`default_tabs.py`** — registers the `notebook` tab (hidden by default, `duplicate_enabled=True`) via `build_default_tab_definitions`.
- **`help_content.py`** — adds the `notebook` entry to `DEFAULT_SIDEBAR_TAB_HELP`.
- **`test_notebook_tab.py`** — 17 TDD tests (written and confirmed failing before implementation) covering: tab registration in the default registry, help metadata, graceful degradation (Jupyter absent → install prompt), normal path (Jupyter present), session-metadata isolation per instance, and DbC type guards.

## TDD approach

Tests were written first (red), implementation followed (green). All 17 tests passed after implementation. Existing 11 sidebar tests also still pass (28 total in the UI test suite).

## Test plan

- [ ] `python3 -m pytest tests/shared/python/upstream_drift_tools/ui/test_notebook_tab.py` — all 17 pass
- [ ] `python3 -m ruff check` — zero violations on changed files
- [ ] `python3 -m ruff format --check` — zero diffs on changed files
- [ ] `python3 -m mypy ... --ignore-missing-imports` — no new errors introduced in changed files
- [ ] Full sidebar UI test suite: 28/28 pass

Closes #2875

🤖 Generated with [Claude Code](https://claude.com/claude-code)