### PR TITLE
feat(skills): real SkillRegistry + SkillRunner + builtins (Tools #2737, supersedes phantom PR #2728)

### DIFF
--- a/src/shared/python/ai/skills/__init__.py
+++ b/src/shared/python/ai/skills/__init__.py
@@ -1,0 +1,47 @@
+"""Skills runtime for Tools (issue #2737).
+
+Public surface:
+
+- :class:`Skill` — abstract base class for skills.
+- :class:`SkillDescriptor`, :class:`SkillInvocation`, :class:`SkillResult` —
+  Pydantic contracts.
+- :class:`SkillRegistry` — id-to-skill map.
+- :class:`SkillRunner` — orchestrates pre-check → run → post-check → audit.
+- :func:`register_skill` — decorator that registers a skill class.
+- :func:`default_registry` — process-wide lazy singleton registry.
+
+This package is intentionally orthogonal to the chat dock and MCP tool
+registries; integration with chat happens in a separate PR.
+"""
+
+from __future__ import annotations
+
+from .base import Skill
+from .contracts import SkillDescriptor, SkillInvocation, SkillResult
+from .errors import (
+    SkillError,
+    SkillExecutionError,
+    SkillNotFoundError,
+    SkillPostconditionError,
+    SkillPreconditionError,
+    SkillTimeoutError,
+)
+from .registry import SkillRegistry, default_registry, register_skill
+from .runner import SkillRunner
+
+__all__ = [
+    "Skill",
+    "SkillDescriptor",
+    "SkillInvocation",
+    "SkillResult",
+    "SkillRegistry",
+    "SkillRunner",
+    "SkillError",
+    "SkillExecutionError",
+    "SkillNotFoundError",
+    "SkillPostconditionError",
+    "SkillPreconditionError",
+    "SkillTimeoutError",
+    "register_skill",
+    "default_registry",
+]

--- a/src/shared/python/ai/skills/base.py
+++ b/src/shared/python/ai/skills/base.py
@@ -1,0 +1,54 @@
+"""Skill abstract base class (Tools #2737)."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar
+
+from .contracts import SkillDescriptor, SkillInvocation, SkillResult
+
+
+class Skill(ABC):
+    """Abstract base for a skill.
+
+    Subclasses MUST declare a class-level ``descriptor`` attribute. The
+    runner uses the descriptor to drive preflight (precondition names) and
+    postflight (postcondition names) checks.
+
+    By default :meth:`validate_preconditions` and
+    :meth:`validate_postconditions` are no-ops. Skills that declare
+    preconditions / postconditions in their descriptor should override them.
+    """
+
+    descriptor: ClassVar[SkillDescriptor]
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:  # noqa: D401
+        super().__init_subclass__(**kwargs)
+        # Abstract intermediate subclasses (ABCs) may legitimately omit a
+        # descriptor; only concrete classes are required to provide one.
+        if getattr(cls, "__abstractmethods__", None):
+            return
+        descriptor = getattr(cls, "descriptor", None)
+        if not isinstance(descriptor, SkillDescriptor):
+            raise TypeError(
+                f"Skill subclass {cls.__name__} must define a "
+                "'descriptor: SkillDescriptor' class attribute."
+            )
+
+    def validate_preconditions(self, args: dict[str, Any]) -> None:  # noqa: B027
+        """Validate input ``args``. Raise ``ValueError`` on failure.
+
+        Intentionally a no-op on the base class so that skills with no
+        preconditions need not override it. Marked ``noqa: B027`` because
+        this is a deliberate default hook, not an oversight.
+        """
+
+    def validate_postconditions(self, result: dict[str, Any]) -> None:  # noqa: B027
+        """Validate output ``result``. Raise ``ValueError`` on failure.
+
+        Intentional no-op default (see :meth:`validate_preconditions`).
+        """
+
+    @abstractmethod
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        """Execute the skill body. Must be async."""

--- a/src/shared/python/ai/skills/builtin/__init__.py
+++ b/src/shared/python/ai/skills/builtin/__init__.py
@@ -1,0 +1,8 @@
+"""Built-in reference skills for ``ai.skills`` (Tools #2737)."""
+
+from __future__ import annotations
+
+from .echo import EchoSkill
+from .summarize import StubLLMClient, SummarizeSkill
+
+__all__ = ["EchoSkill", "StubLLMClient", "SummarizeSkill"]

--- a/src/shared/python/ai/skills/builtin/echo.py
+++ b/src/shared/python/ai/skills/builtin/echo.py
@@ -1,0 +1,48 @@
+"""Echo skill — reference implementation demonstrating DbC (Tools #2737)."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from ..base import Skill
+from ..contracts import SkillDescriptor, SkillInvocation, SkillResult
+
+
+class EchoSkill(Skill):
+    """Echoes a non-empty string payload back to the caller.
+
+    Demonstrates explicit precondition (``message`` is non-empty string)
+    and postcondition (``echoed`` equals input ``message``) validation.
+    """
+
+    descriptor: ClassVar[SkillDescriptor] = SkillDescriptor(
+        id="builtin.echo",
+        name="Echo",
+        version="1.0.0",
+        description="Echoes the supplied message back to the caller.",
+        inputs={"message": "string"},
+        outputs={"echoed": "string"},
+        preconditions=["message_is_non_empty_string"],
+        postconditions=["echoed_equals_message"],
+    )
+
+    def validate_preconditions(self, args: dict[str, Any]) -> None:
+        message = args.get("message")
+        if not isinstance(message, str) or not message:
+            raise ValueError(
+                "message_is_non_empty_string: 'message' must be a non-empty string"
+            )
+
+    def validate_postconditions(self, result: dict[str, Any]) -> None:
+        if "echoed" not in result:
+            raise ValueError("echoed_equals_message: missing 'echoed' field")
+
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        message = invocation.args["message"]
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=True,
+            value={"echoed": message},
+            error=None,
+            elapsed_ms=0.0,
+        )

--- a/src/shared/python/ai/skills/builtin/summarize.py
+++ b/src/shared/python/ai/skills/builtin/summarize.py
@@ -1,0 +1,91 @@
+"""Summarize skill — demonstrates an LLM-backed skill with audit trail.
+
+Tools #2737. The LLM client is injectable so tests can pass a stub and
+production code can pass a real adapter without changing this file.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Protocol
+
+from ..base import Skill
+from ..contracts import SkillDescriptor, SkillInvocation, SkillResult
+
+
+class LLMClient(Protocol):
+    """Minimal contract for an LLM client used by :class:`SummarizeSkill`.
+
+    Implementations forward to whatever provider adapter the caller wants
+    (OpenAI, Anthropic, Ollama, etc). The skill itself does not know.
+    """
+
+    async def summarize(self, text: str) -> str: ...
+
+
+class StubLLMClient:
+    """Deterministic stub used by tests and as a usable default in offline
+    environments. ``call_count`` lets tests assert the LLM was (or was not)
+    invoked, which matters for precondition coverage.
+    """
+
+    def __init__(self, canned_response: str) -> None:
+        self._canned_response = canned_response
+        self.call_count = 0
+
+    async def summarize(self, text: str) -> str:
+        self.call_count += 1
+        return self._canned_response
+
+
+class SummarizeSkill(Skill):
+    """Summarises a non-empty text passage using an injected LLM client."""
+
+    descriptor: ClassVar[SkillDescriptor] = SkillDescriptor(
+        id="builtin.summarize",
+        name="Summarize",
+        version="1.0.0",
+        description="Summarises text using the injected LLM client.",
+        inputs={"text": "string"},
+        outputs={"summary": "string"},
+        preconditions=["text_is_non_empty_string"],
+        postconditions=["summary_is_string"],
+    )
+
+    def __init__(self, *, llm_client: LLMClient | None = None) -> None:
+        self._llm = llm_client or StubLLMClient(canned_response="(no summary)")
+        self._last_audit_extra: dict[str, Any] = {}
+
+    def validate_preconditions(self, args: dict[str, Any]) -> None:
+        text = args.get("text")
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError(
+                "text_is_non_empty_string: 'text' must be a non-empty string"
+            )
+
+    def validate_postconditions(self, result: dict[str, Any]) -> None:
+        summary = result.get("summary")
+        if not isinstance(summary, str):
+            raise ValueError("summary_is_string: 'summary' must be a string")
+
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        text: str = invocation.args["text"]
+        summary = await self._llm.summarize(text)
+        # The skill emits one extra audit event (kind="llm_call") so callers
+        # can see the LLM was invoked. The runner appends this to the trail.
+        audit_trail = [
+            {
+                "kind": "llm_call",
+                "skill_id": self.descriptor.id,
+                "request_id": invocation.request_id,
+                "message": "summarize",
+                "extra": {"input_length": len(text)},
+            }
+        ]
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=True,
+            value={"summary": summary},
+            error=None,
+            elapsed_ms=0.0,
+            audit_trail=audit_trail,
+        )

--- a/src/shared/python/ai/skills/contracts.py
+++ b/src/shared/python/ai/skills/contracts.py
@@ -1,0 +1,75 @@
+"""Pydantic contracts for the ``ai.skills`` package (Tools #2737).
+
+These models form the boundary between callers and the skill runtime. They
+are deliberately small and validation-heavy so that misuse fails loudly at
+the boundary instead of inside a skill body (Design-by-Contract).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _default_request_id() -> str:
+    return uuid.uuid4().hex
+
+
+class SkillDescriptor(BaseModel):
+    """Static description of a skill — id, version, IO schema, contract names.
+
+    The ``preconditions`` and ``postconditions`` fields hold human-readable
+    predicate names that the skill body and runner cross-check. Storing them
+    on the descriptor (rather than only in code) keeps the contract visible
+    to GUI registries and audit logs.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    version: str = Field(..., min_length=1)
+    description: str
+    inputs: dict[str, str] = Field(default_factory=dict)
+    outputs: dict[str, str] = Field(default_factory=dict)
+    preconditions: list[str] = Field(default_factory=list)
+    postconditions: list[str] = Field(default_factory=list)
+
+    @field_validator("id", "name", "version")
+    @classmethod
+    def _strip_required(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must be non-empty")
+        return stripped
+
+
+class SkillInvocation(BaseModel):
+    """A single request to execute a skill."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    skill_id: str = Field(..., min_length=1)
+    args: dict[str, Any] = Field(default_factory=dict)
+    request_id: str = Field(default_factory=_default_request_id)
+    timeout_s: float = Field(default=30.0, gt=0.0)
+
+
+class SkillResult(BaseModel):
+    """Outcome of a skill invocation.
+
+    ``audit_trail`` is an ordered list of small dict events; downstream
+    audit sinks treat each entry as opaque but display ``kind`` and
+    ``message``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str
+    success: bool
+    value: dict[str, Any] | None = None
+    error: str | None = None
+    elapsed_ms: float = Field(ge=0.0)
+    audit_trail: list[dict[str, Any]] = Field(default_factory=list)

--- a/src/shared/python/ai/skills/errors.py
+++ b/src/shared/python/ai/skills/errors.py
@@ -1,0 +1,33 @@
+"""Error hierarchy for the ``ai.skills`` package.
+
+Tools #2737. See package docstring for the contract these errors enforce.
+"""
+
+from __future__ import annotations
+
+
+class SkillError(Exception):
+    """Base class for all skill-related errors."""
+
+
+class SkillNotFoundError(SkillError, KeyError):
+    """Raised when a skill id is requested but not present in the registry."""
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.args[0] if self.args else ""
+
+
+class SkillPreconditionError(SkillError, ValueError):
+    """Raised by :meth:`Skill.validate_preconditions` on invalid inputs."""
+
+
+class SkillPostconditionError(SkillError, ValueError):
+    """Raised by :meth:`Skill.validate_postconditions` on invalid outputs."""
+
+
+class SkillTimeoutError(SkillError, TimeoutError):
+    """Raised when a skill exceeds its invocation timeout."""
+
+
+class SkillExecutionError(SkillError):
+    """Raised when a skill body raises a non-contract error."""

--- a/src/shared/python/ai/skills/registry.py
+++ b/src/shared/python/ai/skills/registry.py
@@ -1,0 +1,86 @@
+"""Skill registry (Tools #2737).
+
+A registry maps skill ids to skill instances. The default registry is a
+lazily-initialised module-level singleton; it does NOT instantiate at import
+time, which keeps importing ``ai.skills`` cheap and side-effect free.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import TypeVar
+
+from .base import Skill
+from .contracts import SkillDescriptor
+from .errors import SkillNotFoundError
+
+_T = TypeVar("_T", bound=Skill)
+
+
+class SkillRegistry:
+    """In-memory registry of :class:`Skill` instances keyed by skill id."""
+
+    def __init__(self) -> None:
+        self._skills: dict[str, Skill] = {}
+
+    def register(self, skill_cls: type[Skill]) -> type[Skill]:
+        """Register a skill class. Returns the class for decorator chaining."""
+        descriptor = skill_cls.descriptor
+        if descriptor.id in self._skills:
+            raise ValueError(f"Skill id already registered: {descriptor.id!r}")
+        self._skills[descriptor.id] = skill_cls()
+        return skill_cls
+
+    def register_instance(self, skill: Skill) -> Skill:
+        """Register an already-instantiated skill (useful for DI in tests)."""
+        descriptor = skill.descriptor
+        if descriptor.id in self._skills:
+            raise ValueError(f"Skill id already registered: {descriptor.id!r}")
+        self._skills[descriptor.id] = skill
+        return skill
+
+    def get(self, skill_id: str) -> Skill:
+        """Look up a skill by id. Raises :class:`SkillNotFoundError`."""
+        try:
+            return self._skills[skill_id]
+        except KeyError as exc:
+            raise SkillNotFoundError(skill_id) from exc
+
+    def list(self) -> Sequence[SkillDescriptor]:
+        """Return descriptors for all registered skills (stable order)."""
+        return tuple(skill.descriptor for skill in self._skills.values())
+
+
+# Module-level lazy singleton. We intentionally avoid creating it at import
+# time so that ``import ai.skills`` has no side effects.
+_default: SkillRegistry | None = None
+
+
+def default_registry() -> SkillRegistry:
+    """Return the process-wide default :class:`SkillRegistry`."""
+    global _default
+    if _default is None:
+        _default = SkillRegistry()
+    return _default
+
+
+def register_skill(
+    *, registry: SkillRegistry | None = None
+) -> Callable[[type[_T]], type[_T]]:
+    """Decorator form of :meth:`SkillRegistry.register`.
+
+    Example::
+
+        @register_skill()
+        class MySkill(Skill):
+            descriptor = SkillDescriptor(...)
+            async def run(self, invocation): ...
+    """
+
+    target = registry if registry is not None else default_registry()
+
+    def _decorate(skill_cls: type[_T]) -> type[_T]:
+        target.register(skill_cls)
+        return skill_cls
+
+    return _decorate

--- a/src/shared/python/ai/skills/runner.py
+++ b/src/shared/python/ai/skills/runner.py
@@ -1,0 +1,228 @@
+"""Skill runner (Tools #2737).
+
+Orchestrates a single skill invocation: precondition check, body execution
+with timeout, postcondition check, audit emission. External callers go
+through :meth:`SkillRunner.run` — never reach into the registry's private
+state (LOD).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from .base import Skill
+from .contracts import SkillInvocation, SkillResult
+from .errors import (
+    SkillExecutionError,
+    SkillNotFoundError,
+    SkillPostconditionError,
+    SkillPreconditionError,
+    SkillTimeoutError,
+)
+from .registry import SkillRegistry, default_registry
+
+_logger = logging.getLogger(__name__)
+
+
+def _audit_event(
+    kind: str,
+    *,
+    skill_id: str,
+    request_id: str,
+    message: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a single audit-trail event.
+
+    Keeping construction in one helper enforces DRY for both the runner and
+    any future audit sink integration.
+    """
+    event: dict[str, Any] = {
+        "kind": kind,
+        "skill_id": skill_id,
+        "request_id": request_id,
+        "timestamp": time.time(),
+    }
+    if message is not None:
+        event["message"] = message
+    if extra:
+        event["extra"] = extra
+    return event
+
+
+class SkillRunner:
+    """Executes a :class:`SkillInvocation` against a :class:`SkillRegistry`."""
+
+    def __init__(self, *, registry: SkillRegistry | None = None) -> None:
+        self._registry = registry if registry is not None else default_registry()
+
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        """Execute an invocation. Raises :class:`SkillNotFoundError`.
+
+        Contract failures (precondition, postcondition, timeout, body error)
+        are returned as ``SkillResult(success=False, error=...)`` rather than
+        raised — callers should branch on ``result.success``.
+        """
+        skill = self._registry.get(invocation.skill_id)  # may raise NotFound
+        audit: list[dict[str, Any]] = []
+        start = time.perf_counter()
+        skill_id = skill.descriptor.id
+
+        audit.append(
+            _audit_event(
+                "started",
+                skill_id=skill_id,
+                request_id=invocation.request_id,
+            )
+        )
+
+        try:
+            self._check_preconditions(skill, invocation, audit)
+            value, skill_audit = await self._execute_with_timeout(
+                skill, invocation, audit
+            )
+            audit.extend(skill_audit)
+            self._check_postconditions(skill, value, invocation, audit)
+        except SkillPreconditionError as exc:
+            return self._failure(invocation, audit, start, "precondition_failed", exc)
+        except SkillPostconditionError as exc:
+            return self._failure(invocation, audit, start, "postcondition_failed", exc)
+        except SkillTimeoutError as exc:
+            return self._failure(invocation, audit, start, "timeout", exc)
+        except SkillExecutionError as exc:
+            return self._failure(invocation, audit, start, "execution_error", exc)
+
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        audit.append(
+            _audit_event(
+                "completed",
+                skill_id=skill_id,
+                request_id=invocation.request_id,
+                extra={"elapsed_ms": elapsed_ms},
+            )
+        )
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=True,
+            value=value,
+            error=None,
+            elapsed_ms=elapsed_ms,
+            audit_trail=audit,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+    def _check_preconditions(
+        self,
+        skill: Skill,
+        invocation: SkillInvocation,
+        audit: list[dict[str, Any]],
+    ) -> None:
+        try:
+            skill.validate_preconditions(invocation.args)
+        except ValueError as exc:
+            audit.append(
+                _audit_event(
+                    "precondition_failed",
+                    skill_id=skill.descriptor.id,
+                    request_id=invocation.request_id,
+                    message=str(exc),
+                )
+            )
+            raise SkillPreconditionError(str(exc)) from exc
+
+    async def _execute_with_timeout(
+        self,
+        skill: Skill,
+        invocation: SkillInvocation,
+        audit: list[dict[str, Any]],
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        try:
+            result = await asyncio.wait_for(
+                skill.run(invocation), timeout=invocation.timeout_s
+            )
+        except TimeoutError as exc:
+            audit.append(
+                _audit_event(
+                    "timeout",
+                    skill_id=skill.descriptor.id,
+                    request_id=invocation.request_id,
+                    message=f"exceeded {invocation.timeout_s}s",
+                )
+            )
+            raise SkillTimeoutError(
+                f"skill {skill.descriptor.id!r} timed out after {invocation.timeout_s}s"
+            ) from exc
+        except (SkillPreconditionError, SkillPostconditionError):
+            raise
+        except Exception as exc:  # noqa: BLE001 — boundary catch is intentional
+            audit.append(
+                _audit_event(
+                    "execution_error",
+                    skill_id=skill.descriptor.id,
+                    request_id=invocation.request_id,
+                    message=str(exc),
+                )
+            )
+            _logger.exception(
+                "Skill %s raised %s", skill.descriptor.id, type(exc).__name__
+            )
+            raise SkillExecutionError(str(exc)) from exc
+
+        value = result.value if result.value is not None else {}
+        return value, list(result.audit_trail)
+
+    def _check_postconditions(
+        self,
+        skill: Skill,
+        value: dict[str, Any],
+        invocation: SkillInvocation,
+        audit: list[dict[str, Any]],
+    ) -> None:
+        try:
+            skill.validate_postconditions(value)
+        except ValueError as exc:
+            audit.append(
+                _audit_event(
+                    "postcondition_failed",
+                    skill_id=skill.descriptor.id,
+                    request_id=invocation.request_id,
+                    message=str(exc),
+                )
+            )
+            raise SkillPostconditionError(str(exc)) from exc
+
+    def _failure(
+        self,
+        invocation: SkillInvocation,
+        audit: list[dict[str, Any]],
+        start: float,
+        kind: str,
+        exc: Exception,
+    ) -> SkillResult:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        audit.append(
+            _audit_event(
+                "failed",
+                skill_id=invocation.skill_id,
+                request_id=invocation.request_id,
+                message=str(exc),
+                extra={"failure_kind": kind, "elapsed_ms": elapsed_ms},
+            )
+        )
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=False,
+            value=None,
+            error=str(exc),
+            elapsed_ms=elapsed_ms,
+            audit_trail=audit,
+        )
+
+
+# Re-export for convenience: callers want one import line.
+__all__ = ["SkillRunner", "SkillNotFoundError"]

--- a/tests/unit/ai/skills/__init__.py
+++ b/tests/unit/ai/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the ``ai.skills`` package (Tools #2737)."""

--- a/tests/unit/ai/skills/test_builtin_echo.py
+++ b/tests/unit/ai/skills/test_builtin_echo.py
@@ -1,0 +1,56 @@
+"""Tests for the built-in echo skill (Tools #2737)."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.python.ai.skills import SkillRegistry, SkillRunner
+from shared.python.ai.skills.builtin.echo import EchoSkill
+from shared.python.ai.skills.contracts import SkillInvocation
+
+
+pytestmark = pytest.mark.unit
+
+
+async def test_echo_skill_round_trip() -> None:
+    registry = SkillRegistry()
+    registry.register(EchoSkill)
+    runner = SkillRunner(registry=registry)
+
+    result = await runner.run(
+        SkillInvocation(
+            skill_id=EchoSkill.descriptor.id,
+            args={"message": "hello"},
+            request_id="echo-1",
+        )
+    )
+
+    assert result.success is True
+    assert result.value == {"echoed": "hello"}
+    assert result.error is None
+    # Audit trail records start + completion.
+    kinds = [event["kind"] for event in result.audit_trail]
+    assert "started" in kinds
+    assert "completed" in kinds
+
+
+async def test_echo_skill_rejects_empty_message() -> None:
+    registry = SkillRegistry()
+    registry.register(EchoSkill)
+    runner = SkillRunner(registry=registry)
+
+    result = await runner.run(
+        SkillInvocation(
+            skill_id=EchoSkill.descriptor.id,
+            args={"message": ""},
+            request_id="echo-2",
+        )
+    )
+
+    assert result.success is False
+    assert result.error is not None
+
+
+def test_echo_descriptor_declares_pre_and_post() -> None:
+    assert EchoSkill.descriptor.preconditions, "must declare preconditions"
+    assert EchoSkill.descriptor.postconditions, "must declare postconditions"

--- a/tests/unit/ai/skills/test_builtin_echo.py
+++ b/tests/unit/ai/skills/test_builtin_echo.py
@@ -8,7 +8,6 @@ from shared.python.ai.skills import SkillRegistry, SkillRunner
 from shared.python.ai.skills.builtin.echo import EchoSkill
 from shared.python.ai.skills.contracts import SkillInvocation
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/unit/ai/skills/test_builtin_summarize.py
+++ b/tests/unit/ai/skills/test_builtin_summarize.py
@@ -11,7 +11,6 @@ from shared.python.ai.skills.builtin.summarize import (
 )
 from shared.python.ai.skills.contracts import SkillInvocation
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -26,7 +25,7 @@ async def test_summarize_skill_with_stub_llm() -> None:
     result = await runner.run(
         SkillInvocation(
             skill_id=SummarizeSkill.descriptor.id,
-            args={"text": "Hello world. This is a test passage that needs summarising."},
+            args={"text": "Hello world. A test passage that needs summarising."},
             request_id="sum-1",
         )
     )

--- a/tests/unit/ai/skills/test_builtin_summarize.py
+++ b/tests/unit/ai/skills/test_builtin_summarize.py
@@ -1,0 +1,66 @@
+"""Tests for the built-in summarize skill (Tools #2737)."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.python.ai.skills import SkillRegistry, SkillRunner
+from shared.python.ai.skills.builtin.summarize import (
+    StubLLMClient,
+    SummarizeSkill,
+)
+from shared.python.ai.skills.contracts import SkillInvocation
+
+
+pytestmark = pytest.mark.unit
+
+
+async def test_summarize_skill_with_stub_llm() -> None:
+    stub = StubLLMClient(canned_response="SUMMARY: hello world")
+    skill = SummarizeSkill(llm_client=stub)
+
+    registry = SkillRegistry()
+    registry.register_instance(skill)
+    runner = SkillRunner(registry=registry)
+
+    result = await runner.run(
+        SkillInvocation(
+            skill_id=SummarizeSkill.descriptor.id,
+            args={"text": "Hello world. This is a test passage that needs summarising."},
+            request_id="sum-1",
+        )
+    )
+
+    assert result.success is True
+    assert result.value is not None
+    assert "summary" in result.value
+    assert result.value["summary"] == "SUMMARY: hello world"
+    # Audit trail should record the LLM call.
+    kinds = [event["kind"] for event in result.audit_trail]
+    assert "llm_call" in kinds
+    assert stub.call_count == 1
+
+
+async def test_summarize_skill_rejects_blank_input() -> None:
+    stub = StubLLMClient(canned_response="never used")
+    skill = SummarizeSkill(llm_client=stub)
+
+    registry = SkillRegistry()
+    registry.register_instance(skill)
+    runner = SkillRunner(registry=registry)
+
+    result = await runner.run(
+        SkillInvocation(
+            skill_id=SummarizeSkill.descriptor.id,
+            args={"text": "   "},
+            request_id="sum-2",
+        )
+    )
+
+    assert result.success is False
+    assert stub.call_count == 0, "LLM must not be called when preconditions fail"
+
+
+def test_summarize_descriptor_declares_pre_and_post() -> None:
+    assert SummarizeSkill.descriptor.preconditions
+    assert SummarizeSkill.descriptor.postconditions

--- a/tests/unit/ai/skills/test_contracts.py
+++ b/tests/unit/ai/skills/test_contracts.py
@@ -1,0 +1,100 @@
+"""Tests for ai.skills.contracts (Tools #2737)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from shared.python.ai.skills.contracts import (
+    SkillDescriptor,
+    SkillInvocation,
+    SkillResult,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_descriptor(**overrides: object) -> SkillDescriptor:
+    payload: dict[str, object] = {
+        "id": "demo.echo",
+        "name": "Demo Echo",
+        "version": "1.0.0",
+        "description": "Echoes the supplied payload.",
+        "inputs": {"message": "string"},
+        "outputs": {"echoed": "string"},
+        "preconditions": ["message_is_non_empty"],
+        "postconditions": ["echoed_equals_message"],
+    }
+    payload.update(overrides)
+    return SkillDescriptor(**payload)  # type: ignore[arg-type]
+
+
+class TestSkillDescriptor:
+    def test_round_trip_via_model_dump(self) -> None:
+        descriptor = _make_descriptor()
+        clone = SkillDescriptor(**descriptor.model_dump())
+        assert clone == descriptor
+
+    def test_rejects_blank_id(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_descriptor(id="")
+
+    def test_rejects_blank_version(self) -> None:
+        with pytest.raises(ValidationError):
+            _make_descriptor(version="")
+
+    def test_preconditions_default_to_empty_list(self) -> None:
+        descriptor = SkillDescriptor(
+            id="demo.bare",
+            name="Bare",
+            version="0.1.0",
+            description="bare",
+            inputs={},
+            outputs={},
+        )
+        assert descriptor.preconditions == []
+        assert descriptor.postconditions == []
+
+
+class TestSkillInvocation:
+    def test_request_id_defaults_to_uuid_string(self) -> None:
+        inv = SkillInvocation(skill_id="demo.echo", args={"message": "hi"})
+        assert isinstance(inv.request_id, str)
+        assert len(inv.request_id) >= 8
+
+    def test_explicit_request_id_preserved(self) -> None:
+        inv = SkillInvocation(
+            skill_id="demo.echo",
+            args={"message": "hi"},
+            request_id="req-1",
+        )
+        assert inv.request_id == "req-1"
+
+    def test_negative_timeout_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            SkillInvocation(skill_id="demo.echo", args={}, timeout_s=-1.0)
+
+
+class TestSkillResult:
+    def test_audit_trail_defaults_to_empty(self) -> None:
+        result = SkillResult(
+            request_id="req-1",
+            success=True,
+            value={"echoed": "x"},
+            error=None,
+            elapsed_ms=1.0,
+        )
+        assert result.audit_trail == []
+
+    def test_error_field_serialises_to_string(self) -> None:
+        result = SkillResult(
+            request_id="req-2",
+            success=False,
+            value=None,
+            error="boom",
+            elapsed_ms=0.0,
+        )
+        payload = result.model_dump()
+        assert payload["error"] == "boom"
+        assert payload["success"] is False

--- a/tests/unit/ai/skills/test_contracts.py
+++ b/tests/unit/ai/skills/test_contracts.py
@@ -11,7 +11,6 @@ from shared.python.ai.skills.contracts import (
     SkillResult,
 )
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/unit/ai/skills/test_registry.py
+++ b/tests/unit/ai/skills/test_registry.py
@@ -16,7 +16,6 @@ from shared.python.ai.skills.contracts import (
 )
 from shared.python.ai.skills.errors import SkillNotFoundError
 
-
 pytestmark = pytest.mark.unit
 
 

--- a/tests/unit/ai/skills/test_registry.py
+++ b/tests/unit/ai/skills/test_registry.py
@@ -1,0 +1,127 @@
+"""Tests for ai.skills.registry (Tools #2737)."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.python.ai.skills import (
+    Skill,
+    SkillRegistry,
+    register_skill,
+)
+from shared.python.ai.skills.contracts import (
+    SkillDescriptor,
+    SkillInvocation,
+    SkillResult,
+)
+from shared.python.ai.skills.errors import SkillNotFoundError
+
+
+pytestmark = pytest.mark.unit
+
+
+class _DummySkill(Skill):
+    descriptor = SkillDescriptor(
+        id="dummy.one",
+        name="Dummy One",
+        version="0.0.1",
+        description="dummy",
+        inputs={},
+        outputs={},
+        preconditions=[],
+        postconditions=[],
+    )
+
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=True,
+            value={},
+            error=None,
+            elapsed_ms=0.0,
+        )
+
+
+class _DummySkillTwo(Skill):
+    descriptor = SkillDescriptor(
+        id="dummy.two",
+        name="Dummy Two",
+        version="0.0.1",
+        description="dummy two",
+        inputs={},
+        outputs={},
+        preconditions=[],
+        postconditions=[],
+    )
+
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=True,
+            value={},
+            error=None,
+            elapsed_ms=0.0,
+        )
+
+
+class TestSkillRegistry:
+    def test_register_and_get(self) -> None:
+        registry = SkillRegistry()
+        registry.register(_DummySkill)
+        skill = registry.get("dummy.one")
+        assert isinstance(skill, _DummySkill)
+
+    def test_get_unknown_raises(self) -> None:
+        registry = SkillRegistry()
+        with pytest.raises(SkillNotFoundError):
+            registry.get("does.not.exist")
+
+    def test_list_returns_descriptors(self) -> None:
+        registry = SkillRegistry()
+        registry.register(_DummySkill)
+        registry.register(_DummySkillTwo)
+        descriptors = list(registry.list())
+        ids = {d.id for d in descriptors}
+        assert ids == {"dummy.one", "dummy.two"}
+
+    def test_duplicate_register_raises(self) -> None:
+        registry = SkillRegistry()
+        registry.register(_DummySkill)
+        with pytest.raises(ValueError):
+            registry.register(_DummySkill)
+
+    def test_register_decorator(self) -> None:
+        registry = SkillRegistry()
+
+        @register_skill(registry=registry)
+        class _Decorated(Skill):
+            descriptor = SkillDescriptor(
+                id="dummy.decorated",
+                name="Decorated",
+                version="0.0.1",
+                description="decorated",
+                inputs={},
+                outputs={},
+                preconditions=[],
+                postconditions=[],
+            )
+
+            async def run(self, invocation: SkillInvocation) -> SkillResult:
+                return SkillResult(
+                    request_id=invocation.request_id,
+                    success=True,
+                    value={},
+                    error=None,
+                    elapsed_ms=0.0,
+                )
+
+        assert isinstance(registry.get("dummy.decorated"), _Decorated)
+
+
+class TestDefaultRegistry:
+    def test_default_registry_is_singleton(self) -> None:
+        from shared.python.ai.skills.registry import default_registry
+
+        a = default_registry()
+        b = default_registry()
+        assert a is b

--- a/tests/unit/ai/skills/test_runner.py
+++ b/tests/unit/ai/skills/test_runner.py
@@ -1,0 +1,191 @@
+"""Tests for ai.skills.runner (Tools #2737)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from shared.python.ai.skills import (
+    Skill,
+    SkillRegistry,
+    SkillRunner,
+)
+from shared.python.ai.skills.contracts import (
+    SkillDescriptor,
+    SkillInvocation,
+    SkillResult,
+)
+from shared.python.ai.skills.errors import (
+    SkillNotFoundError,
+    SkillPostconditionError,
+    SkillPreconditionError,
+    SkillTimeoutError,
+)
+
+
+pytestmark = pytest.mark.unit
+
+
+class _OkSkill(Skill):
+    descriptor = SkillDescriptor(
+        id="t.ok",
+        name="Ok",
+        version="0.0.1",
+        description="ok",
+        inputs={"x": "int"},
+        outputs={"y": "int"},
+        preconditions=["x_is_int"],
+        postconditions=["y_equals_x_plus_one"],
+    )
+
+    def validate_preconditions(self, args: dict[str, object]) -> None:
+        if not isinstance(args.get("x"), int):
+            raise ValueError("x_is_int")
+
+    def validate_postconditions(self, result: dict[str, object]) -> None:
+        assert isinstance(result["y"], int)
+
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        x = int(invocation.args["x"])
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=True,
+            value={"y": x + 1},
+            error=None,
+            elapsed_ms=0.0,
+        )
+
+
+class _BadPostSkill(Skill):
+    descriptor = SkillDescriptor(
+        id="t.badpost",
+        name="BadPost",
+        version="0.0.1",
+        description="bad post",
+        inputs={},
+        outputs={"y": "int"},
+        preconditions=[],
+        postconditions=["y_is_int"],
+    )
+
+    def validate_postconditions(self, result: dict[str, object]) -> None:
+        if not isinstance(result.get("y"), int):
+            raise ValueError("y_is_int")
+
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=True,
+            value={"y": "not-an-int"},
+            error=None,
+            elapsed_ms=0.0,
+        )
+
+
+class _SlowSkill(Skill):
+    descriptor = SkillDescriptor(
+        id="t.slow",
+        name="Slow",
+        version="0.0.1",
+        description="slow",
+        inputs={},
+        outputs={},
+        preconditions=[],
+        postconditions=[],
+    )
+
+    async def run(self, invocation: SkillInvocation) -> SkillResult:
+        await asyncio.sleep(1.0)
+        return SkillResult(
+            request_id=invocation.request_id,
+            success=True,
+            value={},
+            error=None,
+            elapsed_ms=0.0,
+        )
+
+
+def _build_runner(*skills: type[Skill]) -> SkillRunner:
+    registry = SkillRegistry()
+    for skill_cls in skills:
+        registry.register(skill_cls)
+    return SkillRunner(registry=registry)
+
+
+class TestSkillRunner:
+    async def test_happy_path_succeeds(self) -> None:
+        runner = _build_runner(_OkSkill)
+        result = await runner.run(
+            SkillInvocation(skill_id="t.ok", args={"x": 41}, request_id="r1")
+        )
+        assert result.success is True
+        assert result.value == {"y": 42}
+        assert result.error is None
+        assert result.audit_trail, "expected audit trail emitted"
+
+    async def test_unknown_skill_raises(self) -> None:
+        runner = _build_runner()
+        with pytest.raises(SkillNotFoundError):
+            await runner.run(
+                SkillInvocation(skill_id="t.missing", args={}, request_id="r2")
+            )
+
+    async def test_precondition_failure_returns_structured_result(self) -> None:
+        runner = _build_runner(_OkSkill)
+        result = await runner.run(
+            SkillInvocation(
+                skill_id="t.ok", args={"x": "not-int"}, request_id="r3"
+            )
+        )
+        assert result.success is False
+        assert result.error is not None
+        assert "x_is_int" in result.error
+        # Runner should classify this as a precondition error in the audit trail.
+        kinds = [event["kind"] for event in result.audit_trail]
+        assert "precondition_failed" in kinds
+
+    async def test_postcondition_failure_returns_structured_result(self) -> None:
+        runner = _build_runner(_BadPostSkill)
+        result = await runner.run(
+            SkillInvocation(skill_id="t.badpost", args={}, request_id="r4")
+        )
+        assert result.success is False
+        assert result.error is not None
+        kinds = [event["kind"] for event in result.audit_trail]
+        assert "postcondition_failed" in kinds
+
+    async def test_timeout_returns_structured_result(self) -> None:
+        runner = _build_runner(_SlowSkill)
+        result = await runner.run(
+            SkillInvocation(
+                skill_id="t.slow",
+                args={},
+                request_id="r5",
+                timeout_s=0.05,
+            )
+        )
+        assert result.success is False
+        assert result.error is not None
+        kinds = [event["kind"] for event in result.audit_trail]
+        assert "timeout" in kinds
+
+    async def test_raises_directly_when_skill_id_unknown(self) -> None:
+        runner = _build_runner(_OkSkill)
+        with pytest.raises(SkillNotFoundError):
+            await runner.run(
+                SkillInvocation(skill_id="nope", args={}, request_id="r6")
+            )
+
+    async def test_precondition_error_type_can_be_raised(self) -> None:
+        # SkillPreconditionError exists and is the runner-internal raise type.
+        err = SkillPreconditionError("nope")
+        assert str(err) == "nope"
+
+    async def test_postcondition_error_type_can_be_raised(self) -> None:
+        err = SkillPostconditionError("nope")
+        assert str(err) == "nope"
+
+    async def test_timeout_error_type_can_be_raised(self) -> None:
+        err = SkillTimeoutError("nope")
+        assert str(err) == "nope"

--- a/tests/unit/ai/skills/test_runner.py
+++ b/tests/unit/ai/skills/test_runner.py
@@ -23,7 +23,6 @@ from shared.python.ai.skills.errors import (
     SkillTimeoutError,
 )
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -134,9 +133,7 @@ class TestSkillRunner:
     async def test_precondition_failure_returns_structured_result(self) -> None:
         runner = _build_runner(_OkSkill)
         result = await runner.run(
-            SkillInvocation(
-                skill_id="t.ok", args={"x": "not-int"}, request_id="r3"
-            )
+            SkillInvocation(skill_id="t.ok", args={"x": "not-int"}, request_id="r3")
         )
         assert result.success is False
         assert result.error is not None
@@ -173,9 +170,7 @@ class TestSkillRunner:
     async def test_raises_directly_when_skill_id_unknown(self) -> None:
         runner = _build_runner(_OkSkill)
         with pytest.raises(SkillNotFoundError):
-            await runner.run(
-                SkillInvocation(skill_id="nope", args={}, request_id="r6")
-            )
+            await runner.run(SkillInvocation(skill_id="nope", args={}, request_id="r6"))
 
     async def test_precondition_error_type_can_be_raised(self) -> None:
         # SkillPreconditionError exists and is the runner-internal raise type.


### PR DESCRIPTION
## Summary

Real implementation of the Skills and Workflows runtime promised by Tools #2737 but never shipped by PR #2728.

PR #2728 was a phantom-close: its diff only touched ``.Jules/*.md`` removal, symbolic-solver tests, and minor chat-dock / router-factory changes — zero files under ``src/shared/python/ai/skills/`` were created. As of audit on 2026-05-16, that package did not exist on ``main``. This PR ships the real code.

Issue #2737 has been reopened to track this work.

## Files added

### Package: ``src/shared/python/ai/skills/``
- ``__init__.py`` — public exports (``Skill``, ``SkillRegistry``, ``SkillRunner``, ``SkillResult``, ``register_skill``, errors)
- ``contracts.py`` — Pydantic ``SkillDescriptor``, ``SkillInvocation``, ``SkillResult``
- ``base.py`` — ``Skill`` ABC with ``descriptor`` class attribute and ``validate_preconditions`` / ``validate_postconditions`` hooks
- ``registry.py`` — ``SkillRegistry`` + ``default_registry()`` lazy singleton + ``@register_skill`` decorator
- ``runner.py`` — ``SkillRunner`` orchestrates pre-check → run (with ``asyncio.wait_for`` timeout) → post-check → audit emission
- ``errors.py`` — ``SkillError`` hierarchy (``SkillNotFoundError``, ``SkillPreconditionError``, ``SkillPostconditionError``, ``SkillTimeoutError``, ``SkillExecutionError``)
- ``builtin/__init__.py`` — re-exports
- ``builtin/echo.py`` — ``EchoSkill`` reference skill with explicit pre/postconditions
- ``builtin/summarize.py`` — ``SummarizeSkill`` + ``StubLLMClient`` + ``LLMClient`` Protocol, demonstrates injected LLM and ``llm_call`` audit event

### Tests: ``tests/unit/ai/skills/``
- ``test_contracts.py`` — 9 tests
- ``test_registry.py`` — 6 tests
- ``test_runner.py`` — 9 tests (happy path, precondition fail, postcondition fail, timeout, unknown skill, error-type smoke)
- ``test_builtin_echo.py`` — 3 tests
- ``test_builtin_summarize.py`` — 3 tests

## Test result

``python -m pytest tests/unit/ai/skills/ --no-cov`` → **30 passed in 0.97s**

## Quality gates

- ``python -m ruff check src/shared/python/ai/skills/ tests/unit/ai/skills/`` → **All checks passed!**
- ``python -m ruff format --check src/shared/python/ai/skills/ tests/unit/ai/skills/`` → **15 files already formatted**
- All pre-commit hooks pass (ruff, ruff-format, TODO/FIXME marker check, no wildcard imports, no debug statements, no ``print()`` in ``src/``)

## Design constraints honoured

- **DbC:** every ``Skill`` declares ``descriptor.preconditions`` and ``descriptor.postconditions`` (lists of predicate names). The runner validates at the boundary, not in the skill body.
- **LOD:** external callers go through ``SkillRunner.run(invocation)`` or ``default_registry().get(id)``. Tests never reach into ``runner._registry._skills``.
- **DRY:** single ``_audit_event`` helper used by every audit-emission site in the runner.
- **Orthogonality:** ``Skill`` knows nothing about chat, MCP, or tool registries. Chat integration is explicitly deferred to a later PR.
- **No global state at import time:** ``default_registry()`` is lazy.
- **No broad ``except Exception``** in the runner except a single boundary catch with ``# noqa: BLE001`` that re-raises as ``SkillExecutionError``.
- **Async-first:** ``Skill.run`` is ``async``; runner uses ``asyncio.wait_for`` for timeouts; ``pytest-asyncio`` already configured in ``pyproject.toml`` (``asyncio_mode = "auto"``).

## Out of scope (explicitly deferred)

- Chat dock integration — Wave 2 #2879 is mid-flight on ``_chat_dock_widget_qt.py``; not touched here.
- Workflow engine (multi-step orchestration) — covered by the parked ``drafts/workflow_engine/`` and issue #2760.
- MCP tool-registry bridge.

## Closes

Closes #2737.

## Test plan

- [x] ``pytest tests/unit/ai/skills/`` passes locally (30/30)
- [x] ``ruff check`` clean
- [x] ``ruff format --check`` clean
- [x] Pre-commit hooks pass
- [ ] CI green