### PR TITLE
fix(chat): headless-safe __dict__ access + worktree conftest path priority (UpstreamDrift#5621)

### DIFF
--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -1389,7 +1389,10 @@ class ChatDockWidget(QDockWidget):
         """
         if not target:
             return None
-        manager = getattr(self, "_session_manager", None)
+        # Use __dict__ rather than getattr because Qt's metaclass throws
+        # RuntimeError when accessed on objects whose C++ super-class was not
+        # initialised (e.g. tests that build the dock via __new__).
+        manager = self.__dict__.get("_session_manager")
         if manager is None:
             return None
         sessions = list(manager.list_sessions())
@@ -1429,15 +1432,20 @@ class ChatDockWidget(QDockWidget):
         """
         if not session_id:
             raise ValueError("session_id must be provided")
-        if session_id in self._loaded_context_sessions:
+        # Use __dict__ to avoid Qt metaclass RuntimeError in headless tests.
+        loaded = self.__dict__.get("_loaded_context_sessions", [])
+        if session_id in loaded:
             return
-        self._loaded_context_sessions.append(session_id)
+        loaded.append(session_id)
+        self.__dict__["_loaded_context_sessions"] = loaded
         self._refresh_breadcrumb()
 
     def _remove_context_session(self, session_id: str) -> None:
         """Remove ``session_id`` from the breadcrumb context list."""
-        if session_id in self._loaded_context_sessions:
-            self._loaded_context_sessions.remove(session_id)
+        loaded = self.__dict__.get("_loaded_context_sessions", [])
+        if session_id in loaded:
+            loaded.remove(session_id)
+            self.__dict__["_loaded_context_sessions"] = loaded
             self._refresh_breadcrumb()
 
     def breadcrumb_labels(self) -> list[str]:
@@ -1446,12 +1454,13 @@ class ChatDockWidget(QDockWidget):
         Used by tests + the breadcrumb strip renderer. LOD-compliant —
         callers do not need to inspect the session manager themselves.
         """
-        manager = getattr(self, "_session_manager", None)
+        # Use __dict__ to avoid Qt metaclass RuntimeError in headless tests.
+        manager = self.__dict__.get("_session_manager")
         if manager is None:
             return []
         info_by_id = {info.get("id"): info for info in manager.list_sessions()}
         labels: list[str] = []
-        for sid in self._loaded_context_sessions:
+        for sid in self.__dict__.get("_loaded_context_sessions", []):
             info = info_by_id.get(sid)
             if info is None:
                 labels.append(sid)

--- a/tests/unit/chat/conftest.py
+++ b/tests/unit/chat/conftest.py
@@ -16,6 +16,7 @@ from pathlib import Path
 _HERE = Path(__file__).resolve()
 _REPO_ROOT = _HERE.parents[3]
 _TREE_SRC = _REPO_ROOT / "src" / "shared" / "python"
+_WORKTREE_CHAT_DIR = str(_TREE_SRC / "chat")
 
 # Prepend the in-tree shared/python so it wins over any editable install.
 _path_str = str(_TREE_SRC)
@@ -23,13 +24,31 @@ if _path_str in sys.path:
     sys.path.remove(_path_str)
 sys.path.insert(0, _path_str)
 
-# Evict the chat package from sys.modules so the next ``import chat``
-# resolves through the prepended path. Only purge entries whose origin
-# is *not* this test directory; otherwise we lose pytest's discovery of
-# its own conftest under ``chat.conftest``.
+# Prepend the worktree chat directory to the chat package's __path__ so that
+# reimports of chat.* submodules resolve from the in-tree source first, before
+# the editable-install path. We do NOT evict ``chat`` itself to avoid losing
+# pytest's conftest-tracking entries.
+_chat_mod = sys.modules.get("chat")
+if _chat_mod is not None:
+    _existing_path = list(getattr(_chat_mod, "__path__", []))
+    if _WORKTREE_CHAT_DIR not in _existing_path:
+        try:
+            _chat_mod.__path__ = [_WORKTREE_CHAT_DIR] + _existing_path  # type: ignore[assignment]
+        except (AttributeError, TypeError):
+            pass
+    elif _existing_path[0] != _WORKTREE_CHAT_DIR:
+        # Already present but not first — move it to front.
+        _existing_path.remove(_WORKTREE_CHAT_DIR)
+        try:
+            _chat_mod.__path__ = [_WORKTREE_CHAT_DIR] + _existing_path  # type: ignore[assignment]
+        except (AttributeError, TypeError):
+            pass
+
+# Evict cached chat.* submodules (not chat itself, not test-dir entries)
+# so they are reimported from the updated __path__ on next access.
 _test_dir = str(_HERE.parent)
 for _name in list(sys.modules):
-    if not (_name == "chat" or _name.startswith("chat.")):
+    if not _name.startswith("chat."):
         continue
     _mod = sys.modules.get(_name)
     _file = getattr(_mod, "__file__", "") or ""


### PR DESCRIPTION
## Summary

- Replace `getattr(self, ...)` with `self.__dict__.get(...)` in headless-safe `ChatDockWidget` methods (`_resolve_use_session_target`, `_add_context_session`, `_remove_context_session`, `breadcrumb_labels`) so they do not raise `RuntimeError` when the Qt C++ super-class `__init__()` was not called (tests that build the dock via `__new__`)
- Update `tests/unit/chat/conftest.py` to prepend the worktree's `chat` directory to `chat.__path__` before evicting stale submodules, ensuring `HistorySidebar` and other symbols added in this branch resolve from in-tree source rather than the editable-install baseline on main

The core feature work (session `unarchive`/`search`/`export`, `load_context_from`, `HistorySidebar`, breadcrumb strip, `/use-session` slash command) was already delivered in PR #2879 (commit `0588a58f`). This PR completes the feature by making all 23 tests in `test_session_manager_2872.py` and `test_chat_dock_widget_history_browser.py` green.

Closes D-sorganization/UpstreamDrift#5621

## Test plan

- [x] `tests/unit/ai/gui/test_session_manager_2872.py` — 15 tests pass (unarchive, is_archived, search, export, load_context_from)
- [x] `tests/unit/chat/test_chat_dock_widget_history_browser.py` — 8 tests pass (HistorySidebar sections/search/restore/export, slash command, breadcrumb add/remove)
- [x] `ruff check` — zero violations on changed files
- [x] `ruff format --check` — zero diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)