### PR TITLE
feat(chat): surface Claude CLI/Codex CLI/Cline providers in Sidekick chat header

### DIFF
--- a/src/shared/python/chat/__init__.py
+++ b/src/shared/python/chat/__init__.py
@@ -22,6 +22,10 @@ Usage::
 
 from typing import Any
 
+from .cli_provider_availability import (
+    CliProviderEntry,
+    list_available_cli_providers,
+)
 from .service_base import ChatMessage, ChatServiceBase, ChatSession
 from .terminal_contracts import (
     TerminalAgentEvent,
@@ -130,4 +134,6 @@ __all__ = [
     "TerminalProcessAdapter",
     "TerminalRuntimeError",
     "TerminalSessionRuntime",
+    "CliProviderEntry",
+    "list_available_cli_providers",
 ]

--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -58,6 +58,7 @@ from .chat_dock_widget import (
     _session_file_path,
     _write_shared_session_id,
 )
+from .cli_provider_availability import list_available_cli_providers
 from .terminal_contracts import TerminalProviderRegistry
 from .terminal_providers import build_default_terminal_provider_registry
 from .voice_input_manager import VoiceInputManager
@@ -876,16 +877,42 @@ class ChatDockWidget(QDockWidget):
         combo.setToolTip(f"Select AI {label}")
         return combo
 
+    @staticmethod
+    def _build_available_cli_provider_items() -> list[tuple[str, str]]:
+        """Return ``(display_name, provider_id)`` pairs for installed CLI agents.
+
+        Probes the local ``PATH`` via :func:`shutil.which` through
+        :func:`~cli_provider_availability.list_available_cli_providers`.
+        Only CLI agents whose binary is found are included so the dropdown
+        never shows unavailable entries.
+
+        Returns:
+            A list of ``(display_name, provider_id)`` tuples, empty when
+            no CLI agents are installed.
+        """
+        return [
+            (entry.display_name, entry.provider_id)
+            for entry in list_available_cli_providers()
+        ]
+
     def _build_ai_dropdowns(self, mode_row: QHBoxLayout) -> None:
         """Construct + wire the three AI header dropdowns.
 
         Side-effect only: instantiates ``_ai_provider_combo``,
         ``_ai_model_combo``, ``_ai_thinking_combo`` and inserts them
         into ``mode_row`` left-to-right.
+
+        CLI agent providers (Claude CLI, Codex CLI, Cline) are probed via
+        :func:`~_build_available_cli_provider_items` and appended to the
+        provider combo after the API providers so they are always visible
+        when the binary is installed (Tools issue UpstreamDrift#5622).
         """
+        api_items = list(self._AI_DEFAULT_PROVIDERS)
+        cli_items = self._build_available_cli_provider_items()
+        all_provider_items = api_items + cli_items
         self._ai_provider_combo = self._build_header_combobox(
             label="provider",
-            items=list(self._AI_DEFAULT_PROVIDERS),
+            items=all_provider_items,
         )
         mode_row.addWidget(self._ai_provider_combo)
 

--- a/src/shared/python/chat/cli_provider_availability.py
+++ b/src/shared/python/chat/cli_provider_availability.py
@@ -1,0 +1,109 @@
+"""Runtime availability probe for terminal CLI agent providers.
+
+This module exposes :func:`list_available_cli_providers`, which probes the
+local ``PATH`` via :func:`shutil.which` and returns only the CLI providers
+whose binary is actually installed.  The result is intended to populate the
+Sidekick chat header provider dropdown (Tools issue UpstreamDrift#5622).
+
+The probe is intentionally lightweight — it does *not* run the binary or
+validate authentication.  Use the existing ``terminal_providers`` probe
+commands (``provider_probe_commands``) for a more thorough health check.
+
+Design-by-Contract:
+    Preconditions:
+        - :class:`CliProviderEntry` fields ``provider_id`` and
+          ``display_name`` must be non-empty strings.
+    Postconditions:
+        - :func:`list_available_cli_providers` returns a list (possibly
+          empty) of :class:`CliProviderEntry` instances.
+        - Every returned entry's ``provider_id`` is present in the
+          :func:`~terminal_providers.build_default_terminal_provider_registry`.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CliProviderEntry:
+    """Metadata for a CLI agent provider that is available on the local PATH.
+
+    Preconditions:
+        - ``provider_id`` must be a non-empty string.
+        - ``display_name`` must be a non-empty string.
+
+    Attributes:
+        provider_id: Stable registry identifier (matches
+            :class:`~terminal_contracts.TerminalAgentProviderInfo`).
+        display_name: Human-readable label for use in UI dropdowns.
+        binary_path: Resolved path to the executable, as returned by
+            ``shutil.which``.  ``None`` if the binary was not found (in
+            practice, entries with ``None`` are never returned by
+            :func:`list_available_cli_providers`).
+    """
+
+    provider_id: str
+    display_name: str
+    binary_path: str | None
+
+    def __post_init__(self) -> None:
+        if not self.provider_id:
+            raise ValueError("provider_id must be a non-empty string")
+        if not self.display_name:
+            raise ValueError("display_name must be a non-empty string")
+
+
+# ---------------------------------------------------------------------------
+# Canonical CLI agent descriptor table
+#
+# Each tuple contains:
+#   (registry_provider_id, ui_display_name, binary_to_probe)
+#
+# The ``ui_display_name`` is what appears in the dropdown — kept short and
+# human-friendly, intentionally distinct from the registry's internal
+# ``display_name`` so both can evolve independently.
+# ---------------------------------------------------------------------------
+
+_CLI_AGENT_DESCRIPTORS: tuple[tuple[str, str, str], ...] = (
+    ("claude-code", "Claude CLI", "claude"),
+    ("codex", "Codex CLI", "codex"),
+    ("cline-cli", "Cline", "cline"),
+    ("gemini-cli", "Gemini CLI", "gemini"),
+)
+
+
+def list_available_cli_providers() -> list[CliProviderEntry]:
+    """Return CLI agent providers whose binary is present on ``PATH``.
+
+    Probes each known CLI agent executable with :func:`shutil.which`.
+    Only providers whose binary resolves to a non-``None`` path are
+    included in the result.
+
+    Returns:
+        A list of :class:`CliProviderEntry` instances, one per available
+        provider, in the order defined by ``_CLI_AGENT_DESCRIPTORS``.
+        Returns an empty list when no providers are installed.
+
+    Example::
+
+        from src.shared.python.chat.cli_provider_availability import (
+            list_available_cli_providers,
+        )
+
+        for entry in list_available_cli_providers():
+            print(entry.display_name, "->", entry.binary_path)
+    """
+    available: list[CliProviderEntry] = []
+    for provider_id, display_name, executable in _CLI_AGENT_DESCRIPTORS:
+        binary_path = shutil.which(executable)
+        if binary_path is not None:
+            available.append(
+                CliProviderEntry(
+                    provider_id=provider_id,
+                    display_name=display_name,
+                    binary_path=binary_path,
+                )
+            )
+    return available

--- a/tests/shared/python/chat/test_cli_agent_adapters.py
+++ b/tests/shared/python/chat/test_cli_agent_adapters.py
@@ -1,0 +1,234 @@
+"""Tests for CLI agent adapter health checks and session start wiring.
+
+Covers the TerminalSessionRuntime integration for CLI provider selection
+in the ChatDockWidget, plus DbC negative cases for empty messages.
+
+Tools issue: UpstreamDrift#5622
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Register src namespace packages so dotted imports resolve correctly
+_src_pkg = types.ModuleType("src")
+_src_pkg.__path__ = [str(ROOT / "src")]  # type: ignore[attr-defined]
+sys.modules.setdefault("src", _src_pkg)
+
+for _ns in (
+    "src.shared",
+    "src.shared.python",
+    "src.shared.python.chat",
+    "src.shared.python.contracts",
+):
+    _parts = _ns.split(".")
+    _mod = types.ModuleType(_ns)
+    _mod.__path__ = [str(ROOT.joinpath(*_parts))]  # type: ignore[attr-defined]
+    sys.modules.setdefault(_ns, _mod)
+
+logging_pkg = types.ModuleType("src.shared.python.logging_pkg")
+logging_config = types.ModuleType("src.shared.python.logging_pkg.logging_config")
+logging_config.get_logger = logging.getLogger  # type: ignore[attr-defined]
+logging_config.setup_logging = lambda *a, **kw: None  # type: ignore[attr-defined]
+sys.modules.setdefault("src.shared.python.logging_pkg", logging_pkg)
+sys.modules.setdefault("src.shared.python.logging_pkg.logging_config", logging_config)
+
+from src.shared.python.chat.cli_provider_availability import (  # noqa: E402
+    list_available_cli_providers,
+)
+from src.shared.python.chat.terminal_providers import (  # noqa: E402
+    build_default_terminal_provider_registry,
+)
+from src.shared.python.chat.terminal_runtime import (  # noqa: E402
+    TerminalSessionRuntime,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# health_check helpers via list_available_cli_providers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCliProviderHealthChecks:
+    def test_health_check_passes_when_claude_binary_found(self) -> None:
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        claude_entries = [p for p in providers if p.provider_id == "claude-code"]
+        assert len(claude_entries) == 1
+        assert claude_entries[0].binary_path is not None
+
+    def test_health_check_fails_when_all_binaries_missing(self) -> None:
+        with patch("shutil.which", return_value=None):
+            providers = list_available_cli_providers()
+        assert providers == []
+
+    def test_health_check_fails_when_only_codex_missing(self) -> None:
+        available = {"claude", "cline"}
+
+        def _which(name: str) -> str | None:
+            return f"/usr/bin/{name}" if name in available else None
+
+        with patch("shutil.which", side_effect=_which):
+            providers = list_available_cli_providers()
+        ids = [p.provider_id for p in providers]
+        assert "codex" not in ids
+        assert "claude-code" in ids
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TerminalSessionRuntime integration — start returns session info
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTerminalSessionRuntimeCliIntegration:
+    """Verify TerminalSessionRuntime can start CLI provider sessions."""
+
+    def _make_runtime(self) -> TerminalSessionRuntime:
+        registry = build_default_terminal_provider_registry()
+        adapter = MagicMock()
+        adapter.start.return_value = "proc-001"
+        return TerminalSessionRuntime(registry, adapter)
+
+    def test_start_claude_cli_session_returns_info(self, tmp_path: Path) -> None:
+        from src.shared.python.chat.terminal_contracts import (
+            TerminalAgentSessionRequest,
+        )
+
+        runtime = self._make_runtime()
+        request = TerminalAgentSessionRequest(
+            app_context="sidekick",
+            project_root=tmp_path,
+            shell_id="bash",
+            provider_id="claude-code",
+        )
+        info = runtime.start(request)
+        assert info.provider_id == "claude-code"
+        assert info.state == "running"
+
+    def test_start_codex_session_returns_info(self, tmp_path: Path) -> None:
+        from src.shared.python.chat.terminal_contracts import (
+            TerminalAgentSessionRequest,
+        )
+
+        runtime = self._make_runtime()
+        request = TerminalAgentSessionRequest(
+            app_context="sidekick",
+            project_root=tmp_path,
+            shell_id="bash",
+            provider_id="codex",
+        )
+        info = runtime.start(request)
+        assert info.provider_id == "codex"
+        assert info.state == "running"
+
+    def test_start_cline_session_returns_info(self, tmp_path: Path) -> None:
+        from src.shared.python.chat.terminal_contracts import (
+            TerminalAgentSessionRequest,
+        )
+
+        runtime = self._make_runtime()
+        request = TerminalAgentSessionRequest(
+            app_context="sidekick",
+            project_root=tmp_path,
+            shell_id="bash",
+            provider_id="cline-cli",
+        )
+        info = runtime.start(request)
+        assert info.provider_id == "cline-cli"
+        assert info.state == "running"
+
+    def test_write_raises_on_empty_input(self, tmp_path: Path) -> None:
+        from src.shared.python.chat.terminal_contracts import (
+            TerminalAgentSessionRequest,
+        )
+        from src.shared.python.chat.terminal_runtime import TerminalRuntimeError
+
+        runtime = self._make_runtime()
+        request = TerminalAgentSessionRequest(
+            app_context="sidekick",
+            project_root=tmp_path,
+            shell_id="bash",
+            provider_id="claude-code",
+        )
+        info = runtime.start(request)
+        with pytest.raises(TerminalRuntimeError):
+            runtime.write(info.session_id, "")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Default registry has correct CLI provider display names
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDefaultRegistryCliProviders:
+    """Verify the registry exposes the expected CLI providers."""
+
+    def test_claude_code_provider_in_registry(self) -> None:
+        registry = build_default_terminal_provider_registry()
+        provider = registry.get_provider("claude-code")
+        assert provider.display_name == "Claude Code"
+        assert provider.executable == "claude"
+
+    def test_codex_provider_in_registry(self) -> None:
+        registry = build_default_terminal_provider_registry()
+        provider = registry.get_provider("codex")
+        assert provider.display_name == "Codex"
+        assert provider.executable == "codex"
+
+    def test_cline_cli_provider_in_registry(self) -> None:
+        registry = build_default_terminal_provider_registry()
+        provider = registry.get_provider("cline-cli")
+        assert provider.display_name == "Cline CLI"
+        assert provider.executable == "cline"
+
+    def test_all_cli_providers_support_bash_shell(self) -> None:
+        registry = build_default_terminal_provider_registry()
+        for pid in ("claude-code", "codex", "cline-cli"):
+            provider = registry.get_provider(pid)
+            assert "bash" in provider.supported_shells, f"{pid} should support bash"
+
+    def test_providers_for_bash_includes_all_cli_agents(self) -> None:
+        registry = build_default_terminal_provider_registry()
+        providers = registry.providers_for_shell("bash")
+        ids = [p.id for p in providers]
+        assert "claude-code" in ids
+        assert "codex" in ids
+        assert "cline-cli" in ids
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# list_available_cli_providers + terminal registry alignment
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCliProviderAlignmentWithRegistry:
+    """provider_ids from list_available_cli_providers must exist in registry."""
+
+    def test_all_returned_provider_ids_are_in_registry(self) -> None:
+        registry = build_default_terminal_provider_registry()
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        for entry in providers:
+            # Must not raise TerminalRegistryError
+            registry.get_provider(entry.provider_id)
+
+    def test_display_names_match_registry(self) -> None:
+        registry = build_default_terminal_provider_registry()
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        for entry in providers:
+            reg_provider = registry.get_provider(entry.provider_id)
+            # The UI display name comes from the entry; registry has its own
+            # canonical display name. They may differ (e.g. "Claude CLI" vs
+            # "Claude Code") — the important thing is both are non-empty.
+            assert entry.display_name
+            assert reg_provider.display_name

--- a/tests/shared/python/chat/test_cli_provider_dropdown.py
+++ b/tests/shared/python/chat/test_cli_provider_dropdown.py
@@ -1,0 +1,202 @@
+"""Tests for CLI agent provider surfacing in the ChatDockWidget provider dropdown.
+
+Covers:
+- list_available_providers() probes with shutil.which and returns correct entries
+- Installed providers appear; missing ones are excluded
+- Providers include the three CLI agents: Claude CLI, Codex CLI, Cline
+- ChatDockWidget provider combo includes CLI providers when installed
+- CLI provider availability check integrates with TerminalSessionRuntime
+
+Tools issue: UpstreamDrift#5622
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Register src namespace packages so dotted imports resolve correctly
+_src_pkg = types.ModuleType("src")
+_src_pkg.__path__ = [str(ROOT / "src")]  # type: ignore[attr-defined]
+sys.modules.setdefault("src", _src_pkg)
+
+for _ns in ("src.shared", "src.shared.python", "src.shared.python.chat"):
+    _parts = _ns.split(".")
+    _mod = types.ModuleType(_ns)
+    _mod.__path__ = [str(ROOT.joinpath(*_parts))]  # type: ignore[attr-defined]
+    sys.modules.setdefault(_ns, _mod)
+
+# Stub PyQt6 so widget construction tests can run headless
+_qt_widgets = types.ModuleType("PyQt6.QtWidgets")
+_qt_core = types.ModuleType("PyQt6.QtCore")
+_qt_gui = types.ModuleType("PyQt6.QtGui")
+_qt_ws = types.ModuleType("PyQt6.QtWebSockets")
+_qt6 = types.ModuleType("PyQt6")
+
+for _attr in [
+    "QDockWidget",
+    "QWidget",
+    "QVBoxLayout",
+    "QHBoxLayout",
+    "QLabel",
+    "QPushButton",
+    "QComboBox",
+    "QScrollArea",
+    "QPlainTextEdit",
+    "QStackedWidget",
+    "QFrame",
+    "QMenu",
+    "QFileDialog",
+    "QApplication",
+]:
+    setattr(_qt_widgets, _attr, MagicMock)
+
+for _attr in ["Qt", "QTimer", "QUrl", "pyqtSignal"]:
+    setattr(_qt_core, _attr, MagicMock)
+for _attr in ["QKeySequence", "QShortcut"]:
+    setattr(_qt_gui, _attr, MagicMock)
+_qt_ws.QWebSocket = MagicMock
+
+_qt6.QtWidgets = _qt_widgets
+_qt6.QtCore = _qt_core
+_qt6.QtGui = _qt_gui
+_qt6.QtWebSockets = _qt_ws
+
+sys.modules.setdefault("PyQt6", _qt6)
+sys.modules.setdefault("PyQt6.QtWidgets", _qt_widgets)
+sys.modules.setdefault("PyQt6.QtCore", _qt_core)
+sys.modules.setdefault("PyQt6.QtGui", _qt_gui)
+sys.modules.setdefault("PyQt6.QtWebSockets", _qt_ws)
+
+# Stub out logging config dependency used by sub-modules
+logging_pkg = types.ModuleType("src.shared.python.logging_pkg")
+logging_config = types.ModuleType("src.shared.python.logging_pkg.logging_config")
+logging_config.get_logger = logging.getLogger  # type: ignore[attr-defined]
+logging_config.setup_logging = lambda *a, **kw: None  # type: ignore[attr-defined]
+sys.modules.setdefault("src.shared.python.logging_pkg", logging_pkg)
+sys.modules.setdefault("src.shared.python.logging_pkg.logging_config", logging_config)
+
+from src.shared.python.chat.cli_provider_availability import (  # noqa: E402
+    CliProviderEntry,
+    list_available_cli_providers,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# list_available_cli_providers()
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestListAvailableCliProviders:
+    """Tests for the shutil.which-based provider probe."""
+
+    def test_returns_list(self) -> None:
+        with patch("shutil.which", return_value=None):
+            result = list_available_cli_providers()
+        assert isinstance(result, list)
+
+    def test_all_three_appear_when_all_installed(self) -> None:
+        """When shutil.which finds claude/codex/cline, all three are returned."""
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        names = [p.display_name for p in providers]
+        assert "Claude CLI" in names
+        assert "Codex CLI" in names
+        assert "Cline" in names
+
+    def test_omits_missing_providers(self) -> None:
+        """Providers whose binary is absent are excluded."""
+        with patch("shutil.which", return_value=None):
+            providers = list_available_cli_providers()
+        assert providers == []
+
+    def test_partial_availability(self) -> None:
+        """Only installed providers are returned."""
+        available = {"claude"}
+
+        def _which(name: str) -> str | None:
+            return f"/usr/bin/{name}" if name in available else None
+
+        with patch("shutil.which", side_effect=_which):
+            providers = list_available_cli_providers()
+        names = [p.display_name for p in providers]
+        assert "Claude CLI" in names
+        assert "Codex CLI" not in names
+        assert "Cline" not in names
+
+    def test_entry_has_binary_path(self) -> None:
+        """Each returned entry carries the resolved binary path."""
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        for entry in providers:
+            assert entry.binary_path is not None
+            assert entry.binary_path.startswith("/usr/bin/")
+
+    def test_entry_has_provider_id(self) -> None:
+        """Each entry exposes a stable provider_id matching the registry."""
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        ids = [p.provider_id for p in providers]
+        assert "claude-code" in ids
+        assert "codex" in ids
+        assert "cline-cli" in ids
+
+    def test_returns_cli_provider_entry_instances(self) -> None:
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        for entry in providers:
+            assert isinstance(entry, CliProviderEntry)
+
+    def test_gemini_cli_also_included_when_installed(self) -> None:
+        """Gemini CLI is also surfaced when available."""
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        names = [p.display_name for p in providers]
+        assert "Gemini CLI" in names
+
+    def test_no_duplicates(self) -> None:
+        with patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"):
+            providers = list_available_cli_providers()
+        ids = [p.provider_id for p in providers]
+        assert len(ids) == len(set(ids))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CliProviderEntry contract
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCliProviderEntry:
+    def test_fields_accessible(self) -> None:
+        entry = CliProviderEntry(
+            provider_id="claude-code",
+            display_name="Claude CLI",
+            binary_path="/usr/bin/claude",
+        )
+        assert entry.provider_id == "claude-code"
+        assert entry.display_name == "Claude CLI"
+        assert entry.binary_path == "/usr/bin/claude"
+
+    def test_display_name_cannot_be_empty(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            CliProviderEntry(
+                provider_id="x",
+                display_name="",
+                binary_path="/usr/bin/x",
+            )
+
+    def test_provider_id_cannot_be_empty(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            CliProviderEntry(
+                provider_id="",
+                display_name="X",
+                binary_path="/usr/bin/x",
+            )


### PR DESCRIPTION
## Summary

- Adds `src/shared/python/chat/cli_provider_availability.py` with `list_available_cli_providers()` that probes `shutil.which` at runtime and returns `CliProviderEntry` instances only for installed CLI agents (Claude CLI, Codex CLI, Cline, Gemini CLI).
- Wires the probe into `ChatDockWidget._build_ai_dropdowns()` via the new `_build_available_cli_provider_items()` static method so the provider header combo dynamically includes installed CLI agents alongside API providers.
- Exports `CliProviderEntry` and `list_available_cli_providers()` from `chat/__init__.py` for downstream consumers.
- 26 new unit tests covering availability probe, `CliProviderEntry` contract, `TerminalSessionRuntime` integration for all three CLI agents, and alignment with the provider registry.

Closes D-sorganization/UpstreamDrift#5622

## Test plan

- [x] `python3 -m pytest tests/shared/python/chat/test_cli_provider_dropdown.py tests/shared/python/chat/test_cli_agent_adapters.py` — 26 passed
- [x] `python3 -m ruff check` — clean on all changed files
- [x] `python3 -m ruff format --check` — clean on all changed files
- [x] Pre-existing baseline failures in `test_ai_memory_manager.py` confirmed not caused by this PR (reproduced identically on clean baseline stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)