### PR TITLE
fix(sidekick): repair shim circular import that blocks all test collection (regression from PR #2885)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ include = [
     "chat*",
     "notes*",
     "upstream_drift_tools*",
+    "sidekick*",
     "model_generation*",
     "humanoid_character_builder*",
     "signal_toolkit*",

--- a/src/shared/python/sidekick/process_calculators/constants.py
+++ b/src/shared/python/sidekick/process_calculators/constants.py
@@ -11,7 +11,7 @@ needed by the standalone process calculators. Values are sourced from:
 
 from typing import Final
 
-from upstream_drift_tools.utils.unit_constants import (
+from sidekick.utils.unit_constants import (
     ATM_TO_KPA,
     ATMOSPHERE_TO_PASCAL,
     AVOGADRO_NUMBER,
@@ -37,22 +37,22 @@ from upstream_drift_tools.utils.unit_constants import (
     STANDARD_GRAVITY,
     TORR_TO_PASCAL,
 )
-from upstream_drift_tools.utils.unit_constants import (
+from sidekick.utils.unit_constants import (
     CELSIUS_OFFSET as CELSIUS_TO_KELVIN_OFFSET,
 )
-from upstream_drift_tools.utils.unit_constants import (
+from sidekick.utils.unit_constants import (
     DENSITY_WATER_STD as _DENSITY_WATER_STD,
 )
-from upstream_drift_tools.utils.unit_constants import (
+from sidekick.utils.unit_constants import (
     HOURS_PER_DAY as _HOURS_PER_DAY,
 )
-from upstream_drift_tools.utils.unit_constants import (
+from sidekick.utils.unit_constants import (
     KG_TO_LB as _KG_TO_LB,
 )
-from upstream_drift_tools.utils.unit_constants import (
+from sidekick.utils.unit_constants import (
     R_UNIVERSAL_KMOL as _R_UNIVERSAL_KMOL,
 )
-from upstream_drift_tools.utils.unit_constants import (
+from sidekick.utils.unit_constants import (
     STP_TEMPERATURE_K as _STP_TEMPERATURE_K,
 )
 

--- a/src/shared/python/sidekick/process_calculators/pressure_drop_calculator/_legacy.py
+++ b/src/shared/python/sidekick/process_calculators/pressure_drop_calculator/_legacy.py
@@ -18,7 +18,7 @@ import math
 from dataclasses import dataclass
 from typing import Final
 
-from upstream_drift_tools.utils.unit_constants import R_UNIVERSAL
+from sidekick.utils.unit_constants import R_UNIVERSAL
 
 # Standard Pipe Dimensions (Schedule 40) - Inner Diameter in meters
 PIPE_DIMENSIONS_SCH40: Final[dict[str, float]] = {

--- a/src/shared/python/sidekick/process_calculators/pressure_drop_calculator/utils/flow_rate_converter.py
+++ b/src/shared/python/sidekick/process_calculators/pressure_drop_calculator/utils/flow_rate_converter.py
@@ -1,11 +1,11 @@
 """Flow rate conversion utilities — re-export from canonical location.
 
 This module re-exports all public symbols from
-``upstream_drift_tools.calculators.conversion.flow_rate_converter``
+``sidekick.calculators.conversion.flow_rate_converter``
 to maintain backward compatibility with internal imports.
 """
 
-from upstream_drift_tools.calculators.conversion.flow_rate_converter import (
+from sidekick.calculators.conversion.flow_rate_converter import (
     MASS_FLOW_CONVERSIONS,
     MOLAR_FLOW_CONVERSIONS,
     STANDARD_CONDITIONS,

--- a/src/shared/python/sidekick/process_calculators/wgs_reactor_calculator.py
+++ b/src/shared/python/sidekick/process_calculators/wgs_reactor_calculator.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any
 
 # matplotlib and scipy imported lazily to prevent Windows hang at module load
 import numpy as np
-from upstream_drift_tools.utils.state_manager import safe_read_json
+from sidekick.utils.state_manager import safe_read_json
 
 from shared.python.theme.integration import get_theme_manager
 from shared.python.theme.matplotlib_style import apply_plot_theme

--- a/tests/unit/sidekick/__init__.py
+++ b/tests/unit/sidekick/__init__.py
@@ -1,1 +1,0 @@
-"""Sidekick tests."""

--- a/tests/unit/sidekick/jupyter_tab/__init__.py
+++ b/tests/unit/sidekick/jupyter_tab/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for the Sidekick Jupyter notebook tab (Tools #2875)."""


### PR DESCRIPTION
## Summary

**Regression source: PR #2885** (`refactor: rename upstream_drift_tools → sidekick with compat shim`, merged at commit `a6e321e`).

PR #2885 renamed `upstream_drift_tools` → `sidekick` and added a compat shim, but left the codebase in a state where:
- `import upstream_drift_tools` fails with `ModuleNotFoundError`
- `import sidekick` fails with `ModuleNotFoundError`
- `pytest --collect-only tests/unit/` aborts with 6 collection errors

This PR is the minimal fix to restore both imports and pytest collection. It does **not** close any specific issue — it fixes a regression.

## Original error trace

```
>>> import upstream_drift_tools
DeprecationWarning: upstream_drift_tools is deprecated... Import from sidekick instead.
Traceback (most recent call last):
  File "src/shared/python/upstream_drift_tools/__init__.py", line 25, in <module>
    import sidekick  # noqa: E402
ModuleNotFoundError: No module named 'sidekick'
```

Then after partial fixes:
```
File "src/shared/python/upstream_drift_tools/__init__.py", line 29, in <module>
    import sidekick.process_calculators as process_calculators
File "src/shared/python/sidekick/process_calculators/__init__.py", line 33, in <module>
    from .acid_gas_dewpoint_calculator import AcidGasDewpointCalculator
ModuleNotFoundError: No module named 'sidekick.calculators'
```

## Strategy chosen: B (break the cross-shim dependency)

Three root causes, fixed with the smallest possible diff (7 files, +12/-13 lines):

1. **Cross-shim source imports** — 4 sidekick source files (`process_calculators/constants.py`, `wgs_reactor_calculator.py`, `pressure_drop_calculator/utils/flow_rate_converter.py`, `pressure_drop_calculator/_legacy.py`) imported from `upstream_drift_tools.*`. The canonical package must not depend on the deprecation alias. Replaced with `sidekick.*` equivalents (all target modules already exist in sidekick).

2. **Missing `sidekick*` in `[tool.setuptools.packages.find]` include list** — `pip install -e .` registered only `upstream_drift_tools*`, so `import sidekick` failed on a clean install. Added `sidekick*` next to `upstream_drift_tools*`.

3. **Test-directory shadowing** — `tests/unit/sidekick/__init__.py` and `tests/unit/sidekick/jupyter_tab/__init__.py` were bare docstring `__init__.py` files. After the rename, pytest's rootdir discovery picked up `tests/unit/sidekick/` as a Python package and shadowed the installed `sidekick`. Deleted both files (no exported symbols, just `"""Sidekick tests."""`); pytest collects fine without them.

**Why Strategy B over A** — sidekick is the new canonical package and should not depend on the deprecation shim. Strategy A (deferring the eager import in the shim) would have papered over the architectural debt and left a cycle that would re-bite as soon as anyone adds another cross-import.

## Before / after pytest collection

| Metric | Before | After |
|---|---|---|
| `pytest --collect-only tests/unit/` collected | 222 | **245** |
| `pytest --collect-only tests/unit/` errors | 6 | **0** |
| `pytest tests/unit/sidekick/` collected | 41 (with 6 errors) | **64** |
| `pytest tests/unit/sidekick/` results | aborted | **61 passed, 3 skipped (Qt)** |
| `import sidekick` | `ModuleNotFoundError` | OK |
| `import upstream_drift_tools` | `ModuleNotFoundError` | OK (DeprecationWarning) |

## Verification

```
python -m ruff check <touched files>      # clean (3 pre-existing E501 unchanged, not from this PR)
python -m ruff format --check <touched files>   # 5 files already formatted
python -m pytest --collect-only tests/unit/     # 245 collected, 0 errors
python -m pytest tests/unit/sidekick/           # 61 passed, 3 skipped
```

## Unblocks

- PR #2883 (already merged, but its tests were uncollectable on `main` after #2885)
- Any open PR whose CI was failing in test collection due to the import errors
- All downstream consumers attempting `from sidekick import ...` or `from upstream_drift_tools import ...`

## Test plan

- [x] `import sidekick` succeeds
- [x] `import upstream_drift_tools` succeeds (emits DeprecationWarning)
- [x] `pytest --collect-only tests/unit/` collects cleanly
- [x] `pytest tests/unit/sidekick/ -o addopts=-v --timeout=30` passes (61 passed, 3 Qt-skipped)
- [x] `ruff check` on touched files clean
- [x] `ruff format --check` on touched files clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)