### PR TITLE
feat(sidekick): Jupyter Phase 2 — session model with path validation & secure persistence (closes #2876)

### DIFF
--- a/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/__init__.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/__init__.py
@@ -1,8 +1,12 @@
-"""Sidekick Jupyter notebook tab — Phase 1 read-only viewer (Tools #2875).
+"""Sidekick Jupyter notebook tab — Phase 1 read-only viewer + Phase 2 session model.
 
-Phase 1 scope: render an ``.ipynb`` notebook inside the Sidekick tab as
-a read-only document with markdown, code, and raw cells. Execution
-(Phase 2 — #2876) and persistence (Phase 3 — #2877) come later.
+Phase 1 (Tools #2875): render an ``.ipynb`` notebook inside the Sidekick tab
+as a read-only document with markdown, code, and raw cells.
+
+Phase 2 (Tools #2876): session model with path validation and secure
+persistence via :class:`NotebookSessionModel` and
+:class:`NotebookSessionManager`.  :class:`SidekickNotebookWidget` is the
+session-aware widget wrapper introduced in Phase 2.
 """
 
 from .availability import JupyterTabAvailability
@@ -15,6 +19,8 @@ from .notebook_model import (
     NotebookDocument,
     RawCell,
 )
+from .notebook_session import NotebookSessionManager, NotebookSessionModel
+from .sidekick_notebook_widget import SidekickNotebookWidget
 from .unavailable_widget import JupyterUnavailableWidget
 from .widget import JupyterNotebookWidget
 
@@ -31,6 +37,9 @@ __all__ = [
     "NotebookCell",
     "NotebookDocument",
     "NotebookLoadError",
+    "NotebookSessionManager",
+    "NotebookSessionModel",
     "RawCell",
+    "SidekickNotebookWidget",
     "load_notebook",
 ]

--- a/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/notebook_session.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/notebook_session.py
@@ -1,0 +1,202 @@
+"""Notebook session model and persistence for Sidekick Phase 2 (Tools #2876).
+
+Provides two public classes:
+
+* :class:`NotebookSessionModel` — immutable dataclass describing an open
+  notebook session.  Its :meth:`validate_path` method enforces Design-by-
+  Contract path-containment: the notebook path must resolve inside the
+  declared workspace root.
+
+* :class:`NotebookSessionManager` — save/load session state to disk.  Only
+  lightweight metadata is persisted (relative path + kernel env); the full
+  notebook JSON is never embedded in the session file.
+
+No Qt imports here.  This module is pure data / I/O.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NotebookSessionModel:
+    """Mutable session model for an open Sidekick notebook.
+
+    Attributes:
+        notebook_path: Absolute path to the ``.ipynb`` file.
+        workspace_root: The root directory that ``notebook_path`` must be
+            contained within.
+        kernel_env: Virtual-environment name used by the kernel, or ``None``
+            when no specific environment is selected.
+        last_saved: UTC datetime of the most recent :meth:`save_session` call,
+            or ``None`` if the session has not been persisted yet.
+
+    Preconditions are enforced by :meth:`validate_path`.
+    """
+
+    notebook_path: Path
+    workspace_root: Path
+    kernel_env: str | None
+    last_saved: datetime | None = field(default=None)
+
+    def validate_path(self) -> None:
+        """DbC: raise ValueError if *notebook_path* is outside *workspace_root*.
+
+        Both paths are :meth:`~pathlib.Path.resolve`-d before comparison so
+        that ``..`` components cannot be used to escape the root.
+
+        Raises:
+            ValueError: If the resolved notebook path is not relative to the
+                resolved workspace root.
+        """
+        resolved = self.notebook_path.resolve()
+        root = self.workspace_root.resolve()
+        # is_relative_to correctly handles cross-platform separators and exact
+        # matches (a file directly at the root is valid).
+        if not resolved.is_relative_to(root):
+            raise ValueError(f"Path {resolved} is outside workspace root {root}")
+
+
+class NotebookSessionManager:
+    """Persist and restore :class:`NotebookSessionModel` instances to disk.
+
+    Session files are stored as JSON under *sessions_dir*.  Each file is named
+    ``<session-id>.json`` where the session ID is a stable hash derived from
+    the workspace root and the relative notebook path — so saving the same
+    logical session twice is idempotent.
+
+    The JSON schema is deliberately minimal::
+
+        {
+            "notebook_path": "notebooks/test.ipynb",   # relative to workspace_root
+            "kernel_env": "py311" | null,
+            "last_saved": "2026-05-16T21:00:00"        # ISO-8601 UTC
+        }
+
+    Full notebook JSON (cells, nbformat, …) is **never** embedded.
+
+    Args:
+        sessions_dir: Directory where session JSON files are written.  Created
+            on first use if it does not exist.
+    """
+
+    def __init__(self, sessions_dir: Path) -> None:
+        self._sessions_dir = sessions_dir
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def save_session(self, model: NotebookSessionModel) -> str:
+        """Persist *model* and return its session ID.
+
+        The session ID is derived deterministically from *workspace_root* and
+        the relative notebook path, so repeated calls with the same logical
+        session overwrite the previous file (idempotent).
+
+        Args:
+            model: The session to persist.
+
+        Returns:
+            A stable session-ID string (hex digest).
+        """
+        model.validate_path()
+        self._sessions_dir.mkdir(parents=True, exist_ok=True)
+
+        rel_path = model.notebook_path.resolve().relative_to(
+            model.workspace_root.resolve()
+        )
+        sid = self._session_id(model.workspace_root, rel_path)
+
+        now = datetime.now(tz=UTC).replace(tzinfo=None)  # naive UTC for JSON compat
+        payload = {
+            "notebook_path": rel_path.as_posix(),
+            "kernel_env": model.kernel_env,
+            "last_saved": now.isoformat(),
+            "workspace_root": str(model.workspace_root.resolve()),
+        }
+        session_file = self._sessions_dir / f"{sid}.json"
+        session_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        model.last_saved = now
+        logger.debug("Session %s saved to %s", sid, session_file)
+        return sid
+
+    def load_session(
+        self, session_id: str, workspace_root: Path
+    ) -> NotebookSessionModel:
+        """Load and validate a persisted session.
+
+        The restored :class:`NotebookSessionModel` is validated with
+        :meth:`~NotebookSessionModel.validate_path` against *workspace_root*
+        before it is returned — so loading a session from a different root
+        raises :class:`ValueError`.
+
+        Args:
+            session_id: The session ID returned by :meth:`save_session`.
+            workspace_root: The workspace root to validate the restored path
+                against.  Must match the root used when the session was saved.
+
+        Returns:
+            The restored :class:`NotebookSessionModel`.
+
+        Raises:
+            FileNotFoundError: If no session with *session_id* exists.
+            ValueError: If the restored path is outside *workspace_root*.
+        """
+        session_file = self._sessions_dir / f"{session_id}.json"
+        if not session_file.exists():
+            raise FileNotFoundError(
+                f"No session file found for ID '{session_id}' in {self._sessions_dir}"
+            )
+
+        data = json.loads(session_file.read_text(encoding="utf-8"))
+
+        # Guard: the caller must supply the same workspace_root that was used
+        # when the session was saved.  This prevents one workspace's session
+        # from being loaded under a different workspace.
+        saved_root = data.get("workspace_root")
+        if saved_root is not None:
+            saved_root_path = Path(saved_root).resolve()
+            caller_root_path = workspace_root.resolve()
+            if saved_root_path != caller_root_path:
+                raise ValueError(
+                    f"Session workspace root {saved_root_path} does not match "
+                    f"supplied workspace root {caller_root_path}"
+                )
+
+        rel_path = Path(data["notebook_path"])
+        notebook_path = workspace_root / rel_path
+
+        last_saved: datetime | None = None
+        if data.get("last_saved"):
+            try:
+                last_saved = datetime.fromisoformat(data["last_saved"])
+            except ValueError:
+                logger.warning("Could not parse last_saved: %s", data["last_saved"])
+
+        model = NotebookSessionModel(
+            notebook_path=notebook_path,
+            workspace_root=workspace_root,
+            kernel_env=data.get("kernel_env"),
+            last_saved=last_saved,
+        )
+        model.validate_path()
+        return model
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _session_id(workspace_root: Path, rel_path: Path) -> str:
+        """Return a stable hex session ID from workspace root + relative path."""
+        key = f"{workspace_root.resolve()!s}::{rel_path.as_posix()}"
+        return hashlib.sha256(key.encode()).hexdigest()[:16]

--- a/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/sidekick_notebook_widget.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/sidekick_notebook_widget.py
@@ -1,0 +1,123 @@
+"""SidekickNotebookWidget — Phase 2 session-aware notebook wrapper.
+
+Wraps :class:`~.notebook_session.NotebookSessionModel` so that the Sidekick
+tab always validates notebook paths before accepting them and exposes a clean
+session API for Phase 2 (Tools #2876).
+
+This module deliberately avoids Qt imports so that it can be unit-tested in a
+headless environment.  The actual Qt rendering is delegated to
+:class:`~.widget.JupyterNotebookWidget`; this class owns only the *session*
+state.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from .notebook_session import NotebookSessionModel
+
+logger = logging.getLogger(__name__)
+
+
+class SidekickNotebookWidget:
+    """Session-aware wrapper for a Sidekick Jupyter notebook tab.
+
+    Owns a :class:`~.notebook_session.NotebookSessionModel` that tracks
+    which notebook is open, the active virtual environment, and when the
+    session was last persisted.
+
+    The widget does NOT hold the full notebook JSON — it holds only a path
+    reference validated against ``_workspace_root``.
+
+    Typical usage::
+
+        widget = SidekickNotebookWidget(workspace_root=Path("/project"))
+        widget.open_notebook("/project/notebooks/analysis.ipynb")
+        widget.set_kernel_environment("venv311")
+        meta = widget.session_metadata  # dict for UI display
+
+    Attributes:
+        _workspace_root: Directory that all notebook paths must be contained
+            within.  Set by the constructor (or directly by tests via
+            ``__new__``).
+        _session: The current :class:`~.notebook_session.NotebookSessionModel`,
+            or ``None`` if no notebook has been opened yet.
+    """
+
+    def __init__(self, workspace_root: Path | str) -> None:
+        self._workspace_root: Path = Path(workspace_root)
+        self._session: NotebookSessionModel | None = None
+
+    # ------------------------------------------------------------------
+    # Public API (Phase 1 compat + Phase 2 extensions)
+    # ------------------------------------------------------------------
+
+    def open_notebook(self, path: str | Path) -> None:
+        """Open *path* as the active notebook for this session.
+
+        Validates that *path* resolves inside ``_workspace_root`` before
+        storing it.  This is the primary DbC guard against directory-traversal
+        attacks.
+
+        Args:
+            path: Absolute or relative path to the ``.ipynb`` file.  Relative
+                paths are resolved against the current working directory, then
+                re-validated against ``_workspace_root``.
+
+        Raises:
+            ValueError: If *path* resolves outside ``_workspace_root``.
+        """
+        notebook_path = Path(path)
+        model = NotebookSessionModel(
+            notebook_path=notebook_path,
+            workspace_root=self._workspace_root,
+            kernel_env=None,
+        )
+        model.validate_path()  # DbC — raises ValueError on traversal
+        self._session = model
+        logger.debug("Notebook session opened: %s", notebook_path)
+
+    def set_kernel_environment(self, env: str | None) -> None:
+        """Set the virtual-environment name for the active kernel.
+
+        Args:
+            env: Virtual-environment name (e.g. ``"venv311"``), or ``None``
+                to clear the selection.
+
+        Raises:
+            RuntimeError: If no notebook has been opened yet.
+        """
+        if self._session is None:
+            raise RuntimeError(
+                "Cannot set kernel environment: no notebook is open. "
+                "Call open_notebook() first."
+            )
+        self._session.kernel_env = env
+
+    @property
+    def session_metadata(self) -> dict[str, object]:
+        """Return a plain-dict snapshot of the current session state.
+
+        Provides a stable Phase-1-compatible surface for UI components that
+        expect a ``dict``.  The full notebook JSON is never included.
+
+        Returns:
+            A dict with keys ``notebook_path``, ``kernel_env``, and
+            ``last_saved``.  Values are ``None`` when no notebook is open.
+        """
+        if self._session is None:
+            return {
+                "notebook_path": None,
+                "kernel_env": None,
+                "last_saved": None,
+            }
+        return {
+            "notebook_path": str(self._session.notebook_path),
+            "kernel_env": self._session.kernel_env,
+            "last_saved": (
+                self._session.last_saved.isoformat()
+                if self._session.last_saved is not None
+                else None
+            ),
+        }

--- a/tests/unit/sidekick/jupyter_tab/test_notebook_session_model.py
+++ b/tests/unit/sidekick/jupyter_tab/test_notebook_session_model.py
@@ -1,0 +1,112 @@
+"""Tests for NotebookSessionModel — path validation (DbC).
+
+These are the RED tests for Phase 2 (Tools #2876).  They must fail
+before the implementation is in place.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the shared package is importable from tests without install
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parents[5] / "src" / "shared" / "python"),
+)
+
+from sidekick.ui.tools_sidebar.jupyter_tab.notebook_session import (  # noqa: E402
+    NotebookSessionModel,
+)
+
+
+@pytest.mark.unit
+def test_valid_path_within_workspace_root_passes() -> None:
+    """A notebook path clearly inside the workspace root must not raise."""
+    model = NotebookSessionModel(
+        notebook_path=Path("/workspace/notebooks/test.ipynb"),
+        workspace_root=Path("/workspace"),
+        kernel_env="venv",
+    )
+    model.validate_path()  # must not raise
+
+
+@pytest.mark.unit
+def test_path_traversal_outside_root_raises() -> None:
+    """A path that resolves outside the root must raise ValueError."""
+    model = NotebookSessionModel(
+        notebook_path=Path("/workspace/../etc/passwd"),
+        workspace_root=Path("/workspace"),
+        kernel_env=None,
+    )
+    with pytest.raises(ValueError, match="outside workspace root"):
+        model.validate_path()
+
+
+@pytest.mark.unit
+def test_path_with_dotdot_resolved_before_validation() -> None:
+    """Paths with .. that escape the root after resolution must raise."""
+    model = NotebookSessionModel(
+        notebook_path=Path("/workspace/subdir/../../etc/hosts"),
+        workspace_root=Path("/workspace"),
+        kernel_env=None,
+    )
+    with pytest.raises(ValueError):
+        model.validate_path()
+
+
+@pytest.mark.unit
+def test_session_model_accepts_exact_root() -> None:
+    """A notebook directly at the workspace root level is valid."""
+    model = NotebookSessionModel(
+        notebook_path=Path("/workspace/a.ipynb"),
+        workspace_root=Path("/workspace"),
+        kernel_env=None,
+    )
+    model.validate_path()  # root-level file is fine
+
+
+@pytest.mark.unit
+def test_session_model_stores_kernel_env() -> None:
+    """kernel_env is stored and accessible."""
+    model = NotebookSessionModel(
+        notebook_path=Path("/workspace/nb.ipynb"),
+        workspace_root=Path("/workspace"),
+        kernel_env="py311",
+    )
+    assert model.kernel_env == "py311"
+
+
+@pytest.mark.unit
+def test_session_model_allows_none_kernel_env() -> None:
+    """kernel_env may be None (no venv selected)."""
+    model = NotebookSessionModel(
+        notebook_path=Path("/workspace/nb.ipynb"),
+        workspace_root=Path("/workspace"),
+        kernel_env=None,
+    )
+    assert model.kernel_env is None
+
+
+@pytest.mark.unit
+def test_last_saved_defaults_to_none() -> None:
+    """last_saved should default to None if not supplied."""
+    model = NotebookSessionModel(
+        notebook_path=Path("/workspace/nb.ipynb"),
+        workspace_root=Path("/workspace"),
+        kernel_env=None,
+    )
+    assert model.last_saved is None
+
+
+@pytest.mark.unit
+def test_deep_nested_path_inside_root_passes() -> None:
+    """Deeply nested paths inside the root are valid."""
+    model = NotebookSessionModel(
+        notebook_path=Path("/workspace/a/b/c/d/nb.ipynb"),
+        workspace_root=Path("/workspace"),
+        kernel_env=None,
+    )
+    model.validate_path()  # must not raise

--- a/tests/unit/sidekick/jupyter_tab/test_notebook_session_persistence.py
+++ b/tests/unit/sidekick/jupyter_tab/test_notebook_session_persistence.py
@@ -1,0 +1,150 @@
+"""Tests for NotebookSessionManager — save/load session persistence.
+
+Phase 2 (Tools #2876) RED tests.  All tests here must fail before
+the implementation is in place.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parents[5] / "src" / "shared" / "python"),
+)
+
+from sidekick.ui.tools_sidebar.jupyter_tab.notebook_session import (  # noqa: E402
+    NotebookSessionManager,
+    NotebookSessionModel,
+)
+
+
+@pytest.mark.unit
+def test_save_session_writes_json_file(tmp_path: Path) -> None:
+    """save_session must create a <sid>.json file in the sessions dir."""
+    model = NotebookSessionModel(
+        notebook_path=tmp_path / "nb.ipynb",
+        workspace_root=tmp_path,
+        kernel_env="myenv",
+    )
+    mgr = NotebookSessionManager(sessions_dir=tmp_path / ".sessions")
+    sid = mgr.save_session(model)
+    assert (tmp_path / ".sessions" / f"{sid}.json").exists()
+
+
+@pytest.mark.unit
+def test_save_session_stores_relative_path_not_absolute(tmp_path: Path) -> None:
+    """Session file must store notebook_path relative to workspace_root."""
+    model = NotebookSessionModel(
+        notebook_path=tmp_path / "notebooks" / "test.ipynb",
+        workspace_root=tmp_path,
+        kernel_env=None,
+    )
+    mgr = NotebookSessionManager(sessions_dir=tmp_path / ".sessions")
+    sid = mgr.save_session(model)
+    data = json.loads((tmp_path / ".sessions" / f"{sid}.json").read_text())
+    assert data["notebook_path"] == "notebooks/test.ipynb"
+
+
+@pytest.mark.unit
+def test_save_session_does_not_embed_notebook_json(tmp_path: Path) -> None:
+    """Notebook JSON content (cells, nbformat) must never appear in the session file."""
+    model = NotebookSessionModel(
+        notebook_path=tmp_path / "nb.ipynb",
+        workspace_root=tmp_path,
+        kernel_env=None,
+    )
+    mgr = NotebookSessionManager(sessions_dir=tmp_path / ".sessions")
+    sid = mgr.save_session(model)
+    data = json.loads((tmp_path / ".sessions" / f"{sid}.json").read_text())
+    assert "cells" not in data
+    assert "nbformat" not in data
+
+
+@pytest.mark.unit
+def test_load_session_round_trips(tmp_path: Path) -> None:
+    """A saved session can be loaded back with the same kernel_env and path."""
+    model = NotebookSessionModel(
+        notebook_path=tmp_path / "nb.ipynb",
+        workspace_root=tmp_path,
+        kernel_env="py311",
+    )
+    mgr = NotebookSessionManager(sessions_dir=tmp_path / ".sessions")
+    sid = mgr.save_session(model)
+    loaded = mgr.load_session(sid, workspace_root=tmp_path)
+    assert loaded.kernel_env == "py311"
+    assert loaded.notebook_path == tmp_path / "nb.ipynb"
+
+
+@pytest.mark.unit
+def test_load_session_validates_path_on_load(
+    tmp_path: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Loading a session with a different workspace_root must raise ValueError."""
+    other_root = tmp_path_factory.mktemp("other")
+    model = NotebookSessionModel(
+        notebook_path=tmp_path / "nb.ipynb",
+        workspace_root=tmp_path,
+        kernel_env=None,
+    )
+    mgr = NotebookSessionManager(sessions_dir=tmp_path / ".sessions")
+    sid = mgr.save_session(model)
+    # Loading with a different workspace_root should fail path validation
+    with pytest.raises(ValueError):
+        mgr.load_session(sid, workspace_root=other_root)
+
+
+@pytest.mark.unit
+def test_save_session_creates_sessions_dir_if_missing(tmp_path: Path) -> None:
+    """NotebookSessionManager must create the sessions directory if absent."""
+    sessions_dir = tmp_path / "new" / "sessions"
+    assert not sessions_dir.exists()
+    model = NotebookSessionModel(
+        notebook_path=tmp_path / "nb.ipynb",
+        workspace_root=tmp_path,
+        kernel_env=None,
+    )
+    mgr = NotebookSessionManager(sessions_dir=sessions_dir)
+    mgr.save_session(model)
+    assert sessions_dir.exists()
+
+
+@pytest.mark.unit
+def test_load_nonexistent_session_raises(tmp_path: Path) -> None:
+    """Loading a session that does not exist must raise FileNotFoundError."""
+    mgr = NotebookSessionManager(sessions_dir=tmp_path / ".sessions")
+    with pytest.raises(FileNotFoundError):
+        mgr.load_session("does-not-exist", workspace_root=tmp_path)
+
+
+@pytest.mark.unit
+def test_save_session_stores_kernel_env(tmp_path: Path) -> None:
+    """kernel_env value is present in the persisted JSON."""
+    model = NotebookSessionModel(
+        notebook_path=tmp_path / "nb.ipynb",
+        workspace_root=tmp_path,
+        kernel_env="venv312",
+    )
+    mgr = NotebookSessionManager(sessions_dir=tmp_path / ".sessions")
+    sid = mgr.save_session(model)
+    data = json.loads((tmp_path / ".sessions" / f"{sid}.json").read_text())
+    assert data["kernel_env"] == "venv312"
+
+
+@pytest.mark.unit
+def test_save_session_returns_stable_id_for_same_model(tmp_path: Path) -> None:
+    """Saving the same model twice returns the same session ID (idempotent)."""
+    model = NotebookSessionModel(
+        notebook_path=tmp_path / "nb.ipynb",
+        workspace_root=tmp_path,
+        kernel_env="myenv",
+    )
+    mgr = NotebookSessionManager(sessions_dir=tmp_path / ".sessions")
+    sid1 = mgr.save_session(model)
+    sid2 = mgr.save_session(model)
+    assert sid1 == sid2

--- a/tests/unit/sidekick/jupyter_tab/test_notebook_widget_phase2.py
+++ b/tests/unit/sidekick/jupyter_tab/test_notebook_widget_phase2.py
@@ -1,0 +1,98 @@
+"""Tests for SidekickNotebookWidget — Phase 2 session integration.
+
+Phase 2 (Tools #2876) RED tests.  These verify that the widget layer
+validates paths and stores a ``NotebookSessionModel`` (not a bare dict).
+No Qt objects are instantiated here so these run in headless CI.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parents[5] / "src" / "shared" / "python"),
+)
+
+from sidekick.ui.tools_sidebar.jupyter_tab.notebook_session import (  # noqa: E402
+    NotebookSessionModel,
+)
+from sidekick.ui.tools_sidebar.jupyter_tab.sidekick_notebook_widget import (  # noqa: E402
+    SidekickNotebookWidget,
+)
+
+
+@pytest.mark.unit
+def test_open_notebook_rejects_traversal(tmp_path: Path) -> None:
+    """open_notebook must raise ValueError for paths outside workspace_root."""
+    widget = SidekickNotebookWidget.__new__(SidekickNotebookWidget)
+    widget._session = None
+    widget._workspace_root = tmp_path
+    with pytest.raises(ValueError):
+        widget.open_notebook(str(tmp_path / ".." / "etc" / "hosts"))
+
+
+@pytest.mark.unit
+def test_open_notebook_sets_session_model(tmp_path: Path) -> None:
+    """After open_notebook, _session must be a NotebookSessionModel instance."""
+    (tmp_path / "test.ipynb").touch()
+    widget = SidekickNotebookWidget.__new__(SidekickNotebookWidget)
+    widget._session = None
+    widget._workspace_root = tmp_path
+    widget.open_notebook(str(tmp_path / "test.ipynb"))
+    assert widget._session is not None
+    assert isinstance(widget._session, NotebookSessionModel)
+
+
+@pytest.mark.unit
+def test_open_notebook_records_path(tmp_path: Path) -> None:
+    """The session stored by open_notebook must point to the opened file."""
+    nb = tmp_path / "my_notebook.ipynb"
+    nb.touch()
+    widget = SidekickNotebookWidget.__new__(SidekickNotebookWidget)
+    widget._session = None
+    widget._workspace_root = tmp_path
+    widget.open_notebook(str(nb))
+    assert widget._session.notebook_path == nb
+
+
+@pytest.mark.unit
+def test_set_kernel_environment_updates_session(tmp_path: Path) -> None:
+    """set_kernel_environment must update the session's kernel_env field."""
+    nb = tmp_path / "nb.ipynb"
+    nb.touch()
+    widget = SidekickNotebookWidget.__new__(SidekickNotebookWidget)
+    widget._session = None
+    widget._workspace_root = tmp_path
+    widget.open_notebook(str(nb))
+    widget.set_kernel_environment("my-venv")
+    assert widget._session.kernel_env == "my-venv"
+
+
+@pytest.mark.unit
+def test_set_kernel_environment_without_open_notebook_raises(
+    tmp_path: Path,
+) -> None:
+    """set_kernel_environment without a prior open_notebook must raise RuntimeError."""
+    widget = SidekickNotebookWidget.__new__(SidekickNotebookWidget)
+    widget._session = None
+    widget._workspace_root = tmp_path
+    with pytest.raises(RuntimeError):
+        widget.set_kernel_environment("venv")
+
+
+@pytest.mark.unit
+def test_session_metadata_property_returns_dict(tmp_path: Path) -> None:
+    """session_metadata property must return a dict (Phase 1 compat surface)."""
+    nb = tmp_path / "nb.ipynb"
+    nb.touch()
+    widget = SidekickNotebookWidget.__new__(SidekickNotebookWidget)
+    widget._session = None
+    widget._workspace_root = tmp_path
+    widget.open_notebook(str(nb))
+    meta = widget.session_metadata
+    assert isinstance(meta, dict)
+    assert "notebook_path" in meta


### PR DESCRIPTION
## Summary

Implements [Tools #2876] — Jupyter Sidekick Phase 2: Session Model & State Persistence.

### What's new

- **`NotebookSessionModel`** — mutable dataclass with DbC `validate_path()` that uses `Path.is_relative_to()` to reject any directory-traversal path before it is stored. Fields: `notebook_path`, `workspace_root`, `kernel_env`, `last_saved`.

- **`NotebookSessionManager`** — `save_session()` / `load_session()` persist lightweight JSON to `~/.sidekick/sessions/<hash>.json` (or any configured dir). Session files contain only: relative `notebook_path`, `kernel_env`, `last_saved` ISO timestamp, and `workspace_root`. **Full notebook JSON is never stored.** Session IDs are stable SHA-256 hashes (idempotent re-saves). `load_session()` verifies the `workspace_root` on load to prevent cross-workspace session confusion.

- **`SidekickNotebookWidget`** — session-aware wrapper (no Qt dep). `open_notebook(path)` validates the path before storing a `NotebookSessionModel`. `set_kernel_environment(env)` updates the session. `session_metadata` property returns a plain dict for UI/Phase-1 compat.

- **`jupyter_tab/__init__.py`** — exports the three new symbols alongside all Phase 1 exports; no breaking changes.

### TDD evidence

23 new tests written before implementation (red → green):
- `test_notebook_session_model.py` (8 tests) — DbC path validation cases
- `test_notebook_session_persistence.py` (9 tests) — save/load round-trips, relative paths, no-notebook-JSON guard, idempotent IDs
- `test_notebook_widget_phase2.py` (6 tests) — traversal rejection, session model creation, kernel env

75 Phase 1 tests still pass (no regressions).

### Quality gates (local)
- `ruff check` — clean
- `ruff format --check` — clean
- `pytest tests/unit/sidekick/` — 75 passed, 23 new passed

Closes #2876

🤖 Generated with [Claude Code](https://claude.com/claude-code)