### PR TITLE
feat(chat): advanced export — per-message copy, copy thread, save as markdown (closes #2735)

### DIFF
--- a/src/shared/python/ai/gui/_panel_header.py
+++ b/src/shared/python/ai/gui/_panel_header.py
@@ -53,6 +53,8 @@ class PanelHeaderController(QFrame):
     new_chat_requested = pyqtSignal()
     settings_requested = pyqtSignal()
     close_requested = pyqtSignal()
+    copy_thread_requested = pyqtSignal()
+    save_thread_requested = pyqtSignal()
 
     def __init__(self, initial_settings: AISettings, parent: Any = None) -> None:
         super().__init__(parent)
@@ -127,6 +129,16 @@ class PanelHeaderController(QFrame):
         )
         self.auto_index_checkbox.toggled.connect(self.auto_index_toggled.emit)
         layout.addWidget(self.auto_index_checkbox)
+
+        copy_thread_btn = QPushButton("Copy Thread")
+        copy_thread_btn.setToolTip("Copy full conversation to clipboard")
+        copy_thread_btn.clicked.connect(self.copy_thread_requested.emit)
+        layout.addWidget(copy_thread_btn)
+
+        save_thread_btn = QPushButton("Save as Markdown")
+        save_thread_btn.setToolTip("Save conversation to a .md file")
+        save_thread_btn.clicked.connect(self.save_thread_requested.emit)
+        layout.addWidget(save_thread_btn)
 
         new_chat_btn = QPushButton("New Chat")
         new_chat_btn.clicked.connect(self.new_chat_requested.emit)

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -40,6 +40,10 @@ from src.shared.python.ai.gui._message_display import MessageDisplayController
 from src.shared.python.ai.gui._panel_header import PanelHeaderController
 from src.shared.python.ai.gui._panel_tools import register_panel_tools
 from src.shared.python.ai.gui.assistant_widgets import MessageWidget, StreamWorker
+from src.shared.python.ai.gui.chat_export import (
+    copy_thread_to_clipboard,
+    save_thread_as_markdown,
+)
 from src.shared.python.ai.gui.history_sidebar import ChatHistorySidebar
 from src.shared.python.ai.gui.session_manager import ChatSessionManager
 from src.shared.python.ai.gui.settings_dialog import (
@@ -206,6 +210,8 @@ class AIAssistantPanel(QWidget):
         h.new_chat_requested.connect(self._on_new_chat)
         h.settings_requested.connect(self._show_settings)
         h.close_requested.connect(self.close_requested.emit)
+        h.copy_thread_requested.connect(self._on_copy_thread)
+        h.save_thread_requested.connect(self._on_save_thread)
 
         self._adapter_mgr.adapter_changed.connect(self._on_adapter_changed)
         self._adapter_mgr.system_message.connect(self._add_system_message)
@@ -572,6 +578,19 @@ class AIAssistantPanel(QWidget):
         self._refresh_prompt_memory()
         self._save_history()
         self._add_system_message("🔄 New chat started. How can I help you?")
+
+    # ------------------------------------------------------------------
+    # Export / copy handlers
+    # ------------------------------------------------------------------
+    def _on_copy_thread(self) -> None:
+        """Copy the full conversation thread to the system clipboard."""
+        copy_thread_to_clipboard(self._context.messages)
+        n = len(self._context.messages)
+        logger.info("Thread copied to clipboard (%d messages)", n)
+
+    def _on_save_thread(self) -> None:
+        """Prompt the user for a file path and save the thread as markdown."""
+        save_thread_as_markdown(self._context.messages, parent=self)
 
     # ------------------------------------------------------------------
     # Tool declarations

--- a/src/shared/python/ai/gui/assistant_widgets.py
+++ b/src/shared/python/ai/gui/assistant_widgets.py
@@ -14,6 +14,7 @@ from PyQt6.QtWidgets import (
     QPlainTextEdit,
     QSizePolicy,
     QTextEdit,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -66,6 +67,16 @@ class MessageWidget(QFrame):
         time_label = QLabel(self._timestamp.strftime("%H:%M"))
         time_label.setStyleSheet(Styles.TEXT_MUTED)
         header.addWidget(time_label)
+
+        self._copy_btn = QToolButton()
+        self._copy_btn.setText("Copy")
+        self._copy_btn.setToolTip("Copy message to clipboard")
+        self._copy_btn.setStyleSheet(
+            "QToolButton { color: #aaaaaa; border: none; padding: 2px 4px; }"
+            "QToolButton:hover { color: #ffffff; }"
+        )
+        self._copy_btn.clicked.connect(self._on_copy_clicked)
+        header.addWidget(self._copy_btn)
 
         layout.addLayout(header)
 
@@ -162,6 +173,17 @@ class MessageWidget(QFrame):
     def get_content(self) -> str:
         """Get current content."""
         return self._content
+
+    def _on_copy_clicked(self) -> None:
+        """Copy this message's raw text to the system clipboard."""
+        from src.shared.python.ai.gui.chat_export import copy_message_to_clipboard
+
+        copy_message_to_clipboard(self._content)
+        original = self._copy_btn.text()
+        self._copy_btn.setText("Copied!")
+        from PyQt6.QtCore import QTimer
+
+        QTimer.singleShot(1500, lambda: self._copy_btn.setText(original))
 
 
 class StreamWorker(QThread):

--- a/src/shared/python/ai/gui/chat_export.py
+++ b/src/shared/python/ai/gui/chat_export.py
@@ -1,0 +1,150 @@
+"""Chat export and copy utilities for the AI assistant.
+
+Provides:
+- ``export_thread_to_markdown`` — convert a list of Messages to a structured
+  markdown string (``**User:** ...\\n\\n**Agent:** ...``).
+- ``copy_message_to_clipboard`` — copy a single text string to the system clipboard.
+- ``copy_thread_to_clipboard`` — aggregate a full conversation and copy it.
+- ``save_thread_as_markdown`` — prompt the user with QFileDialog and write to .md file.
+
+Design by contract
+------------------
+Every public function validates its inputs and raises ``TypeError`` or
+``ValueError`` on invalid arguments.  No ``print()`` calls; use ``logging``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtWidgets import QApplication, QFileDialog
+
+logger = logging.getLogger(__name__)
+
+# Role display labels used in the exported markdown
+_ROLE_LABELS: dict[str, str] = {
+    "user": "User",
+    "assistant": "Agent",
+}
+
+# Roles that are silently skipped when exporting
+_SKIP_ROLES: frozenset[str] = frozenset({"system", "tool"})
+
+
+def export_thread_to_markdown(messages: list[Any]) -> str:
+    """Convert a conversation thread to structured markdown.
+
+    The output format is::
+
+        **User:** <message text>
+
+        **Agent:** <response text>
+
+    System and tool messages are omitted.
+
+    Args:
+        messages: List of :class:`~src.shared.python.ai.types.Message` objects.
+
+    Returns:
+        Markdown string representing the conversation.  Returns an empty
+        string when *messages* is empty.
+
+    Raises:
+        TypeError: If *messages* is not a list.
+        ValueError: If *messages* is ``None``.
+    """
+    if messages is None:
+        raise ValueError("messages must not be None")
+    if not isinstance(messages, list):
+        raise TypeError(f"messages must be a list, got {type(messages).__name__!r}")
+
+    parts: list[str] = []
+    for msg in messages:
+        role: str = getattr(msg, "role", "")
+        if role in _SKIP_ROLES:
+            continue
+        content: str = getattr(msg, "content", "")
+        label = _ROLE_LABELS.get(role, role.title())
+        parts.append(f"**{label}:** {content}")
+
+    return "\n\n".join(parts)
+
+
+def copy_message_to_clipboard(text: str) -> None:
+    """Copy a single text string to the system clipboard.
+
+    Args:
+        text: The text to copy.  Must not be ``None``.
+
+    Raises:
+        ValueError: If *text* is ``None``.
+        TypeError: If *text* is not a string.
+    """
+    if text is None:
+        raise ValueError("text must not be None")
+    if not isinstance(text, str):
+        raise TypeError(f"text must be a str, got {type(text).__name__!r}")
+
+    clipboard = QApplication.clipboard()
+    if clipboard is not None:
+        clipboard.setText(text)
+    logger.debug("Copied %d characters to clipboard", len(text))
+
+
+def copy_thread_to_clipboard(messages: list[Any]) -> None:
+    """Aggregate the full conversation and copy it to the clipboard.
+
+    Args:
+        messages: List of :class:`~src.shared.python.ai.types.Message` objects.
+
+    Raises:
+        TypeError: If *messages* is not a list.
+        ValueError: If *messages* is ``None``.
+    """
+    markdown = export_thread_to_markdown(messages)
+    clipboard = QApplication.clipboard()
+    if clipboard is not None:
+        clipboard.setText(markdown)
+    logger.debug("Copied thread (%d messages) to clipboard", len(messages))
+
+
+def save_thread_as_markdown(
+    messages: list[Any],
+    parent: Any = None,
+) -> Path | None:
+    """Prompt the user for a file path and write the conversation as markdown.
+
+    Opens a :class:`QFileDialog` save dialog.  If the user cancels the dialog,
+    this function returns ``None`` without raising.
+
+    Args:
+        messages: List of :class:`~src.shared.python.ai.types.Message` objects.
+        parent: Optional parent widget for the dialog.
+
+    Returns:
+        The :class:`pathlib.Path` written, or ``None`` if the dialog was
+        cancelled.
+
+    Raises:
+        TypeError: If *messages* is not a list.
+        ValueError: If *messages* is ``None``.
+        OSError: If the file cannot be written.
+    """
+    markdown = export_thread_to_markdown(messages)
+
+    path_str, _ = QFileDialog.getSaveFileName(
+        parent,
+        "Save Thread as Markdown",
+        "chat_export.md",
+        "Markdown (*.md);;All Files (*)",
+    )
+    if not path_str:
+        logger.debug("Save-as-markdown dialog cancelled by user")
+        return None
+
+    dest = Path(path_str)
+    dest.write_text(markdown, encoding="utf-8")
+    logger.info("Thread exported to %s", dest)
+    return dest

--- a/tests/unit/ai/gui/test_chat_export.py
+++ b/tests/unit/ai/gui/test_chat_export.py
@@ -1,0 +1,318 @@
+"""RED tests for Tools issue #2735 — Advanced Export and Copy Capabilities.
+
+Covers:
+- ``export_thread_to_markdown`` helper function (data model layer)
+- Per-message copy button presence on MessageWidget
+- Copy-thread clipboard aggregation
+- Save-as-markdown file dialog (mocked)
+
+All tests run without a display server; PyQt6 widgets are skipped gracefully
+when a QApplication cannot be created.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Stub out heavy deps so the module can load without a display server
+# ---------------------------------------------------------------------------
+
+
+def _ensure_pkg(name: str, path: Path) -> None:
+    if name in sys.modules:
+        return
+    mod = types.ModuleType(name)
+    mod.__path__ = [str(path)]
+    sys.modules[name] = mod
+
+
+_ensure_pkg("src", ROOT / "src")
+_ensure_pkg("src.shared", ROOT / "src" / "shared")
+_ensure_pkg("src.shared.python", ROOT / "src" / "shared" / "python")
+_ensure_pkg("src.shared.python.ai", ROOT / "src" / "shared" / "python" / "ai")
+_ensure_pkg(
+    "src.shared.python.ai.gui",
+    ROOT / "src" / "shared" / "python" / "ai" / "gui",
+)
+
+logging_pkg = types.ModuleType("src.shared.python.logging_pkg")
+logging_config = types.ModuleType("src.shared.python.logging_pkg.logging_config")
+logging_config.get_logger = logging.getLogger
+logging_config.setup_logging = lambda *args, **kwargs: None
+sys.modules.setdefault("src.shared.python.logging_pkg", logging_pkg)
+sys.modules.setdefault("src.shared.python.logging_pkg.logging_config", logging_config)
+
+# Require PyQt6 — skip entire module on headless CI without Qt
+pytest.importorskip("PyQt6.QtCore", reason="PyQt6 required")
+
+
+# ---------------------------------------------------------------------------
+# Module loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_module(name: str, rel_path: str):
+    full = ROOT / "src" / "shared" / "python" / rel_path
+    spec = importlib.util.spec_from_file_location(name, full)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_types_mod = _load_module("src.shared.python.ai.types", "ai/types.py")
+Message = _types_mod.Message
+ConversationContext = _types_mod.ConversationContext
+
+_export_mod = _load_module(
+    "src.shared.python.ai.gui.chat_export",
+    "ai/gui/chat_export.py",
+)
+export_thread_to_markdown = _export_mod.export_thread_to_markdown
+
+
+# ---------------------------------------------------------------------------
+# Tests: export_thread_to_markdown (pure-Python, no Qt required)
+# ---------------------------------------------------------------------------
+
+
+class TestExportThreadToMarkdown:
+    def test_formats_user_and_agent_messages(self) -> None:
+        messages = [
+            Message(role="user", content="Hello there"),
+            Message(role="assistant", content="Hi! How can I help?"),
+        ]
+        result = export_thread_to_markdown(messages)
+        assert "**User:** Hello there" in result
+        assert "**Agent:** Hi! How can I help?" in result
+
+    def test_user_and_agent_separated_by_blank_line(self) -> None:
+        messages = [
+            Message(role="user", content="Q"),
+            Message(role="assistant", content="A"),
+        ]
+        result = export_thread_to_markdown(messages)
+        # Must have a blank separator between consecutive messages
+        assert "\n\n" in result
+
+    def test_handles_code_blocks(self) -> None:
+        code_content = "Here is code:\n```python\nprint('hello')\n```"
+        messages = [
+            Message(role="user", content="Show me code"),
+            Message(role="assistant", content=code_content),
+        ]
+        result = export_thread_to_markdown(messages)
+        assert "```python" in result
+        assert "print('hello')" in result
+
+    def test_empty_thread_returns_empty_string(self) -> None:
+        result = export_thread_to_markdown([])
+        assert result == ""
+
+    def test_skips_system_messages(self) -> None:
+        messages = [
+            Message(role="system", content="You are a helpful assistant."),
+            Message(role="user", content="Hello"),
+            Message(role="assistant", content="Hi"),
+        ]
+        result = export_thread_to_markdown(messages)
+        assert "You are a helpful assistant." not in result
+        assert "**User:** Hello" in result
+
+    def test_raises_value_error_on_non_list_input(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            export_thread_to_markdown("not a list")  # type: ignore[arg-type]
+
+    def test_raises_value_error_on_none_input(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            export_thread_to_markdown(None)  # type: ignore[arg-type]
+
+    def test_multiple_exchanges_ordered_correctly(self) -> None:
+        messages = [
+            Message(role="user", content="First question"),
+            Message(role="assistant", content="First answer"),
+            Message(role="user", content="Second question"),
+            Message(role="assistant", content="Second answer"),
+        ]
+        result = export_thread_to_markdown(messages)
+        idx_first_q = result.index("First question")
+        idx_first_a = result.index("First answer")
+        idx_second_q = result.index("Second question")
+        idx_second_a = result.index("Second answer")
+        assert idx_first_q < idx_first_a < idx_second_q < idx_second_a
+
+    def test_special_characters_preserved(self) -> None:
+        messages = [
+            Message(role="user", content="What is 2 < 3 & 4 > 1?"),
+            Message(role="assistant", content="Yes, 2 < 3 and 4 > 1."),
+        ]
+        result = export_thread_to_markdown(messages)
+        assert "2 < 3" in result
+        assert "4 > 1" in result
+
+
+# ---------------------------------------------------------------------------
+# Tests: copy_message writes to clipboard
+# ---------------------------------------------------------------------------
+
+
+class TestCopyMessageToClipboard:
+    def test_copy_message_writes_to_clipboard(self) -> None:
+        """copy_message_to_clipboard(text) calls QApplication.clipboard().setText()."""
+        copy_fn = _export_mod.copy_message_to_clipboard
+
+        mock_clipboard = MagicMock()
+        with patch("src.shared.python.ai.gui.chat_export.QApplication") as mock_app_cls:
+            mock_app_cls.clipboard.return_value = mock_clipboard
+            copy_fn("Hello clipboard")
+            mock_clipboard.setText.assert_called_once_with("Hello clipboard")
+
+    def test_copy_message_to_clipboard_raises_on_none(self) -> None:
+        copy_fn = _export_mod.copy_message_to_clipboard
+        with pytest.raises((ValueError, TypeError)):
+            copy_fn(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Tests: copy_thread aggregates all messages
+# ---------------------------------------------------------------------------
+
+
+class TestCopyThread:
+    def test_copy_thread_aggregates_all_messages(self) -> None:
+        """copy_thread_to_clipboard(messages) must put full markdown on clipboard."""
+        copy_thread = _export_mod.copy_thread_to_clipboard
+
+        messages = [
+            Message(role="user", content="User says hi"),
+            Message(role="assistant", content="Agent says hello"),
+        ]
+
+        mock_clipboard = MagicMock()
+        with patch("src.shared.python.ai.gui.chat_export.QApplication") as mock_app_cls:
+            mock_app_cls.clipboard.return_value = mock_clipboard
+            copy_thread(messages)
+            call_args = mock_clipboard.setText.call_args[0][0]
+            assert "User says hi" in call_args
+            assert "Agent says hello" in call_args
+
+    def test_copy_thread_empty_list_copies_empty_string(self) -> None:
+        copy_thread = _export_mod.copy_thread_to_clipboard
+
+        mock_clipboard = MagicMock()
+        with patch("src.shared.python.ai.gui.chat_export.QApplication") as mock_app_cls:
+            mock_app_cls.clipboard.return_value = mock_clipboard
+            copy_thread([])
+            mock_clipboard.setText.assert_called_once_with("")
+
+
+# ---------------------------------------------------------------------------
+# Tests: save_thread_as_markdown writes file
+# ---------------------------------------------------------------------------
+
+
+class TestSaveThreadAsMarkdown:
+    def test_save_thread_creates_markdown_file(self, tmp_path: Path) -> None:
+        """save_thread_as_markdown writes structured markdown to chosen path."""
+        save_fn = _export_mod.save_thread_as_markdown
+
+        messages = [
+            Message(role="user", content="Save this"),
+            Message(role="assistant", content="Saved!"),
+        ]
+        dest = tmp_path / "chat_export.md"
+
+        with patch(
+            "src.shared.python.ai.gui.chat_export.QFileDialog"
+        ) as mock_dialog_cls:
+            mock_dialog_cls.getSaveFileName.return_value = (
+                str(dest),
+                "Markdown (*.md)",
+            )
+            save_fn(messages, parent=None)
+
+        assert dest.exists()
+        content = dest.read_text(encoding="utf-8")
+        assert "**User:** Save this" in content
+        assert "**Agent:** Saved!" in content
+
+    def test_save_thread_does_nothing_when_dialog_cancelled(
+        self, tmp_path: Path
+    ) -> None:
+        """Cancelled dialog (empty path) must not raise or write anything."""
+        save_fn = _export_mod.save_thread_as_markdown
+
+        messages = [Message(role="user", content="Irrelevant")]
+
+        with patch(
+            "src.shared.python.ai.gui.chat_export.QFileDialog"
+        ) as mock_dialog_cls:
+            mock_dialog_cls.getSaveFileName.return_value = ("", "")
+            # Must not raise
+            save_fn(messages, parent=None)
+
+
+# ---------------------------------------------------------------------------
+# Tests: MessageWidget has a copy button
+# ---------------------------------------------------------------------------
+
+
+class TestMessageWidgetCopyButton:
+    """Verify the per-message copy QToolButton is present on MessageWidget."""
+
+    def _load_widget_module(self):
+        """Load assistant_widgets with theme stubs."""
+        theme_mod = types.ModuleType("src.shared.python.theme")
+        theme_mod.__path__ = []
+        style_mod = types.ModuleType("src.shared.python.theme.style_constants")
+
+        class _Styles:
+            TEXT_LABEL_BOLD_WHITE = "font-weight: bold; color: white;"
+            TEXT_MUTED = "color: grey;"
+            TEXT_CONTENT_TRANSPARENT = "background: transparent;"
+            CONTAINER_DARK = "background-color: #1e1e1e;"
+
+        style_mod.Styles = _Styles()
+        theme_manager_mod = types.ModuleType("src.shared.python.theme.theme_manager")
+        theme_manager_mod.get_theme_manager = MagicMock(
+            return_value=MagicMock(get_current_colors=MagicMock(return_value={}))
+        )
+        sys.modules.setdefault("src.shared.python.theme", theme_mod)
+        sys.modules.setdefault("src.shared.python.theme.style_constants", style_mod)
+        sys.modules.setdefault(
+            "src.shared.python.theme.theme_manager", theme_manager_mod
+        )
+
+        return _load_module(
+            "src.shared.python.ai.gui.assistant_widgets",
+            "ai/gui/assistant_widgets.py",
+        )
+
+    def test_copy_button_visible_on_message_widget(self) -> None:
+        """Each MessageWidget must have a _copy_btn QToolButton attribute."""
+        from PyQt6.QtWidgets import QApplication, QToolButton
+
+        app = QApplication.instance() or QApplication(sys.argv)
+        widget_mod = self._load_widget_module()
+        MessageWidget = widget_mod.MessageWidget
+
+        widget = MessageWidget("user", "Hello world")
+        assert hasattr(widget, "_copy_btn"), "MessageWidget missing _copy_btn attribute"
+        assert isinstance(widget._copy_btn, QToolButton), (
+            "_copy_btn must be a QToolButton"
+        )
+        _ = app  # keep reference alive


### PR DESCRIPTION
## Summary

- Adds export_thread_to_markdown() helper in new chat_export.py module with full DbC validation (raises ValueError/TypeError on bad input), skips system/tool messages, preserves code blocks and special characters
- Adds per-message _copy_btn QToolButton to MessageWidget with 1.5 s 'Copied!' visual feedback
- Adds 'Copy Thread' and 'Save as Markdown' toolbar buttons to PanelHeaderController (two new signals: copy_thread_requested, save_thread_requested)
- Wires signals in AIAssistantPanel via _on_copy_thread / _on_save_thread handlers

## Changes

- src/shared/python/ai/gui/chat_export.py -- new module (4 public functions)
- src/shared/python/ai/gui/assistant_widgets.py -- copy button on MessageWidget
- src/shared/python/ai/gui/_panel_header.py -- toolbar export actions
- src/shared/python/ai/gui/assistant_panel.py -- wiring + imports
- tests/unit/ai/gui/test_chat_export.py -- 16 TDD tests (all pass)

## Verification

- [x] 16 TDD tests pass (pytest tests/unit/ai/gui/test_chat_export.py)
- [x] ruff check -- zero violations
- [x] ruff format -- zero diffs

Closes #2735