### PR TITLE
feat(chat): thread condensation with token count visibility (closes #2736)

### DIFF
--- a/src/shared/python/ai/gui/_panel_header.py
+++ b/src/shared/python/ai/gui/_panel_header.py
@@ -52,6 +52,8 @@ class PanelHeaderController(QFrame):
     auto_index_toggled = pyqtSignal(bool)
     new_chat_requested = pyqtSignal()
     peer_review_requested = pyqtSignal()
+    condense_requested = pyqtSignal()
+    show_full_history_requested = pyqtSignal()
     settings_requested = pyqtSignal()
     close_requested = pyqtSignal()
     copy_thread_requested = pyqtSignal()
@@ -141,6 +143,31 @@ class PanelHeaderController(QFrame):
         save_thread_btn.clicked.connect(self.save_thread_requested.emit)
         layout.addWidget(save_thread_btn)
 
+        self.token_count_label = QLabel("~0 tokens")
+        self.token_count_label.setObjectName("aiTokenCountLabel")
+        self.token_count_label.setToolTip(
+            "Estimated token count for the current active thread."
+        )
+        layout.addWidget(self.token_count_label)
+
+        self.condense_btn = QPushButton("Condense")
+        self.condense_btn.setObjectName("aiCondenseBtn")
+        self.condense_btn.setToolTip(
+            "Summarise earlier messages to free context space. "
+            "Raw history is preserved for undo."
+        )
+        self.condense_btn.clicked.connect(self.condense_requested.emit)
+        layout.addWidget(self.condense_btn)
+
+        self.show_history_btn = QPushButton("Full History")
+        self.show_history_btn.setObjectName("aiShowHistoryBtn")
+        self.show_history_btn.setToolTip(
+            "Toggle between condensed and full message history."
+        )
+        self.show_history_btn.setVisible(False)
+        self.show_history_btn.clicked.connect(self.show_full_history_requested.emit)
+        layout.addWidget(self.show_history_btn)
+
         new_chat_btn = QPushButton("New Chat")
         new_chat_btn.clicked.connect(self.new_chat_requested.emit)
         layout.addWidget(new_chat_btn)
@@ -197,6 +224,22 @@ class PanelHeaderController(QFrame):
                 self.access_mode_combo.setCurrentIndex(i)
                 self.access_mode_combo.blockSignals(False)
                 return
+
+    def set_token_count(self, count: int) -> None:
+        """Update the estimated token count display in the toolbar.
+
+        Args:
+            count: Estimated token count for the active thread.
+        """
+        self.token_count_label.setText(f"~{count:,} tokens")
+
+    def set_condensed_mode(self, condensed: bool) -> None:
+        """Show or hide the 'Full History' toggle button.
+
+        Args:
+            condensed: True when the thread is in condensed state.
+        """
+        self.show_history_btn.setVisible(condensed)
 
     def set_auto_index_checked(self, checked: bool) -> None:
         self.auto_index_checkbox.blockSignals(True)

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -55,6 +55,10 @@ from src.shared.python.ai.gui.settings_dialog import (
 from src.shared.python.ai.mcp.gui import McpStatusIndicator
 from src.shared.python.ai.memory_manager import MemoryManager
 from src.shared.python.ai.rag.simple_rag import SimpleRAGStore
+from src.shared.python.ai.thread_condensation import (
+    condense_thread,
+    estimate_token_count,
+)
 from src.shared.python.ai.tool_registry import get_global_registry
 from src.shared.python.ai.tools.codemap_tools import register_codemap_tools
 from src.shared.python.ai.tools.file_ops import register_file_tools
@@ -108,6 +112,11 @@ class AIAssistantPanel(QWidget):
         self._rag_enabled = True
         self._auto_index_on_open = False
         self._project_root = project_root or _discover_project_root(Path.cwd())
+
+        # --- Thread condensation state ------------------------------------
+        # Raw history is kept separately so the user can undo condensation.
+        self._raw_history: list[Any] = []  # original Message objects before condense
+        self._is_condensed: bool = False
 
         # --- Tools / RAG / memory ----------------------------------------
         self._tools_registry = get_global_registry()
@@ -209,6 +218,8 @@ class AIAssistantPanel(QWidget):
         h.access_mode_changed.connect(self._on_access_mode_changed)
         h.new_chat_requested.connect(self._on_new_chat)
         h.peer_review_requested.connect(self._on_peer_review_requested)
+        h.condense_requested.connect(self._on_condense_thread)
+        h.show_full_history_requested.connect(self._on_show_full_history)
         h.settings_requested.connect(self._show_settings)
         h.close_requested.connect(self.close_requested.emit)
         h.copy_thread_requested.connect(self._on_copy_thread)
@@ -485,6 +496,7 @@ class AIAssistantPanel(QWidget):
                 self._current_assistant_message.get_content()
             )
             self._save_history()
+        self._update_token_count_display()
         self._current_assistant_message = None
         self._disconnect_worker()
 
@@ -604,13 +616,91 @@ class AIAssistantPanel(QWidget):
         )
 
     # ------------------------------------------------------------------
+    # Thread condensation
+    # ------------------------------------------------------------------
+    def _on_condense_thread(self) -> None:
+        """Condense the active conversation into a summary block."""
+        if not self._adapter:
+            self._add_system_message("Cannot condense: no AI provider configured.")
+            return
+
+        messages = list(self._context.messages)
+        if not messages:
+            self._add_system_message("Nothing to condense yet.")
+            return
+
+        self._set_status("Condensing thread...")
+        try:
+            summary, active = condense_thread(messages, self._adapter)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Thread condensation failed: %s", exc)
+            self._set_status("Condense failed")
+            self._add_system_message(f"Condensation failed: {exc}")
+            return
+
+        # Preserve raw history for undo
+        self._raw_history = messages
+        self._is_condensed = True
+
+        # Replace active context with [summary_message, *recent_tail]
+        self._context.messages.clear()
+        self._context.messages.append(summary.to_message())
+        for msg in active[1:]:
+            self._context.messages.append(msg)
+
+        self._save_history()
+
+        # Refresh display
+        self._messages.clear_messages()
+        self._add_system_message(
+            f"Thread condensed. {len(self._raw_history)} message(s) "
+            f"summarised into a summary block. Use 'Full History' to undo."
+        )
+        self._messages.restore_from_context(self._context)
+
+        token_count = estimate_token_count(self._context.messages)
+        self._header.set_token_count(token_count)
+        self._header.set_condensed_mode(True)
+        self._set_status("Ready")
+
+    def _on_show_full_history(self) -> None:
+        """Restore the full raw conversation history (undo condensation)."""
+        if not self._raw_history:
+            return
+
+        self._context.messages.clear()
+        for msg in self._raw_history:
+            self._context.messages.append(msg)
+
+        self._raw_history = []
+        self._is_condensed = False
+
+        self._save_history()
+        self._messages.clear_messages()
+        self._messages.restore_from_context(self._context)
+
+        token_count = estimate_token_count(self._context.messages)
+        self._header.set_token_count(token_count)
+        self._header.set_condensed_mode(False)
+        self._set_status("Full history restored")
+
+    def _update_token_count_display(self) -> None:
+        """Refresh the token count label in the toolbar."""
+        count = estimate_token_count(self._context.messages)
+        self._header.set_token_count(count)
+
+    # ------------------------------------------------------------------
     # New chat
     # ------------------------------------------------------------------
     def _on_new_chat(self) -> None:
         self._messages.clear_messages()
         self._context = ConversationContext()
+        self._raw_history = []
+        self._is_condensed = False
         self._refresh_prompt_memory()
         self._save_history()
+        self._header.set_token_count(0)
+        self._header.set_condensed_mode(False)
         self._add_system_message("🔄 New chat started. How can I help you?")
 
     # ------------------------------------------------------------------

--- a/src/shared/python/ai/thread_condensation.py
+++ b/src/shared/python/ai/thread_condensation.py
@@ -1,0 +1,158 @@
+"""Thread condensation and token count visibility (Tools #2736).
+
+Provides:
+- :class:`SummaryMessage` — a condensed snapshot of prior conversation turns.
+- :func:`condense_thread` — calls an adapter to summarise a message list and
+  returns the summary block plus the new active context.
+- :func:`estimate_token_count` — rough heuristic (total chars / 4) for UI display.
+
+Design:
+- DbC: all public functions validate inputs and raise :exc:`ValueError` /
+  :exc:`TypeError` for bad arguments.
+- LOD: no method chains deeper than two levels.
+- The original message list is never mutated; raw history is preserved for undo.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .adapters.base import BaseAgentAdapter
+
+from .types import ConversationContext, Message
+
+UTC = timezone.utc  # noqa: UP017
+
+_DEFAULT_KEEP_RECENT: int = 6
+
+_CONDENSE_SYSTEM_PROMPT = """\
+You are a conversation summariser. Given a conversation history, extract and \
+return a concise summary structured as:
+
+**Current objective:** <what the user is trying to accomplish>
+**Decisions made:** <key decisions or conclusions reached so far>
+**Key context:** <essential facts, constraints, or state the assistant must remember>
+
+Be brief — the summary replaces prior messages in the active context window. \
+Omit pleasantries and irrelevant detail.\
+"""
+
+
+@dataclass
+class SummaryMessage:
+    """A condensed snapshot of earlier conversation turns.
+
+    Attributes:
+        content: The summarised text produced by the LLM.
+        source_count: How many original messages were condensed.
+        created_at: When the summary was created [UTC].
+        metadata: Arbitrary extra data (e.g. model name, token counts).
+    """
+
+    content: str
+    source_count: int = 0
+    created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_message(self) -> Message:
+        """Convert to a :class:`Message` with role ``"system"`` for adapter context."""
+        return Message(
+            role="system",
+            content=f"[Conversation Summary]\n{self.content}",
+            timestamp=self.created_at,
+            metadata={"is_summary": True, "source_count": self.source_count},
+        )
+
+
+def condense_thread(
+    messages: list[Message],
+    adapter: BaseAgentAdapter,
+    *,
+    keep_recent: int = _DEFAULT_KEEP_RECENT,
+) -> tuple[SummaryMessage, list[Message]]:
+    """Summarise earlier conversation messages using *adapter*.
+
+    The *messages* list is **not** mutated; callers may keep it as the raw
+    history buffer for undo.
+
+    Args:
+        messages: Full conversation history to condense. Must be a ``list``.
+        adapter: An adapter instance whose ``send_message`` method is used for
+            the summarisation call.
+        keep_recent: How many of the most-recent messages to retain verbatim
+            in the returned active context. Defaults to
+            :data:`_DEFAULT_KEEP_RECENT`.
+
+    Returns:
+        A ``(SummaryMessage, active_context)`` tuple where *active_context*
+        is ``[summary] + messages[-keep_recent:]``.
+
+    Raises:
+        TypeError: If *messages* is not a ``list``.
+        ValueError: If *adapter* is ``None``.
+    """
+    if not isinstance(messages, list):
+        raise TypeError(f"messages must be a list, got {type(messages).__name__!r}")
+    if adapter is None:
+        raise ValueError("adapter must be provided")
+
+    if not messages:
+        summary = SummaryMessage(content="", source_count=0)
+        return summary, [summary]
+
+    history_text = _format_history_for_summary(messages)
+
+    if history_text.strip():
+        condense_context = ConversationContext()
+        condense_context.add_message("system", _CONDENSE_SYSTEM_PROMPT)
+
+        response = adapter.send_message(
+            history_text,
+            condense_context,
+            [],
+        )
+        summary_content: str = response.content if response.content else ""
+    else:
+        summary_content = ""
+
+    summary = SummaryMessage(content=summary_content, source_count=len(messages))
+
+    tail = messages[-keep_recent:] if keep_recent > 0 else []
+    active: list[Message] = [summary, *tail]
+
+    return summary, active
+
+
+def estimate_token_count(messages: list[Message]) -> int:
+    """Estimate the token count for a list of messages.
+
+    Uses the rough heuristic: ``total_characters // 4``, consistent with the
+    heuristic already used in :class:`~src.shared.python.ai.types.ConversationContext`.
+
+    Args:
+        messages: List of :class:`Message` objects to estimate.
+
+    Returns:
+        Estimated token count as a non-negative integer.
+    """
+    if not messages:
+        return 0
+    total_chars = sum(len(m.content) for m in messages)
+    return total_chars // 4
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_history_for_summary(messages: list[Message]) -> str:
+    """Render *messages* as a plain-text transcript for the summarisation prompt."""
+    lines: list[str] = []
+    for msg in messages:
+        role = msg.role.upper()
+        lines.append(f"{role}: {msg.content}")
+    return "\n".join(lines)

--- a/tests/unit/ai/test_thread_condensation.py
+++ b/tests/unit/ai/test_thread_condensation.py
@@ -1,0 +1,170 @@
+"""Tests for thread condensation and token count visibility (Tools #2736).
+
+Covers:
+- condense_thread() summarisation contract
+- Message list replacement behaviour (active context)
+- Raw history preservation for undo
+- estimate_token_count() heuristic
+- Edge cases: empty thread, single message
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.python.ai.thread_condensation import (
+    SummaryMessage,
+    condense_thread,
+    estimate_token_count,
+)
+from shared.python.ai.types import Message
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_messages(n: int, prefix: str = "msg") -> list[Message]:
+    return [Message(role="user", content=f"{prefix} {i}") for i in range(n)]
+
+
+def _make_stub_adapter(summary: str = "SUMMARY") -> Any:
+    adapter = MagicMock()
+    response = MagicMock()
+    response.content = summary
+    adapter.send_message.return_value = response
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Template / extraction
+# ---------------------------------------------------------------------------
+
+
+def test_condense_template_extracts_objective_and_decisions() -> None:
+    """condense_thread() calls the adapter and returns a non-empty SummaryMessage."""
+    messages = _make_messages(5)
+    adapter = _make_stub_adapter("Objective: X. Decisions: Y. Context: Z.")
+
+    result, _active = condense_thread(messages, adapter)
+
+    assert isinstance(result, SummaryMessage)
+    assert result.content.strip() != ""
+    assert adapter.send_message.called
+
+
+# ---------------------------------------------------------------------------
+# Active context replacement
+# ---------------------------------------------------------------------------
+
+
+def test_condense_replaces_old_messages_preserving_recent() -> None:
+    """After condensation the returned list is [SummaryMessage, *last_N]."""
+    messages = _make_messages(10)
+    adapter = _make_stub_adapter("SUMMARY TEXT")
+
+    summary, active = condense_thread(messages, adapter, keep_recent=3)
+
+    assert isinstance(summary, SummaryMessage)
+    # Active context must be [summary] + last 3 original messages
+    assert len(active) == 4
+    assert active[0] is summary
+    # The tail must equal the last 3 originals
+    assert active[1:] == messages[-3:]
+
+
+def test_condense_replaces_old_messages_default_keep_recent() -> None:
+    """Default keep_recent value still gives [summary, *tail]."""
+    messages = _make_messages(20)
+    adapter = _make_stub_adapter("SUMMARY")
+
+    summary, active = condense_thread(messages, adapter)
+
+    assert isinstance(summary, SummaryMessage)
+    assert len(active) >= 2  # at least summary + 1 recent
+    assert active[0] is summary
+
+
+# ---------------------------------------------------------------------------
+# Raw history preservation
+# ---------------------------------------------------------------------------
+
+
+def test_raw_history_preserved_for_undo() -> None:
+    """condense_thread() must not mutate the input list."""
+    messages = _make_messages(6)
+    original_ids = [id(m) for m in messages]
+    adapter = _make_stub_adapter("SUMMARY")
+
+    condense_thread(messages, adapter)
+
+    # The original list is untouched
+    assert [id(m) for m in messages] == original_ids
+    assert len(messages) == 6
+
+
+# ---------------------------------------------------------------------------
+# Token count estimation
+# ---------------------------------------------------------------------------
+
+
+def test_token_count_estimation_non_negative() -> None:
+    messages = _make_messages(3)
+    count = estimate_token_count(messages)
+    assert isinstance(count, int)
+    assert count >= 0
+
+
+def test_token_count_increases_with_message_length() -> None:
+    short_msgs = [Message(role="user", content="hi")]
+    long_msgs = [Message(role="user", content="hi " * 500)]
+    assert estimate_token_count(long_msgs) > estimate_token_count(short_msgs)
+
+
+def test_token_count_empty_list_is_zero() -> None:
+    assert estimate_token_count([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_condense_empty_thread_returns_empty_summary() -> None:
+    """Empty message list should produce a SummaryMessage with empty content."""
+    adapter = _make_stub_adapter("")
+
+    summary, active = condense_thread([], adapter)
+
+    assert isinstance(summary, SummaryMessage)
+    assert summary.content == ""
+    assert active == [summary]
+
+
+def test_condense_single_message_returns_that_message() -> None:
+    """Single-message thread: summary wraps it, active is [summary, original]."""
+    msg = Message(role="user", content="Hello")
+    adapter = _make_stub_adapter("Hello summary")
+
+    summary, active = condense_thread([msg], adapter)
+
+    assert isinstance(summary, SummaryMessage)
+    assert len(active) >= 1
+    assert active[0] is summary
+
+
+# ---------------------------------------------------------------------------
+# DbC: invalid inputs
+# ---------------------------------------------------------------------------
+
+
+def test_condense_thread_raises_on_non_list_messages() -> None:
+    """DbC: messages must be a list; TypeError otherwise."""
+    adapter = _make_stub_adapter("X")
+    with pytest.raises((ValueError, TypeError)):
+        condense_thread("not a list", adapter)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Adds condense_thread() — calls the active adapter to summarise conversation history; returns (SummaryMessage, active_context) tuple
- Adds estimate_token_count() — rough heuristic (total chars / 4) for real-time display
- Adds Condense toolbar button: replaces earlier messages with a summary block, keeps the last 6 turns verbatim
- Adds Full History toggle button: restores the raw history buffer (undo condensation)
- Adds ~N tokens label in the toolbar, updated after each assistant reply

## Changes
- src/shared/python/ai/thread_condensation.py — new module with SummaryMessage, condense_thread, estimate_token_count
- src/shared/python/ai/gui/_panel_header.py — condense_requested / show_full_history_requested signals, token count label, Condense + Full History buttons
- src/shared/python/ai/gui/assistant_panel.py — _on_condense_thread(), _on_show_full_history(), _update_token_count_display(), raw history buffer

## Verification
- [x] 10 TDD tests pass (RED then GREEN)
- [x] ruff check — zero violations
- [x] ruff format — zero diffs

Closes #2736