### PR TITLE
feat(sidekick): dock close/collapse chrome, Ctrl+B toggle (closes #2881)

### DIFF
--- a/src/shared/python/sidekick/ui/tools_sidebar/dock_title_bar.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/dock_title_bar.py
@@ -1,0 +1,182 @@
+"""Custom dock title bar for the Sidekick sidebar (issue #2881).
+
+Replaces the default ``QDockWidget`` title bar with a compact widget that
+exposes:
+
+- A small "×" close button (``sidekick-close``) — hides the dock.
+  Tooltip: "Close Sidekick (Ctrl+B to reopen)".
+- A small "—" collapse button (``sidekick-collapse``) — collapses the dock to
+  an icon-strip without fully hiding it.
+- The dock title label.
+
+The DRY factory :func:`_make_dock_chrome_button` produces both buttons so
+the icon / sizing / styling is guaranteed consistent.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .qt_compat import QtWidgets
+
+
+def _make_dock_chrome_button(
+    icon_name: str,
+    tooltip: str,
+    on_click: Callable[[], None],
+    *,
+    parent: QtWidgets.QWidget | None = None,
+) -> QtWidgets.QPushButton:
+    """DRY factory for dock-chrome icon buttons (close / collapse / re-dock).
+
+    Args:
+        icon_name: The text label shown on the button (e.g. ``"×"`` or
+            ``"—"``).  Also used as the ``objectName`` via the mapping
+            maintained in this module so tests can locate the button with
+            ``findChild``.
+        tooltip: Full tooltip string shown on hover.
+        on_click: Zero-argument callable wired to the ``clicked`` signal.
+        parent: Optional Qt parent widget.
+
+    Returns:
+        A styled :class:`QPushButton` ready to be added to a layout.
+
+    Raises:
+        ValueError: If ``icon_name`` or ``tooltip`` is empty / whitespace.
+        TypeError: If ``on_click`` is not callable.
+    """
+    if not isinstance(icon_name, str) or not icon_name.strip():
+        raise ValueError("_make_dock_chrome_button: icon_name must be non-empty")
+    if not isinstance(tooltip, str) or not tooltip.strip():
+        raise ValueError("_make_dock_chrome_button: tooltip must be non-empty")
+    if not callable(on_click):
+        raise TypeError("_make_dock_chrome_button: on_click must be callable")
+
+    btn = QtWidgets.QPushButton(icon_name, parent)
+    btn.setToolTip(tooltip)
+    btn.setFixedSize(18, 18)
+    btn.setFlat(True)
+    btn.setStyleSheet(
+        "QPushButton {"
+        "  background: transparent;"
+        "  color: #aaa;"
+        "  border: none;"
+        "  font-size: 12px;"
+        "  font-weight: bold;"
+        "  padding: 0;"
+        "}"
+        "QPushButton:hover {"
+        "  color: #fff;"
+        "  background: rgba(255,255,255,0.12);"
+        "  border-radius: 3px;"
+        "}"
+    )
+    btn.clicked.connect(on_click)
+    return btn
+
+
+# ── Object-name constants (used by tests + accessibility) ─────────────────────
+
+_CLOSE_OBJECT_NAME = "sidekick-close"
+_COLLAPSE_OBJECT_NAME = "sidekick-collapse"
+_REDOCK_OBJECT_NAME = "sidekick-redock"
+
+
+class SidekickDockTitleBar(QtWidgets.QWidget):
+    """Compact custom title bar for the Sidekick dock widget.
+
+    Replaces the default ``QDockWidget`` chrome with a slim bar that shows
+    the sidebar's title plus close (×) and collapse (—) action buttons.
+
+    Args:
+        title: Text shown in the title label.
+        on_close: Callback invoked when the close button is clicked.
+        on_collapse: Callback invoked when the collapse button is clicked.
+        parent: Optional Qt parent.
+
+    Raises:
+        TypeError: If ``on_close`` or ``on_collapse`` is not callable.
+    """
+
+    def __init__(
+        self,
+        title: str = "Tools",
+        *,
+        on_close: Callable[[], None],
+        on_collapse: Callable[[], None],
+        parent: QtWidgets.QWidget | None = None,
+    ) -> None:
+        if not callable(on_close):
+            raise TypeError("on_close must be callable")
+        if not callable(on_collapse):
+            raise TypeError("on_collapse must be callable")
+        super().__init__(parent)
+        self.setObjectName("SidekickDockTitleBar")
+
+        layout = QtWidgets.QHBoxLayout(self)
+        layout.setContentsMargins(4, 2, 4, 2)
+        layout.setSpacing(2)
+
+        title_label = QtWidgets.QLabel(title, self)
+        title_label.setObjectName("SidekickDockTitleLabel")
+        title_label.setStyleSheet(
+            "QLabel {  font-size: 11px;  font-weight: bold;  color: #ccc;}"
+        )
+        layout.addWidget(title_label, stretch=1)
+
+        # DRY: both buttons share the same factory ────────────────────────────
+        collapse_btn = _make_dock_chrome_button(
+            "—",
+            "Collapse Sidekick (Ctrl+Shift+B)",
+            on_collapse,
+            parent=self,
+        )
+        collapse_btn.setObjectName(_COLLAPSE_OBJECT_NAME)
+        layout.addWidget(collapse_btn)
+
+        close_btn = _make_dock_chrome_button(
+            "×",
+            "Close Sidekick (Ctrl+B to reopen)",
+            on_close,
+            parent=self,
+        )
+        close_btn.setObjectName(_CLOSE_OBJECT_NAME)
+        layout.addWidget(close_btn)
+
+        self.setStyleSheet(
+            "SidekickDockTitleBar {"
+            "  background: #2a2a2a;"
+            "  border-bottom: 1px solid #444;"
+            "}"
+        )
+
+
+def make_redock_button(
+    on_redock: Callable[[], None],
+    *,
+    parent: QtWidgets.QWidget | None = None,
+) -> QtWidgets.QPushButton:
+    """Create a "Re-dock" button for popped-out floating windows.
+
+    Args:
+        on_redock: Callback invoked when the button is clicked.
+        parent: Optional Qt parent.
+
+    Returns:
+        A :class:`QPushButton` with ``objectName`` ``"sidekick-redock"``.
+
+    Raises:
+        TypeError: If ``on_redock`` is not callable.
+    """
+    if not callable(on_redock):
+        raise TypeError("make_redock_button: on_redock must be callable")
+
+    btn = _make_dock_chrome_button(
+        "⬇ Re-dock",
+        "Return this tab to the Sidekick dock",
+        on_redock,
+        parent=parent,
+    )
+    btn.setObjectName(_REDOCK_OBJECT_NAME)
+    btn.setFixedSize(80, 24)  # wider than icon-only buttons
+    return btn

--- a/src/shared/python/sidekick/ui/tools_sidebar/sidebar.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/sidebar.py
@@ -21,6 +21,7 @@ from .default_tabs import (
     refresh_workspace_list,
     set_project_explorer_root,
 )
+from .dock_title_bar import SidekickDockTitleBar
 from .help_content import render_help_markdown
 from .qt_compat import QtCore, QtWidgets, Signal, all_sidebar_dock_features, dock_area
 from .registry import WorkspaceRegistry
@@ -138,7 +139,11 @@ class UnifiedToolsSidebar(
             settings=self._state.theme_settings,
         )
         self._dock_widget: QtWidgets.QDockWidget | None = None
+        self._title_bar: SidekickDockTitleBar | None = None
+        self._is_collapsed: bool = False
         self._expanded_width = self._state.width
+        # Per-tab last pop-out positions (issue #2881)
+        self._popout_positions: dict[str, tuple[int, int]] = {}
         self._tab_ids: list[str] = []
         self._tab_definitions: dict[str, SidebarTabDefinition] = {}
         self._tab_widgets: dict[str, QtWidgets.QWidget] = {}
@@ -190,9 +195,112 @@ class UnifiedToolsSidebar(
         return self._dock_widget
 
     @property
+    def dock(self) -> QtWidgets.QDockWidget | None:
+        """Alias for :attr:`dock_widget` — preferred by UI tests."""
+        return self._dock_widget
+
+    @property
     def project_root(self) -> Path:
         """Return the current project root used by runtime tabs."""
         return self._project_root
+
+    # ── Dock chrome helpers (issue #2881) ─────────────────────────────────────
+
+    def dock_title_widget(self) -> SidekickDockTitleBar | None:
+        """Return the custom title-bar widget installed on the dock.
+
+        Returns ``None`` if the dock has not been installed yet (i.e.
+        :meth:`install_as_dock` has not been called).
+        """
+        return self._title_bar
+
+    def is_collapsed(self) -> bool:
+        """Return ``True`` when the sidebar is in collapsed (icon-strip) mode."""
+        return self._is_collapsed
+
+    def toggle_collapsed(self) -> None:
+        """Toggle between collapsed (icon-strip) and expanded states.
+
+        In the collapsed state the sidebar shrinks to a narrow icon strip
+        (``≤ 56 px``) and the tab content is hidden.  Calling this method
+        again restores the previous expanded width.
+        """
+        if self._is_collapsed:
+            # Expand
+            self._is_collapsed = False
+            self.tabs.setVisible(True)
+            self.setMaximumWidth(16777215)
+            self.resize(max(self._expanded_width, 240), self.height())
+        else:
+            # Collapse
+            self._is_collapsed = True
+            self._expanded_width = max(self.width(), self._expanded_width)
+            self.tabs.setVisible(False)
+            self.setMaximumWidth(56)
+        self._emit_context()
+
+    def toggle_visibility(self) -> None:
+        """Toggle the dock's visibility (Ctrl+B shortcut handler).
+
+        Hides the dock when visible, shows it when hidden.
+
+        Pre: dock has been installed via :meth:`install_as_dock`.
+        Post: ``self.dock.isVisible()`` is the negation of the pre-call value.
+        """
+        if self._dock_widget is None:
+            return
+        if self._dock_widget.isVisible():
+            self._dock_widget.hide()
+        else:
+            self._dock_widget.show()
+
+    def register_shortcuts(self, main_window: QtWidgets.QMainWindow) -> None:
+        """Wire Ctrl+B and Ctrl+Shift+B shortcuts onto ``main_window``.
+
+        Args:
+            main_window: The host main window that will receive the key events.
+
+        Keyboard bindings registered:
+            - ``Ctrl+B`` → :meth:`toggle_visibility`
+            - ``Ctrl+Shift+B`` → :meth:`toggle_collapsed`
+        """
+        try:
+            from PyQt6.QtGui import (  # type: ignore[attr-defined]
+                QKeySequence,
+                QShortcut,
+            )
+        except ImportError:
+            try:
+                from PyQt5.QtGui import QKeySequence  # type: ignore[no-redef]
+                from PyQt5.QtWidgets import QShortcut  # type: ignore[no-redef]
+            except ImportError:
+                return  # Qt not available — gracefully skip shortcut registration
+
+        sc_toggle = QShortcut(QKeySequence("Ctrl+B"), main_window)
+        sc_toggle.activated.connect(self.toggle_visibility)  # type: ignore[union-attr]
+
+        sc_collapse = QShortcut(QKeySequence("Ctrl+Shift+B"), main_window)
+        sc_collapse.activated.connect(self.toggle_collapsed)  # type: ignore[union-attr]
+
+    def re_dock(self, tab_id: str) -> bool:
+        """Re-dock a tab that is currently in a floating pop-out window.
+
+        Args:
+            tab_id: The stable tab identifier to re-dock.
+
+        Returns:
+            ``True`` on success.
+
+        Raises:
+            RuntimeError: If ``tab_id`` is not currently floating (DbC
+                precondition — the tab must be in a pop-out window).
+        """
+        if tab_id not in self._popout_windows:
+            raise RuntimeError(
+                f"re_dock precondition failed: tab '{tab_id}' is not floating. "
+                "Only floating tabs can be re-docked."
+            )
+        return self.redock_tab(tab_id)
 
     def add_tab(self, tab_id: str, title: str, widget: QtWidgets.QWidget) -> None:
         """Add a tab with a stable persistence id."""
@@ -384,7 +492,12 @@ class UnifiedToolsSidebar(
         title: str = "Tools",
         state_path: str | Path | None = None,
     ) -> QtWidgets.QDockWidget:
-        """Install this sidebar into ``main_window`` as a QDockWidget."""
+        """Install this sidebar into ``main_window`` as a QDockWidget.
+
+        Replaces the default QDockWidget title bar with a custom
+        :class:`~.dock_title_bar.SidekickDockTitleBar` that exposes
+        close (×) and collapse (—) buttons per issue #2881.
+        """
         if state_path is not None:
             self.apply_state(SidebarState.load_json(state_path))
 
@@ -396,6 +509,16 @@ class UnifiedToolsSidebar(
         dock.resize(self._state.width, self._state.height)
         main_window.addDockWidget(dock_area(area or self._state.dock_area), dock)
         self._dock_widget = dock
+
+        # Install custom title bar (issue #2881)
+        self._title_bar = SidekickDockTitleBar(
+            title,
+            on_close=self.toggle_visibility,
+            on_collapse=self.toggle_collapsed,
+            parent=dock,
+        )
+        dock.setTitleBarWidget(self._title_bar)
+
         self._emit_context()
         return dock
 

--- a/src/shared/python/sidekick/ui/tools_sidebar/tab_popout.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/tab_popout.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import replace
 from typing import Any
 
+from .dock_title_bar import make_redock_button
 from .qt_compat import QtWidgets
 
 
@@ -19,6 +20,8 @@ class TabPopoutMixin:
     _duplicate_counts: dict[str, int]
     _state: Any
     tabs: QtWidgets.QTabWidget
+    # Per-tab last pop-out positions: {tab_id: (x, y)}
+    _popout_positions: dict[str, tuple[int, int]]
 
     def tab_display_name(self, tab_id: str) -> str:
         raise NotImplementedError
@@ -39,6 +42,18 @@ class TabPopoutMixin:
         raise NotImplementedError
 
     def pop_out_tab(self, tab_id: str) -> QtWidgets.QMainWindow | None:
+        """Pop a sidebar tab out into a floating window.
+
+        Adds a "Re-dock" button to the floating window's toolbar (issue #2881).
+        Restores the window to the last-remembered position if available.
+
+        Args:
+            tab_id: Stable tab identifier to pop out.
+
+        Returns:
+            The floating :class:`~PyQt6.QtWidgets.QMainWindow`, or ``None``
+            if the tab cannot be popped out.
+        """
         definition = self._tab_definitions.get(tab_id)
         if (
             definition is None
@@ -58,15 +73,54 @@ class TabPopoutMixin:
         window.setCentralWidget(widget)
         window.resize(max(self._state.width, 360), max(self._state.height, 360))
         window.closeEvent = self._redock_close_event(tab_id, window)
+
+        # --- Re-dock button (issue #2881) -----------------------------------
+        toolbar = window.addToolBar("Sidekick")
+        toolbar.setObjectName("SidekickPopoutToolbar")
+        toolbar.setMovable(False)
+
+        def _do_redock() -> None:
+            self.redock_tab(tab_id)
+
+        redock_btn = make_redock_button(_do_redock, parent=window)
+        toolbar.addWidget(redock_btn)
+
         self._popout_windows[tab_id] = window
+
+        # Restore last-remembered position (issue #2881)
+        positions = getattr(self, "_popout_positions", {})
+        if tab_id in positions:
+            x, y = positions[tab_id]
+            window.move(x, y)
+
         window.show()
         self._emit_context()
         return window
 
     def redock_tab(self, tab_id: str) -> bool:
+        """Redock a floating pop-out tab back into the sidebar.
+
+        Saves the floating window's current position so the next pop-out
+        restores it (issue #2881).
+
+        Args:
+            tab_id: Stable tab identifier to redock.
+
+        Returns:
+            ``True`` when the tab is (now) in the sidebar.
+        """
         window = self._popout_windows.pop(tab_id, None)
         if window is None:
             return tab_id in self._tab_ids
+
+        # Persist last position before hiding (issue #2881)
+        positions = getattr(self, "_popout_positions", None)
+        if positions is None:
+            self._popout_positions = {}
+            positions = self._popout_positions
+        pos = window.pos()
+        positions[tab_id] = (pos.x(), pos.y())
+
         widget = window.centralWidget()
         window.setCentralWidget(None)
         window.hide()

--- a/tests/unit/sidekick/test_dock_close_affordances.py
+++ b/tests/unit/sidekick/test_dock_close_affordances.py
@@ -1,0 +1,178 @@
+"""Tests for dock title-bar close/collapse chrome (issue #2881).
+
+TDD red phase: these tests drive the DockTitleBar widget and the
+toggle_collapsed / toggle_visibility / dock_title_widget API on
+UnifiedToolsSidebar.
+
+Import strategy: ``tests/unit/sidekick/`` is a Python package that shadows the
+production ``sidekick`` package.  Each test function fixes this by evicting
+the test-directory ``sidekick`` from ``sys.modules`` before importing
+production code.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+_SHARED = Path(__file__).resolve().parents[3] / "src" / "shared" / "python"
+_TEST_PKG = Path(__file__).resolve().parent  # tests/unit/sidekick/
+
+
+def _fix_sidekick_import():
+    """Remove test-package shadow and ensure production sidekick is loaded.
+
+    The ``tests/unit/sidekick/`` directory is a pytest test package whose name
+    shadows the production ``sidekick`` package.  We remove only the bare
+    ``sidekick`` top-level entry from sys.modules (not ``sidekick.conftest``
+    or ``sidekick.test_*`` which pytest has already registered) then re-import
+    from the correct location.
+    """
+    shared_str = str(_SHARED)
+    if shared_str not in sys.path:
+        sys.path.insert(0, shared_str)
+    else:
+        # Ensure it's first
+        sys.path.remove(shared_str)
+        sys.path.insert(0, shared_str)
+
+    # Only evict the top-level 'sidekick' if it points to the test directory.
+    test_dir = str(_TEST_PKG)
+    top_mod = sys.modules.get("sidekick")
+    if (
+        top_mod is not None
+        and getattr(top_mod, "__file__", None) is not None
+        and test_dir in str(Path(top_mod.__file__).resolve().parent)
+    ):
+        del sys.modules["sidekick"]
+
+
+def _get_classes():
+    """Return production (UnifiedToolsSidebar, QtWidgets)."""
+    _fix_sidekick_import()
+    from PyQt6 import QtWidgets
+    from sidekick.ui.tools_sidebar.sidebar import UnifiedToolsSidebar
+
+    return UnifiedToolsSidebar, QtWidgets
+
+
+def _make_sidebar(tmp_path):
+    """Create a minimal sidebar with a QMainWindow parent for dock install."""
+    UnifiedToolsSidebar, QtWidgets = _get_classes()
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    win = QtWidgets.QMainWindow()
+    sidebar = UnifiedToolsSidebar(project_root=tmp_path, parent=win)
+    sidebar.install_as_dock(win, title="Sidekick")
+    return sidebar, win, app
+
+
+# ── Title-bar widget presence ─────────────────────────────────────────────────
+
+
+def test_dock_title_widget_is_not_none(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    assert sidebar.dock_title_widget() is not None
+
+
+def test_dock_title_bar_has_close_button(tmp_path):
+    from PyQt6.QtWidgets import QPushButton
+
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    close_btn = sidebar.dock_title_widget().findChild(QPushButton, "sidekick-close")
+    assert close_btn is not None
+
+
+def test_dock_title_bar_has_collapse_button(tmp_path):
+    from PyQt6.QtWidgets import QPushButton
+
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    collapse_btn = sidebar.dock_title_widget().findChild(
+        QPushButton, "sidekick-collapse"
+    )
+    assert collapse_btn is not None
+
+
+def test_close_button_tooltip_mentions_ctrl_b(tmp_path):
+    from PyQt6.QtWidgets import QPushButton
+
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    close_btn = sidebar.dock_title_widget().findChild(QPushButton, "sidekick-close")
+    assert close_btn is not None
+    assert "Ctrl+B" in close_btn.toolTip()
+
+
+# ── Close behaviour ───────────────────────────────────────────────────────────
+
+
+def test_dock_close_button_hides_dock(tmp_path):
+    from PyQt6.QtWidgets import QPushButton
+
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    win.show()
+    assert sidebar.dock is not None
+    close_btn = sidebar.dock_title_widget().findChild(QPushButton, "sidekick-close")
+    assert close_btn is not None
+    close_btn.click()
+    assert sidebar.dock.isVisible() is False
+
+
+# ── Collapse / expand ─────────────────────────────────────────────────────────
+
+
+def test_is_collapsed_false_by_default(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    assert sidebar.is_collapsed() is False
+
+
+def test_toggle_collapsed_collapses_to_icon_strip(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    win.show()
+    sidebar.toggle_collapsed()
+    assert sidebar.is_collapsed() is True
+    assert sidebar.width() < 80
+
+
+def test_toggle_collapsed_restores_width(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    win.show()
+    sidebar.resize(320, 600)
+    sidebar.toggle_collapsed()
+    sidebar.toggle_collapsed()
+    assert sidebar.is_collapsed() is False
+    assert sidebar.width() >= 200  # tolerance: restored to at least 200
+
+
+def test_collapse_button_click_toggles_collapsed(tmp_path):
+    from PyQt6.QtWidgets import QPushButton
+
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    win.show()
+    collapse_btn = sidebar.dock_title_widget().findChild(
+        QPushButton, "sidekick-collapse"
+    )
+    assert collapse_btn is not None
+    collapse_btn.click()
+    assert sidebar.is_collapsed() is True
+
+
+# ── toggle_visibility (Ctrl+B) ────────────────────────────────────────────────
+
+
+def test_toggle_visibility_hides_dock(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    win.show()
+    assert sidebar.dock.isVisible()
+    sidebar.toggle_visibility()
+    assert sidebar.dock.isVisible() is False
+
+
+def test_toggle_visibility_shows_dock(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    win.show()
+    sidebar.toggle_visibility()  # hide
+    sidebar.toggle_visibility()  # show again
+    assert sidebar.dock.isVisible() is True

--- a/tests/unit/sidekick/test_dock_keyboard_shortcuts.py
+++ b/tests/unit/sidekick/test_dock_keyboard_shortcuts.py
@@ -1,0 +1,143 @@
+"""Tests for keyboard shortcut wiring (issue #2881).
+
+TDD red phase: Ctrl+B, Ctrl+Shift+B, Esc-in-chat-input behaviour.
+
+Import strategy: uses the same sidekick-shadow eviction as
+``test_dock_close_affordances.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+_SHARED = Path(__file__).resolve().parents[3] / "src" / "shared" / "python"
+_TEST_PKG = Path(__file__).resolve().parent  # tests/unit/sidekick/
+
+
+def _fix_sidekick_import():
+    """Remove test-package shadow and ensure production sidekick is loaded."""
+    shared_str = str(_SHARED)
+    if shared_str not in sys.path:
+        sys.path.insert(0, shared_str)
+    else:
+        sys.path.remove(shared_str)
+        sys.path.insert(0, shared_str)
+
+    test_dir = str(_TEST_PKG)
+    top_mod = sys.modules.get("sidekick")
+    if (
+        top_mod is not None
+        and getattr(top_mod, "__file__", None) is not None
+        and test_dir in str(Path(top_mod.__file__).resolve().parent)
+    ):
+        del sys.modules["sidekick"]
+
+
+def _get_sidebar_class():
+    _fix_sidekick_import()
+    from sidekick.ui.tools_sidebar.sidebar import UnifiedToolsSidebar
+    from PyQt6 import QtWidgets
+
+    return UnifiedToolsSidebar, QtWidgets
+
+
+def _make_sidebar(tmp_path):
+    UnifiedToolsSidebar, QtWidgets = _get_sidebar_class()
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    win = QtWidgets.QMainWindow()
+    sidebar = UnifiedToolsSidebar(project_root=tmp_path, parent=win)
+    sidebar.install_as_dock(win, title="Sidekick")
+    sidebar.register_shortcuts(win)
+    win.show()
+    return sidebar, win, app
+
+
+# ── Ctrl+B — toggle dock visibility ─────────────────────────────────────────
+# We test the shortcut behaviour by directly invoking toggle_visibility()
+# (the shortcut's target).  QTest.keySequence requires a visible, active
+# window which is not guaranteed in headless CI.  A separate integration test
+# would cover the OS-level shortcut dispatch; these unit tests verify the
+# *logic* wired to the shortcut.
+
+
+def test_ctrl_b_toggles_dock_visibility(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    was_visible = sidebar.dock.isVisible()
+    sidebar.toggle_visibility()  # Ctrl+B calls this
+    assert sidebar.dock.isVisible() != was_visible
+
+
+def test_ctrl_b_twice_restores_visibility(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    was_visible = sidebar.dock.isVisible()
+    sidebar.toggle_visibility()
+    sidebar.toggle_visibility()
+    assert sidebar.dock.isVisible() == was_visible
+
+
+def test_ctrl_b_shortcut_is_registered(tmp_path):
+    """Ctrl+B shortcut is wired to toggle_visibility on the main window."""
+    from PyQt6.QtGui import QKeySequence
+
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    shortcuts = win.findChildren(type(None).__class__, "")
+    # Verify register_shortcuts created QShortcut objects bound to Ctrl+B
+    from PyQt6.QtGui import QShortcut
+
+    all_shortcuts = win.findChildren(QShortcut)
+    sequences = [sc.key().toString() for sc in all_shortcuts]
+    assert "Ctrl+B" in sequences
+
+
+# ── Ctrl+Shift+B — toggle collapse ──────────────────────────────────────────
+
+
+def test_ctrl_shift_b_toggles_collapse(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    was_collapsed = sidebar.is_collapsed()
+    sidebar.toggle_collapsed()  # Ctrl+Shift+B calls this
+    assert sidebar.is_collapsed() != was_collapsed
+
+
+def test_ctrl_shift_b_twice_restores_collapsed(tmp_path):
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    was_collapsed = sidebar.is_collapsed()
+    sidebar.toggle_collapsed()
+    sidebar.toggle_collapsed()
+    assert sidebar.is_collapsed() == was_collapsed
+
+
+def test_ctrl_shift_b_shortcut_is_registered(tmp_path):
+    """Ctrl+Shift+B shortcut is wired to toggle_collapsed on the main window."""
+    from PyQt6.QtGui import QShortcut
+
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    all_shortcuts = win.findChildren(QShortcut)
+    sequences = [sc.key().toString() for sc in all_shortcuts]
+    assert "Ctrl+Shift+B" in sequences
+
+
+# ── Esc in chat-input must not hide dock ────────────────────────────────────
+
+
+def test_esc_in_chat_input_does_not_hide_dock(tmp_path):
+    """Pressing Escape in a plain text edit must leave the dock visible."""
+    from PyQt6 import QtCore
+    from PyQt6.QtWidgets import QPlainTextEdit
+    from PyQt6.QtTest import QTest
+
+    sidebar, win, _ = _make_sidebar(tmp_path)
+    # Create a simple chat-input-like widget and add it to the sidebar
+    chat_input = QPlainTextEdit(sidebar)
+    chat_input.setObjectName("sidekick-chat-input")
+    sidebar.layout().addWidget(chat_input)
+    chat_input.show()
+    chat_input.setFocus()
+    QTest.keyClick(chat_input, QtCore.Qt.Key.Key_Escape)
+    # Dock must still be visible
+    assert sidebar.dock.isVisible() is True

--- a/tests/unit/sidekick/test_popped_chat_redock.py
+++ b/tests/unit/sidekick/test_popped_chat_redock.py
@@ -1,0 +1,147 @@
+"""Tests for re-dock affordance on popped-out chat windows (issue #2881).
+
+TDD red phase: drives the pop_out_tab / redock_tab API extensions and the
+"Re-dock" button on floating windows.
+
+Import strategy: uses the same sidekick-shadow eviction as
+``test_dock_close_affordances.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+_SHARED = Path(__file__).resolve().parents[3] / "src" / "shared" / "python"
+_TEST_PKG = Path(__file__).resolve().parent  # tests/unit/sidekick/
+
+
+def _fix_sidekick_import():
+    """Remove test-package shadow and ensure production sidekick is loaded."""
+    shared_str = str(_SHARED)
+    if shared_str not in sys.path:
+        sys.path.insert(0, shared_str)
+    else:
+        sys.path.remove(shared_str)
+        sys.path.insert(0, shared_str)
+
+    test_dir = str(_TEST_PKG)
+    top_mod = sys.modules.get("sidekick")
+    if (
+        top_mod is not None
+        and getattr(top_mod, "__file__", None) is not None
+        and test_dir in str(Path(top_mod.__file__).resolve().parent)
+    ):
+        del sys.modules["sidekick"]
+
+
+def _get_classes():
+    _fix_sidekick_import()
+    from PyQt6 import QtWidgets
+    from sidekick.ui.tools_sidebar.sidebar import UnifiedToolsSidebar
+    from sidekick.ui.tools_sidebar.tab_definition import SidebarTabDefinition
+
+    return UnifiedToolsSidebar, SidebarTabDefinition, QtWidgets
+
+
+def _make_sidebar_with_popout_tab(tmp_path):
+    """Return (sidebar, tab_id, floating_window, win, app)."""
+    UnifiedToolsSidebar, SidebarTabDefinition, QtWidgets = _get_classes()
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    win = QtWidgets.QMainWindow()
+    tab_def = SidebarTabDefinition(
+        tab_id="test_tab",
+        title="Test",
+        factory=lambda _sb: QtWidgets.QLabel("hello"),
+        popout_enabled=True,
+    )
+    sidebar = UnifiedToolsSidebar(
+        project_root=tmp_path,
+        tab_definitions=[tab_def],
+        parent=win,
+    )
+    sidebar.install_as_dock(win, title="Sidekick")
+    win.show()
+    floating_win = sidebar.pop_out_tab("test_tab")
+    return sidebar, "test_tab", floating_win, win, app
+
+
+# ── Re-dock button presence ───────────────────────────────────────────────────
+
+
+def test_popped_chat_has_redock_button(tmp_path):
+    from PyQt6.QtWidgets import QPushButton
+
+    sidebar, tab_id, floating_win, win, _ = _make_sidebar_with_popout_tab(tmp_path)
+    assert floating_win is not None
+    redock_btn = floating_win.findChild(QPushButton, "sidekick-redock")
+    assert redock_btn is not None
+
+
+# ── Re-dock behaviour ─────────────────────────────────────────────────────────
+
+
+def test_redock_returns_tab_to_sidebar(tmp_path):
+    from PyQt6.QtWidgets import QPushButton
+
+    sidebar, tab_id, floating_win, win, _ = _make_sidebar_with_popout_tab(tmp_path)
+    redock_btn = floating_win.findChild(QPushButton, "sidekick-redock")
+    assert redock_btn is not None
+    redock_btn.click()
+    assert tab_id in sidebar.visible_tab_ids()
+
+
+def test_redock_closes_floating_window(tmp_path):
+    from PyQt6.QtWidgets import QPushButton
+
+    sidebar, tab_id, floating_win, win, _ = _make_sidebar_with_popout_tab(tmp_path)
+    redock_btn = floating_win.findChild(QPushButton, "sidekick-redock")
+    assert redock_btn is not None
+    redock_btn.click()
+    assert not floating_win.isVisible()
+
+
+# ── DbC: re_dock precondition ─────────────────────────────────────────────────
+
+
+def test_redock_tab_precondition_not_floating_raises(tmp_path):
+    UnifiedToolsSidebar, SidebarTabDefinition, QtWidgets = _get_classes()
+
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    win = QtWidgets.QMainWindow()
+    tab_def = SidebarTabDefinition(
+        tab_id="test_tab2",
+        title="Test2",
+        factory=lambda _sb: QtWidgets.QLabel("hello"),
+        popout_enabled=True,
+    )
+    sidebar = UnifiedToolsSidebar(
+        project_root=tmp_path,
+        tab_definitions=[tab_def],
+        parent=win,
+    )
+    sidebar.install_as_dock(win, title="Sidekick")
+    # test_tab2 is docked, not floating — re_dock should raise
+    with pytest.raises(RuntimeError, match="not floating"):
+        sidebar.re_dock("test_tab2")
+
+
+# ── Last pop-out position memory ─────────────────────────────────────────────
+
+
+def test_repop_remembers_last_position(tmp_path):
+    sidebar, tab_id, win1, win, _ = _make_sidebar_with_popout_tab(tmp_path)
+    # Move the window to a specific position before redocking
+    win1.move(400, 300)
+    pos1 = win1.pos()
+    # redock
+    sidebar.redock_tab(tab_id)
+    # pop out again
+    win2 = sidebar.pop_out_tab(tab_id)
+    assert win2 is not None
+    assert abs(win2.pos().x() - pos1.x()) < 100  # within 100px tolerance


### PR DESCRIPTION
## Summary

Implements issue #2881 — replaces the default `QDockWidget` title bar chrome with a compact custom widget and adds keyboard shortcuts for dock visibility/collapse toggling.

- **Custom dock title bar** (`SidekickDockTitleBar`): compact `×` close button (`sidekick-close`) and `—` collapse button (`sidekick-collapse`), wired to `toggle_visibility()` and `toggle_collapsed()` respectively. Close button tooltip includes "Ctrl+B" as the reopen hint.
- **DRY button factory** (`_make_dock_chrome_button`): single factory used for all three chrome buttons (close, collapse, re-dock) — same sizing, styling, and signal wiring.
- **Keyboard shortcuts** via `register_shortcuts(main_window)`: `Ctrl+B` → `toggle_visibility()`, `Ctrl+Shift+B` → `toggle_collapsed()`.
- **Collapse/expand**: `toggle_collapsed()` shrinks the dock to a 56 px icon-strip and restores to the previous width. `is_collapsed()` returns the current state.
- **Re-dock button** (`make_redock_button`): added to the toolbar of every floating pop-out window via `TabPopoutMixin.pop_out_tab()`. Clicking it calls `redock_tab()`.
- **Pop-out position memory**: `redock_tab()` saves the floating window's last `QPoint` to `_popout_positions`; `pop_out_tab()` restores it on next pop-out.
- **DbC `re_dock()`**: new public method on `UnifiedToolsSidebar` — raises `RuntimeError("tab '...' is not floating")` if the tab is not currently in a pop-out window.

## New files

- `src/shared/python/sidekick/ui/tools_sidebar/dock_title_bar.py`
- `tests/unit/sidekick/test_dock_close_affordances.py` (11 tests)
- `tests/unit/sidekick/test_dock_keyboard_shortcuts.py` (7 tests)
- `tests/unit/sidekick/test_popped_chat_redock.py` (5 tests)

## Modified files

- `src/shared/python/sidekick/ui/tools_sidebar/sidebar.py` — `install_as_dock`, `dock` property, new methods
- `src/shared/python/sidekick/ui/tools_sidebar/tab_popout.py` — re-dock button + position memory
- `tests/unit/sidekick/conftest.py` — added docstring explaining package-shadow fix

## Test plan

- [x] `python3 -m pytest tests/unit/sidekick/test_dock_close_affordances.py -v` — 11/11 pass
- [x] `python3 -m pytest tests/unit/sidekick/test_dock_keyboard_shortcuts.py -v` — 7/7 pass
- [x] `python3 -m pytest tests/unit/sidekick/test_popped_chat_redock.py -v` — 5/5 pass
- [x] `ruff check .` — 0 violations
- [x] `ruff format --check .` — 0 diffs

Closes #2881

🤖 Generated with [Claude Code](https://claude.com/claude-code)