### PR TITLE
feat(mcp): preset server catalogue + Claude Desktop autoimport (closes #2901)

### DIFF
--- a/src/shared/python/ai/mcp/__init__.py
+++ b/src/shared/python/ai/mcp/__init__.py
@@ -18,7 +18,13 @@ indexing into ``pool._clients`` directly (LOD).
 from __future__ import annotations
 
 from src.shared.python.ai.mcp.client import McpClient
-from src.shared.python.ai.mcp.config_loader import load_mcp_servers
+from src.shared.python.ai.mcp.config_loader import (
+    apply_preset_to_config,
+    discover_claude_desktop_config,
+    is_preset_installed,
+    load_mcp_servers,
+    merge_external_config,
+)
 from src.shared.python.ai.mcp.config_writer import (
     McpServersFile,
     read,
@@ -31,16 +37,32 @@ from src.shared.python.ai.mcp.contracts import (
     McpTransport,
 )
 from src.shared.python.ai.mcp.pool import McpClientPool
+from src.shared.python.ai.mcp.presets import (
+    MCP_SERVER_PRESETS,
+    McpServerPreset,
+    apply_preset,
+    get_preset,
+    list_preset_ids,
+)
 
 __all__ = [
+    "MCP_SERVER_PRESETS",
     "McpClient",
     "McpClientPool",
     "McpResourceDescriptor",
     "McpServerConfig",
+    "McpServerPreset",
     "McpServersFile",
     "McpToolDescriptor",
     "McpTransport",
+    "apply_preset",
+    "apply_preset_to_config",
+    "discover_claude_desktop_config",
+    "get_preset",
+    "is_preset_installed",
+    "list_preset_ids",
     "load_mcp_servers",
+    "merge_external_config",
     "read",
     "write",
 ]

--- a/src/shared/python/ai/mcp/config_loader.py
+++ b/src/shared/python/ai/mcp/config_loader.py
@@ -31,12 +31,15 @@ Behaviour:
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import os
 import re
+import subprocess
+import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import ValidationError
 
@@ -45,6 +48,13 @@ from src.shared.python.ai.mcp.contracts import McpServerConfig
 _LOG = logging.getLogger(__name__)
 _ENV_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 DEFAULT_CONFIG_PATH = Path.home() / ".upstreamdrift" / "mcp_servers.json"
+
+MergeStrategy = Literal["skip_existing", "overwrite", "prefix_imported"]
+_VALID_STRATEGIES: tuple[MergeStrategy, ...] = (
+    "skip_existing",
+    "overwrite",
+    "prefix_imported",
+)
 
 
 def expand_env_vars(value: str) -> str:
@@ -131,3 +141,299 @@ def load_mcp_servers(path: Path | None = None) -> list[McpServerConfig]:
         _LOG.warning("MCP config: top-level JSON is not an object; ignoring")
         return []
     return parse_mcp_servers(raw_data)
+
+
+# ---------------------------------------------------------------------------
+# Claude-Desktop discovery + merge
+# ---------------------------------------------------------------------------
+
+
+def _claude_desktop_candidate_paths() -> list[Path]:
+    """Standard locations Claude Desktop uses for ``claude_desktop_config.json``.
+
+    Order: Windows (APPDATA), macOS (~/Library/Application Support),
+    Linux (~/.config). All three are checked regardless of host OS so a
+    cross-platform dev workflow Just Works.
+    """
+    home = Path.home()
+    candidates: list[Path] = []
+    # Windows
+    appdata = os.environ.get("APPDATA")
+    if appdata:
+        candidates.append(Path(appdata) / "Claude" / "claude_desktop_config.json")
+    # macOS
+    candidates.append(
+        home
+        / "Library"
+        / "Application Support"
+        / "Claude"
+        / "claude_desktop_config.json"
+    )
+    # Linux
+    candidates.append(home / ".config" / "Claude" / "claude_desktop_config.json")
+    return candidates
+
+
+def discover_claude_desktop_config() -> Path | None:
+    """Locate the user's Claude Desktop config file, if any.
+
+    Returns:
+        Absolute path to the first existing config file from the standard
+        locations, or ``None`` if none exists.
+    """
+    for path in _claude_desktop_candidate_paths():
+        if path.exists() and path.is_file():
+            return path
+    return None
+
+
+def _read_json_dict(path: Path) -> dict[str, Any]:
+    """Read a JSON file and return its top-level dict (or empty)."""
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+    except (OSError, json.JSONDecodeError) as exc:
+        _LOG.warning("MCP config: failed to read %s: %s", path, exc)
+        return {}
+    if not isinstance(data, dict):
+        _LOG.warning("MCP config: %s is not a JSON object; ignoring", path)
+        return {}
+    return data
+
+
+def _entry_round_trips(name: str, entry: dict[str, Any]) -> bool:
+    """Return True iff ``entry`` validates as an :class:`McpServerConfig`."""
+    if not isinstance(entry, dict):
+        return False
+    parsed = parse_mcp_servers({"mcpServers": {name: entry}})
+    return len(parsed) == 1
+
+
+def merge_external_config(
+    target: Path,
+    source: Path,
+    *,
+    strategy: MergeStrategy = "skip_existing",
+) -> int:
+    """Merge ``source`` (e.g. a Claude Desktop config) into ``target``.
+
+    Args:
+        target: Absolute path to the Sidekick ``mcp_servers.json``. The file
+            is created if it does not exist. Its parent directory is created
+            as needed.
+        source: Absolute path to the external config to import.
+        strategy:
+            * ``"skip_existing"`` — entries already present in ``target`` are
+              left untouched; only new names are added.
+            * ``"overwrite"`` — every valid source entry replaces the target's
+              entry of the same name.
+            * ``"prefix_imported"`` — conflicting source entries are renamed
+              to ``imported_<name>`` so both versions coexist.
+
+    Returns:
+        The number of entries actually written/added (not counting skipped
+        duplicates or invalid entries).
+
+    Raises:
+        ValueError: ``target`` or ``source`` is not absolute, or ``strategy``
+            is unknown.
+        FileNotFoundError: ``source`` does not exist.
+    """
+    if not target.is_absolute():
+        raise ValueError(f"target must be an absolute path, got {target!r}")
+    if not source.is_absolute():
+        raise ValueError(f"source must be an absolute path, got {source!r}")
+    if strategy not in _VALID_STRATEGIES:
+        raise ValueError(
+            f"unknown merge strategy {strategy!r}; expected one of {_VALID_STRATEGIES}"
+        )
+    if not source.exists():
+        raise FileNotFoundError(f"source config does not exist: {source}")
+
+    source_data = _read_json_dict(source)
+    source_servers = source_data.get("mcpServers", {})
+    if not isinstance(source_servers, dict):
+        _LOG.warning(
+            "MCP import: source 'mcpServers' is not a JSON object; nothing to merge"
+        )
+        return 0
+
+    target_data = _read_json_dict(target)
+    target_servers_raw = target_data.get("mcpServers", {})
+    target_servers: dict[str, Any] = (
+        dict(target_servers_raw) if isinstance(target_servers_raw, dict) else {}
+    )
+
+    added = 0
+    for name, entry in source_servers.items():
+        if not _entry_round_trips(name, entry):
+            _LOG.warning("MCP import: skipping invalid source entry %r", name)
+            continue
+        if name in target_servers:
+            if strategy == "skip_existing":
+                _LOG.info("MCP import: %r already exists in target; skipping", name)
+                continue
+            if strategy == "overwrite":
+                target_servers[name] = entry
+                added += 1
+                continue
+            if strategy == "prefix_imported":
+                new_name = f"imported_{name}"
+                # Ensure no collision on the prefixed name either.
+                suffix = 2
+                while new_name in target_servers:
+                    new_name = f"imported_{name}_{suffix}"
+                    suffix += 1
+                target_servers[new_name] = entry
+                added += 1
+                continue
+        else:
+            target_servers[name] = entry
+            added += 1
+
+    target_data["mcpServers"] = target_servers
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(target_data, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return added
+
+
+# ---------------------------------------------------------------------------
+# Preset application + install probes
+# ---------------------------------------------------------------------------
+
+
+def apply_preset_to_config(
+    preset_id: str,
+    target: Path,
+    *,
+    name: str | None = None,
+    env: dict[str, str] | None = None,
+    command: str | None = None,
+    args: list[str] | None = None,
+) -> McpServerConfig:
+    """Apply a preset and persist it to ``target``.
+
+    This is the LOD-friendly entry point: callers say "add the ``github``
+    preset to my config" without reaching into ``MCP_SERVER_PRESETS``
+    themselves.
+
+    Args:
+        preset_id: Key into the preset catalogue.
+        target: Absolute path to ``mcp_servers.json`` (created as needed).
+        name: Optional override for the entry name.
+        env: User-supplied env values (replaces ``${VAR}`` placeholders).
+        command: Optional command override.
+        args: Optional args override.
+
+    Returns:
+        The :class:`McpServerConfig` that was written to disk.
+
+    Raises:
+        KeyError: ``preset_id`` is not in the catalogue.
+        ValueError: ``target`` is not absolute.
+    """
+    # Lazy import to avoid circular dependency at module load.
+    from src.shared.python.ai.mcp.presets import apply_preset
+
+    if not target.is_absolute():
+        raise ValueError(f"target must be an absolute path, got {target!r}")
+    cfg = apply_preset(
+        preset_id,
+        name=name,
+        env=env,
+        command=command,
+        args=args,
+        validate_env=False,
+    )
+    target_data = _read_json_dict(target)
+    target_servers = target_data.get("mcpServers", {})
+    if not isinstance(target_servers, dict):
+        target_servers = {}
+    entry: dict[str, Any] = {
+        "transport": cfg.transport.value,
+        "args": list(cfg.args),
+        "env": dict(cfg.env),
+        "timeoutSeconds": cfg.timeout_seconds,
+    }
+    if cfg.command is not None:
+        entry["command"] = cfg.command
+    if cfg.url is not None:
+        entry["url"] = cfg.url
+    target_servers[cfg.name] = entry
+    target_data["mcpServers"] = target_servers
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(target_data, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def _preset_npm_package(preset_id: str) -> str | None:
+    """Return the npm package name an npx-launched preset depends on, if any."""
+    from src.shared.python.ai.mcp.presets import MCP_SERVER_PRESETS
+
+    if preset_id not in MCP_SERVER_PRESETS:
+        return None
+    preset = MCP_SERVER_PRESETS[preset_id]
+    if preset.config.command != "npx":
+        return None
+    # ``npx -y <package> ...`` — the package is the first non-flag arg.
+    for arg in preset.config.args:
+        if arg.startswith("-"):
+            continue
+        return arg
+    return None
+
+
+def is_preset_installed(preset_id: str) -> bool:
+    """Probe whether a preset's runtime dependencies are available locally.
+
+    Heuristics:
+        * For ``notebooklm`` (in-tree Python shim): try to import the module.
+        * For npx-launched presets: ``npm view <pkg> version`` — if the
+          package is reachable on the registry, ``npx -y`` will succeed.
+        * Other commands (uvx, python, local binaries): conservatively
+          return False since we can't reliably probe them without running.
+
+    Args:
+        preset_id: Key into the preset catalogue.
+
+    Returns:
+        ``True`` if we have positive evidence the preset can run;
+        ``False`` otherwise (including unknown preset IDs).
+    """
+    from src.shared.python.ai.mcp.presets import MCP_SERVER_PRESETS
+
+    if preset_id not in MCP_SERVER_PRESETS:
+        return False
+
+    # In-tree Python shim — importable iff its module is on sys.path.
+    if preset_id == "notebooklm":
+        try:
+            importlib.import_module("src.shared.python.ai.mcp.notebooklm_server")
+        except ImportError:
+            return False
+        return True
+
+    package = _preset_npm_package(preset_id)
+    if package is None:
+        return False
+
+    try:
+        result = subprocess.run(  # noqa: S603 - trusted args
+            ["npm", "view", package, "version"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            shell=sys.platform == "win32",
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        _LOG.debug("npm view %s failed: %s", package, exc)
+        return False
+    return result.returncode == 0 and bool(result.stdout.strip())

--- a/src/shared/python/ai/mcp/presets.py
+++ b/src/shared/python/ai/mcp/presets.py
@@ -1,0 +1,386 @@
+"""MCP server preset catalogue.
+
+A curated registry of well-known MCP servers (GitHub, Linear, Notion, etc.)
+that the UD launcher's preferences UI can present as a pick-list instead of
+forcing users to hand-author ``~/.upstreamdrift/mcp_servers.json`` entries.
+
+Each preset bundles:
+
+- A stable, snake_case ``id``.
+- User-facing ``display_name`` + 1-line ``description``.
+- A ready-to-go ``McpServerConfig`` with ``${ENV_VAR}`` placeholders for
+  any secrets the user still needs to supply.
+- ``required_env``: env vars the UI must prompt for before launch.
+- A ``category`` (``code``, ``docs``, ``productivity``, etc.) for grouping.
+- Optional ``docs_url`` linking to the upstream server's documentation.
+
+Design rules:
+
+- **DRY**: callers consume presets via :func:`apply_preset`, never by indexing
+  ``MCP_SERVER_PRESETS`` directly. This way preset cloning, env override
+  validation, and command normalization stay in one place.
+- **DbC**: :func:`apply_preset` validates that the preset ID exists, and
+  optionally that every required env var has a concrete value (no placeholder
+  left behind).
+- **Reversibility**: the returned ``McpServerConfig`` is a fresh model
+  instance; mutating it never reaches back into the catalogue.
+
+The dict is exposed for read-only introspection (tests, UI catalogue
+rendering); for instantiation always use :func:`apply_preset`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Final, Literal
+
+from src.shared.python.ai.mcp.contracts import McpServerConfig, McpTransport
+
+PresetCategory = Literal[
+    "code",
+    "docs",
+    "productivity",
+    "search",
+    "memory",
+    "filesystem",
+    "thinking",
+    "time",
+]
+
+_ENV_PLACEHOLDER = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+@dataclass(frozen=True)
+class McpServerPreset:
+    """A pre-baked MCP server configuration ready for one-click install.
+
+    Attributes:
+        id: Stable, snake_case identifier (also used as dict key in the catalogue).
+        display_name: Title-case label shown in the UI.
+        description: One-line description shown in the picker.
+        config: Ready-to-drop ``McpServerConfig`` with ``${VAR}`` placeholders.
+        required_env: Env vars the user must supply before the server can start.
+        category: Grouping label for the picker UI.
+        docs_url: Link to upstream documentation (optional).
+        optional_env: Env vars the user *may* supply (informational; unused values
+            stay as ``${VAR}`` placeholders).
+        homepage_url: Project homepage (optional).
+    """
+
+    id: str
+    display_name: str
+    description: str
+    config: McpServerConfig
+    required_env: tuple[str, ...] = field(default_factory=tuple)
+    category: PresetCategory = "productivity"
+    docs_url: str | None = None
+    optional_env: tuple[str, ...] = field(default_factory=tuple)
+    homepage_url: str | None = None
+
+
+def _normalize_command_args(command: str, args: list[str]) -> tuple[str, list[str]]:
+    """Normalize command+args for cross-platform stdio launches.
+
+    npx/uvx commands are kept verbatim — the OS-level shim handles dispatch.
+    Returns a (command, args) tuple with a defensive copy of ``args``.
+    """
+    if not command:
+        raise ValueError("preset command must be non-empty")
+    return command, list(args)
+
+
+def _build_stdio_preset(
+    *,
+    id_: str,
+    display_name: str,
+    description: str,
+    command: str,
+    args: list[str],
+    env: dict[str, str] | None = None,
+    required_env: tuple[str, ...] = (),
+    category: PresetCategory = "productivity",
+    docs_url: str | None = None,
+    optional_env: tuple[str, ...] = (),
+    homepage_url: str | None = None,
+) -> McpServerPreset:
+    """DRY helper for stdio-transport presets (the common case)."""
+    cmd, normalized_args = _normalize_command_args(command, args)
+    config = McpServerConfig(
+        name=id_,
+        transport=McpTransport.STDIO,
+        command=cmd,
+        args=normalized_args,
+        env=dict(env or {}),
+    )
+    return McpServerPreset(
+        id=id_,
+        display_name=display_name,
+        description=description,
+        config=config,
+        required_env=required_env,
+        category=category,
+        docs_url=docs_url,
+        optional_env=optional_env,
+        homepage_url=homepage_url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Catalogue
+# ---------------------------------------------------------------------------
+
+_GITHUB = _build_stdio_preset(
+    id_="github",
+    display_name="GitHub",
+    description="Access GitHub repos, issues, and PRs via the official MCP server.",
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-github"],
+    env={"GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"},
+    required_env=("GITHUB_PERSONAL_ACCESS_TOKEN",),
+    category="code",
+    docs_url="https://github.com/modelcontextprotocol/servers/tree/main/src/github",
+    homepage_url="https://github.com",
+)
+
+_LINEAR = _build_stdio_preset(
+    id_="linear",
+    display_name="Linear",
+    description="Query and manage Linear issues, projects, and cycles.",
+    command="npx",
+    args=["-y", "mcp-linear"],
+    env={"LINEAR_API_KEY": "${LINEAR_API_KEY}"},
+    required_env=("LINEAR_API_KEY",),
+    category="productivity",
+    docs_url="https://linear.app/developers/mcp",
+    homepage_url="https://linear.app",
+)
+
+_NOTION = _build_stdio_preset(
+    id_="notion",
+    display_name="Notion",
+    description="Read and write Notion pages, databases, and comments.",
+    command="npx",
+    args=["-y", "@notionhq/notion-mcp-server"],
+    env={"NOTION_API_KEY": "${NOTION_API_KEY}"},
+    required_env=("NOTION_API_KEY",),
+    category="docs",
+    docs_url="https://developers.notion.com/docs/mcp",
+    homepage_url="https://notion.so",
+)
+
+_SLACK = _build_stdio_preset(
+    id_="slack",
+    display_name="Slack",
+    description="Read messages, post to channels, and search Slack history.",
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-slack"],
+    env={
+        "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
+        "SLACK_TEAM_ID": "${SLACK_TEAM_ID}",
+    },
+    required_env=("SLACK_BOT_TOKEN", "SLACK_TEAM_ID"),
+    category="productivity",
+    docs_url="https://github.com/modelcontextprotocol/servers/tree/main/src/slack",
+    homepage_url="https://slack.com",
+)
+
+_OBSIDIAN = _build_stdio_preset(
+    id_="obsidian",
+    display_name="Obsidian",
+    description="Query your local Obsidian vault for notes and backlinks.",
+    command="npx",
+    args=["-y", "mcp-obsidian"],
+    env={"OBSIDIAN_VAULT_PATH": "${OBSIDIAN_VAULT_PATH}"},
+    required_env=("OBSIDIAN_VAULT_PATH",),
+    category="docs",
+    docs_url="https://github.com/MarkusPfundstein/mcp-obsidian",
+    homepage_url="https://obsidian.md",
+)
+
+_FILESYSTEM = _build_stdio_preset(
+    id_="filesystem",
+    display_name="Filesystem",
+    description="Sandboxed local-filesystem access to a whitelisted directory.",
+    command="npx",
+    args=[
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        str(os.path.expanduser("~/Documents")),
+    ],
+    category="filesystem",
+    docs_url="https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+)
+
+_MEMORY = _build_stdio_preset(
+    id_="memory",
+    display_name="Memory",
+    description="Persistent in-process knowledge graph the agent can write to.",
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-memory"],
+    category="memory",
+    docs_url="https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+)
+
+_SEQUENTIAL_THINKING = _build_stdio_preset(
+    id_="sequential_thinking",
+    display_name="Sequential Thinking",
+    description="Structured step-by-step reasoning scaffold for the agent.",
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-sequential-thinking"],
+    category="thinking",
+    docs_url=(
+        "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking"
+    ),
+)
+
+_BRAVE_SEARCH = _build_stdio_preset(
+    id_="brave_search",
+    display_name="Brave Search",
+    description="Web search via the Brave Search API (privacy-preserving).",
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-brave-search"],
+    env={"BRAVE_API_KEY": "${BRAVE_API_KEY}"},
+    required_env=("BRAVE_API_KEY",),
+    category="search",
+    docs_url="https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search",
+    homepage_url="https://brave.com/search/api/",
+)
+
+_TIME = _build_stdio_preset(
+    id_="time",
+    display_name="Time",
+    description="Timezone-aware current time + arithmetic helpers.",
+    command="uvx",
+    args=["mcp-server-time"],
+    category="time",
+    docs_url="https://github.com/modelcontextprotocol/servers/tree/main/src/time",
+)
+
+_NOTEBOOKLM = _build_stdio_preset(
+    id_="notebooklm",
+    display_name="NotebookLM (local shim)",
+    description="In-tree Python NotebookLM shim — no install, no auth.",
+    command="python",
+    args=["-m", "src.shared.python.ai.mcp.notebooklm_server"],
+    category="docs",
+    docs_url=None,
+)
+
+
+MCP_SERVER_PRESETS: Final[dict[str, McpServerPreset]] = {
+    preset.id: preset
+    for preset in (
+        _GITHUB,
+        _LINEAR,
+        _NOTION,
+        _SLACK,
+        _OBSIDIAN,
+        _FILESYSTEM,
+        _MEMORY,
+        _SEQUENTIAL_THINKING,
+        _BRAVE_SEARCH,
+        _TIME,
+        _NOTEBOOKLM,
+    )
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_preset_ids() -> list[str]:
+    """Return the sorted list of available preset IDs."""
+    return sorted(MCP_SERVER_PRESETS)
+
+
+def get_preset(preset_id: str) -> McpServerPreset:
+    """Return the preset descriptor by ID.
+
+    Raises:
+        KeyError: if ``preset_id`` is not in the catalogue.
+    """
+    if preset_id not in MCP_SERVER_PRESETS:
+        raise KeyError(
+            f"Unknown MCP preset {preset_id!r}; "
+            f"known IDs: {', '.join(list_preset_ids())}"
+        )
+    return MCP_SERVER_PRESETS[preset_id]
+
+
+def apply_preset(
+    preset_id: str,
+    *,
+    name: str | None = None,
+    env: dict[str, str] | None = None,
+    command: str | None = None,
+    args: list[str] | None = None,
+    validate_env: bool = False,
+) -> McpServerConfig:
+    """Instantiate a preset, optionally with user overrides.
+
+    Args:
+        preset_id: Key into :data:`MCP_SERVER_PRESETS`.
+        name: Override the server name (defaults to ``preset_id``).
+        env: User-supplied env values. Keys present here replace the
+            ``${VAR}`` placeholders in the preset's config.env.
+            Any keys not in the preset's env template are added verbatim.
+        command: Override the command (rare; for advanced users).
+        args: Override the args list (rare; for advanced users).
+        validate_env: If True, raise :class:`ValueError` when any
+            ``required_env`` value is still a ``${VAR}`` placeholder.
+
+    Returns:
+        A fresh :class:`McpServerConfig`. Mutations on the returned model
+        do not propagate back to the catalogue.
+
+    Raises:
+        KeyError: ``preset_id`` is not in the catalogue.
+        ValueError: ``validate_env=True`` and a required env var is missing.
+    """
+    preset = get_preset(preset_id)
+
+    # Start from a deep-copy-equivalent: re-build the config from a dict.
+    base = preset.config
+    merged_env = dict(base.env)
+    if env:
+        for key, value in env.items():
+            merged_env[key] = value
+
+    final_command = command if command is not None else base.command
+    if args is not None:
+        final_args = list(args)
+    else:
+        final_args = list(base.args)
+
+    if validate_env:
+        for var in preset.required_env:
+            value = merged_env.get(var, "")
+            if _ENV_PLACEHOLDER.fullmatch(value or ""):
+                raise ValueError(
+                    f"preset {preset_id!r} requires {var!r} to be set "
+                    f"(got placeholder {value!r})"
+                )
+
+    return McpServerConfig(
+        name=name or preset_id,
+        transport=base.transport,
+        command=final_command,
+        args=final_args,
+        env=merged_env,
+        url=base.url,
+        timeout_seconds=base.timeout_seconds,
+    )
+
+
+__all__ = [
+    "MCP_SERVER_PRESETS",
+    "McpServerPreset",
+    "PresetCategory",
+    "apply_preset",
+    "get_preset",
+    "list_preset_ids",
+]

--- a/tests/unit/ai/mcp/test_claude_desktop_import.py
+++ b/tests/unit/ai/mcp/test_claude_desktop_import.py
@@ -1,0 +1,238 @@
+"""Tests for Claude-Desktop config discovery and import."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from src.shared.python.ai.mcp.config_loader import (
+    discover_claude_desktop_config,
+    merge_external_config,
+)
+
+_SAMPLE_CD_CONFIG = {
+    "mcpServers": {
+        "github": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-github"],
+            "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxx"},
+        },
+        "memory": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-memory"],
+        },
+    }
+}
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+# -------------------- discover_claude_desktop_config --------------------
+
+
+def test_discover_returns_none_when_no_config_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("APPDATA", str(tmp_path / "AppData" / "Roaming"))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert discover_claude_desktop_config() is None
+
+
+def test_discover_finds_windows_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    appdata = tmp_path / "AppData" / "Roaming"
+    cd_path = appdata / "Claude" / "claude_desktop_config.json"
+    _write_json(cd_path, _SAMPLE_CD_CONFIG)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.setenv("APPDATA", str(appdata))
+
+    found = discover_claude_desktop_config()
+    assert found == cd_path
+
+
+def test_discover_finds_macos_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cd_path = (
+        tmp_path
+        / "Library"
+        / "Application Support"
+        / "Claude"
+        / "claude_desktop_config.json"
+    )
+    _write_json(cd_path, _SAMPLE_CD_CONFIG)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    found = discover_claude_desktop_config()
+    assert found == cd_path
+
+
+def test_discover_finds_linux_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cd_path = tmp_path / ".config" / "Claude" / "claude_desktop_config.json"
+    _write_json(cd_path, _SAMPLE_CD_CONFIG)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    monkeypatch.delenv("APPDATA", raising=False)
+
+    found = discover_claude_desktop_config()
+    assert found == cd_path
+
+
+# -------------------- merge_external_config --------------------
+
+
+def test_merge_into_empty_target(tmp_path: Path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    source = tmp_path / "cd.json"
+    _write_json(source, _SAMPLE_CD_CONFIG)
+
+    added = merge_external_config(target.resolve(), source.resolve())
+    assert added == 2
+    data = json.loads(target.read_text())
+    assert set(data["mcpServers"]) == {"github", "memory"}
+
+
+def test_merge_skip_existing_default(tmp_path: Path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    _write_json(
+        target,
+        {"mcpServers": {"github": {"command": "existing", "args": []}}},
+    )
+    source = tmp_path / "cd.json"
+    _write_json(source, _SAMPLE_CD_CONFIG)
+
+    added = merge_external_config(target.resolve(), source.resolve())
+    assert added == 1  # only memory added; github skipped
+    data = json.loads(target.read_text())
+    assert data["mcpServers"]["github"]["command"] == "existing"
+    assert "memory" in data["mcpServers"]
+
+
+def test_merge_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    source = tmp_path / "cd.json"
+    _write_json(source, _SAMPLE_CD_CONFIG)
+
+    first = merge_external_config(target.resolve(), source.resolve())
+    second = merge_external_config(target.resolve(), source.resolve())
+    assert first == 2
+    assert second == 0
+    data = json.loads(target.read_text())
+    assert len(data["mcpServers"]) == 2
+
+
+def test_merge_overwrite_strategy(tmp_path: Path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    _write_json(
+        target,
+        {"mcpServers": {"github": {"command": "stale", "args": []}}},
+    )
+    source = tmp_path / "cd.json"
+    _write_json(source, _SAMPLE_CD_CONFIG)
+
+    added = merge_external_config(
+        target.resolve(), source.resolve(), strategy="overwrite"
+    )
+    # overwrite counts replacements + new
+    assert added == 2
+    data = json.loads(target.read_text())
+    assert data["mcpServers"]["github"]["command"] == "npx"
+
+
+def test_merge_prefix_imported_strategy(tmp_path: Path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    _write_json(
+        target,
+        {"mcpServers": {"github": {"command": "existing", "args": []}}},
+    )
+    source = tmp_path / "cd.json"
+    _write_json(source, _SAMPLE_CD_CONFIG)
+
+    added = merge_external_config(
+        target.resolve(), source.resolve(), strategy="prefix_imported"
+    )
+    assert added == 2
+    data = json.loads(target.read_text())
+    assert "github" in data["mcpServers"]  # original preserved
+    assert "imported_github" in data["mcpServers"]
+    assert "memory" in data["mcpServers"]  # no conflict, no prefix
+
+
+def test_merge_skips_invalid_entries_with_warning(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    target = tmp_path / "mcp_servers.json"
+    source = tmp_path / "cd.json"
+    _write_json(
+        source,
+        {
+            "mcpServers": {
+                "good": {"command": "python", "args": []},
+                "bad": {"transport": "websocket"},  # unsupported
+            }
+        },
+    )
+    with caplog.at_level(logging.WARNING):
+        added = merge_external_config(target.resolve(), source.resolve())
+    assert added == 1
+    data = json.loads(target.read_text())
+    assert set(data["mcpServers"]) == {"good"}
+    assert any(
+        "bad" in record.message.lower() or "skipping" in record.message.lower()
+        for record in caplog.records
+    )
+
+
+def test_merge_requires_absolute_paths_target(tmp_path: Path) -> None:
+    rel = Path("relative.json")
+    abs_source = tmp_path / "cd.json"
+    _write_json(abs_source, _SAMPLE_CD_CONFIG)
+    with pytest.raises(ValueError, match="absolute"):
+        merge_external_config(rel, abs_source.resolve())
+
+
+def test_merge_requires_absolute_paths_source(tmp_path: Path) -> None:
+    abs_target = tmp_path / "mcp_servers.json"
+    rel = Path("relative.json")
+    with pytest.raises(ValueError, match="absolute"):
+        merge_external_config(abs_target.resolve(), rel)
+
+
+def test_merge_missing_source_raises(tmp_path: Path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    missing = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        merge_external_config(target.resolve(), missing.resolve())
+
+
+def test_merge_unknown_strategy_raises(tmp_path: Path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    source = tmp_path / "cd.json"
+    _write_json(source, _SAMPLE_CD_CONFIG)
+    with pytest.raises(ValueError, match="strategy"):
+        merge_external_config(target.resolve(), source.resolve(), strategy="bogus")
+
+
+def test_merge_preserves_existing_unrelated_entries(tmp_path: Path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    _write_json(
+        target,
+        {"mcpServers": {"local_only": {"command": "python", "args": ["-m", "thing"]}}},
+    )
+    source = tmp_path / "cd.json"
+    _write_json(source, _SAMPLE_CD_CONFIG)
+    added = merge_external_config(target.resolve(), source.resolve())
+    assert added == 2
+    data = json.loads(target.read_text())
+    assert "local_only" in data["mcpServers"]
+    assert "github" in data["mcpServers"]

--- a/tests/unit/ai/mcp/test_config_loader_presets.py
+++ b/tests/unit/ai/mcp/test_config_loader_presets.py
@@ -1,0 +1,84 @@
+"""Tests for preset application + installation probes via config_loader."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.shared.python.ai.mcp.config_loader import (
+    apply_preset_to_config,
+    is_preset_installed,
+)
+
+
+def test_apply_preset_to_config_writes_new_entry(tmp_path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    cfg = apply_preset_to_config(
+        "memory",
+        target.resolve(),
+        env={},
+    )
+    assert cfg.name == "memory"
+    import json
+
+    data = json.loads(target.read_text())
+    assert "memory" in data["mcpServers"]
+
+
+def test_apply_preset_to_config_with_env_overrides(tmp_path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    cfg = apply_preset_to_config(
+        "github",
+        target.resolve(),
+        env={"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_test"},
+    )
+    assert cfg.env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_test"
+
+
+def test_apply_preset_to_config_custom_name(tmp_path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    cfg = apply_preset_to_config(
+        "memory",
+        target.resolve(),
+        name="my_memory",
+    )
+    assert cfg.name == "my_memory"
+    import json
+
+    data = json.loads(target.read_text())
+    assert "my_memory" in data["mcpServers"]
+
+
+def test_apply_preset_unknown_raises(tmp_path) -> None:
+    target = tmp_path / "mcp_servers.json"
+    with pytest.raises(KeyError):
+        apply_preset_to_config("nope", target.resolve())
+
+
+def test_is_preset_installed_unknown_returns_false() -> None:
+    assert is_preset_installed("not_a_real_preset_xyz") is False
+
+
+def test_is_preset_installed_npm_success() -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="1.0.0\n")
+        assert is_preset_installed("memory") is True
+
+
+def test_is_preset_installed_npm_failure() -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        assert is_preset_installed("memory") is False
+
+
+def test_is_preset_installed_npm_timeout() -> None:
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="npm", timeout=5)
+        assert is_preset_installed("memory") is False
+
+
+def test_is_preset_installed_notebooklm_local_python() -> None:
+    # NotebookLM uses local python shim — should be importable in-tree.
+    assert is_preset_installed("notebooklm") is True

--- a/tests/unit/ai/mcp/test_presets.py
+++ b/tests/unit/ai/mcp/test_presets.py
@@ -1,0 +1,204 @@
+"""Tests for the MCP preset server catalogue.
+
+Each preset must:
+
+- Have stable, unique, snake_case ``id``.
+- Round-trip through ``parse_mcp_servers`` without warnings (after env vars
+  are filled in by the user).
+- Declare all required env vars used by its ``config.env`` template values.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from src.shared.python.ai.mcp.config_loader import parse_mcp_servers
+from src.shared.python.ai.mcp.contracts import McpServerConfig, McpTransport
+from src.shared.python.ai.mcp.presets import (
+    MCP_SERVER_PRESETS,
+    McpServerPreset,
+    apply_preset,
+    list_preset_ids,
+)
+
+_SNAKE_CASE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def test_preset_catalogue_non_empty() -> None:
+    assert len(MCP_SERVER_PRESETS) >= 10
+
+
+def test_expected_preset_ids_present() -> None:
+    expected = {
+        "github",
+        "linear",
+        "notion",
+        "slack",
+        "obsidian",
+        "filesystem",
+        "memory",
+        "sequential_thinking",
+        "brave_search",
+        "time",
+        "notebooklm",
+    }
+    assert expected.issubset(set(MCP_SERVER_PRESETS))
+
+
+def test_preset_ids_are_unique() -> None:
+    ids = [preset.id for preset in MCP_SERVER_PRESETS.values()]
+    assert len(ids) == len(set(ids))
+    # The dict key must equal the preset's declared id.
+    for key, preset in MCP_SERVER_PRESETS.items():
+        assert key == preset.id
+
+
+@pytest.mark.parametrize("preset_id", sorted(MCP_SERVER_PRESETS))
+def test_preset_id_is_snake_case(preset_id: str) -> None:
+    assert _SNAKE_CASE.match(preset_id), preset_id
+
+
+@pytest.mark.parametrize("preset_id", sorted(MCP_SERVER_PRESETS))
+def test_preset_has_required_metadata(preset_id: str) -> None:
+    preset = MCP_SERVER_PRESETS[preset_id]
+    assert isinstance(preset, McpServerPreset)
+    assert preset.display_name
+    assert preset.description
+    assert preset.category
+    assert isinstance(preset.config, McpServerConfig)
+    assert isinstance(preset.required_env, tuple)
+    # docs_url is optional but must be a string if provided.
+    if preset.docs_url is not None:
+        assert preset.docs_url.startswith(("http://", "https://"))
+
+
+@pytest.mark.parametrize("preset_id", sorted(MCP_SERVER_PRESETS))
+def test_preset_config_round_trips_without_warning(
+    preset_id: str, caplog: pytest.LogCaptureFixture
+) -> None:
+    preset = MCP_SERVER_PRESETS[preset_id]
+    raw = {
+        "mcpServers": {
+            preset.id: {
+                "transport": preset.config.transport.value,
+                "command": preset.config.command,
+                "args": list(preset.config.args),
+                "env": dict(preset.config.env),
+                "url": preset.config.url,
+                "timeoutSeconds": preset.config.timeout_seconds,
+            }
+        }
+    }
+    with caplog.at_level(logging.WARNING):
+        configs = parse_mcp_servers(raw)
+    assert len(configs) == 1, f"{preset_id} failed to parse"
+    # No 'skipping' warnings should fire.
+    assert not any("skipping" in record.message.lower() for record in caplog.records), [
+        r.message for r in caplog.records
+    ]
+
+
+@pytest.mark.parametrize("preset_id", sorted(MCP_SERVER_PRESETS))
+def test_preset_required_env_referenced_in_config(preset_id: str) -> None:
+    """Every required_env must appear as a ${VAR} placeholder in config.env."""
+    preset = MCP_SERVER_PRESETS[preset_id]
+    rendered = " ".join(preset.config.env.values())
+    for env_name in preset.required_env:
+        assert f"${{{env_name}}}" in rendered, (
+            f"{preset_id} declares required env {env_name} "
+            f"but it does not appear in config.env"
+        )
+
+
+def test_list_preset_ids_returns_sorted() -> None:
+    ids = list_preset_ids()
+    assert ids == sorted(ids)
+    assert set(ids) == set(MCP_SERVER_PRESETS)
+
+
+def test_apply_preset_unknown_raises() -> None:
+    with pytest.raises(KeyError, match="not_a_real_preset"):
+        apply_preset("not_a_real_preset")
+
+
+def test_apply_preset_default_returns_clone() -> None:
+    cfg = apply_preset("memory")
+    assert isinstance(cfg, McpServerConfig)
+    assert cfg.name == "memory"
+    # Modifying the returned config must not mutate the catalogue.
+    cfg.args.append("--mutated")
+    assert "--mutated" not in MCP_SERVER_PRESETS["memory"].config.args
+
+
+def test_apply_preset_name_override() -> None:
+    cfg = apply_preset("memory", name="my_memory")
+    assert cfg.name == "my_memory"
+
+
+def test_apply_preset_env_override_resolves_required() -> None:
+    cfg = apply_preset(
+        "github",
+        env={"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_real_token"},
+    )
+    assert cfg.env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_real_token"
+
+
+def test_apply_preset_missing_required_env_raises() -> None:
+    # GitHub requires GITHUB_PERSONAL_ACCESS_TOKEN.
+    with pytest.raises(ValueError, match="GITHUB_PERSONAL_ACCESS_TOKEN"):
+        apply_preset("github", validate_env=True)
+
+
+def test_apply_preset_no_validate_env_allows_placeholder() -> None:
+    cfg = apply_preset("github", validate_env=False)
+    assert cfg.env["GITHUB_PERSONAL_ACCESS_TOKEN"].startswith("${")
+
+
+def test_apply_preset_command_override() -> None:
+    cfg = apply_preset("memory", command="python")
+    assert cfg.command == "python"
+
+
+def test_apply_preset_args_override() -> None:
+    cfg = apply_preset("filesystem", args=["/extra/path"])
+    assert cfg.args == ["/extra/path"]
+
+
+def test_filesystem_preset_has_directory_args() -> None:
+    """Filesystem preset must include a directory whitelist in args."""
+    preset = MCP_SERVER_PRESETS["filesystem"]
+    assert len(preset.config.args) >= 2  # at least: -y pkg + 1 directory
+
+
+def test_github_preset_transport_stdio() -> None:
+    preset = MCP_SERVER_PRESETS["github"]
+    assert preset.config.transport is McpTransport.STDIO
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in preset.required_env
+
+
+def test_notebooklm_preset_has_no_required_env() -> None:
+    preset = MCP_SERVER_PRESETS["notebooklm"]
+    assert preset.required_env == ()
+
+
+def test_memory_preset_has_no_required_env() -> None:
+    preset = MCP_SERVER_PRESETS["memory"]
+    assert preset.required_env == ()
+
+
+@pytest.mark.parametrize("preset_id", sorted(MCP_SERVER_PRESETS))
+def test_preset_category_is_known(preset_id: str) -> None:
+    preset = MCP_SERVER_PRESETS[preset_id]
+    assert preset.category in {
+        "code",
+        "docs",
+        "productivity",
+        "search",
+        "memory",
+        "filesystem",
+        "thinking",
+        "time",
+    }


### PR DESCRIPTION
Implements #2901.

## Summary

Adds a curated MCP server preset catalogue and a Claude-Desktop config auto-import path so users can add MCP servers with **zero hand-edits to** `~/.upstreamdrift/mcp_servers.json`. This is the highest-leverage piece of the integration batch — it unblocks **UD #5642 (MCP Prefs UI)**, **GM #3742**, and **Tools #2897 (GitHub MCP entry)**.

## What's new

### `src/shared/python/ai/mcp/presets.py` (new, ~315 lines)
Frozen-dataclass `McpServerPreset` + `MCP_SERVER_PRESETS: dict[str, McpServerPreset]` catalogue covering:

| ID | Server | Required env |
|---|---|---|
| `github` | `npx -y @modelcontextprotocol/server-github` | `GITHUB_PERSONAL_ACCESS_TOKEN` |
| `linear` | `npx -y mcp-linear` | `LINEAR_API_KEY` |
| `notion` | `npx -y @notionhq/notion-mcp-server` | `NOTION_API_KEY` |
| `slack` | `npx -y @modelcontextprotocol/server-slack` | `SLACK_BOT_TOKEN`, `SLACK_TEAM_ID` |
| `obsidian` | `npx -y mcp-obsidian` | `OBSIDIAN_VAULT_PATH` |
| `filesystem` | `npx -y @modelcontextprotocol/server-filesystem ~/Documents` | (none) |
| `memory` | `npx -y @modelcontextprotocol/server-memory` | (none) |
| `sequential_thinking` | `npx -y @modelcontextprotocol/server-sequential-thinking` | (none) |
| `brave_search` | `npx -y @modelcontextprotocol/server-brave-search` | `BRAVE_API_KEY` |
| `time` | `uvx mcp-server-time` | (none) |
| `notebooklm` | `python -m src.shared.python.ai.mcp.notebooklm_server` | (none) |

Public API: `apply_preset(id, *, name, env, command, args, validate_env)`, `get_preset`, `list_preset_ids`. Direct dict access is discouraged (LOD).

### `src/shared/python/ai/mcp/config_loader.py` (extended)
- `discover_claude_desktop_config() -> Path | None` — checks Windows (`%APPDATA%/Claude/...`), macOS (`~/Library/Application Support/Claude/...`), and Linux (`~/.config/Claude/...`) in order.
- `merge_external_config(target, source, *, strategy)` — three strategies:
  - `skip_existing` (default) — preserves target entries, adds new names
  - `overwrite` — source replaces target on conflict
  - `prefix_imported` — conflicting source entries become `imported_<name>`
  Idempotent; skips entries that don't round-trip through `parse_mcp_servers`.
- `apply_preset_to_config(preset_id, target, ...)` — one-shot install: instantiate preset and persist to `mcp_servers.json`.
- `is_preset_installed(preset_id)` — probes `npm view <pkg> version` for npx-launched presets, importability check for the local NotebookLM shim.

### Tests (3 new files, 95 cases)
- `tests/unit/ai/mcp/test_presets.py` — catalogue completeness, round-trip parse, env-var declarations match `${VAR}` placeholders, override semantics
- `tests/unit/ai/mcp/test_claude_desktop_import.py` — all 3 platform paths, every merge strategy, idempotency, absolute-path DbC, invalid-entry skipping with WARNING
- `tests/unit/ai/mcp/test_config_loader_presets.py` — `apply_preset_to_config` persistence, `is_preset_installed` mocking `subprocess.run`

## DbC / LOD / DRY

- **DbC**: `apply_preset` raises `KeyError` on unknown IDs, `ValueError` on `validate_env=True` with unresolved required env. `merge_external_config` enforces absolute paths and known strategies.
- **LOD**: Callers go through `apply_preset(...)` / `apply_preset_to_config(...)` rather than indexing `MCP_SERVER_PRESETS` directly.
- **DRY**: `_build_stdio_preset` helper consolidates the 10 stdio-transport presets; `_normalize_command_args` is the single seam for cross-platform command quirks.

## Quality gates

- `python -m ruff check src/shared/python/ai/mcp/ tests/unit/ai/mcp/` — All checks passed!
- `python -m ruff format --check src/shared/python/ai/mcp/ tests/unit/ai/mcp/` — 19 files already formatted
- `python -m pytest tests/unit/ai/mcp/` — **145 passed in 15s** (95 new + 50 pre-existing, no regressions)

## Unblocks

- **UpstreamDrift #5642** (MCP Prefs UI) — can now show a preset picker instead of a free-text JSON editor
- **Gasification_Model #3742** — shared catalogue available cross-repo
- **Tools #2897** (GitHub MCP entry) — `github` preset shipped here