### PR TITLE
feat(github-mcp): GitHub MCP server integration via MCP pool (closes #2897)

### DIFF
--- a/src/shared/python/ai/integrations/github_mcp/__init__.py
+++ b/src/shared/python/ai/integrations/github_mcp/__init__.py
@@ -1,0 +1,63 @@
+"""GitHub MCP server integration for Sidekick.
+
+Wires the official `@modelcontextprotocol/server-github` MCP server into
+the shared :class:`McpClientPool`, so its tools (list_repos, list_issues,
+list_prs, get_issue, get_pr_diff, create_issue, add_comment, search_code,
+search_issues, merge_pr) become discoverable via the standard
+``<server>:<tool>`` namespacing.
+
+This package is one of two GitHub integration paths in the fleet:
+
+* This module (Tools #2897) — MCP-based, broad surface, delegates auth
+  to the MCP server subprocess.
+* The GitHub CLI agent provider (Tools #2899) — ``gh``-backed, narrow
+  surface, used when ``gh`` is already the auth source of truth.
+
+Public surface:
+
+* :func:`build_github_mcp_config` — construct a validated
+  :class:`McpServerConfig` pre-wired for the official server.
+* :data:`GITHUB_MCP_TOOL_DESCRIPTORS` — declarative list of the tools the
+  server is expected to expose, including which are write operations.
+* :func:`is_github_mcp_available` — pre-flight check (token + ``npx`` +
+  package resolvable).
+* :func:`register_github_mcp` — convenience helper to add the server to
+  an :class:`McpClientPool`.
+
+External callers should use :func:`register_github_mcp` rather than
+poking the pool's internals (LOD).
+"""
+
+from __future__ import annotations
+
+from src.shared.python.ai.integrations.github_mcp.discovery import (
+    is_github_mcp_available,
+)
+from src.shared.python.ai.integrations.github_mcp.integration import (
+    register_github_mcp,
+)
+from src.shared.python.ai.integrations.github_mcp.server_config import (
+    GITHUB_MCP_PACKAGE,
+    GITHUB_MCP_SERVER_NAME,
+    GITHUB_MCP_TOKEN_ENV_VAR,
+    build_github_mcp_config,
+)
+from src.shared.python.ai.integrations.github_mcp.tool_descriptors import (
+    GITHUB_MCP_TOOL_DESCRIPTORS,
+    GitHubMcpToolDescriptor,
+    get_tool_descriptor,
+    write_tool_names,
+)
+
+__all__ = [
+    "GITHUB_MCP_PACKAGE",
+    "GITHUB_MCP_SERVER_NAME",
+    "GITHUB_MCP_TOKEN_ENV_VAR",
+    "GITHUB_MCP_TOOL_DESCRIPTORS",
+    "GitHubMcpToolDescriptor",
+    "build_github_mcp_config",
+    "get_tool_descriptor",
+    "is_github_mcp_available",
+    "register_github_mcp",
+    "write_tool_names",
+]

--- a/src/shared/python/ai/integrations/github_mcp/discovery.py
+++ b/src/shared/python/ai/integrations/github_mcp/discovery.py
@@ -1,0 +1,67 @@
+"""Pre-flight discovery for the GitHub MCP server integration.
+
+Before adding the GitHub server to an :class:`McpClientPool`, callers
+(typically the UD MCP Prefs UI) want to know whether the integration is
+actually usable on this machine. :func:`is_github_mcp_available` reports
+that without spawning a subprocess.
+
+Checks performed (in order, short-circuiting on the first failure so the
+returned message points at the *first* thing the operator needs to fix):
+
+1. ``GITHUB_PERSONAL_ACCESS_TOKEN`` env var is set and non-empty (unless
+   an explicit ``token`` argument is passed by the caller).
+2. ``npx`` is on ``PATH`` (the launcher we use for the server package).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+
+from src.shared.python.ai.integrations.github_mcp.server_config import (
+    GITHUB_MCP_PACKAGE,
+    GITHUB_MCP_TOKEN_ENV_VAR,
+)
+
+_LOG = logging.getLogger(__name__)
+
+
+def is_github_mcp_available(token: str | None = None) -> tuple[bool, str]:
+    """Return ``(available, reason)``.
+
+    Args:
+        token: Optional explicit token override. When supplied, the env-var
+            check is bypassed and the token's emptiness is what matters
+            (this is the path the UD Prefs UI uses when the operator has
+            just typed a token into the form but hasn't exported it yet).
+
+    Returns:
+        A ``(bool, str)`` tuple. The string is operator-facing and explains
+        either why the integration is unavailable, or confirms it is ready.
+    """
+    effective_token = (
+        token if token is not None else os.environ.get(GITHUB_MCP_TOKEN_ENV_VAR)
+    )
+    if not effective_token or not effective_token.strip():
+        msg = (
+            f"GitHub MCP unavailable: {GITHUB_MCP_TOKEN_ENV_VAR} is not set. "
+            "Create a Personal Access Token at https://github.com/settings/tokens "
+            "and export it as that env var."
+        )
+        _LOG.debug(msg)
+        return False, msg
+
+    if shutil.which("npx") is None:
+        msg = (
+            "GitHub MCP unavailable: 'npx' was not found on PATH. "
+            "Install Node.js (which provides npx) to launch "
+            f"{GITHUB_MCP_PACKAGE}."
+        )
+        _LOG.debug(msg)
+        return False, msg
+
+    return True, (
+        f"GitHub MCP available via npx + {GITHUB_MCP_PACKAGE} "
+        f"(auth from {GITHUB_MCP_TOKEN_ENV_VAR})."
+    )

--- a/src/shared/python/ai/integrations/github_mcp/integration.py
+++ b/src/shared/python/ai/integrations/github_mcp/integration.py
@@ -1,0 +1,88 @@
+"""Convenience helper for adding the GitHub MCP server to a pool.
+
+External callers (the UD MCP Prefs UI from #5642, automated config
+bootstrap, smoke tests) should reach the pool through this helper rather
+than building an :class:`McpServerConfig` and calling
+:meth:`McpClientPool.add_server` themselves — that keeps the npm package
+name, env var name, and default server name in one place (DRY) and keeps
+callers from poking the pool's internals (LOD).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Protocol
+
+from src.shared.python.ai.integrations.github_mcp.server_config import (
+    GITHUB_MCP_SERVER_NAME,
+    GITHUB_MCP_TOKEN_ENV_VAR,
+    build_github_mcp_config,
+)
+from src.shared.python.ai.mcp.contracts import McpServerConfig
+
+_LOG = logging.getLogger(__name__)
+
+
+class _PoolLike(Protocol):
+    """The subset of :class:`McpClientPool` this helper depends on.
+
+    Declared as a :class:`Protocol` so unit tests can pass a fake pool
+    without dragging the real one (and its transport stack) into the
+    test's import graph.
+    """
+
+    @property
+    def is_started(self) -> bool: ...
+
+    def add_server(self, config: McpServerConfig) -> None: ...
+
+
+def register_github_mcp(
+    pool: _PoolLike,
+    token: str | None = None,
+    *,
+    name: str = GITHUB_MCP_SERVER_NAME,
+    extra_env: dict[str, str] | None = None,
+) -> McpServerConfig:
+    """Add the GitHub MCP server to an already-started :class:`McpClientPool`.
+
+    Args:
+        pool: A pool with :pyattr:`is_started` already ``True``. The MCP
+            infrastructure expects servers to be added pre-start; this
+            helper is the explicit "register after the pool is live"
+            entry point used by interactive flows (Prefs UI).
+        token: Personal Access Token. If ``None``, the env var
+            ``GITHUB_PERSONAL_ACCESS_TOKEN`` is read instead.
+        name: Override the default server name (``"github"``). Useful for
+            multi-account setups.
+        extra_env: Optional extra env vars (e.g. ``GITHUB_API_URL`` for
+            GitHub Enterprise).
+
+    Returns:
+        The :class:`McpServerConfig` that was registered. Returning it
+        lets callers chain follow-up actions (e.g. ``await pool.start_all()``
+        for a deferred-start flow, or persisting the config to disk).
+
+    Raises:
+        RuntimeError: If ``pool.is_started`` is ``False``.
+        ValueError: If no token is supplied and the env var is unset.
+        ValueError: Propagated from the pool if a server named ``name``
+            is already registered.
+    """
+    if not pool.is_started:
+        raise RuntimeError(
+            "register_github_mcp precondition failed: pool must be started"
+        )
+
+    effective_token = (
+        token if token is not None else os.environ.get(GITHUB_MCP_TOKEN_ENV_VAR)
+    )
+    config = build_github_mcp_config(
+        token=effective_token,
+        name=name,
+        extra_env=extra_env,
+    )
+    pool.add_server(config)
+    _LOG.info("registered GitHub MCP server as %r", name)
+    return config

--- a/src/shared/python/ai/integrations/github_mcp/server_config.py
+++ b/src/shared/python/ai/integrations/github_mcp/server_config.py
@@ -1,0 +1,75 @@
+"""Construct a validated :class:`McpServerConfig` for the GitHub MCP server.
+
+The official server is published as the npm package
+``@modelcontextprotocol/server-github`` and is launched via
+``npx -y @modelcontextprotocol/server-github``. Authentication is delegated
+to the server subprocess via the ``GITHUB_PERSONAL_ACCESS_TOKEN`` env var.
+
+DbC:
+
+* :func:`build_github_mcp_config` requires a non-empty token. Empty or
+  whitespace-only tokens raise :class:`ValueError` — they would only fail
+  later inside the subprocess with an opaque "401 unauthorized" message,
+  so we catch the misconfiguration at construction time.
+
+DRY:
+
+* The npm package name, the env var, and the default server name live here
+  as module-level constants so every consumer (tool descriptors, discovery,
+  integration helper, future preset catalogue) references the same source
+  of truth.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.ai.mcp.contracts import McpServerConfig, McpTransport
+
+#: Default server name used when adding this server to an :class:`McpClientPool`.
+GITHUB_MCP_SERVER_NAME = "github"
+
+#: Env var the official server reads for authentication.
+GITHUB_MCP_TOKEN_ENV_VAR = "GITHUB_PERSONAL_ACCESS_TOKEN"
+
+#: npm package id launched via ``npx``.
+GITHUB_MCP_PACKAGE = "@modelcontextprotocol/server-github"
+
+
+def build_github_mcp_config(
+    token: str | None,
+    *,
+    name: str = GITHUB_MCP_SERVER_NAME,
+    extra_env: dict[str, str] | None = None,
+) -> McpServerConfig:
+    """Build an :class:`McpServerConfig` wired for the official GitHub MCP server.
+
+    Args:
+        token: A GitHub Personal Access Token (or fine-grained token). Must
+            be a non-empty, non-whitespace string. Required.
+        name: Server name used for namespacing tools as ``<name>:<tool>``.
+            Defaults to ``"github"``. Override when configuring multiple
+            GitHub accounts (e.g. ``"github-personal"``, ``"github-work"``).
+        extra_env: Additional env vars to pass to the subprocess (for
+            example ``GITHUB_API_URL`` for GitHub Enterprise). The explicit
+            ``token`` argument always wins over a colliding entry here.
+
+    Returns:
+        A fully-validated, ready-to-register :class:`McpServerConfig`.
+
+    Raises:
+        ValueError: If ``token`` is ``None``, empty, or whitespace-only.
+    """
+    if token is None or not token.strip():
+        raise ValueError("GitHub token required")
+
+    env: dict[str, str] = dict(extra_env or {})
+    # The explicit token wins over extra_env collisions — this is the
+    # single source of truth for the credential.
+    env[GITHUB_MCP_TOKEN_ENV_VAR] = token
+
+    return McpServerConfig(
+        name=name,
+        transport=McpTransport.STDIO,
+        command="npx",
+        args=["-y", GITHUB_MCP_PACKAGE],
+        env=env,
+    )

--- a/src/shared/python/ai/integrations/github_mcp/tool_descriptors.py
+++ b/src/shared/python/ai/integrations/github_mcp/tool_descriptors.py
@@ -1,0 +1,102 @@
+"""Declarative descriptors for the GitHub MCP server's tool surface.
+
+These descriptors are the **single source of truth** (DRY) for what the
+Sidekick UI and tool registry should expect from the GitHub MCP server.
+The actual tool list is verified at runtime when the server connects —
+this list is what callers can rely on without having to spawn the
+subprocess to find out.
+
+Each descriptor carries a ``requires_confirmation`` flag. The chat tool
+registry / UI uses this to gate write operations behind an explicit user
+confirmation, matching how Claude Desktop / Cline handle MCP write tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubMcpToolDescriptor:
+    """A tool the GitHub MCP server is expected to expose.
+
+    Attributes:
+        name: Tool name as advertised by the MCP server (un-namespaced).
+            The pool prefixes this with ``<server>:`` at aggregation time.
+        description: Short, operator-facing description.
+        requires_confirmation: ``True`` for mutating operations (issue
+            creation, PR merge, comment posting). The chat UI must prompt
+            the user before invoking these.
+    """
+
+    name: str
+    description: str
+    requires_confirmation: bool = False
+
+
+GITHUB_MCP_TOOL_DESCRIPTORS: tuple[GitHubMcpToolDescriptor, ...] = (
+    # ---- Read tools ----
+    GitHubMcpToolDescriptor(
+        name="list_repos",
+        description="List repositories accessible to the authenticated user.",
+    ),
+    GitHubMcpToolDescriptor(
+        name="list_issues",
+        description="List issues in a repository, with optional filters.",
+    ),
+    GitHubMcpToolDescriptor(
+        name="list_prs",
+        description="List pull requests in a repository, with optional filters.",
+    ),
+    GitHubMcpToolDescriptor(
+        name="get_issue",
+        description="Fetch a single issue by number, including body and metadata.",
+    ),
+    GitHubMcpToolDescriptor(
+        name="get_pr_diff",
+        description="Fetch the unified diff for a pull request.",
+    ),
+    GitHubMcpToolDescriptor(
+        name="search_code",
+        description="Search code across repositories using GitHub code search.",
+    ),
+    GitHubMcpToolDescriptor(
+        name="search_issues",
+        description="Search issues and pull requests across repositories.",
+    ),
+    # ---- Write tools (confirmation-gated) ----
+    GitHubMcpToolDescriptor(
+        name="create_issue",
+        description="Create a new issue in a repository.",
+        requires_confirmation=True,
+    ),
+    GitHubMcpToolDescriptor(
+        name="add_comment",
+        description="Post a comment on an existing issue or pull request.",
+        requires_confirmation=True,
+    ),
+    GitHubMcpToolDescriptor(
+        name="merge_pr",
+        description="Merge a pull request (merge / squash / rebase strategy).",
+        requires_confirmation=True,
+    ),
+)
+
+
+_DESCRIPTOR_BY_NAME: dict[str, GitHubMcpToolDescriptor] = {
+    descriptor.name: descriptor for descriptor in GITHUB_MCP_TOOL_DESCRIPTORS
+}
+
+
+def get_tool_descriptor(name: str) -> GitHubMcpToolDescriptor | None:
+    """Return the descriptor for ``name`` or ``None`` if unknown."""
+    return _DESCRIPTOR_BY_NAME.get(name)
+
+
+def write_tool_names() -> tuple[str, ...]:
+    """Return the names of tools that require confirmation before invocation."""
+    return tuple(
+        descriptor.name
+        for descriptor in GITHUB_MCP_TOOL_DESCRIPTORS
+        if descriptor.requires_confirmation
+    )

--- a/tests/unit/ai/integrations/github_mcp/conftest.py
+++ b/tests/unit/ai/integrations/github_mcp/conftest.py
@@ -1,0 +1,42 @@
+"""Local conftest for GitHub MCP integration unit tests.
+
+Mirrors ``tests/unit/ai/mcp/conftest.py`` — bootstraps the
+``src.shared.python.ai.integrations.github_mcp.*`` package tree so test
+imports of the form ``from src.shared.python.ai.integrations.github_mcp ...``
+resolve correctly under pytest's rootdir-driven discovery.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+    ("src.shared.python.ai.mcp", "src/shared/python/ai/mcp"),
+    ("src.shared.python.ai.integrations", "src/shared/python/ai/integrations"),
+    (
+        "src.shared.python.ai.integrations.github_mcp",
+        "src/shared/python/ai/integrations/github_mcp",
+    ),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    existing = sys.modules.get(_mod_name)
+    target = str(_REPO_ROOT / _rel_path)
+    if existing is None:
+        stub = types.ModuleType(_mod_name)
+        stub.__path__ = [target]
+        sys.modules[_mod_name] = stub
+    else:
+        existing_path = list(getattr(existing, "__path__", []) or [])
+        if target not in existing_path:
+            existing_path.insert(0, target)
+            existing.__path__ = existing_path  # type: ignore[attr-defined]

--- a/tests/unit/ai/integrations/github_mcp/test_discovery.py
+++ b/tests/unit/ai/integrations/github_mcp/test_discovery.py
@@ -1,0 +1,78 @@
+"""Tests for ``is_github_mcp_available`` — pre-flight discovery."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.shared.python.ai.integrations.github_mcp import discovery
+
+
+def _patch_env(token: str | None) -> dict[str, str]:
+    """Build an environ dict optionally containing the token env var."""
+    env: dict[str, str] = {}
+    if token is not None:
+        env["GITHUB_PERSONAL_ACCESS_TOKEN"] = token
+    return env
+
+
+def test_available_when_token_and_npx_present() -> None:
+    with (
+        patch.dict("os.environ", _patch_env("ghp_real"), clear=True),
+        patch.object(discovery.shutil, "which", return_value="/usr/bin/npx"),
+    ):
+        ok, msg = discovery.is_github_mcp_available()
+    assert ok is True
+    assert "available" in msg.lower()
+
+
+def test_unavailable_when_token_missing() -> None:
+    with (
+        patch.dict("os.environ", _patch_env(None), clear=True),
+        patch.object(discovery.shutil, "which", return_value="/usr/bin/npx"),
+    ):
+        ok, msg = discovery.is_github_mcp_available()
+    assert ok is False
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in msg
+
+
+def test_unavailable_when_token_blank() -> None:
+    with (
+        patch.dict("os.environ", _patch_env("   "), clear=True),
+        patch.object(discovery.shutil, "which", return_value="/usr/bin/npx"),
+    ):
+        ok, msg = discovery.is_github_mcp_available()
+    assert ok is False
+    assert "GITHUB_PERSONAL_ACCESS_TOKEN" in msg
+
+
+def test_unavailable_when_npx_missing() -> None:
+    with (
+        patch.dict("os.environ", _patch_env("ghp_real"), clear=True),
+        patch.object(discovery.shutil, "which", return_value=None),
+    ):
+        ok, msg = discovery.is_github_mcp_available()
+    assert ok is False
+    assert "npx" in msg.lower()
+
+
+def test_unavailable_message_actionable() -> None:
+    """Operator-facing messages must guide remediation, not just say ``no``."""
+    with (
+        patch.dict("os.environ", _patch_env(None), clear=True),
+        patch.object(discovery.shutil, "which", return_value=None),
+    ):
+        ok, msg = discovery.is_github_mcp_available()
+    assert ok is False
+    # Whatever check fails first, the message must mention what to fix.
+    assert msg.strip()
+    assert len(msg) > 10
+
+
+def test_check_token_helper_via_explicit_arg() -> None:
+    """The helper accepts an explicit token override (used by Prefs UI)."""
+    with (
+        patch.dict("os.environ", _patch_env(None), clear=True),
+        patch.object(discovery.shutil, "which", return_value="/usr/bin/npx"),
+    ):
+        ok, msg = discovery.is_github_mcp_available(token="ghp_supplied")
+    assert ok is True, msg

--- a/tests/unit/ai/integrations/github_mcp/test_integration.py
+++ b/tests/unit/ai/integrations/github_mcp/test_integration.py
@@ -1,0 +1,82 @@
+"""Tests for ``register_github_mcp`` — pool-integration helper."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.shared.python.ai.integrations.github_mcp.integration import (
+    register_github_mcp,
+)
+from src.shared.python.ai.mcp.contracts import McpServerConfig
+
+
+class _FakePool:
+    """Test double for ``McpClientPool`` exposing only the LOD-approved surface."""
+
+    def __init__(self, started: bool = True) -> None:
+        self._started = started
+        self.add_server = MagicMock()
+
+    @property
+    def is_started(self) -> bool:
+        return self._started
+
+
+def test_register_uses_explicit_token() -> None:
+    pool = _FakePool(started=True)
+    register_github_mcp(pool, token="ghp_explicit")  # type: ignore[arg-type]
+
+    pool.add_server.assert_called_once()
+    cfg = pool.add_server.call_args.args[0]
+    assert isinstance(cfg, McpServerConfig)
+    assert cfg.name == "github"
+    assert cfg.env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_explicit"
+
+
+def test_register_falls_back_to_env_var() -> None:
+    pool = _FakePool(started=True)
+    with patch.dict(
+        os.environ, {"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_from_env"}, clear=False
+    ):
+        register_github_mcp(pool)  # type: ignore[arg-type]
+
+    cfg = pool.add_server.call_args.args[0]
+    assert cfg.env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_from_env"
+
+
+def test_register_raises_when_pool_not_started() -> None:
+    """DbC precondition: ``pool.is_started`` must hold."""
+    pool = _FakePool(started=False)
+    with pytest.raises(RuntimeError, match="pool"):
+        register_github_mcp(pool, token="ghp_x")  # type: ignore[arg-type]
+    pool.add_server.assert_not_called()
+
+
+def test_register_raises_when_no_token_anywhere() -> None:
+    pool = _FakePool(started=True)
+    # Strip the env var if it's set in the host shell
+    env_copy = {
+        k: v for k, v in os.environ.items() if k != "GITHUB_PERSONAL_ACCESS_TOKEN"
+    }
+    with patch.dict(os.environ, env_copy, clear=True):  # noqa: SIM117
+        with pytest.raises(ValueError, match="GitHub token required"):
+            register_github_mcp(pool)  # type: ignore[arg-type]
+    pool.add_server.assert_not_called()
+
+
+def test_register_custom_name_propagates() -> None:
+    pool = _FakePool(started=True)
+    register_github_mcp(pool, token="ghp_x", name="github-work")  # type: ignore[arg-type]
+    cfg = pool.add_server.call_args.args[0]
+    assert cfg.name == "github-work"
+
+
+def test_register_is_idempotent_when_duplicate_rejected_by_pool() -> None:
+    """If the pool already has a 'github' server, the helper surfaces the error."""
+    pool = _FakePool(started=True)
+    pool.add_server.side_effect = ValueError("server already registered: github")
+    with pytest.raises(ValueError, match="already registered"):
+        register_github_mcp(pool, token="ghp_x")  # type: ignore[arg-type]

--- a/tests/unit/ai/integrations/github_mcp/test_server_config.py
+++ b/tests/unit/ai/integrations/github_mcp/test_server_config.py
@@ -1,0 +1,84 @@
+"""Tests for ``build_github_mcp_config`` — config builder + DbC."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.ai.integrations.github_mcp.server_config import (
+    GITHUB_MCP_SERVER_NAME,
+    GITHUB_MCP_TOKEN_ENV_VAR,
+    build_github_mcp_config,
+)
+from src.shared.python.ai.mcp.contracts import McpServerConfig, McpTransport
+
+
+def test_build_config_returns_mcp_server_config() -> None:
+    """Builder returns a fully-validated ``McpServerConfig`` instance."""
+    cfg = build_github_mcp_config(token="ghp_test_token_123")
+    assert isinstance(cfg, McpServerConfig)
+
+
+def test_build_config_default_name_is_github() -> None:
+    cfg = build_github_mcp_config(token="ghp_test_token_123")
+    assert cfg.name == GITHUB_MCP_SERVER_NAME
+    assert cfg.name == "github"
+
+
+def test_build_config_uses_npx_command() -> None:
+    """The default invocation is ``npx -y @modelcontextprotocol/server-github``."""
+    cfg = build_github_mcp_config(token="ghp_test_token_123")
+    assert cfg.command == "npx"
+    assert "@modelcontextprotocol/server-github" in cfg.args
+    # ``-y`` ensures non-interactive install on first run.
+    assert "-y" in cfg.args
+
+
+def test_build_config_uses_stdio_transport() -> None:
+    cfg = build_github_mcp_config(token="ghp_test_token_123")
+    assert cfg.transport is McpTransport.STDIO
+
+
+def test_build_config_sets_token_env_var() -> None:
+    """The token is plumbed via ``GITHUB_PERSONAL_ACCESS_TOKEN``."""
+    cfg = build_github_mcp_config(token="ghp_test_token_xyz")
+    assert GITHUB_MCP_TOKEN_ENV_VAR == "GITHUB_PERSONAL_ACCESS_TOKEN"
+    assert cfg.env[GITHUB_MCP_TOKEN_ENV_VAR] == "ghp_test_token_xyz"
+
+
+def test_build_config_none_token_raises() -> None:
+    """DbC precondition: token is required."""
+    with pytest.raises(ValueError, match="GitHub token required"):
+        build_github_mcp_config(token=None)
+
+
+def test_build_config_empty_token_raises() -> None:
+    """DbC precondition: empty / whitespace token is rejected."""
+    with pytest.raises(ValueError, match="GitHub token required"):
+        build_github_mcp_config(token="")
+    with pytest.raises(ValueError, match="GitHub token required"):
+        build_github_mcp_config(token="   ")
+
+
+def test_build_config_custom_name_supported() -> None:
+    """Operators can override the server name for multi-account setups."""
+    cfg = build_github_mcp_config(token="ghp_x", name="github-personal")
+    assert cfg.name == "github-personal"
+
+
+def test_build_config_extra_env_merged() -> None:
+    """Extra env vars supplied by caller are merged with the token env."""
+    cfg = build_github_mcp_config(
+        token="ghp_x",
+        extra_env={"GITHUB_API_URL": "https://ghe.example.com/api/v3"},
+    )
+    assert cfg.env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_x"
+    assert cfg.env["GITHUB_API_URL"] == "https://ghe.example.com/api/v3"
+
+
+def test_build_config_extra_env_does_not_override_token() -> None:
+    """The explicit ``token`` argument wins over a colliding ``extra_env`` entry."""
+    cfg = build_github_mcp_config(
+        token="ghp_real",
+        extra_env={"GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_fake"},
+    )
+    assert cfg.env["GITHUB_PERSONAL_ACCESS_TOKEN"] == "ghp_real"

--- a/tests/unit/ai/integrations/github_mcp/test_tool_descriptors.py
+++ b/tests/unit/ai/integrations/github_mcp/test_tool_descriptors.py
@@ -1,0 +1,81 @@
+"""Tests for declarative GitHub MCP tool descriptors."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.shared.python.ai.integrations.github_mcp.tool_descriptors import (
+    GITHUB_MCP_TOOL_DESCRIPTORS,
+    GitHubMcpToolDescriptor,
+    get_tool_descriptor,
+    write_tool_names,
+)
+
+_EXPECTED_TOOLS = {
+    "list_repos",
+    "list_issues",
+    "list_prs",
+    "get_issue",
+    "get_pr_diff",
+    "create_issue",
+    "add_comment",
+    "search_code",
+    "search_issues",
+    "merge_pr",
+}
+
+_EXPECTED_WRITE_TOOLS = {"create_issue", "add_comment", "merge_pr"}
+
+
+def test_all_expected_tools_present() -> None:
+    """Declarative list covers every tool named in the issue scope."""
+    names = {tool.name for tool in GITHUB_MCP_TOOL_DESCRIPTORS}
+    assert names == _EXPECTED_TOOLS
+
+
+def test_descriptor_is_immutable_dataclass() -> None:
+    """Descriptors are frozen so the declarative list cannot be mutated at runtime."""
+    descriptor = GITHUB_MCP_TOOL_DESCRIPTORS[0]
+    assert isinstance(descriptor, GitHubMcpToolDescriptor)
+    with pytest.raises((AttributeError, TypeError)):
+        descriptor.name = "mutated"  # type: ignore[misc]
+
+
+def test_write_tools_require_confirmation() -> None:
+    """Mutating tools must opt into ``requires_confirmation=True``."""
+    for tool in GITHUB_MCP_TOOL_DESCRIPTORS:
+        if tool.name in _EXPECTED_WRITE_TOOLS:
+            assert tool.requires_confirmation is True, (
+                f"write tool {tool.name} must require confirmation"
+            )
+        else:
+            assert tool.requires_confirmation is False, (
+                f"read tool {tool.name} must not require confirmation"
+            )
+
+
+def test_write_tool_names_helper() -> None:
+    """``write_tool_names`` returns exactly the confirmation-gated tools."""
+    assert set(write_tool_names()) == _EXPECTED_WRITE_TOOLS
+
+
+def test_every_descriptor_has_description() -> None:
+    """No-op-looking tools are a footgun; require a non-empty description."""
+    for tool in GITHUB_MCP_TOOL_DESCRIPTORS:
+        assert tool.description.strip(), f"{tool.name} missing description"
+
+
+def test_get_tool_descriptor_returns_known() -> None:
+    descriptor = get_tool_descriptor("list_issues")
+    assert descriptor is not None
+    assert descriptor.name == "list_issues"
+    assert descriptor.requires_confirmation is False
+
+
+def test_get_tool_descriptor_returns_none_for_unknown() -> None:
+    assert get_tool_descriptor("definitely_not_a_real_tool") is None
+
+
+def test_tool_descriptor_list_has_no_duplicates() -> None:
+    names = [tool.name for tool in GITHUB_MCP_TOOL_DESCRIPTORS]
+    assert len(names) == len(set(names))


### PR DESCRIPTION
## Summary

Implements #2897 — wires the official `@modelcontextprotocol/server-github` MCP server into Sidekick via the shared `McpClientPool`. This is one of two GitHub integration paths in the fleet; the other is the GitHub CLI agent provider tracked under #2899.

GitHub tools become discoverable through standard `<server>:<tool>` namespacing (e.g. `github:list_issues`, `github:create_issue`) and write tools are gated behind a `requires_confirmation` flag the chat UI can honor.

## Scope

New package `src/shared/python/ai/integrations/github_mcp/`:

- `server_config.py` — `build_github_mcp_config(token, name=, extra_env=)` returning a validated `McpServerConfig` pre-wired for `npx -y @modelcontextprotocol/server-github` with `GITHUB_PERSONAL_ACCESS_TOKEN` env plumbing.
- `tool_descriptors.py` — single-source-of-truth declarative list of the 10 expected tools (`list_repos`, `list_issues`, `list_prs`, `get_issue`, `get_pr_diff`, `search_code`, `search_issues`, `create_issue`, `add_comment`, `merge_pr`) with `requires_confirmation=True` on the 3 write tools.
- `discovery.py` — `is_github_mcp_available(token=None) -> (bool, str)` checking token + `npx` on PATH with operator-facing actionable messages.
- `integration.py` — `register_github_mcp(pool, token=None, name=, extra_env=)` convenience helper. DbC precondition: `pool.is_started`.
- `__init__.py` — public surface exports.

## DbC / LOD / DRY

- DbC: `build_github_mcp_config(None)` / `("")` raises `ValueError("GitHub token required")`. `register_github_mcp` requires `pool.is_started`.
- LOD: callers use `register_github_mcp(pool, token)` — the helper takes a `Protocol`-typed pool so no internals leak across the boundary.
- DRY: npm package id, env var name, and default server name live as module-level constants in `server_config.py`; tool descriptors are the single source of truth referenced by descriptor lookups and confirmation logic.

## Coordination

The MCP preset catalogue (#2901) is in flight in a sibling PR. This PR does **not** touch `src/shared/python/ai/mcp/presets.py` — a one-line follow-up after both merge can add GitHub to that catalogue using `build_github_mcp_config`.

## Tests

30 new unit tests under `tests/unit/ai/integrations/github_mcp/` — fully mocked, no subprocess or network. Covers config builder, descriptor surface + write-tool flags, discovery success/failure paths with actionable messages, pool registration with explicit/env-var token sources and DbC precondition failures.

## Test plan

- [x] `python3 -m ruff check src/shared/python/ai/integrations/github_mcp/ tests/unit/ai/integrations/github_mcp/` — green
- [x] `python3 -m ruff format --check src/shared/python/ai/integrations/github_mcp/ tests/unit/ai/integrations/github_mcp/` — green
- [x] `python3 -m pytest tests/unit/ai/integrations/github_mcp/` — 30 passed

Implements #2897

Generated with Claude Code