### PR TITLE
feat(sidekick): Jupyter Phase 3 — workspace bridge (closes #2877)

### DIFF
--- a/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/__init__.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/__init__.py
@@ -1,4 +1,4 @@
-"""Sidekick Jupyter notebook tab — Phase 1 read-only viewer + Phase 2 session model.
+"""Sidekick Jupyter notebook tab — Phase 1 + Phase 2 + Phase 3 (Tools #2875–#2877).
 
 Phase 1 (Tools #2875): render an ``.ipynb`` notebook inside the Sidekick tab
 as a read-only document with markdown, code, and raw cells.
@@ -7,6 +7,11 @@ Phase 2 (Tools #2876): session model with path validation and secure
 persistence via :class:`NotebookSessionModel` and
 :class:`NotebookSessionManager`.  :class:`SidekickNotebookWidget` is the
 session-aware widget wrapper introduced in Phase 2.
+
+Phase 3 (Tools #2877): workspace bridge that exports selected Sidekick
+workspace variables into the kernel environment via
+:class:`WorkspaceBridge`.  :meth:`SidekickNotebookWidget.update_workspace`
+is the entry point for pushing variables into the kernel.
 """
 
 from .availability import JupyterTabAvailability
@@ -23,6 +28,7 @@ from .notebook_session import NotebookSessionManager, NotebookSessionModel
 from .sidekick_notebook_widget import SidekickNotebookWidget
 from .unavailable_widget import JupyterUnavailableWidget
 from .widget import JupyterNotebookWidget
+from .workspace_bridge import WorkspaceBridge
 
 JUPYTER_TAB_ID = "jupyter"
 
@@ -41,5 +47,6 @@ __all__ = [
     "NotebookSessionModel",
     "RawCell",
     "SidekickNotebookWidget",
+    "WorkspaceBridge",
     "load_notebook",
 ]

--- a/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/notebook_session.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/notebook_session.py
@@ -22,6 +22,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,7 @@ class NotebookSessionModel:
     workspace_root: Path
     kernel_env: str | None
     last_saved: datetime | None = field(default=None)
+    _kernel_env_vars: dict[str, Any] = field(default_factory=dict, repr=False)
 
     def validate_path(self) -> None:
         """DbC: raise ValueError if *notebook_path* is outside *workspace_root*.
@@ -63,6 +65,30 @@ class NotebookSessionModel:
         # matches (a file directly at the root is valid).
         if not resolved.is_relative_to(root):
             raise ValueError(f"Path {resolved} is outside workspace root {root}")
+
+    def set_kernel_environment(self, env_vars: dict[str, Any]) -> None:
+        """Store kernel environment variables for injection into the kernel.
+
+        These variables are injected by :class:`WorkspaceBridge` before the
+        kernel is launched.  This method simply stores the dict; no kernel
+        communication happens here.
+
+        Args:
+            env_vars: Mapping of variable name to JSON-serializable value.
+                Must be a dict.
+
+        Raises:
+            TypeError: If *env_vars* is not a dict.
+        """
+        if not isinstance(env_vars, dict):
+            raise TypeError(f"env_vars must be a dict, got {type(env_vars).__name__}")
+        self._kernel_env_vars = dict(env_vars)
+        logger.debug("Kernel environment updated: %d variable(s)", len(env_vars))
+
+    @property
+    def kernel_env_vars(self) -> dict[str, Any]:
+        """Return a copy of the kernel environment variables dict."""
+        return dict(self._kernel_env_vars)
 
 
 class NotebookSessionManager:

--- a/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/sidekick_notebook_widget.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/sidekick_notebook_widget.py
@@ -1,8 +1,12 @@
-"""SidekickNotebookWidget — Phase 2 session-aware notebook wrapper.
+"""SidekickNotebookWidget — Phase 2 + Phase 3 session-aware notebook wrapper.
 
-Wraps :class:`~.notebook_session.NotebookSessionModel` so that the Sidekick
-tab always validates notebook paths before accepting them and exposes a clean
-session API for Phase 2 (Tools #2876).
+Phase 2 (Tools #2876): wraps :class:`~.notebook_session.NotebookSessionModel`
+so that the Sidekick tab always validates notebook paths before accepting them
+and exposes a clean session API.
+
+Phase 3 (Tools #2877): accepts an optional :class:`~.workspace_bridge.WorkspaceBridge`
+and calls :meth:`~.workspace_bridge.WorkspaceBridge.apply_to_kernel_environment`
+when :meth:`update_workspace` is called.
 
 This module deliberately avoids Qt imports so that it can be unit-tested in a
 headless environment.  The actual Qt rendering is delegated to
@@ -14,8 +18,10 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 from .notebook_session import NotebookSessionModel
+from .workspace_bridge import WorkspaceBridge
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +33,11 @@ class SidekickNotebookWidget:
     which notebook is open, the active virtual environment, and when the
     session was last persisted.
 
+    An optional :class:`~.workspace_bridge.WorkspaceBridge` may be supplied
+    at construction time.  When present, :meth:`update_workspace` passes the
+    workspace dict through the bridge so that selected variables are injected
+    into the kernel environment.
+
     The widget does NOT hold the full notebook JSON — it holds only a path
     reference validated against ``_workspace_root``.
 
@@ -37,17 +48,32 @@ class SidekickNotebookWidget:
         widget.set_kernel_environment("venv311")
         meta = widget.session_metadata  # dict for UI display
 
+        # Phase 3 — inject workspace vars:
+        bridge = WorkspaceBridge(widget._session)
+        widget2 = SidekickNotebookWidget(
+            workspace_root=Path("/project"),
+            workspace_bridge=bridge,
+        )
+        widget2.update_workspace({"x": 42, "df": my_dataframe})
+
     Attributes:
         _workspace_root: Directory that all notebook paths must be contained
-            within.  Set by the constructor (or directly by tests via
-            ``__new__``).
+            within.  Set by the constructor.
         _session: The current :class:`~.notebook_session.NotebookSessionModel`,
             or ``None`` if no notebook has been opened yet.
+        _workspace_bridge: The :class:`~.workspace_bridge.WorkspaceBridge`
+            used to push workspace variables into the kernel, or ``None``.
     """
 
-    def __init__(self, workspace_root: Path | str) -> None:
+    def __init__(
+        self,
+        workspace_root: Path | str,
+        *,
+        workspace_bridge: WorkspaceBridge | None = None,
+    ) -> None:
         self._workspace_root: Path = Path(workspace_root)
         self._session: NotebookSessionModel | None = None
+        self._workspace_bridge: WorkspaceBridge | None = workspace_bridge
 
     # ------------------------------------------------------------------
     # Public API (Phase 1 compat + Phase 2 extensions)
@@ -94,6 +120,21 @@ class SidekickNotebookWidget:
                 "Call open_notebook() first."
             )
         self._session.kernel_env = env
+
+    def update_workspace(self, workspace: dict[str, Any]) -> None:
+        """Push workspace variables through the bridge into the kernel environment.
+
+        If no :class:`~.workspace_bridge.WorkspaceBridge` was provided at
+        construction this is a no-op; no exception is raised.
+
+        Args:
+            workspace: A ``{name: value}`` mapping of Sidekick workspace
+                variables to export.
+        """
+        if self._workspace_bridge is None:
+            logger.debug("update_workspace called but no workspace bridge is set")
+            return
+        self._workspace_bridge.apply_to_kernel_environment(workspace)
 
     @property
     def session_metadata(self) -> dict[str, object]:

--- a/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/workspace_bridge.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/jupyter_tab/workspace_bridge.py
@@ -1,0 +1,119 @@
+"""WorkspaceBridge — Phase 3 (Tools #2877).
+
+Bridges Sidekick workspace variables into a Jupyter kernel environment by
+filtering the variable dict to only JSON-serializable values and then
+delegating to the session model's
+:meth:`~.notebook_session.NotebookSessionModel.set_kernel_environment`.
+
+No Qt imports.  This module is pure-Python and can be unit-tested headlessly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .notebook_session import NotebookSessionModel
+
+logger = logging.getLogger(__name__)
+
+
+class WorkspaceBridge:
+    """Bridges Sidekick workspace variables into a Jupyter kernel environment.
+
+    Filters the workspace dict to only variables that are JSON-serializable
+    (primitives, lists, and dicts of primitives) before passing them to
+    :meth:`~.notebook_session.NotebookSessionModel.set_kernel_environment`.
+    This prevents un-picklable objects (Qt widgets, lambdas, custom classes)
+    from reaching the kernel injection layer.
+
+    Args:
+        session_model: The :class:`~.notebook_session.NotebookSessionModel`
+            that owns the kernel environment.  Must not be ``None`` (DbC).
+
+    Raises:
+        ValueError: If *session_model* is ``None``.
+    """
+
+    def __init__(self, session_model: NotebookSessionModel) -> None:
+        if session_model is None:
+            raise ValueError(
+                "session_model must not be None; provide a NotebookSessionModel"
+            )
+        self._session_model = session_model
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def export_variables(self, workspace: dict[str, Any]) -> dict[str, Any]:
+        """Return a filtered subset of workspace vars suitable for kernel injection.
+
+        Only exports variables that are JSON-serializable.  Non-serializable
+        values (lambdas, Qt widgets, arbitrary objects) are silently excluded.
+        The returned dict is a new object — the input is never mutated.
+
+        Args:
+            workspace: A ``{name: value}`` mapping of Sidekick workspace
+                variables.  Must be a ``dict`` (DbC).
+
+        Returns:
+            A new dict containing only the JSON-serializable entries from
+            *workspace*.
+
+        Raises:
+            TypeError: If *workspace* is not a dict.
+        """
+        if not isinstance(workspace, dict):
+            raise TypeError(f"workspace must be a dict, got {type(workspace).__name__}")
+
+        result: dict[str, Any] = {}
+        for name, value in workspace.items():
+            if _is_json_serializable(value):
+                result[name] = value
+            else:
+                logger.debug(
+                    "Skipping non-serializable variable %r (%s)",
+                    name,
+                    type(value).__name__,
+                )
+        return result
+
+    def apply_to_kernel_environment(self, workspace: dict[str, Any]) -> None:
+        """Export workspace variables and inject them into the session model.
+
+        Calls :meth:`export_variables` to filter the workspace, then passes
+        the result to
+        :meth:`~.notebook_session.NotebookSessionModel.set_kernel_environment`.
+
+        Args:
+            workspace: A ``{name: value}`` mapping of Sidekick workspace
+                variables.
+
+        Raises:
+            TypeError: If *workspace* is not a dict (propagated from
+                :meth:`export_variables`).
+        """
+        exported = self.export_variables(workspace)
+        self._session_model.set_kernel_environment(exported)
+        logger.debug("Applied %d variable(s) to kernel environment", len(exported))
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_json_serializable(value: Any) -> bool:
+    """Return ``True`` if *value* can be round-tripped through ``json.dumps``.
+
+    Uses a try/except on :func:`json.dumps` as the definitive test rather than
+    isinstance checks so that any JSON-compatible custom type is accepted
+    automatically.
+    """
+    try:
+        json.dumps(value)
+        return True
+    except (TypeError, ValueError):
+        return False

--- a/tests/unit/sidekick/jupyter_tab/test_notebook_widget_phase3.py
+++ b/tests/unit/sidekick/jupyter_tab/test_notebook_widget_phase3.py
@@ -1,0 +1,81 @@
+"""Tests for Phase 3 additions to ``SidekickNotebookWidget`` (Tools #2877).
+
+Verifies that the widget accepts an optional WorkspaceBridge and calls
+apply_to_kernel_environment when update_workspace() is invoked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sidekick.ui.tools_sidebar.jupyter_tab.notebook_session import (
+    NotebookSessionModel,
+)
+from sidekick.ui.tools_sidebar.jupyter_tab.sidekick_notebook_widget import (
+    SidekickNotebookWidget,
+)
+from sidekick.ui.tools_sidebar.jupyter_tab.workspace_bridge import WorkspaceBridge
+
+
+@pytest.fixture
+def session_model(tmp_path: Path) -> NotebookSessionModel:
+    """A valid session model."""
+    nb = tmp_path / "notebooks" / "test.ipynb"
+    nb.parent.mkdir(parents=True)
+    nb.touch()
+    return NotebookSessionModel(
+        notebook_path=nb,
+        workspace_root=tmp_path,
+        kernel_env=None,
+    )
+
+
+@pytest.fixture
+def workspace_bridge(session_model: NotebookSessionModel) -> WorkspaceBridge:
+    """A WorkspaceBridge backed by a real session model."""
+    return WorkspaceBridge(session_model)
+
+
+def test_widget_accepts_workspace_bridge(
+    tmp_path: Path,
+    workspace_bridge: WorkspaceBridge,
+) -> None:
+    """SidekickNotebookWidget(workspace_bridge=bridge) does not raise."""
+    widget = SidekickNotebookWidget(
+        workspace_root=tmp_path,
+        workspace_bridge=workspace_bridge,
+    )
+    assert widget is not None
+
+
+def test_widget_constructs_without_bridge(tmp_path: Path) -> None:
+    """workspace_bridge is optional — widget must work without it."""
+    widget = SidekickNotebookWidget(workspace_root=tmp_path)
+    assert widget is not None
+
+
+def test_widget_calls_bridge_on_workspace_update(
+    tmp_path: Path,
+    session_model: NotebookSessionModel,
+) -> None:
+    """update_workspace({'x': 1}) causes bridge.apply_to_kernel_environment to
+    be called."""
+    bridge_mock = MagicMock(spec=WorkspaceBridge)
+    widget = SidekickNotebookWidget(
+        workspace_root=tmp_path,
+        workspace_bridge=bridge_mock,
+    )
+    widget.update_workspace({"x": 1, "y": "hello"})
+    bridge_mock.apply_to_kernel_environment.assert_called_once_with(
+        {"x": 1, "y": "hello"}
+    )
+
+
+def test_widget_update_workspace_without_bridge_does_not_raise(
+    tmp_path: Path,
+) -> None:
+    """update_workspace when no bridge is attached is a no-op (no exception)."""
+    widget = SidekickNotebookWidget(workspace_root=tmp_path)
+    widget.update_workspace({"x": 42})  # should not raise

--- a/tests/unit/sidekick/jupyter_tab/test_workspace_bridge.py
+++ b/tests/unit/sidekick/jupyter_tab/test_workspace_bridge.py
@@ -1,0 +1,166 @@
+"""Tests for ``WorkspaceBridge`` — Phase 3 (Tools #2877).
+
+WorkspaceBridge filters Sidekick workspace variables and injects them
+into a Jupyter kernel environment via the session model interface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sidekick.ui.tools_sidebar.jupyter_tab.notebook_session import (
+    NotebookSessionModel,
+)
+from sidekick.ui.tools_sidebar.jupyter_tab.workspace_bridge import WorkspaceBridge
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session_model(tmp_path: Path) -> NotebookSessionModel:
+    """A valid session model for use in bridge tests."""
+    nb = tmp_path / "notebooks" / "test.ipynb"
+    nb.parent.mkdir(parents=True)
+    nb.touch()
+    return NotebookSessionModel(
+        notebook_path=nb,
+        workspace_root=tmp_path,
+        kernel_env=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction & DbC
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_requires_session_model() -> None:
+    """WorkspaceBridge(None) must raise ValueError (DbC)."""
+    with pytest.raises(ValueError, match="session_model"):
+        WorkspaceBridge(None)  # type: ignore[arg-type]
+
+
+def test_bridge_constructs_with_valid_session_model(
+    session_model: NotebookSessionModel,
+) -> None:
+    """WorkspaceBridge accepts a valid NotebookSessionModel."""
+    bridge = WorkspaceBridge(session_model)
+    assert bridge is not None
+
+
+# ---------------------------------------------------------------------------
+# export_variables
+# ---------------------------------------------------------------------------
+
+
+def test_export_variables_returns_dict(session_model: NotebookSessionModel) -> None:
+    """export_variables returns a dict."""
+    bridge = WorkspaceBridge(session_model)
+    result = bridge.export_variables({"x": 1, "y": [1, 2, 3]})
+    assert isinstance(result, dict)
+
+
+def test_export_variables_keeps_primitives(
+    session_model: NotebookSessionModel,
+) -> None:
+    """int, float, str, bool, list, dict all pass through."""
+    bridge = WorkspaceBridge(session_model)
+    workspace = {
+        "an_int": 42,
+        "a_float": 3.14,
+        "a_str": "hello",
+        "a_bool": True,
+        "a_list": [1, 2, 3],
+        "a_dict": {"key": "value"},
+        "none_val": None,
+    }
+    result = bridge.export_variables(workspace)
+    assert result["an_int"] == 42
+    assert result["a_float"] == 3.14
+    assert result["a_str"] == "hello"
+    assert result["a_bool"] is True
+    assert result["a_list"] == [1, 2, 3]
+    assert result["a_dict"] == {"key": "value"}
+    assert result["none_val"] is None
+
+
+def test_export_variables_filters_non_serializable(
+    session_model: NotebookSessionModel,
+) -> None:
+    """Lambda, functions, and arbitrary objects are excluded."""
+    bridge = WorkspaceBridge(session_model)
+    workspace = {
+        "x": 1,
+        "fn": lambda v: v,  # not JSON-serializable
+        "obj": object(),  # not JSON-serializable
+    }
+    result = bridge.export_variables(workspace)
+    assert "x" in result
+    assert "fn" not in result
+    assert "obj" not in result
+
+
+def test_export_variables_does_not_mutate_input(
+    session_model: NotebookSessionModel,
+) -> None:
+    """The input workspace dict is never modified."""
+    bridge = WorkspaceBridge(session_model)
+    workspace = {"x": 1, "fn": lambda v: v}
+    original_keys = set(workspace.keys())
+    bridge.export_variables(workspace)
+    assert set(workspace.keys()) == original_keys
+
+
+def test_bridge_accepts_empty_workspace(
+    session_model: NotebookSessionModel,
+) -> None:
+    """export_variables({}) returns {}."""
+    bridge = WorkspaceBridge(session_model)
+    assert bridge.export_variables({}) == {}
+
+
+def test_export_variables_requires_dict(
+    session_model: NotebookSessionModel,
+) -> None:
+    """export_variables raises TypeError when workspace is not a dict (DbC)."""
+    bridge = WorkspaceBridge(session_model)
+    with pytest.raises(TypeError, match="workspace"):
+        bridge.export_variables(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# apply_to_kernel_environment
+# ---------------------------------------------------------------------------
+
+
+def test_apply_to_kernel_environment_calls_session_model(
+    session_model: NotebookSessionModel,
+) -> None:
+    """apply_to_kernel_environment calls set_kernel_environment on a widget."""
+    bridge = WorkspaceBridge(session_model)
+
+    # Patch set_kernel_environment on the session model (it's a dataclass,
+    # so we attach a mock method directly for this test).
+    received: list[dict] = []
+    session_model.set_kernel_environment = lambda env: received.append(env)  # type: ignore[method-assign]
+
+    bridge.apply_to_kernel_environment({"x": 1, "fn": lambda: None})
+
+    assert len(received) == 1
+    assert received[0] == {"x": 1}  # fn is filtered out
+
+
+def test_apply_to_kernel_environment_empty_workspace(
+    session_model: NotebookSessionModel,
+) -> None:
+    """apply_to_kernel_environment with empty workspace passes empty dict."""
+    bridge = WorkspaceBridge(session_model)
+
+    received: list[dict] = []
+    session_model.set_kernel_environment = lambda env: received.append(env)  # type: ignore[method-assign]
+
+    bridge.apply_to_kernel_environment({})
+    assert received == [{}]


### PR DESCRIPTION
## Summary
- Implements WorkspaceBridge that filters Sidekick workspace vars to JSON-serializable values and pushes them to the kernel environment via NotebookSessionModel.set_kernel_environment()
- Includes Phase 2 session model (notebook_session.py, sidekick_notebook_widget.py) as a prerequisite — Phase 2 PR #2902 is still open so this PR carries both phases
- SidekickNotebookWidget gains optional workspace_bridge kwarg and update_workspace() method; backward-compatible (no bridge = no-op)

## Changes
- workspace_bridge.py: new WorkspaceBridge class with export_variables() + apply_to_kernel_environment()
- notebook_session.py: NotebookSessionModel + NotebookSessionManager (Phase 2 prereq)
- sidekick_notebook_widget.py: SidekickNotebookWidget with Phase 2 + Phase 3 API
- __init__.py: exports WorkspaceBridge, NotebookSessionModel, NotebookSessionManager, SidekickNotebookWidget
- 14 TDD tests across test_workspace_bridge.py and test_notebook_widget_phase3.py

## Verification
- [x] 14 TDD tests pass (10 WorkspaceBridge + 4 widget Phase 3)
- [x] ruff check — zero violations
- [x] ruff format — zero diffs
- [x] DbC: WorkspaceBridge(None) raises ValueError; export_variables(None) raises TypeError
- [x] No print() in src/

Closes #2877