### PR TITLE
feat(mcp): shared Qt widgets — MCP prefs + integrations health dashboard

### DIFF
--- a/src/shared/python/ai/mcp/__init__.py
+++ b/src/shared/python/ai/mcp/__init__.py
@@ -19,6 +19,11 @@ from __future__ import annotations
 
 from src.shared.python.ai.mcp.client import McpClient
 from src.shared.python.ai.mcp.config_loader import load_mcp_servers
+from src.shared.python.ai.mcp.config_writer import (
+    McpServersFile,
+    read,
+    write,
+)
 from src.shared.python.ai.mcp.contracts import (
     McpResourceDescriptor,
     McpServerConfig,
@@ -32,7 +37,10 @@ __all__ = [
     "McpClientPool",
     "McpResourceDescriptor",
     "McpServerConfig",
+    "McpServersFile",
     "McpToolDescriptor",
     "McpTransport",
     "load_mcp_servers",
+    "read",
+    "write",
 ]

--- a/src/shared/python/ai/mcp/config_writer.py
+++ b/src/shared/python/ai/mcp/config_writer.py
@@ -1,0 +1,215 @@
+"""Pure-data round-trip for the MCP servers JSON config file.
+
+This module is the canonical writer for ``~/.upstreamdrift/mcp_servers.json``
+(and any future per-app override path passed by callers). It is intentionally
+Qt-free and lives in shared Tools so both UpstreamDrift and Gasification_Model
+can write the same file format.
+
+Round-trips with :mod:`src.shared.python.ai.mcp.config_loader`, which already
+handles reading. The writer's documented failure mode is :class:`ValueError`
+(DbC: callers handle a single exception type).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+from src.shared.python.ai.mcp.contracts import McpServerConfig
+
+__all__ = [
+    "DEFAULT_CONFIG_PATH",
+    "ENV_VAR_PATTERN",
+    "McpServersFile",
+    "load",
+    "read",
+    "validate_env_placeholders",
+    "write",
+]
+
+
+DEFAULT_CONFIG_DIR = Path.home() / ".upstreamdrift"
+DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "mcp_servers.json"
+
+ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_BAD_PLACEHOLDER = re.compile(r"\$\{[^}]*$|\$\{\}|\$\{[^A-Za-z_}][^}]*\}")
+
+
+def validate_env_placeholders(value: str) -> str:
+    """Return *value* unchanged after rejecting malformed ``${VAR}`` syntax.
+
+    Raises:
+        ValueError: If *value* contains an unterminated/empty placeholder.
+    """
+    if value is None:
+        raise ValueError("value must be a string, not None")
+    if _BAD_PLACEHOLDER.search(value):
+        raise ValueError(
+            f"Malformed environment-variable placeholder in MCP server env "
+            f"value: {value!r}. Use the form ${{VAR_NAME}}."
+        )
+    return value
+
+
+class McpServersFile(BaseModel):
+    """Top-level JSON structure for ``mcp_servers.json``.
+
+    Uses the Claude-Desktop-compatible layout: a top-level ``mcpServers``
+    object keyed by server name. We model it as a flat list internally
+    for ergonomic UI work and convert at the JSON boundary.
+    """
+
+    version: int = 1
+    servers: list[McpServerConfig] = Field(default_factory=list)
+
+    @field_validator("servers")
+    @classmethod
+    def _unique_names(cls, value: list[McpServerConfig]) -> list[McpServerConfig]:
+        seen: set[str] = set()
+        for server in value:
+            if server.name in seen:
+                raise ValueError(
+                    f"Duplicate MCP server name {server.name!r} — names "
+                    "must be unique within the file."
+                )
+            seen.add(server.name)
+        return value
+
+
+def _coerce_to_canonical_servers(
+    servers: Iterable[McpServerConfig | dict[str, Any]],
+) -> list[McpServerConfig]:
+    result: list[McpServerConfig] = []
+    for raw in servers:
+        if isinstance(raw, McpServerConfig):
+            result.append(raw)
+        elif isinstance(raw, dict):
+            result.append(McpServerConfig(**raw))
+        else:
+            raise TypeError(
+                f"servers entries must be McpServerConfig or dict, "
+                f"got {type(raw).__name__}"
+            )
+    return result
+
+
+def _to_claude_desktop_dict(file_model: McpServersFile) -> dict[str, Any]:
+    """Convert a :class:`McpServersFile` to Claude-Desktop JSON layout."""
+    mcp_servers: dict[str, Any] = {}
+    for srv in file_model.servers:
+        entry: dict[str, Any] = {"transport": srv.transport.value}
+        if srv.command is not None:
+            entry["command"] = srv.command
+        if srv.args:
+            entry["args"] = list(srv.args)
+        if srv.env:
+            entry["env"] = dict(srv.env)
+        if srv.url is not None:
+            entry["url"] = srv.url
+        if srv.timeout_seconds != 30.0:
+            entry["timeoutSeconds"] = srv.timeout_seconds
+        mcp_servers[srv.name] = entry
+    return {"version": file_model.version, "mcpServers": mcp_servers}
+
+
+def write(
+    servers: Iterable[McpServerConfig | dict[str, Any]],
+    *,
+    path: Path | None = None,
+) -> Path:
+    """Write *servers* to the MCP servers JSON file (creates parent dir).
+
+    Args:
+        servers: Iterable of server entries (models or dicts).
+        path: Override destination path (defaults to :data:`DEFAULT_CONFIG_PATH`).
+
+    Returns:
+        The resolved destination path.
+
+    Raises:
+        ValueError: If validation fails (duplicate names, malformed env
+            placeholders, missing required fields).
+        TypeError: If an entry is neither :class:`McpServerConfig` nor dict.
+    """
+    target = path if path is not None else DEFAULT_CONFIG_PATH
+    try:
+        validated = _coerce_to_canonical_servers(servers)
+        file_model = McpServersFile(servers=validated)
+    except ValidationError as exc:
+        raise ValueError(str(exc)) from exc
+
+    # Pre-flight env placeholder check so the writer fails loudly on bad input.
+    for srv in file_model.servers:
+        for raw in srv.env.values():
+            validate_env_placeholders(raw)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = _to_claude_desktop_dict(file_model)
+    target.write_text(
+        json.dumps(payload, indent=2, sort_keys=False) + "\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def read(*, path: Path | None = None) -> McpServersFile:
+    """Read the MCP servers file. Returns an empty file model if missing.
+
+    Args:
+        path: Override source path.
+
+    Returns:
+        Parsed :class:`McpServersFile`. Empty when the file does not exist.
+
+    Raises:
+        ValueError: If the file is malformed JSON.
+    """
+    source = path if path is not None else DEFAULT_CONFIG_PATH
+    if not source.exists():
+        return McpServersFile()
+
+    try:
+        raw = json.loads(source.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValueError(f"Failed to read MCP servers file at {source}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        return McpServersFile()
+
+    # Two accepted shapes: flat ``{"servers": [...]}`` and Claude-Desktop
+    # ``{"mcpServers": {name: {...}}}``. Normalise to the flat form.
+    if isinstance(raw.get("mcpServers"), dict):
+        flat: list[dict[str, Any]] = []
+        for name, entry in raw["mcpServers"].items():
+            if not isinstance(entry, dict):
+                continue
+            flat.append({**entry, "name": name})
+        raw = {"version": raw.get("version", 1), "servers": flat}
+
+    servers_raw = raw.get("servers", [])
+    if not isinstance(servers_raw, list):
+        return McpServersFile()
+
+    good: list[dict[str, Any]] = []
+    for entry in servers_raw:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            McpServerConfig(**entry)
+            good.append(entry)
+        except (ValidationError, TypeError):
+            continue
+    raw["servers"] = good
+
+    try:
+        return McpServersFile(**raw)
+    except ValidationError:
+        return McpServersFile()
+
+
+load = read

--- a/src/shared/python/ai/mcp/widgets/__init__.py
+++ b/src/shared/python/ai/mcp/widgets/__init__.py
@@ -1,0 +1,41 @@
+"""Shared Qt widgets for MCP and integration preferences.
+
+This package is the canonical home for any MCP-related UI surface that
+ships in more than one consumer (UpstreamDrift launcher,
+Gasification_Model preferences, future apps). Local copies in consumer
+repos are explicitly disallowed — extract here instead.
+
+Public widgets:
+    * :class:`McpServersPrefsWidget` — preferences pane that lets the
+      user add / edit / remove MCP servers.
+    * :class:`IntegrationsHealthDashboardWidget` — live dashboard of
+      every configured integration's health.
+    * :func:`health_query_api.list_all_integrations` — pure-data
+      counterpart for non-GUI callers.
+"""
+
+from __future__ import annotations
+
+from src.shared.python.ai.mcp.widgets.health_query_api import (
+    IntegrationStatus,
+    IntegrationStatusLevel,
+    list_all_integrations,
+    query_integration_status,
+)
+from src.shared.python.ai.mcp.widgets.integrations_health_dashboard_widget import (
+    IntegrationsHealthDashboardWidget,
+)
+from src.shared.python.ai.mcp.widgets.mcp_servers_prefs_widget import (
+    McpServerEditDialog,
+    McpServersPrefsWidget,
+)
+
+__all__ = [
+    "IntegrationStatus",
+    "IntegrationStatusLevel",
+    "IntegrationsHealthDashboardWidget",
+    "McpServerEditDialog",
+    "McpServersPrefsWidget",
+    "list_all_integrations",
+    "query_integration_status",
+]

--- a/src/shared/python/ai/mcp/widgets/health_query_api.py
+++ b/src/shared/python/ai/mcp/widgets/health_query_api.py
@@ -1,0 +1,277 @@
+"""Pure-data health query API for AI integrations.
+
+This module is intentionally Qt-free. Anything (CLI, alt-GUI, server-side
+diagnostics) can call :func:`query_integration_status` and
+:func:`list_all_integrations` and get the same per-integration health
+snapshot the dashboard widget displays.
+
+Each integration is described by a small probe function that returns
+:class:`IntegrationStatus`. Probes must never raise — they catch their
+own failures and surface them as ``ERROR``-level statuses.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Protocol
+
+__all__ = [
+    "IntegrationStatus",
+    "IntegrationStatusLevel",
+    "list_all_integrations",
+    "query_integration_status",
+]
+
+
+class IntegrationStatusLevel(StrEnum):
+    """Health-level taxonomy for an integration row."""
+
+    OK = "ok"
+    DEGRADED = "degraded"
+    ERROR = "error"
+    UNCONFIGURED = "unconfigured"
+
+
+@dataclass(frozen=True)
+class IntegrationStatus:
+    """A snapshot of one integration's health.
+
+    Attributes:
+        integration_id: Stable identifier (e.g. ``"linear"``).
+        display_name: Human-facing label (e.g. ``"Linear"``).
+        level: Status bucket.
+        message: One-line human description (last error / "connected" / etc.).
+        tools_exposed: How many tools this integration currently exposes.
+        latency_ms: Last-probe latency in milliseconds (0 if unknown).
+        last_success_iso: ISO-8601 timestamp of last successful probe, if any.
+    """
+
+    integration_id: str
+    display_name: str
+    level: IntegrationStatusLevel
+    message: str = ""
+    tools_exposed: int = 0
+    latency_ms: float = 0.0
+    last_success_iso: str | None = None
+
+
+class _Pool(Protocol):
+    """Subset of :class:`McpClientPool` the dashboard needs."""
+
+    def connected_count(self) -> int: ...
+    def total_count(self) -> int: ...
+
+
+# ---------------------------------------------------------------------------
+# Probes (one per integration). Each takes no arguments and returns a status.
+# ---------------------------------------------------------------------------
+
+
+def _probe_linear() -> IntegrationStatus:
+    start = time.perf_counter()
+    token = os.environ.get("LINEAR_API_KEY")
+    if not token:
+        # Also check the module-level cached token used by linear.py.
+        try:
+            from src.shared.python.ai.integrations import linear as linear_mod
+
+            token = getattr(linear_mod, "_LINEAR_API_TOKEN", None)
+        except ImportError:
+            token = None
+    if not token:
+        return IntegrationStatus(
+            integration_id="linear",
+            display_name="Linear",
+            level=IntegrationStatusLevel.UNCONFIGURED,
+            message="LINEAR_API_KEY not set",
+        )
+    latency = (time.perf_counter() - start) * 1000
+    return IntegrationStatus(
+        integration_id="linear",
+        display_name="Linear",
+        level=IntegrationStatusLevel.OK,
+        message="token configured",
+        tools_exposed=0,
+        latency_ms=latency,
+    )
+
+
+def _probe_notion() -> IntegrationStatus:
+    start = time.perf_counter()
+    token = os.environ.get("NOTION_API_KEY") or os.environ.get("NOTION_TOKEN")
+    if not token:
+        try:
+            from src.shared.python.ai.integrations import notion as notion_mod
+
+            token = getattr(notion_mod, "_NOTION_API_TOKEN", None)
+        except ImportError:
+            token = None
+    if not token:
+        return IntegrationStatus(
+            integration_id="notion",
+            display_name="Notion",
+            level=IntegrationStatusLevel.UNCONFIGURED,
+            message="NOTION_API_KEY not set",
+        )
+    latency = (time.perf_counter() - start) * 1000
+    return IntegrationStatus(
+        integration_id="notion",
+        display_name="Notion",
+        level=IntegrationStatusLevel.OK,
+        message="token configured",
+        latency_ms=latency,
+    )
+
+
+def _probe_affine() -> IntegrationStatus:
+    start = time.perf_counter()
+    token = os.environ.get("AFFINE_API_KEY")
+    if not token:
+        try:
+            from src.shared.python.ai.integrations import affine as affine_mod
+
+            token = getattr(affine_mod, "_AFFINE_API_TOKEN", None)
+        except ImportError:
+            token = None
+    if not token:
+        return IntegrationStatus(
+            integration_id="affine",
+            display_name="AFFiNE",
+            level=IntegrationStatusLevel.UNCONFIGURED,
+            message="AFFINE_API_KEY not set",
+        )
+    latency = (time.perf_counter() - start) * 1000
+    return IntegrationStatus(
+        integration_id="affine",
+        display_name="AFFiNE",
+        level=IntegrationStatusLevel.OK,
+        message="token configured",
+        latency_ms=latency,
+    )
+
+
+def _probe_obsidian() -> IntegrationStatus:
+    start = time.perf_counter()
+    vault_path = os.environ.get("OBSIDIAN_VAULT_PATH")
+    if not vault_path:
+        try:
+            from src.shared.python.ai.integrations import obsidian as obsidian_mod
+
+            vault_path = getattr(obsidian_mod, "_VAULT_PATH", None)
+        except ImportError:
+            vault_path = None
+    if not vault_path:
+        return IntegrationStatus(
+            integration_id="obsidian",
+            display_name="Obsidian",
+            level=IntegrationStatusLevel.UNCONFIGURED,
+            message="OBSIDIAN_VAULT_PATH not set",
+        )
+    latency = (time.perf_counter() - start) * 1000
+    return IntegrationStatus(
+        integration_id="obsidian",
+        display_name="Obsidian",
+        level=IntegrationStatusLevel.OK,
+        message=f"vault: {vault_path}",
+        latency_ms=latency,
+    )
+
+
+def _probe_mcp_pool(pool: _Pool | None) -> IntegrationStatus:
+    if pool is None:
+        return IntegrationStatus(
+            integration_id="mcp-pool",
+            display_name="MCP Pool",
+            level=IntegrationStatusLevel.UNCONFIGURED,
+            message="no pool injected",
+        )
+    try:
+        connected = int(pool.connected_count())
+        total = int(pool.total_count())
+    except (AttributeError, TypeError, ValueError) as exc:
+        return IntegrationStatus(
+            integration_id="mcp-pool",
+            display_name="MCP Pool",
+            level=IntegrationStatusLevel.ERROR,
+            message=f"pool probe failed: {exc}",
+        )
+    if total == 0:
+        level = IntegrationStatusLevel.UNCONFIGURED
+        message = "no servers configured"
+    elif connected == total:
+        level = IntegrationStatusLevel.OK
+        message = f"{connected}/{total} servers connected"
+    elif connected == 0:
+        level = IntegrationStatusLevel.ERROR
+        message = f"0/{total} servers connected"
+    else:
+        level = IntegrationStatusLevel.DEGRADED
+        message = f"{connected}/{total} servers connected"
+    return IntegrationStatus(
+        integration_id="mcp-pool",
+        display_name="MCP Pool",
+        level=level,
+        message=message,
+        tools_exposed=connected,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Probe registry
+# ---------------------------------------------------------------------------
+
+_PROBES: dict[str, Any] = {
+    "linear": _probe_linear,
+    "notion": _probe_notion,
+    "affine": _probe_affine,
+    "obsidian": _probe_obsidian,
+}
+
+
+def query_integration_status(integration_id: str) -> IntegrationStatus:
+    """Probe one integration by id.
+
+    Args:
+        integration_id: Stable integration identifier.
+
+    Returns:
+        :class:`IntegrationStatus`. Unknown ids return
+        :attr:`IntegrationStatusLevel.UNCONFIGURED` rather than raising
+        so callers can render them as a row.
+
+    Raises:
+        TypeError: If *integration_id* is not a string.
+    """
+    if not isinstance(integration_id, str):
+        raise TypeError(
+            f"integration_id must be str, got {type(integration_id).__name__}"
+        )
+    probe = _PROBES.get(integration_id)
+    if probe is None:
+        return IntegrationStatus(
+            integration_id=integration_id,
+            display_name=integration_id.title(),
+            level=IntegrationStatusLevel.UNCONFIGURED,
+            message="no probe registered",
+        )
+    return probe()
+
+
+def list_all_integrations(*, mcp_pool: _Pool | None = None) -> list[IntegrationStatus]:
+    """Return the health snapshot for every known integration.
+
+    Args:
+        mcp_pool: Optional :class:`McpClientPool` for the ``mcp-pool`` row.
+            Injected because the pool is a long-lived runtime singleton
+            that we don't want to construct just to probe.
+
+    Returns:
+        List of :class:`IntegrationStatus` (alphabetical by id then with
+        ``mcp-pool`` appended).
+    """
+    rows = [query_integration_status(name) for name in sorted(_PROBES)]
+    rows.append(_probe_mcp_pool(mcp_pool))
+    return rows

--- a/src/shared/python/ai/mcp/widgets/integrations_health_dashboard_widget.py
+++ b/src/shared/python/ai/mcp/widgets/integrations_health_dashboard_widget.py
@@ -1,0 +1,184 @@
+"""Shared Qt widget — Integrations Health Dashboard.
+
+Surfaces live status for every configured integration in a single table
+view: Linear, Notion, AFFiNE, Obsidian, MCP pool, and any others
+registered through :mod:`health_query_api`.
+
+Design constraints:
+    * Status data is sourced through an injected ``status_provider``
+      callable (default: :func:`health_query_api.list_all_integrations`)
+      so tests can deterministically seed rows without standing up real
+      integrations.
+    * A failing provider must never crash the host app; the dashboard
+      surfaces the exception as an ERROR row.
+    * The widget exposes ``row_data`` as a list of plain dicts so tests
+      and other Qt-free callers can inspect state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from PyQt6.QtCore import QTimer, pyqtSignal
+from PyQt6.QtWidgets import (
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QStackedLayout,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.ai.mcp.widgets.health_query_api import (
+    IntegrationStatus,
+    IntegrationStatusLevel,
+    list_all_integrations,
+)
+
+__all__ = ["IntegrationsHealthDashboardWidget"]
+
+_StatusProvider = Callable[[], list[IntegrationStatus]]
+
+_HEADERS = ("Integration", "Status", "Tools", "Latency (ms)", "Message")
+_AUTO_REFRESH_MS = 30_000
+
+
+class IntegrationsHealthDashboardWidget(QWidget):
+    """Dashboard table showing integration health.
+
+    Args:
+        status_provider: Zero-arg callable returning a list of
+            :class:`IntegrationStatus`. Defaults to
+            :func:`list_all_integrations`.
+        auto_refresh: If True, refresh every 30 s via a QTimer. Defaults
+            to False so tests don't see background ticks.
+        parent: Standard Qt parent.
+
+    Signals:
+        refreshed: Emitted after every refresh (success or error).
+    """
+
+    refreshed = pyqtSignal()
+
+    def __init__(
+        self,
+        *,
+        status_provider: _StatusProvider | None = None,
+        auto_refresh: bool = False,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._provider: _StatusProvider = status_provider or list_all_integrations
+        self._row_data: list[dict[str, Any]] = []
+
+        outer = QVBoxLayout(self)
+        self._stack = QStackedLayout()
+        outer.addLayout(self._stack)
+
+        # Empty-state label.
+        self._empty_label = QLabel(
+            "No integrations configured — set environment variables "
+            "(LINEAR_API_KEY, NOTION_API_KEY, …) or add MCP servers to "
+            "see status here."
+        )
+        self._empty_label.setWordWrap(True)
+        empty_container = QWidget(self)
+        QVBoxLayout(empty_container).addWidget(self._empty_label)
+        self._stack.addWidget(empty_container)
+
+        # Table view.
+        self._table = QTableWidget(0, len(_HEADERS), self)
+        self._table.setHorizontalHeaderLabels(_HEADERS)
+        header = self._table.horizontalHeader()
+        if header is not None:
+            header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        self._stack.addWidget(self._table)
+
+        # Refresh button.
+        btn_row = QHBoxLayout()
+        self._refresh_btn = QPushButton("Refresh", self)
+        self._refresh_btn.clicked.connect(self.refresh)
+        btn_row.addStretch(1)
+        btn_row.addWidget(self._refresh_btn)
+        outer.addLayout(btn_row)
+
+        # Auto-refresh timer (opt-in).
+        self._timer: QTimer | None = None
+        if auto_refresh:
+            self._timer = QTimer(self)
+            self._timer.setInterval(_AUTO_REFRESH_MS)
+            self._timer.timeout.connect(self.refresh)
+            self._timer.start()
+
+        # Initial state: empty until refresh().
+        self._stack.setCurrentIndex(0)
+
+    # ------------------------------------------------------------------ #
+    # Public read API
+    # ------------------------------------------------------------------ #
+
+    @property
+    def row_count(self) -> int:
+        return len(self._row_data)
+
+    @property
+    def row_data(self) -> list[dict[str, Any]]:
+        """List of plain-dict rows; safe for tests and headless callers."""
+        return [dict(r) for r in self._row_data]
+
+    @property
+    def has_empty_state_visible(self) -> bool:
+        return self._stack.currentIndex() == 0
+
+    # ------------------------------------------------------------------ #
+    # Public mutation API
+    # ------------------------------------------------------------------ #
+
+    def refresh(self) -> None:
+        """Re-query the provider and re-render rows. Never raises."""
+        try:
+            statuses = list(self._provider())
+        except Exception as exc:  # noqa: BLE001 — dashboard must not crash host
+            statuses = [
+                IntegrationStatus(
+                    integration_id="dashboard",
+                    display_name="Dashboard",
+                    level=IntegrationStatusLevel.ERROR,
+                    message=str(exc),
+                )
+            ]
+
+        self._row_data = [self._status_to_row(s) for s in statuses]
+        self._render_table()
+        self._stack.setCurrentIndex(0 if not self._row_data else 1)
+        self.refreshed.emit()
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _status_to_row(status: IntegrationStatus) -> dict[str, Any]:
+        return {
+            "integration_id": status.integration_id,
+            "display_name": status.display_name,
+            "level": status.level.value,
+            "tools_exposed": status.tools_exposed,
+            "latency_ms": status.latency_ms,
+            "message": status.message,
+        }
+
+    def _render_table(self) -> None:
+        self._table.setRowCount(0)
+        for row in self._row_data:
+            idx = self._table.rowCount()
+            self._table.insertRow(idx)
+            self._table.setItem(idx, 0, QTableWidgetItem(row["display_name"]))
+            self._table.setItem(idx, 1, QTableWidgetItem(row["level"]))
+            self._table.setItem(idx, 2, QTableWidgetItem(str(row["tools_exposed"])))
+            self._table.setItem(idx, 3, QTableWidgetItem(f"{row['latency_ms']:.1f}"))
+            self._table.setItem(idx, 4, QTableWidgetItem(row["message"]))

--- a/src/shared/python/ai/mcp/widgets/mcp_servers_prefs_widget.py
+++ b/src/shared/python/ai/mcp/widgets/mcp_servers_prefs_widget.py
@@ -1,0 +1,356 @@
+"""Shared Qt widget for MCP server preferences.
+
+Canonical home for the MCP servers preferences UI. Both UpstreamDrift
+and Gasification_Model embed this widget — neither owns a copy.
+
+Design:
+    * The widget is a proper :class:`QWidget` subclass so it can be
+      embedded directly in any host preferences dialog.
+    * Persistence is delegated to
+      :mod:`src.shared.python.ai.mcp.config_writer` (LoD: this widget
+      does not own the on-disk format).
+    * Presets and Claude-Desktop import are wired through small adapter
+      hooks so consumers can override them without subclassing.
+    * A ``servers_changed`` signal lets the host dialog know when to
+      enable a Save button.
+
+LoD: the widget consumes :class:`McpServerConfig` and
+:func:`config_writer.read` / :func:`config_writer.write` only — nothing
+else.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QHBoxLayout,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from src.shared.python.ai.mcp.config_writer import (
+    DEFAULT_CONFIG_PATH,
+    read,
+    write,
+)
+from src.shared.python.ai.mcp.contracts import McpServerConfig, McpTransport
+
+__all__ = [
+    "McpServerEditDialog",
+    "McpServersPrefsWidget",
+]
+
+_LOG = logging.getLogger(__name__)
+
+
+def _discover_claude_desktop_servers() -> list[McpServerConfig]:
+    """Hook: return any MCP servers configured in Claude Desktop.
+
+    Replaced by a richer implementation in Tools issue #2901 (preset +
+    import wave). Until that lands, this returns an empty list. Tests
+    monkeypatch this symbol to supply fake imports.
+    """
+    return []
+
+
+class McpServerEditDialog:
+    """Modal dialog for adding or editing a single MCP server entry.
+
+    Façade over a :class:`QDialog` so tests can drive validation logic
+    without instantiating the full Qt event loop.
+    """
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        initial: McpServerConfig | None = None,
+    ) -> None:
+        self._parent = parent
+        self._initial = initial
+        self._inputs: dict[str, Any] = {}
+
+    def show(self) -> McpServerConfig | None:
+        """Display the dialog modally; return the saved entry or None."""
+        dialog = QDialog(self._parent)
+        dialog.setWindowTitle("MCP Server")
+        form = QFormLayout(dialog)
+
+        name_edit = QLineEdit()
+        command_edit = QLineEdit()
+        args_edit = QLineEdit()
+        env_edit = QLineEdit()
+        enabled_box = QCheckBox("Enabled")
+        enabled_box.setChecked(True)
+
+        if self._initial is not None:
+            name_edit.setText(self._initial.name)
+            command_edit.setText(self._initial.command or "")
+            args_edit.setText(" ".join(self._initial.args))
+            env_edit.setText(",".join(f"{k}={v}" for k, v in self._initial.env.items()))
+
+        form.addRow("Name:", name_edit)
+        form.addRow("Command:", command_edit)
+        form.addRow("Args (space-separated):", args_edit)
+        form.addRow("Env (KEY=VALUE,KEY=VALUE):", env_edit)
+        form.addRow(enabled_box)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel
+        )
+        form.addRow(buttons)
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+
+        self._inputs = {
+            "name": name_edit,
+            "command": command_edit,
+            "args": args_edit,
+            "env": env_edit,
+            "enabled": enabled_box,
+        }
+
+        if dialog.exec() != QDialog.DialogCode.Accepted:
+            return None
+        try:
+            return self._build_entry()
+        except ValueError as exc:
+            QMessageBox.warning(self._parent, "Invalid MCP server entry", str(exc))
+            return None
+
+    def _build_entry(self) -> McpServerConfig:
+        name = self._inputs["name"].text().strip()
+        command = self._inputs["command"].text().strip()
+        args = [a for a in self._inputs["args"].text().split() if a]
+        env: dict[str, str] = {}
+        for pair in self._inputs["env"].text().split(","):
+            pair_s = pair.strip()
+            if not pair_s:
+                continue
+            if "=" not in pair_s:
+                raise ValueError(f"Env entry {pair_s!r} is missing '=' — use KEY=VALUE")
+            key, _, value = pair_s.partition("=")
+            env[key.strip()] = value.strip()
+        return McpServerConfig(
+            name=name,
+            transport=McpTransport.STDIO,
+            command=command,
+            args=args,
+            env=env,
+        )
+
+
+class McpServersPrefsWidget(QWidget):
+    """Qt widget for managing MCP servers in a preferences pane.
+
+    Signals:
+        servers_changed: Emitted whenever the in-memory server list
+            mutates (add/edit/remove/import). Hosts wire this to enable
+            a "Save" button.
+
+    Args:
+        config_path: Override the on-disk JSON path (defaults to
+            ``~/.upstreamdrift/mcp_servers.json``). Useful for tests.
+        parent: Standard Qt parent.
+    """
+
+    servers_changed = pyqtSignal()
+
+    def __init__(
+        self,
+        *,
+        config_path: Path | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._config_path = config_path or DEFAULT_CONFIG_PATH
+        self._servers: list[McpServerConfig] = []
+
+        outer = QVBoxLayout(self)
+        self._table = QTableWidget(0, 4, self)
+        self._table.setHorizontalHeaderLabels(["Name", "Command", "Args", "Enabled"])
+        outer.addWidget(self._table)
+
+        btn_row = QHBoxLayout()
+        self._add_btn = QPushButton("Add…", self)
+        self._edit_btn = QPushButton("Edit…", self)
+        self._remove_btn = QPushButton("Remove", self)
+        self._import_btn = QPushButton("Import from Claude Desktop", self)
+        self._save_btn = QPushButton("Save", self)
+        for btn in (
+            self._add_btn,
+            self._edit_btn,
+            self._remove_btn,
+            self._import_btn,
+            self._save_btn,
+        ):
+            btn_row.addWidget(btn)
+        btn_row.addStretch(1)
+        outer.addLayout(btn_row)
+
+        self._add_btn.clicked.connect(self._on_add)
+        self._edit_btn.clicked.connect(self._on_edit)
+        self._remove_btn.clicked.connect(self._on_remove)
+        self._import_btn.clicked.connect(self.import_from_claude_desktop)
+        self._save_btn.clicked.connect(self.persist)
+
+        self._load_initial()
+
+    # ------------------------------------------------------------------ #
+    # Public read API
+    # ------------------------------------------------------------------ #
+
+    @property
+    def server_count(self) -> int:
+        """Number of currently-configured MCP servers."""
+        return len(self._servers)
+
+    @property
+    def servers(self) -> list[McpServerConfig]:
+        """A defensive copy of the configured server list."""
+        return list(self._servers)
+
+    # ------------------------------------------------------------------ #
+    # Public mutation API (programmatic — used by tests + presets)
+    # ------------------------------------------------------------------ #
+
+    def add_server(self, server: McpServerConfig) -> None:
+        """Append *server* to the configured list.
+
+        Raises:
+            TypeError: If *server* is not an :class:`McpServerConfig`.
+            ValueError: If a server with the same name already exists.
+        """
+        if not isinstance(server, McpServerConfig):
+            raise TypeError(
+                f"server must be McpServerConfig, got {type(server).__name__}"
+            )
+        if any(s.name == server.name for s in self._servers):
+            raise ValueError(f"server already configured: {server.name}")
+        self._servers.append(server)
+        self._refresh_table()
+        self.servers_changed.emit()
+
+    def remove_server(self, name: str) -> bool:
+        """Remove the server named *name*. Returns True if anything changed."""
+        if not isinstance(name, str):
+            raise TypeError(f"name must be str, got {type(name).__name__}")
+        before = len(self._servers)
+        self._servers = [s for s in self._servers if s.name != name]
+        changed = len(self._servers) < before
+        if changed:
+            self._refresh_table()
+            self.servers_changed.emit()
+        return changed
+
+    def apply_preset(self, preset: McpServerConfig) -> bool:
+        """Add *preset* if no server with that name exists.
+
+        Returns:
+            True if added, False if a server with that name was already
+            present (preset apply is idempotent).
+        """
+        if not isinstance(preset, McpServerConfig):
+            raise TypeError(
+                f"preset must be McpServerConfig, got {type(preset).__name__}"
+            )
+        if any(s.name == preset.name for s in self._servers):
+            return False
+        self._servers.append(preset)
+        self._refresh_table()
+        self.servers_changed.emit()
+        return True
+
+    def import_from_claude_desktop(self) -> int:
+        """Import servers configured in Claude Desktop. Returns count added."""
+        discovered = _discover_claude_desktop_servers()
+        added = 0
+        for srv in discovered:
+            if any(existing.name == srv.name for existing in self._servers):
+                continue
+            self._servers.append(srv)
+            added += 1
+        if added:
+            self._refresh_table()
+            self.servers_changed.emit()
+        return added
+
+    def persist(self) -> Path:
+        """Write the current server list to :data:`config_path`."""
+        return write(self._servers, path=self._config_path)
+
+    def replace_all(self, servers: Iterable[McpServerConfig]) -> None:
+        """Replace the entire server list (used after external edits)."""
+        new_list = list(servers)
+        for srv in new_list:
+            if not isinstance(srv, McpServerConfig):
+                raise TypeError("all entries must be McpServerConfig")
+        self._servers = new_list
+        self._refresh_table()
+        self.servers_changed.emit()
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _load_initial(self) -> None:
+        try:
+            loaded = read(path=self._config_path)
+            self._servers = list(loaded.servers)
+        except ValueError as exc:
+            _LOG.warning("Failed to load %s: %s", self._config_path, exc)
+            self._servers = []
+        self._refresh_table()
+
+    def _refresh_table(self) -> None:
+        self._table.setRowCount(0)
+        for srv in self._servers:
+            row = self._table.rowCount()
+            self._table.insertRow(row)
+            self._table.setItem(row, 0, QTableWidgetItem(srv.name))
+            self._table.setItem(row, 1, QTableWidgetItem(srv.command or ""))
+            self._table.setItem(row, 2, QTableWidgetItem(" ".join(srv.args)))
+            self._table.setItem(row, 3, QTableWidgetItem("yes"))
+
+    def _on_add(self) -> None:
+        dialog = McpServerEditDialog(self)
+        entry = dialog.show()
+        if entry is None:
+            return
+        try:
+            self.add_server(entry)
+        except ValueError as exc:
+            QMessageBox.warning(self, "Duplicate server", str(exc))
+
+    def _on_edit(self) -> None:
+        row = self._table.currentRow()
+        if row < 0 or row >= len(self._servers):
+            return
+        dialog = McpServerEditDialog(self, initial=self._servers[row])
+        entry = dialog.show()
+        if entry is None:
+            return
+        self._servers[row] = entry
+        self._refresh_table()
+        self.servers_changed.emit()
+
+    def _on_remove(self) -> None:
+        row = self._table.currentRow()
+        if row < 0 or row >= len(self._servers):
+            return
+        name = self._servers[row].name
+        self.remove_server(name)

--- a/tests/unit/ai/mcp/widgets/__init__.py
+++ b/tests/unit/ai/mcp/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for shared MCP widget package (Tools shared)."""

--- a/tests/unit/ai/mcp/widgets/test_health_query_api.py
+++ b/tests/unit/ai/mcp/widgets/test_health_query_api.py
@@ -1,0 +1,107 @@
+"""Tests for the integrations health query API (pure-data layer).
+
+This API is consumed by the IntegrationsHealthDashboardWidget but is
+intentionally Qt-free so that any consumer (CLI, server, alt-GUI) can
+ask the same question: "which integrations are healthy right now?"
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.shared.python.ai.mcp.widgets.health_query_api import (
+    IntegrationStatus,
+    IntegrationStatusLevel,
+    list_all_integrations,
+    query_integration_status,
+)
+
+
+@pytest.mark.unit
+class TestIntegrationStatus:
+    def test_round_trip(self) -> None:
+        status = IntegrationStatus(
+            integration_id="linear",
+            display_name="Linear",
+            level=IntegrationStatusLevel.OK,
+            message="connected",
+            tools_exposed=4,
+            latency_ms=23.5,
+        )
+        assert status.integration_id == "linear"
+        assert status.level is IntegrationStatusLevel.OK
+        assert status.tools_exposed == 4
+
+    def test_level_enum_values(self) -> None:
+        assert IntegrationStatusLevel.OK.value == "ok"
+        assert IntegrationStatusLevel.DEGRADED.value == "degraded"
+        assert IntegrationStatusLevel.ERROR.value == "error"
+        assert IntegrationStatusLevel.UNCONFIGURED.value == "unconfigured"
+
+
+@pytest.mark.unit
+class TestQueryIntegrationStatus:
+    def test_unknown_integration_returns_unconfigured(self) -> None:
+        status = query_integration_status("does-not-exist")
+        assert status.level is IntegrationStatusLevel.UNCONFIGURED
+        assert status.integration_id == "does-not-exist"
+
+    def test_linear_uses_token_probe(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LINEAR_API_KEY", "lin_test_token")
+        status = query_integration_status("linear")
+        assert status.integration_id == "linear"
+        # With a token set we are at least "configured" (not UNCONFIGURED).
+        assert status.level is not IntegrationStatusLevel.UNCONFIGURED
+
+    def test_linear_without_token_unconfigured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+        # Also clear any module-level token cached.
+        from src.shared.python.ai.integrations import linear as linear_mod
+
+        linear_mod._LINEAR_API_TOKEN = None  # noqa: SLF001 — test cleanup
+        status = query_integration_status("linear")
+        assert status.level is IntegrationStatusLevel.UNCONFIGURED
+
+
+@pytest.mark.unit
+class TestListAllIntegrations:
+    def test_lists_known_integrations(self) -> None:
+        statuses = list_all_integrations()
+        ids = {s.integration_id for s in statuses}
+        # Core set must be present.
+        assert "linear" in ids
+        assert "notion" in ids
+        assert "affine" in ids
+        assert "obsidian" in ids
+        assert "mcp-pool" in ids
+
+    def test_mcp_pool_status_with_injected_pool(self) -> None:
+        # The pool is injected so tests don't need a real one.
+        pool = MagicMock()
+        pool.connected_count.return_value = 2
+        pool.total_count.return_value = 3
+        statuses = list_all_integrations(mcp_pool=pool)
+        mcp_status = next(s for s in statuses if s.integration_id == "mcp-pool")
+        assert mcp_status.tools_exposed >= 0
+        # 2 of 3 connected → DEGRADED (partial connectivity).
+        assert mcp_status.level is IntegrationStatusLevel.DEGRADED
+
+    def test_mcp_pool_all_connected_is_ok(self) -> None:
+        pool = MagicMock()
+        pool.connected_count.return_value = 3
+        pool.total_count.return_value = 3
+        statuses = list_all_integrations(mcp_pool=pool)
+        mcp_status = next(s for s in statuses if s.integration_id == "mcp-pool")
+        assert mcp_status.level is IntegrationStatusLevel.OK
+
+    def test_mcp_pool_zero_total_is_unconfigured(self) -> None:
+        pool = MagicMock()
+        pool.connected_count.return_value = 0
+        pool.total_count.return_value = 0
+        statuses = list_all_integrations(mcp_pool=pool)
+        mcp_status = next(s for s in statuses if s.integration_id == "mcp-pool")
+        assert mcp_status.level is IntegrationStatusLevel.UNCONFIGURED

--- a/tests/unit/ai/mcp/widgets/test_integrations_health_dashboard_widget.py
+++ b/tests/unit/ai/mcp/widgets/test_integrations_health_dashboard_widget.py
@@ -1,0 +1,135 @@
+"""Tests for the shared IntegrationsHealthDashboardWidget.
+
+This widget surfaces live status for every configured integration
+(Linear / Notion / Affine / Obsidian / MCP pool / providers / GitHub).
+It pulls data from the pure-data health_query_api module so that the
+same data is available to non-GUI consumers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("PyQt6.QtWidgets")
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from src.shared.python.ai.mcp.widgets.health_query_api import (  # noqa: E402
+    IntegrationStatus,
+    IntegrationStatusLevel,
+)
+from src.shared.python.ai.mcp.widgets.integrations_health_dashboard_widget import (  # noqa: E402
+    IntegrationsHealthDashboardWidget,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _make_status(
+    integration_id: str = "linear",
+    *,
+    level: IntegrationStatusLevel = IntegrationStatusLevel.OK,
+    tools: int = 3,
+) -> IntegrationStatus:
+    return IntegrationStatus(
+        integration_id=integration_id,
+        display_name=integration_id.title(),
+        level=level,
+        message="seeded",
+        tools_exposed=tools,
+        latency_ms=10.0,
+    )
+
+
+@pytest.mark.unit
+class TestIntegrationsHealthDashboardWidgetConstruction:
+    def test_construct_empty(self, qapp: QApplication) -> None:
+        widget = IntegrationsHealthDashboardWidget(status_provider=lambda: [])
+        assert widget.row_count == 0
+        # An empty state label should be visible.
+        assert widget.has_empty_state_visible
+
+    def test_construct_with_seed(self, qapp: QApplication) -> None:
+        widget = IntegrationsHealthDashboardWidget(
+            status_provider=lambda: [_make_status("linear")]
+        )
+        widget.refresh()
+        assert widget.row_count == 1
+        assert not widget.has_empty_state_visible
+
+
+@pytest.mark.unit
+class TestIntegrationsHealthDashboardWidgetRefresh:
+    def test_refresh_replaces_rows(self, qapp: QApplication) -> None:
+        sequence = iter(
+            [
+                [_make_status("linear")],
+                [_make_status("linear"), _make_status("notion")],
+            ]
+        )
+        widget = IntegrationsHealthDashboardWidget(
+            status_provider=lambda: next(sequence)
+        )
+        widget.refresh()
+        assert widget.row_count == 1
+        widget.refresh()
+        assert widget.row_count == 2
+
+    def test_refresh_button_triggers_provider(self, qapp: QApplication) -> None:
+        provider = MagicMock(return_value=[_make_status("linear")])
+        widget = IntegrationsHealthDashboardWidget(status_provider=provider)
+        widget.refresh()
+        widget.refresh()
+        assert provider.call_count == 2
+
+
+@pytest.mark.unit
+class TestIntegrationsHealthDashboardWidgetRowFormat:
+    def test_row_shows_display_name_and_status(self, qapp: QApplication) -> None:
+        widget = IntegrationsHealthDashboardWidget(
+            status_provider=lambda: [
+                _make_status("linear", level=IntegrationStatusLevel.OK, tools=4),
+                _make_status("notion", level=IntegrationStatusLevel.ERROR, tools=0),
+            ]
+        )
+        widget.refresh()
+        rows = widget.row_data
+        assert rows[0]["display_name"] == "Linear"
+        assert rows[0]["level"] == "ok"
+        assert rows[0]["tools_exposed"] == 4
+        assert rows[1]["level"] == "error"
+
+    def test_row_handles_unconfigured(self, qapp: QApplication) -> None:
+        widget = IntegrationsHealthDashboardWidget(
+            status_provider=lambda: [
+                _make_status("affine", level=IntegrationStatusLevel.UNCONFIGURED),
+            ]
+        )
+        widget.refresh()
+        rows = widget.row_data
+        assert rows[0]["level"] == "unconfigured"
+
+
+@pytest.mark.unit
+class TestIntegrationsHealthDashboardWidgetSafety:
+    def test_provider_exception_is_surfaced_as_error_row(
+        self, qapp: QApplication
+    ) -> None:
+        def boom() -> list[IntegrationStatus]:
+            raise RuntimeError("backend offline")
+
+        widget = IntegrationsHealthDashboardWidget(status_provider=boom)
+        widget.refresh()
+        # We expect a single error row reporting the failure rather than a
+        # raised exception (the dashboard must never crash the host app).
+        assert widget.row_count == 1
+        assert widget.row_data[0]["level"] == "error"
+        assert "backend offline" in widget.row_data[0]["message"]

--- a/tests/unit/ai/mcp/widgets/test_mcp_servers_prefs_widget.py
+++ b/tests/unit/ai/mcp/widgets/test_mcp_servers_prefs_widget.py
@@ -138,13 +138,11 @@ class TestMcpServersPrefsWidgetImport:
         tmp_config_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        from src.shared.python.ai.mcp.widgets import mcp_servers_prefs_widget as mod
+
         widget = McpServersPrefsWidget(config_path=tmp_config_path)
         # Force the discover hook to return an empty list.
-        monkeypatch.setattr(
-            "src.shared.python.ai.mcp.widgets.mcp_servers_prefs_widget"
-            "._discover_claude_desktop_servers",
-            lambda: [],
-        )
+        monkeypatch.setattr(mod, "_discover_claude_desktop_servers", lambda: [])
         imported = widget.import_from_claude_desktop()
         assert imported == 0
         assert widget.server_count == 0
@@ -155,16 +153,14 @@ class TestMcpServersPrefsWidgetImport:
         tmp_config_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        from src.shared.python.ai.mcp.widgets import mcp_servers_prefs_widget as mod
+
         widget = McpServersPrefsWidget(config_path=tmp_config_path)
         servers = [
             McpServerConfig(name="cd-srv-1", command="echo"),
             McpServerConfig(name="cd-srv-2", command="echo"),
         ]
-        monkeypatch.setattr(
-            "src.shared.python.ai.mcp.widgets.mcp_servers_prefs_widget"
-            "._discover_claude_desktop_servers",
-            lambda: servers,
-        )
+        monkeypatch.setattr(mod, "_discover_claude_desktop_servers", lambda: servers)
         imported = widget.import_from_claude_desktop()
         assert imported == 2
         assert widget.server_count == 2
@@ -175,17 +171,15 @@ class TestMcpServersPrefsWidgetImport:
         tmp_config_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        from src.shared.python.ai.mcp.widgets import mcp_servers_prefs_widget as mod
+
         widget = McpServersPrefsWidget(config_path=tmp_config_path)
         widget.add_server(McpServerConfig(name="cd-srv-1", command="echo"))
         servers = [
             McpServerConfig(name="cd-srv-1", command="echo"),
             McpServerConfig(name="cd-srv-2", command="echo"),
         ]
-        monkeypatch.setattr(
-            "src.shared.python.ai.mcp.widgets.mcp_servers_prefs_widget"
-            "._discover_claude_desktop_servers",
-            lambda: servers,
-        )
+        monkeypatch.setattr(mod, "_discover_claude_desktop_servers", lambda: servers)
         imported = widget.import_from_claude_desktop()
         # Only cd-srv-2 is new.
         assert imported == 1

--- a/tests/unit/ai/mcp/widgets/test_mcp_servers_prefs_widget.py
+++ b/tests/unit/ai/mcp/widgets/test_mcp_servers_prefs_widget.py
@@ -1,0 +1,204 @@
+"""Tests for the shared McpServersPrefsWidget.
+
+Architecture: this widget is the canonical home for the MCP server
+preferences UI. Both UpstreamDrift and Gasification_Model embed it in
+their preferences dialogs — neither owns a copy.
+
+The widget is Qt-based so tests run under a QApplication fixture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("PyQt6.QtWidgets")
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+from src.shared.python.ai.mcp.contracts import (  # noqa: E402
+    McpServerConfig,
+    McpTransport,
+)
+from src.shared.python.ai.mcp.widgets.mcp_servers_prefs_widget import (  # noqa: E402
+    McpServersPrefsWidget,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp() -> QApplication:
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.fixture()
+def tmp_config_path(tmp_path: Path) -> Path:
+    return tmp_path / "mcp_servers.json"
+
+
+@pytest.mark.unit
+class TestMcpServersPrefsWidgetConstruction:
+    def test_construct_empty(self, qapp: QApplication, tmp_config_path: Path) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        assert widget.server_count == 0
+
+    def test_construct_loads_existing(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        # Seed the config file with one server.
+        from src.shared.python.ai.mcp.config_writer import write
+
+        cfg = McpServerConfig(
+            name="notebooklm",
+            transport=McpTransport.STDIO,
+            command="python",
+            args=["-m", "notebooklm_mcp"],
+        )
+        write([cfg], path=tmp_config_path)
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        assert widget.server_count == 1
+        assert widget.servers[0].name == "notebooklm"
+
+
+@pytest.mark.unit
+class TestMcpServersPrefsWidgetCrud:
+    def test_add_server_programmatic(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        cfg = McpServerConfig(name="srv1", command="echo")
+        widget.add_server(cfg)
+        assert widget.server_count == 1
+
+    def test_add_server_rejects_non_config(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        with pytest.raises(TypeError):
+            widget.add_server("not-a-config")  # type: ignore[arg-type]
+
+    def test_remove_server_by_name(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        cfg = McpServerConfig(name="srv1", command="echo")
+        widget.add_server(cfg)
+        assert widget.remove_server("srv1") is True
+        assert widget.server_count == 0
+
+    def test_remove_server_missing_returns_false(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        assert widget.remove_server("nope") is False
+
+    def test_persist_writes_file(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        cfg = McpServerConfig(name="srv1", command="echo")
+        widget.add_server(cfg)
+        out = widget.persist()
+        assert out == tmp_config_path
+        assert tmp_config_path.exists()
+        assert "srv1" in tmp_config_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+class TestMcpServersPrefsWidgetPresets:
+    def test_apply_preset_adds_entry(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        # Use a fake preset that we register against the widget.
+        preset = McpServerConfig(name="preset-srv", command="echo", args=["hi"])
+        widget.apply_preset(preset)
+        assert widget.server_count == 1
+        assert widget.servers[0].name == "preset-srv"
+
+    def test_apply_preset_duplicate_name_skipped(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        preset = McpServerConfig(name="preset-srv", command="echo")
+        widget.apply_preset(preset)
+        widget.apply_preset(preset)  # second call must be a no-op
+        assert widget.server_count == 1
+
+
+@pytest.mark.unit
+class TestMcpServersPrefsWidgetImport:
+    def test_import_from_claude_desktop_no_op_when_missing(
+        self,
+        qapp: QApplication,
+        tmp_config_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        # Force the discover hook to return an empty list.
+        monkeypatch.setattr(
+            "src.shared.python.ai.mcp.widgets.mcp_servers_prefs_widget"
+            "._discover_claude_desktop_servers",
+            lambda: [],
+        )
+        imported = widget.import_from_claude_desktop()
+        assert imported == 0
+        assert widget.server_count == 0
+
+    def test_import_from_claude_desktop_adds_entries(
+        self,
+        qapp: QApplication,
+        tmp_config_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        servers = [
+            McpServerConfig(name="cd-srv-1", command="echo"),
+            McpServerConfig(name="cd-srv-2", command="echo"),
+        ]
+        monkeypatch.setattr(
+            "src.shared.python.ai.mcp.widgets.mcp_servers_prefs_widget"
+            "._discover_claude_desktop_servers",
+            lambda: servers,
+        )
+        imported = widget.import_from_claude_desktop()
+        assert imported == 2
+        assert widget.server_count == 2
+
+    def test_import_from_claude_desktop_skips_duplicates(
+        self,
+        qapp: QApplication,
+        tmp_config_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        widget.add_server(McpServerConfig(name="cd-srv-1", command="echo"))
+        servers = [
+            McpServerConfig(name="cd-srv-1", command="echo"),
+            McpServerConfig(name="cd-srv-2", command="echo"),
+        ]
+        monkeypatch.setattr(
+            "src.shared.python.ai.mcp.widgets.mcp_servers_prefs_widget"
+            "._discover_claude_desktop_servers",
+            lambda: servers,
+        )
+        imported = widget.import_from_claude_desktop()
+        # Only cd-srv-2 is new.
+        assert imported == 1
+        assert widget.server_count == 2
+
+
+@pytest.mark.unit
+class TestMcpServersPrefsWidgetSignals:
+    def test_servers_changed_signal_on_add(
+        self, qapp: QApplication, tmp_config_path: Path
+    ) -> None:
+        widget = McpServersPrefsWidget(config_path=tmp_config_path)
+        spy = MagicMock()
+        widget.servers_changed.connect(spy)
+        widget.add_server(McpServerConfig(name="s", command="echo"))
+        assert spy.called


### PR DESCRIPTION
## Summary

Architectural correction: extract the MCP server preferences widget and introduce the integrations health dashboard widget in **shared Tools** so both UpstreamDrift and Gasification_Model can embed them without duplicating the implementation.

UD PR #5646 (still open at time of writing) placed `preferences/mcp_servers_section.py` and `mcp_config_writer.py` inside the UpstreamDrift repo. MCP, however, is shared infrastructure — its contracts, client, pool, and config loader all live here under `src/shared/python/ai/mcp/`. A second consumer (Gasification_Model) would render the exact same prefs UI, so by the rule "if two consumers would render identically, it goes in Tools shared", the widget belongs here.

## What this PR adds

Under `src/shared/python/ai/mcp/`:

- `config_writer.py` — pure-data round-trip writer for `mcp_servers.json`. Pairs with the existing `config_loader.read` to give a Claude-Desktop-compatible layout. `ValueError` is the single documented failure mode (DbC).
- `widgets/__init__.py` — public widget surface.
- `widgets/mcp_servers_prefs_widget.py` — `QWidget` subclass with table view of configured servers, add/edit/remove dialogs, programmatic CRUD API (`add_server`, `remove_server`, `apply_preset`, `import_from_claude_desktop`, `persist`, `replace_all`), and a `servers_changed` signal for hosts to wire to a Save button.
- `widgets/integrations_health_dashboard_widget.py` — `QWidget` table showing live status for every integration (Linear / Notion / AFFiNE / Obsidian / MCP pool). Refresh button, opt-in 30 s auto-refresh, empty state, and failure-safety: a failing status provider surfaces as an ERROR row rather than crashing the host.
- `widgets/health_query_api.py` — Qt-free pure-data layer used by the dashboard and any other consumer (CLI, server diagnostics). `query_integration_status(id)` and `list_all_integrations(*, mcp_pool=None)`.

Under `tests/unit/ai/mcp/widgets/` — 29 new tests cover construction, CRUD, presets, Claude-Desktop import, signals, refresh, row formatting, error safety, and the pure-data probes.

## Architectural rule reinforced

> If two consumers would render identically, it goes in Tools shared.

`src/shared/python/ai/mcp/` already owns contracts (PR #2884), client, pool, config loader, and the lightweight `gui.py` indicator. The new `widgets/` package extends this canonical home with the richer prefs widget and the integrations health dashboard.

## Follow-up

A companion UpstreamDrift refactor PR will:
- Replace UD's `preferences/mcp_servers_section.py` with a thin wrapper that embeds `McpServersPrefsWidget`.
- Delete UD's `mcp_config_writer.py` (re-export from Tools instead).
- Embed `IntegrationsHealthDashboardWidget` in the launcher's Window menu (per UD #5643).

The UD PR will be opened immediately; its CI will be RED until this PR merges (it imports from `src.shared.python.ai.mcp.widgets`).

## Issues

- `Implements UD #5642` — MCP prefs UI; real implementation lives here.
- `Implements UD #5643` — Integrations health dashboard; real implementation lives here.

## Test plan

- [x] `python -m pytest tests/unit/ai/mcp/` — 79 passed (29 new widget + 50 pre-existing).
- [x] `python -m ruff check src/shared/python/ai/mcp/ tests/unit/ai/mcp/widgets/` — All checks passed.
- [x] `python -m ruff format --check` on touched files — clean.
- [ ] CI checks on this PR.
- [ ] Downstream UD PR CI green once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)