### PR TITLE
fix(ci): cancel in-progress benchmark runs on new push

### DIFF
--- a/.github/workflows/benchmark-suite.yml
+++ b/.github/workflows/benchmark-suite.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: benchmarks-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 defaults:
   run:


### PR DESCRIPTION
## Summary

`benchmark-suite.yml` had `concurrency.cancel-in-progress: false`, meaning that when two pushes or PR syncs happened in quick succession, both benchmark runs would hold d-sorg-fleet runners for 30+ minutes simultaneously. This contributed to runner saturation observed fleet-wide (RM #1183).

## Changes

- Change `cancel-in-progress: false` → `true` so the stale benchmark run is cancelled when a newer push triggers a new one

## Verification

- [ ] CI Standard passes
- [ ] Subsequent pushes cancel the previous benchmark run rather than stacking

---
Filed by address-issues skill, agent claude, runner saturation investigation 2026-05-16.