### PR TITLE
ci: add concurrency protection to top-stacking workflows (drop queue ~60%)

### DIFF
--- a/.github/workflows/Jules-PR-AutoFix.yml
+++ b/.github/workflows/Jules-PR-AutoFix.yml
@@ -41,7 +41,7 @@ permissions:
 # Prevent concurrent fixes on the same branch
 concurrency:
   group: pr-autofix-${{ github.event.workflow_run.head_branch || github.event.inputs.branch || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   # Maximum fix attempts per window (reduced from 10 for cost control)

--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,4 +1,9 @@
 name: Auto-Update PRs
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ["master", "main"]


### PR DESCRIPTION
## Summary

Implements **Fix A** from the ops audit. The top stacking workflows account for ~55% of the stalled runner queue across the fleet; adding (or fixing) the canonical concurrency block is the single highest-leverage change. Expected outcome: ~60% reduction in queue depth.

## Changes (Tools)

| Workflow | Status | Change |
|---|---|---|
| `Jules-PR-AutoFix.yml` | modified | flipped `cancel-in-progress: false` -> `true` |
| `auto-update-prs.yml` | modified | added canonical concurrency block after `name:` |
| `benchmark-suite.yml` | skipped | already correctly protected |
| `cross-repo-python-integration.yml` | skipped | already correctly protected |
| `ci-standard.yml` | skipped | already correctly protected |

Canonical block applied:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

YAML parses verified for both edited files.

## Scope

- ONLY the concurrency block is touched. No other workflow logic changed.
- No `runs-on:` label changes, no `if: always()` changes, no `timeout-minutes:` changes (Fixes B/C/D/E queued as follow-ups).

Implements ops audit Fix A.