### PR TITLE
ci: complete concurrency protection — 28 missing + 14 cip:false flipped

### DIFF
--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -34,7 +34,7 @@ permissions:
 
 concurrency:
   group: bot-ci-trigger-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: require a local self-hosted runner and fail closed ──────────────────

--- a/.github/workflows/Code-Metrics.yml
+++ b/.github/workflows/Code-Metrics.yml
@@ -2,6 +2,9 @@ name: Code Metrics
 
 # Informational code quality metrics - never fails CI
 # Reports complexity (radon) and duplication (jscpd) metrics
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   # COST OPTIMIZATION: Removed pull_request and push triggers to reduce CI costs

--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -25,7 +25,7 @@ permissions:
   issues: write
 concurrency:
   group: comment-to-issue-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 env:
   MAX_ISSUES_PER_RUN: 5
 

--- a/.github/workflows/Jules-Archivist.yml
+++ b/.github/workflows/Jules-Archivist.yml
@@ -17,6 +17,9 @@ name: Jules Archivist
 # │  • Only targets branches matching "jules/" prefix — other branches ignored │
 # │  • Gracefully skips on API rate-limit errors                               │
 # └─────────────────────────────────────────────────────────────────────────────┘
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -17,6 +17,9 @@ name: Jules Assessment Generator (Worker)
 # │  • Scheduled/dispatched only via Control Tower — not triggered on push     │
 # │  • Commits are limited to docs/assessments/ path                          │
 # └─────────────────────────────────────────────────────────────────────────────┘
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -67,7 +67,7 @@ permissions:
 # Prevent multiple remediation runs simultaneously
 concurrency:
   group: jules-assessment-remediator
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   MAX_ISSUES_PER_RUN: 10

--- a/.github/workflows/Jules-Auto-Assign-Issues.yml
+++ b/.github/workflows/Jules-Auto-Assign-Issues.yml
@@ -3,6 +3,9 @@ name: Jules Auto-Assign Issues
 # Automatically comments @jules on new issues to trigger the fix workflow
 # IMPORTANT: Only triggers for AUTOMATED issues, NOT manually created ones
 # To manually request Jules help, add the 'jules-triage' label to an issue
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   issues:

--- a/.github/workflows/Jules-Auto-Rebase.yml
+++ b/.github/workflows/Jules-Auto-Rebase.yml
@@ -20,6 +20,9 @@ name: Jules Auto-Rebase (Worker)
 # Replaces Jules-Conflict-Fix workflow
 # Automatically rebases PRs that are behind main
 # Labels PRs that have actual merge conflicts for manual resolution
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Auto-Refactor.yml
+++ b/.github/workflows/Jules-Auto-Refactor.yml
@@ -21,6 +21,9 @@ name: Jules Auto-Refactor (Worker)
 # Replaces Jules-Tech-Custodian workflow
 # Finds files with the most linting issues and auto-fixes them
 # Creates a PR with the automated improvements
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Auto-Repair.yml
+++ b/.github/workflows/Jules-Auto-Repair.yml
@@ -29,6 +29,9 @@ name: Jules Auto-Repair (Worker)
 # 2. Iterates until CI passes or max attempts reached
 # 3. Uses Jules AI for complex fixes (type errors, test failures, logic issues)
 # 4. Proper concurrency controls to prevent loops
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Cleaner.yml
+++ b/.github/workflows/Jules-Cleaner.yml
@@ -1,4 +1,7 @@
 name: Jules Cleaner (Supersede & Close)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/Jules-Code-Quality-Fixer.yml
+++ b/.github/workflows/Jules-Code-Quality-Fixer.yml
@@ -40,7 +40,7 @@ permissions:
 
 concurrency:
   group: jules-code-quality-fixer-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -17,6 +17,9 @@ name: Jules Code Quality Reviewer (Worker)
 # │  • Scheduled/dispatched only via Control Tower                             │
 # │  • Report commit is scoped to docs/assessments/ path                     │
 # └─────────────────────────────────────────────────────────────────────────────┘
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -17,6 +17,9 @@ name: Jules Completist (Incomplete Implementation Auditor)
 # │  • Scheduled (0 8 * * 0,4) or dispatched via Control Tower                │
 # │  • Issues are created for review before any code changes are merged        │
 # └─────────────────────────────────────────────────────────────────────────────┘
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -17,6 +17,9 @@ name: Jules Comprehensive Assessment
 # │  • Scheduled (0 8 * * 0,4) or manual dispatch — not triggered on push     │
 # │  • Report commit scoped to docs/assessments/ path only                   │
 # └─────────────────────────────────────────────────────────────────────────────┘
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   schedule:

--- a/.github/workflows/Jules-Control-Tower.yml
+++ b/.github/workflows/Jules-Control-Tower.yml
@@ -41,7 +41,7 @@ env:
 
 concurrency:
   group: jules-control-tower-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 # Least-privilege: this orchestrator only reads; write grants live in workers.
 permissions:

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -1,4 +1,7 @@
 name: Jules Critics Comments Writer
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Documentation-Auditor.yml
+++ b/.github/workflows/Jules-Documentation-Auditor.yml
@@ -22,6 +22,9 @@ name: Jules Documentation Auditor (Worker)
 # Nightly documentation audit workflow
 # Scans codebase for missing docstrings, documentation gaps, and organization issues
 # Creates issues or PRs for documentation improvements
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Documentation-Scribe.yml
+++ b/.github/workflows/Jules-Documentation-Scribe.yml
@@ -20,6 +20,9 @@ name: Jules Documentation Scribe (Worker)
 # │  • Bot-actor guard in Control Tower prevents doc-scribe loops              │
 # │  • PR requires human review before merge                                   │
 # └─────────────────────────────────────────────────────────────────────────────┘
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Hotfix-Creator.yml
+++ b/.github/workflows/Jules-Hotfix-Creator.yml
@@ -21,6 +21,9 @@ name: Jules Hotfix-Creator (Worker)
 
 # Triggers when CI fails on protected branches (main/master)
 # Creates a hotfix branch, triggers Auto-Repair, and opens urgent PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -14,7 +14,7 @@ permissions:
 
 concurrency:
   group: jules-issue-fix-${{ github.event.issue.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/Jules-Issue-Resolver.yml
+++ b/.github/workflows/Jules-Issue-Resolver.yml
@@ -38,7 +38,7 @@ permissions:
 
 concurrency:
   group: jules-issue-resolver-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -1,4 +1,7 @@
 name: Jules Layman's Terms Writer
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Jules-PR-Cleanup.yml
+++ b/.github/workflows/Jules-PR-Cleanup.yml
@@ -23,7 +23,7 @@ permissions:
 
 concurrency:
   group: jules-pr-cleanup-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/Jules-Sentinel.yml
+++ b/.github/workflows/Jules-Sentinel.yml
@@ -35,7 +35,7 @@ permissions:
 # HARDENING: Prevent concurrent runs
 concurrency:
   group: jules-sentinel-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/Jules-Supersede-Check.yml
+++ b/.github/workflows/Jules-Supersede-Check.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: jules-supersede-check-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/Jules-Tech-Custodian.yml
+++ b/.github/workflows/Jules-Tech-Custodian.yml
@@ -1,4 +1,8 @@
 name: Jules Tech Debt Custodian
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_call:
 

--- a/.github/workflows/Jules-Test-Generator.yml
+++ b/.github/workflows/Jules-Test-Generator.yml
@@ -1,4 +1,7 @@
 name: Jules Test Generator (Worker)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/Maintenance-Global-Control.yml
+++ b/.github/workflows/Maintenance-Global-Control.yml
@@ -1,4 +1,7 @@
 name: Maintenance Global Control
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_dispatch:

--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -18,7 +18,7 @@ permissions:
 # Prevent concurrent runs from corrupting the queue file
 concurrency:
   group: pr-comment-collector-${{ github.repository }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/auto-issue-resolver.yml
+++ b/.github/workflows/auto-issue-resolver.yml
@@ -63,7 +63,7 @@ on:
 
 concurrency:
   group: auto-issue-resolver
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/check-tools-manifest.yml
+++ b/.github/workflows/check-tools-manifest.yml
@@ -1,4 +1,7 @@
 name: Check Tools Manifest
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/docs-governance.yml
+++ b/.github/workflows/docs-governance.yml
@@ -1,4 +1,7 @@
 name: Docs Governance
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/heavy-integration-tests.yml
+++ b/.github/workflows/heavy-integration-tests.yml
@@ -1,4 +1,7 @@
 name: Heavy Integration Tests
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_dispatch:

--- a/.github/workflows/heavy-tests-opt-in.yml
+++ b/.github/workflows/heavy-tests-opt-in.yml
@@ -1,4 +1,7 @@
 name: Heavy Integration Tests (Opt-In)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_dispatch:

--- a/.github/workflows/jules-assessment-runner.yml
+++ b/.github/workflows/jules-assessment-runner.yml
@@ -32,7 +32,7 @@ on:
 # Prevent multiple assessment runs simultaneously
 concurrency:
   group: assessment-runner
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────

--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -1,4 +1,7 @@
 name: Local-Only Workflow Runner Guard
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/nightly-full-repo-quality.yml
+++ b/.github/workflows/nightly-full-repo-quality.yml
@@ -11,6 +11,9 @@ name: Nightly Full-Repo Quality
 # Violation counts are reported in GITHUB_STEP_SUMMARY for trend tracking.
 #
 # Resolves: https://github.com/D-sorganization/Tools/issues/1697
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   schedule:

--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   group: perf-regression-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   benchmark:

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,4 +1,7 @@
 name: Publish Artifacts
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
 
 on:
   release:

--- a/.github/workflows/spec-check.yml
+++ b/.github/workflows/spec-check.yml
@@ -12,6 +12,9 @@
 # your repo's source directories.
 
 name: Spec Check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:

--- a/.github/workflows/topology-governance.yml
+++ b/.github/workflows/topology-governance.yml
@@ -1,4 +1,7 @@
 name: Topology Governance
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary

Closes the remaining concurrency-protection gaps in `.github/workflows/`. This **Implements** the third and final phase of the Fix A campaign that began earlier today.

**Campaign context:**
- Tools PR #2916 (merged): added cancel-in-progress to top-stacking workflows (Jules-PR-AutoFix.yml, auto-update-prs.yml) — dropped the queue ~60%.
- Tools PR #2917 (open): broader workflow protection campaign (path filters, timeouts, preventive lint).
- **This PR**: closes the remaining structural gap — **28 workflows had no `concurrency:` block at all**, and **14 more had `cancel-in-progress: false`** when they should have been true.

**Forensic backdrop:** the May 15 incident showed 38–41 deep Jules-PR-AutoFix stacks queued against the self-hosted fleet. Without `cancel-in-progress: true`, every event spawned a new run instead of superseding the previous one. PR #2916 fixed Jules-PR-AutoFix specifically; this PR closes the same hole across every other workflow that can be triggered repeatedly under the 78+ PR/day load that this fleet sustains.

## Changes

**42 workflow files modified** (99 insertions, 14 deletions). All YAML validated with `yaml.safe_load` before commit. No logic changes outside the `concurrency:` block.

### Workflows where a concurrency block was injected (28)

All inserted at the top level between `name:` and `on:`, using the standard group expression `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`.

| File | cancel-in-progress |
|---|---|
| Code-Metrics.yml | true |
| Jules-Archivist.yml | true |
| Jules-Assessment-Generator.yml | true |
| Jules-Auto-Assign-Issues.yml | true |
| Jules-Auto-Rebase.yml | true |
| Jules-Auto-Refactor.yml | true |
| Jules-Auto-Repair.yml | true |
| Jules-Cleaner.yml | true |
| Jules-Code-Quality-Reviewer.yml | true |
| Jules-Completist.yml | true |
| Jules-Comprehensive-Assessment.yml | true |
| Jules-Critics-Comments.yml | true |
| Jules-Documentation-Auditor.yml | true |
| Jules-Documentation-Scribe.yml | true |
| Jules-Hotfix-Creator.yml | true |
| Jules-Laymans-Terms-Writer.yml | true |
| Jules-Tech-Custodian.yml | true |
| Jules-Test-Generator.yml | true |
| Maintenance-Global-Control.yml | true |
| check-tools-manifest.yml | true |
| docs-governance.yml | true |
| heavy-integration-tests.yml | true |
| heavy-tests-opt-in.yml | true |
| local-only-runner-guard.yml | true |
| nightly-full-repo-quality.yml | true |
| spec-check.yml | true |
| topology-governance.yml | true |
| publish-artifacts.yml | **false** (artifact upload should not be interrupted mid-publish) |

### Workflows flipped from cancel-in-progress: false to true (14)

| File | Why flip is safe |
|---|---|
| Bot-CI-Trigger.yml | Re-runnable trigger logic; supersede is fine |
| Comment-to-Issue-Converter.yml | Idempotent comment scan |
| Jules-Assessment-Remediator.yml | Re-runs assessment; latest commit wins |
| Jules-Code-Quality-Fixer.yml | Re-runs fixer; latest commit wins |
| Jules-Control-Tower.yml | Dispatcher; latest event wins |
| Jules-Issue-Mention-Handler.yml | Idempotent on issue events |
| Jules-Issue-Resolver.yml | Re-runnable on latest issue state |
| Jules-PR-Cleanup.yml | Idempotent cleanup |
| Jules-Sentinel.yml | Re-runs scan; latest commit wins |
| Jules-Supersede-Check.yml | Idempotent supersede check |
| PR-Comment-Responder.yml | Idempotent response logic |
| auto-issue-resolver.yml | Re-runnable on latest issue state |
| jules-assessment-runner.yml | Re-runs assessment; latest commit wins |
| perf-regression.yml | Latest commit's benchmark is what matters |

### Workflows intentionally left at cancel-in-progress: false (2 — legitimate state-writing exceptions)

| File | Why kept false |
|---|---|
| release.yml | Releases must not be interrupted mid-publish |
| publish-artifacts.yml | Artifact publishing must not be interrupted mid-upload |

### Workflows skipped (already protected — no double-fix)

The following 14 workflows already had concurrency with cancel-in-progress: true from prior fixes (including PR #2916) and were left untouched:

Jules-Diff-Verifier.yml, Jules-PR-AutoFix.yml, anti-phantom-merge.yml, auto-update-prs.yml, benchmark-suite.yml, ci-standard.yml, cross-repo-python-integration.yml, cross-repo-rust-integration.yml, detect-secrets.yml, file-size-budget.yml, maturin-ai-backend.yml, pr-auto-labeler.yml, tauri-build.yml, workflow-lint.yml.

## Post-merge state

| Status | Count |
|---|---|
| concurrency + cancel-in-progress: true | 55 |
| concurrency + cancel-in-progress: false (legitimate) | 2 |
| no concurrency block | **0** |

## Test plan

- [ ] CI passes (workflow-lint job re-parses every workflow)
- [ ] Spot-check Actions tab after merge — new pushes to in-flight branches should supersede their predecessors instead of queueing
- [ ] Monitor self-hosted fleet queue depth over next 24h — should stay shallow even under 78+ PR/day load

🤖 Generated with [Claude Code](https://claude.com/claude-code)