### PR TITLE
fix(ci): add timeout-minutes:5 to pip-audit step (hang protection)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -250,6 +250,7 @@ jobs:
           fi
 
       - name: Security Scan (pip-audit)
+        timeout-minutes: 5
         run: |
           # CVE-2026-4539: pygments 2.19.2 vulnerability with no fix version available yet.
           # Ignored until a patched release is published upstream.


### PR DESCRIPTION
pip-audit hangs indefinitely on overloaded runners with no step-level timeout, eventually getting OOM-killed and showing as cancelled (not failed). This poisons CI status across the fleet. Adding timeout-minutes:5 kills the step cleanly with a proper failure. Already fixed on main in OpenSim_Models, Pinocchio_Models, MuJoCo_Models.