### PR TITLE
fix(workflow-lint): allow publish/release workflows to opt out of cancel-in-progress

### DIFF
--- a/.github/workflows/lint-workflow-files.yml
+++ b/.github/workflows/lint-workflow-files.yml
@@ -55,9 +55,18 @@ jobs:
               FAIL="${FAIL}\n  - $f: missing concurrency block"
             fi
             # Check cancel-in-progress: true (only if concurrency exists)
-            if grep -q '^concurrency:' "$f" && ! grep -q 'cancel-in-progress:\s*true' "$f"; then
-              FAIL="${FAIL}\n  - $f: cancel-in-progress not set to true"
-            fi
+            # Exception allowlist — workflows where cancel-in-progress: false is legitimate
+            # (publishes/releases should not be interrupted mid-stream)
+            case "$(basename "$f")" in
+              publish-artifacts.yml|release.yml|publish.yml|deploy.yml|nightly-publish.yml)
+                echo "::notice::Skipping cancel-in-progress check for $f (intentional exception)"
+                ;;
+              *)
+                if grep -q '^concurrency:' "$f" && ! grep -q 'cancel-in-progress:\s*true' "$f"; then
+                  FAIL="${FAIL}\n  - $f: cancel-in-progress not set to true"
+                fi
+                ;;
+            esac
           done <<< "$FILES"
           if [ -n "$FAIL" ]; then
             printf "::error::Workflow lint failed:%b\n" "$FAIL"


### PR DESCRIPTION
Fixes a bug in the lint-workflow-files workflow deployed earlier today: the strict 'cancel-in-progress: true' requirement was incorrectly applied to publish-artifacts.yml and release.yml, which legitimately need cancel-in-progress: false to avoid interrupting publishes mid-stream. Adds an explicit allowlist of basenames (publish-artifacts.yml, release.yml, publish.yml, deploy.yml, nightly-publish.yml) that skip the check with an informational notice instead of failing.