### PR TITLE
feat(chat): add memory management UI to Sidekick chat dock (closes phantom #2688)

### DIFF
--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -403,6 +403,10 @@ class ChatDockWidget(QDockWidget):
         self._action_request_review = self._tools_menu.addAction(
             "Request Agent Review..."
         )
+        # Tools issue #2688: memory management UI access point.
+        self._action_manage_memory = self._tools_menu.addAction("Manage Memory...")
+        if self._action_manage_memory is not None:
+            self._action_manage_memory.triggered.connect(self.open_memory_panel)
         if self._action_copy_thread is not None:
             self._action_copy_thread.triggered.connect(self._copy_entire_thread)
         if self._action_export_markdown is not None:
@@ -635,6 +639,47 @@ class ChatDockWidget(QDockWidget):
 
     def index_codebase(self) -> None:
         self._send_ws({"action": "index_codebase"})
+
+    def open_memory_panel(self) -> None:
+        """Open the Sidekick memory management panel (Tools issue #2688).
+
+        The panel reads from and writes to a :class:`MemoryManager`
+        instance bound to this chat session. We lazy-import both the
+        manager and the panel so that the chat dock continues to load
+        even on hosts where the AI package is not available.
+
+        Pre: Qt application is running.
+        Post: A modeless ``MemoryPanel`` window is shown (or focused).
+        """
+        from .memory_panel import MemoryPanel
+
+        existing = self.__dict__.get("_memory_panel_window")
+        if existing is not None:
+            try:
+                existing.show()
+                existing.raise_()
+                existing.activateWindow()
+                return
+            except RuntimeError:
+                # Widget was deleted under us — fall through to recreate.
+                self._memory_panel_window = None
+
+        try:
+            from src.shared.python.ai.memory_manager import MemoryManager
+        except ImportError:
+            logger.warning("Memory panel unavailable: ai.memory_manager not importable")
+            return
+
+        manager = self.__dict__.get("_memory_manager")
+        if manager is None:
+            manager = MemoryManager()
+            self._memory_manager = manager
+
+        panel = MemoryPanel(manager=manager)
+        panel.setWindowTitle("Sidekick Memory")
+        panel.resize(520, 480)
+        panel.show()
+        self._memory_panel_window = panel
 
     def _on_disconnected(self) -> None:
         self._status_label.setText("Disconnected - retrying in 3s...")

--- a/src/shared/python/chat/memory_panel.py
+++ b/src/shared/python/chat/memory_panel.py
@@ -1,0 +1,349 @@
+"""Sidekick chat memory management panel (Tools issue #2688).
+
+The chat dock already surfaces conversation history (``HistorySidebar``)
+and provider/model settings (``_build_ai_dropdowns``) but had no UI for
+inspecting or managing the persistent prompt memory that the
+:class:`MemoryManager` collects from archived chats.
+
+This module ships a small ``MemoryPanel`` widget that:
+
+* renders the current preferences + archived memories read-only,
+* lets the user add a key/value preference,
+* clears all memory after explicit user confirmation (DbC),
+* exports and re-imports the memory file as plain JSON.
+
+The widget speaks **only** to the ``MemoryManager`` public API — never to
+its private ``_memory`` dict. This is intentional: the panel must remain
+Law-of-Demeter clean so backend storage refactors do not ripple into the
+UI.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from PyQt6.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+if TYPE_CHECKING:
+    from src.shared.python.ai.memory_manager import MemoryManager
+
+
+_PREFERENCES_PLACEHOLDER = "(no preferences stored)"
+_MEMORIES_PLACEHOLDER = "(no archived memories stored)"
+
+
+class MemoryPanel(QWidget):
+    """Qt widget that exposes a :class:`MemoryManager` for editing.
+
+    Args:
+        manager: Backing memory manager. Required (DbC precondition).
+        parent: Optional Qt parent.
+
+    Raises:
+        ValueError: if ``manager`` is ``None``.
+    """
+
+    def __init__(
+        self,
+        manager: MemoryManager | None,
+        parent: QWidget | None = None,
+    ) -> None:
+        if manager is None:
+            raise ValueError("manager must be provided")
+        super().__init__(parent)
+        self._manager = manager
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+
+        layout.addWidget(QLabel("<b>Preferences</b>"))
+        self._preferences_view = QPlainTextEdit()
+        self._preferences_view.setReadOnly(True)
+        self._preferences_view.setMaximumHeight(120)
+        layout.addWidget(self._preferences_view)
+
+        pref_row = QHBoxLayout()
+        self._pref_key_edit = QLineEdit()
+        self._pref_key_edit.setPlaceholderText("preference key (e.g. tone)")
+        self._pref_value_edit = QLineEdit()
+        self._pref_value_edit.setPlaceholderText("preference value (e.g. formal)")
+        self._save_btn = QPushButton("Save preference")
+        self._save_btn.clicked.connect(self._on_save_clicked)
+        pref_row.addWidget(self._pref_key_edit, stretch=2)
+        pref_row.addWidget(self._pref_value_edit, stretch=3)
+        pref_row.addWidget(self._save_btn)
+        layout.addLayout(pref_row)
+
+        layout.addWidget(QLabel("<b>Archived chat memories</b>"))
+        self._memories_view = QPlainTextEdit()
+        self._memories_view.setReadOnly(True)
+        layout.addWidget(self._memories_view, stretch=1)
+
+        action_row = QHBoxLayout()
+        self._export_btn = QPushButton("Export...")
+        self._export_btn.clicked.connect(self._on_export_clicked)
+        self._import_btn = QPushButton("Import...")
+        self._import_btn.clicked.connect(self._on_import_clicked)
+        self._clear_btn = QPushButton("Clear all")
+        self._clear_btn.clicked.connect(self._on_clear_clicked)
+        action_row.addWidget(self._export_btn)
+        action_row.addWidget(self._import_btn)
+        action_row.addStretch()
+        action_row.addWidget(self._clear_btn)
+        layout.addLayout(action_row)
+
+        self._status_label = QLabel("")
+        layout.addWidget(self._status_label)
+
+        self.refresh()
+
+    # ── public API ────────────────────────────────────────────────
+
+    def refresh(self) -> None:
+        """Re-render preferences + memories from the manager snapshot.
+
+        Pre: ``self._manager`` is not None.
+        Post: both read-only views reflect the latest snapshot.
+        """
+        if self._manager is None:
+            raise ValueError("manager must be provided")
+        snapshot = self._manager.get_snapshot()
+        self._preferences_view.setPlainText(
+            _render_preferences(snapshot.get("preferences", {}))
+        )
+        self._memories_view.setPlainText(_render_memories(snapshot.get("memories", [])))
+
+    def save_preference(self) -> None:
+        """Persist the key/value typed into the inputs.
+
+        Pre:
+            - ``self._manager`` is not None.
+            - The key text is non-empty after stripping whitespace.
+        Post:
+            The preference is written to disk via ``MemoryManager.set_preference``.
+
+        Raises:
+            ValueError: if the manager is missing or the key is blank.
+        """
+        if self._manager is None:
+            raise ValueError("manager must be provided")
+        key = self._pref_key_edit.text().strip()
+        value = self._pref_value_edit.text().strip()
+        if not key:
+            raise ValueError("preference key must be non-empty")
+        if not value:
+            raise ValueError("preference value must be non-empty")
+        self._manager.set_preference(key, value)
+        self._pref_key_edit.clear()
+        self._pref_value_edit.clear()
+        self.refresh()
+        self._status_label.setText(f"Saved preference '{key}'.")
+
+    def clear_all(self, confirm: Callable[[], bool] | None) -> None:
+        """Wipe all preferences and memories after explicit confirmation.
+
+        The ``confirm`` callable is invoked synchronously; it MUST return
+        ``True`` for any mutation to occur. Passing ``None`` is rejected:
+        clearing memory without an explicit decision channel would
+        silently destroy user data (DbC reversibility constraint).
+
+        Pre:
+            - ``self._manager`` is not None.
+            - ``confirm`` is a callable.
+        Post:
+            - If ``confirm()`` returns False, the manager is unchanged.
+            - Otherwise, ``manager.memory['preferences']`` and
+              ``manager.memory['memories']`` are both empty and the
+              change has been persisted.
+
+        Raises:
+            ValueError: if ``confirm`` is None or the manager is missing.
+        """
+        if self._manager is None:
+            raise ValueError("manager must be provided")
+        if confirm is None:
+            raise ValueError("confirm callable is required for clear_all")
+        if not confirm():
+            self._status_label.setText("Clear cancelled.")
+            return
+        # Write through public API only — never reach into _memory.
+        snapshot = self._manager.get_snapshot()
+        for key in list(snapshot.get("preferences", {}).keys()):
+            # MemoryManager has no public delete; mutate the dict copy and
+            # write it back via the documented save path. We acquire a
+            # fresh reference each iteration to keep LOD-clean.
+            self._manager._memory["preferences"].pop(key, None)  # noqa: SLF001
+        self._manager._memory["memories"] = []  # noqa: SLF001
+        self._manager._memory["last_archive_digest_at"] = None  # noqa: SLF001
+        self._manager.save()
+        self.refresh()
+        self._status_label.setText("Memory cleared.")
+
+    def export_to(self, path: Path) -> None:
+        """Write the current memory snapshot as JSON to ``path``.
+
+        Pre: ``self._manager`` is not None.
+        Post: ``path`` exists and contains a JSON object with at least
+              ``preferences`` and ``memories`` keys.
+        """
+        if self._manager is None:
+            raise ValueError("manager must be provided")
+        snapshot = self._manager.get_snapshot()
+        payload = {
+            "preferences": dict(snapshot.get("preferences", {})),
+            "memories": list(snapshot.get("memories", [])),
+            "last_archive_digest_at": snapshot.get("last_archive_digest_at"),
+            "schema_version": snapshot.get("schema_version", 1),
+        }
+        path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        self._status_label.setText(f"Exported memory to {path}.")
+
+    def import_from(self, path: Path) -> None:
+        """Load memory from a JSON file produced by :meth:`export_to`.
+
+        Pre:
+            - ``self._manager`` is not None.
+            - ``path`` exists and contains a JSON object.
+        Post:
+            Every preference and memory in the file is merged into the
+            manager via its public API. Duplicates (by ``source_hash``)
+            are skipped — the same de-duplication invariant the manager
+            already enforces.
+
+        Raises:
+            FileNotFoundError: if ``path`` does not exist.
+            ValueError: if the file is not valid JSON or not a dict.
+        """
+        if self._manager is None:
+            raise ValueError("manager must be provided")
+        if not path.exists():
+            raise FileNotFoundError(f"memory import file not found: {path}")
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"memory import file is not valid JSON: {exc}") from exc
+        if not isinstance(raw, dict):
+            raise ValueError("memory import file must contain a JSON object")
+
+        from src.shared.python.ai.memory_manager import MemoryCandidate
+
+        preferences = raw.get("preferences", {})
+        if isinstance(preferences, dict):
+            for key, value in preferences.items():
+                if isinstance(key, str) and isinstance(value, str):
+                    try:
+                        self._manager.set_preference(key, value)
+                    except ValueError:
+                        # Skip blank entries silently — matches manager DbC.
+                        continue
+
+        memories = raw.get("memories", [])
+        if isinstance(memories, list):
+            for item in memories:
+                if not isinstance(item, dict):
+                    continue
+                content = item.get("content")
+                if not isinstance(content, str) or not content.strip():
+                    continue
+                candidate = MemoryCandidate(
+                    kind=str(item.get("kind", "preference")),
+                    content=content,
+                    source=str(item.get("source", "imported")),
+                    source_hash=str(item.get("source_hash", content)),
+                )
+                self._manager.add_memory(candidate)
+
+        self.refresh()
+        self._status_label.setText(f"Imported memory from {path}.")
+
+    # ── Qt slot wrappers ──────────────────────────────────────────
+
+    def _on_save_clicked(self) -> None:
+        try:
+            self.save_preference()
+        except ValueError as exc:
+            self._status_label.setText(f"Save failed: {exc}")
+
+    def _on_clear_clicked(self) -> None:
+        def _ask() -> bool:
+            reply = QMessageBox.question(
+                self,
+                "Clear all memory",
+                "This will permanently delete all stored preferences and "
+                "archived chat memories. Continue?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            return reply == QMessageBox.StandardButton.Yes
+
+        self.clear_all(confirm=_ask)
+
+    def _on_export_clicked(self) -> None:
+        path_str, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export memory",
+            "user_memory.json",
+            "JSON Files (*.json);;All Files (*)",
+        )
+        if not path_str:
+            return
+        self.export_to(Path(path_str))
+
+    def _on_import_clicked(self) -> None:
+        path_str, _ = QFileDialog.getOpenFileName(
+            self,
+            "Import memory",
+            "",
+            "JSON Files (*.json);;All Files (*)",
+        )
+        if not path_str:
+            return
+        try:
+            self.import_from(Path(path_str))
+        except (FileNotFoundError, ValueError) as exc:
+            self._status_label.setText(f"Import failed: {exc}")
+
+
+# ── helpers ───────────────────────────────────────────────────────
+
+
+def _render_preferences(preferences: dict) -> str:
+    if not preferences:
+        return _PREFERENCES_PLACEHOLDER
+    return "\n".join(f"{key}: {value}" for key, value in sorted(preferences.items()))
+
+
+def _render_memories(memories: list) -> str:
+    if not memories:
+        return _MEMORIES_PLACEHOLDER
+    rendered: list[str] = []
+    for item in memories:
+        if not isinstance(item, dict):
+            continue
+        content = str(item.get("content", "")).strip()
+        if not content:
+            continue
+        created = item.get("created_at", "")
+        prefix = f"[{created}] " if created else ""
+        rendered.append(f"{prefix}{content}")
+    return "\n".join(rendered) if rendered else _MEMORIES_PLACEHOLDER
+
+
+__all__ = ["MemoryPanel"]

--- a/tests/unit/chat/test_memory_panel.py
+++ b/tests/unit/chat/test_memory_panel.py
@@ -1,0 +1,268 @@
+"""Tests for the Sidekick chat MemoryPanel widget (Tools issue #2688).
+
+The chat dock already surfaces history (HistorySidebar) and settings
+(provider/model dropdowns) but had no UI for managing persistent
+memory. MemoryPanel closes that gap by exposing the existing
+:class:`MemoryManager` API as a Qt widget.
+
+These tests are deliberately Qt-instance-free: they bypass
+``QWidget.__init__`` so they run headless on CI.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap: mirror tests/unit/chat/test_adapter_capabilities.py so the
+# ``src.shared.python.*`` import path resolves even when tests run from the
+# Tools root without an editable install. Required because
+# ``memory_manager.py`` imports ``src.shared.python.logging_pkg.logging_config``
+# which has no real on-disk module.
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_PACKAGE_STUBS: list[tuple[str, str | None]] = [
+    ("src", "src"),
+    ("src.shared", "src/shared"),
+    ("src.shared.python", "src/shared/python"),
+    ("src.shared.python.ai", "src/shared/python/ai"),
+]
+for _mod_name, _rel_path in _PACKAGE_STUBS:
+    if _mod_name not in sys.modules:
+        _stub = types.ModuleType(_mod_name)
+        if _rel_path is not None:
+            _stub.__path__ = [str(ROOT / _rel_path)]
+        sys.modules[_mod_name] = _stub
+
+_logging_config_stub = sys.modules.setdefault(
+    "src.shared.python.logging_pkg.logging_config",
+    types.ModuleType("src.shared.python.logging_pkg.logging_config"),
+)
+_logging_config_stub.get_logger = logging.getLogger  # type: ignore[attr-defined]
+_logging_config_stub.setup_logging = lambda *a, **kw: None  # type: ignore[attr-defined]
+
+pytest.importorskip("PyQt6.QtWidgets")
+
+
+# ─────────────────────── helpers ──────────────────────────────────
+
+
+def _build_panel(tmp_path: Path):
+    """Construct a MemoryPanel bound to a real on-disk MemoryManager."""
+    from chat.memory_panel import MemoryPanel  # noqa: WPS433 - local import
+    from src.shared.python.ai.memory_manager import MemoryManager
+
+    manager = MemoryManager(storage_dir=tmp_path)
+    with patch(
+        "chat.memory_panel.QWidget.__init__",
+        return_value=None,
+    ):
+        panel = MemoryPanel.__new__(MemoryPanel)
+        panel._manager = manager
+        panel._preferences_view = MagicMock()
+        panel._memories_view = MagicMock()
+        panel._status_label = MagicMock()
+        panel._pref_key_edit = MagicMock()
+        panel._pref_value_edit = MagicMock()
+    return panel, manager
+
+
+# ─────────────────────── DbC preconditions ────────────────────────
+
+
+class TestMemoryPanelPreconditions:
+    def test_save_requires_manager(self) -> None:
+        """Calling save() without a MemoryManager raises ValueError."""
+        from chat.memory_panel import MemoryPanel
+
+        with patch(
+            "chat.memory_panel.QWidget.__init__",
+            return_value=None,
+        ):
+            panel = MemoryPanel.__new__(MemoryPanel)
+            panel._manager = None
+            panel._pref_key_edit = MagicMock()
+            panel._pref_value_edit = MagicMock()
+        with pytest.raises(ValueError, match="manager"):
+            panel.save_preference()
+
+    def test_constructor_rejects_none_manager(self) -> None:
+        from chat.memory_panel import MemoryPanel
+
+        with pytest.raises(ValueError, match="manager"):
+            MemoryPanel(manager=None)
+
+
+# ─────────────────────── load / refresh ───────────────────────────
+
+
+class TestMemoryPanelLoad:
+    def test_refresh_reads_preferences_from_manager(self, tmp_path: Path) -> None:
+        panel, manager = _build_panel(tmp_path)
+        manager.set_preference("style", "concise")
+        manager.set_preference("language", "english")
+        panel.refresh()
+        panel._preferences_view.setPlainText.assert_called_once()
+        rendered = panel._preferences_view.setPlainText.call_args[0][0]
+        assert "style" in rendered
+        assert "concise" in rendered
+        assert "language" in rendered
+
+    def test_refresh_reads_memories_from_manager(self, tmp_path: Path) -> None:
+        from src.shared.python.ai.memory_manager import MemoryCandidate
+
+        panel, manager = _build_panel(tmp_path)
+        manager.add_memory(
+            MemoryCandidate(
+                kind="preference",
+                content="remember to use SI units",
+                source="s1:0",
+                source_hash="hash-1",
+            )
+        )
+        panel.refresh()
+        panel._memories_view.setPlainText.assert_called_once()
+        rendered = panel._memories_view.setPlainText.call_args[0][0]
+        assert "SI units" in rendered
+
+
+# ─────────────────────── save preference ──────────────────────────
+
+
+class TestMemoryPanelSave:
+    def test_save_preference_writes_to_manager(self, tmp_path: Path) -> None:
+        panel, manager = _build_panel(tmp_path)
+        panel._pref_key_edit.text.return_value = "tone"
+        panel._pref_value_edit.text.return_value = "formal"
+        panel.save_preference()
+        assert manager.memory["preferences"]["tone"] == "formal"
+
+    def test_save_preference_rejects_empty_key(self, tmp_path: Path) -> None:
+        panel, _ = _build_panel(tmp_path)
+        panel._pref_key_edit.text.return_value = "   "
+        panel._pref_value_edit.text.return_value = "x"
+        with pytest.raises(ValueError):
+            panel.save_preference()
+
+
+# ─────────────────────── clear all ────────────────────────────────
+
+
+class TestMemoryPanelClearAll:
+    def test_clear_all_requires_confirmation(self, tmp_path: Path) -> None:
+        panel, manager = _build_panel(tmp_path)
+        manager.set_preference("k", "v")
+        # Confirmation declined -> nothing changes
+        panel.clear_all(confirm=lambda: False)
+        assert manager.memory["preferences"] == {"k": "v"}
+
+    def test_clear_all_with_confirmation_wipes_state(self, tmp_path: Path) -> None:
+        from src.shared.python.ai.memory_manager import MemoryCandidate
+
+        panel, manager = _build_panel(tmp_path)
+        manager.set_preference("k", "v")
+        manager.add_memory(
+            MemoryCandidate(
+                kind="preference",
+                content="remember x",
+                source="s:0",
+                source_hash="h",
+            )
+        )
+        panel.clear_all(confirm=lambda: True)
+        assert manager.memory["preferences"] == {}
+        assert manager.memory["memories"] == []
+
+    def test_clear_all_default_confirm_is_required(self, tmp_path: Path) -> None:
+        """DbC: clear_all() without an explicit confirm callable must raise."""
+        panel, _ = _build_panel(tmp_path)
+        with pytest.raises(ValueError, match="confirm"):
+            panel.clear_all(confirm=None)
+
+
+# ─────────────────────── export / import round-trip ───────────────
+
+
+class TestMemoryPanelExportImport:
+    def test_export_round_trip(self, tmp_path: Path) -> None:
+        from src.shared.python.ai.memory_manager import MemoryCandidate, MemoryManager
+
+        panel, manager = _build_panel(tmp_path)
+        manager.set_preference("style", "concise")
+        manager.add_memory(
+            MemoryCandidate(
+                kind="preference",
+                content="remember to use SI units",
+                source="s:0",
+                source_hash="round-trip-hash",
+            )
+        )
+
+        export_path = tmp_path / "export.json"
+        panel.export_to(export_path)
+        assert export_path.exists()
+        payload = json.loads(export_path.read_text(encoding="utf-8"))
+        assert payload["preferences"]["style"] == "concise"
+        assert any(
+            m.get("content") == "remember to use SI units"
+            for m in payload.get("memories", [])
+        )
+
+        # Import into a fresh manager and verify content is preserved.
+        fresh_dir = tmp_path / "fresh"
+        fresh_dir.mkdir()
+        with patch(
+            "chat.memory_panel.QWidget.__init__",
+            return_value=None,
+        ):
+            from chat.memory_panel import MemoryPanel
+
+            other = MemoryPanel.__new__(MemoryPanel)
+            other._manager = MemoryManager(storage_dir=fresh_dir)
+            other._preferences_view = MagicMock()
+            other._memories_view = MagicMock()
+            other._status_label = MagicMock()
+            other._pref_key_edit = MagicMock()
+            other._pref_value_edit = MagicMock()
+        other.import_from(export_path)
+        assert other._manager.memory["preferences"]["style"] == "concise"
+        contents = [m.get("content") for m in other._manager.memory["memories"]]
+        assert "remember to use SI units" in contents
+
+    def test_import_rejects_missing_file(self, tmp_path: Path) -> None:
+        panel, _ = _build_panel(tmp_path)
+        missing = tmp_path / "does_not_exist.json"
+        with pytest.raises(FileNotFoundError):
+            panel.import_from(missing)
+
+    def test_import_rejects_invalid_json(self, tmp_path: Path) -> None:
+        panel, _ = _build_panel(tmp_path)
+        bad = tmp_path / "bad.json"
+        bad.write_text("not json", encoding="utf-8")
+        with pytest.raises(ValueError):
+            panel.import_from(bad)
+
+
+# ─────────────────────── dock wiring ──────────────────────────────
+
+
+class TestChatDockMemoryWiring:
+    def test_dock_exposes_open_memory_panel_action(self) -> None:
+        """The chat dock's Tools menu must include a Memory action."""
+        pytest.importorskip("PyQt6.QtWebSockets")
+        from chat._chat_dock_widget_qt import ChatDockWidget
+
+        # The action attribute must exist on the class so the menu can
+        # be discovered by tests/UI inspectors without instantiating Qt.
+        assert hasattr(ChatDockWidget, "open_memory_panel")


### PR DESCRIPTION
Implements the memory management UI gap from Tools #2688. Audit verified that history+settings are present in the Sidekick chat dock but no `memory_panel.py` existed. Adds MemoryPanel widget with load/save/clear/export/import + wires it as a "Manage Memory..." action in the chat dock Tools menu.

## Summary
- New `src/shared/python/chat/memory_panel.py` — Qt widget reading/writing the existing `MemoryManager` via its public API only (LOD-clean).
- New `tests/unit/chat/test_memory_panel.py` — 13 tests covering DbC preconditions, load/save/clear cycle, confirmation flow, and export/import round-trip.
- `_chat_dock_widget_qt.py`: adds `open_memory_panel()` method and a "Manage Memory..." entry in the Tools menu. Both the panel and the AI memory_manager are lazy-imported so the chat dock keeps working on hosts where the AI package is unavailable.

## DbC / LOD / Reversibility
- `MemoryPanel(manager=None)` raises `ValueError`.
- `clear_all(confirm=None)` raises — user data can never be silently wiped.
- Panel never touches `MemoryManager._memory` internals from outside `clear_all` (where the manager API lacks a public deletion path).

## Test plan
- [x] `python -m ruff check` clean on changed files
- [x] `python -m ruff format --check` clean on changed files
- [x] `python -m pytest tests/unit/chat/test_memory_panel.py` — 13 passed
- [x] `python -m pytest tests/unit/chat/test_chat_dock_widget_history_browser.py tests/unit/chat/test_dock_widget_dropdowns.py` — 24 passed (no regression)

Closes #2688