### PR TITLE
fix(anti-phantom): handle API propagation race (false-positive 0-files on fresh pushes)

### DIFF
--- a/.github/workflows/anti-phantom-merge.yml
+++ b/.github/workflows/anti-phantom-merge.yml
@@ -144,6 +144,37 @@ jobs:
           echo "changed files:"
           echo "$CHANGED_FILES"
 
+          # If git diff reports 0 changed files, cross-check via the GitHub API
+          # and retry up to 3 times. This handles a race condition where the
+          # workflow fires before the PR's push has fully propagated to the
+          # GitHub API / git database (see false-positives on #2898, #2907).
+          RETRIES=0
+          while [ "$NUM_CHANGED" -eq 0 ] && [ $RETRIES -lt 3 ]; do
+            echo "::notice::0 changed files reported; waiting 10s and retrying (attempt $((RETRIES+1))/3)"
+            sleep 10
+            # Re-fetch base + head in case refs propagated since the initial fetch.
+            git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=50 || true
+            git fetch origin "$BASE_SHA" || true
+            git fetch origin "$HEAD_SHA" || true
+            # Cross-check via the API as well.
+            API_STATS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json additions,deletions,changedFiles 2>/dev/null || echo '{}')
+            API_FILES=$(echo "$API_STATS" | jq -r '.changedFiles // 0')
+            API_ADDS=$(echo "$API_STATS" | jq -r '.additions // 0')
+            API_DELS=$(echo "$API_STATS" | jq -r '.deletions // 0')
+            echo "api_changed_files=$API_FILES api_additions=$API_ADDS api_deletions=$API_DELS"
+            MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "$BASE_SHA")
+            CHANGED_FILES=$(git diff --name-only "$MERGE_BASE...$HEAD_SHA" || true)
+            NUM_CHANGED=$(echo "$CHANGED_FILES" | sed '/^$/d' | wc -l)
+            # If the API sees changes but local git still doesn't, trust the API
+            # count to avoid a false-positive rule-1 failure on a racey push.
+            if [ "$NUM_CHANGED" -eq 0 ] && [ "$API_FILES" -gt 0 ]; then
+              echo "::notice::API reports $API_FILES changed files; deferring to API count to avoid race-induced false positive"
+              NUM_CHANGED="$API_FILES"
+            fi
+            RETRIES=$((RETRIES + 1))
+          done
+          echo "post-retry num_changed=$NUM_CHANGED"
+
           # -------- Rule 1 — empty diff --------
           if [ "$NUM_CHANGED" -eq 0 ]; then
             if [ "$PR_TITLE" = "chore: empty PR" ]; then


### PR DESCRIPTION
Phase 4A audit found anti-phantom-merge.yml has a timing race: when the workflow fires immediately on push, the PR's diff may not yet be reflected in the GitHub API / git database, causing it to falsely report 0 changed files even on PRs with hundreds of lines (#2898, #2907). Adds a retry loop: if the diff reports 0 changed files, wait 10s + re-fetch refs + retry up to 3 times before failing the check. Also cross-checks via the GitHub API and defers to its count when the API sees changes the local git clone doesn't.

This handles the race without weakening the actual rules — substantive PRs that genuinely have 0 changed files will still fail after retries.