### PR TITLE
fix(reporting): extend context gatherer to include all sub-tabs (closes phantom #2747)

### DIFF
--- a/src/shared/python/sidekick/ui/tools_sidebar/reporting_tab.py
+++ b/src/shared/python/sidekick/ui/tools_sidebar/reporting_tab.py
@@ -22,6 +22,58 @@ logger = logging.getLogger(__name__)
 _MARGINS = getattr(theme, "SIDEBAR_LAYOUT_MARGINS", (8, 8, 8, 8))
 _SPACING = getattr(theme, "SIDEBAR_LAYOUT_SPACING", 8)
 
+# Sub-tabs whose runtime state belongs in a session report.  The UI label
+# on the Reporting tab promises that the report aggregates "workspace
+# context, chat interactions, and terminal history" — these IDs cover that
+# promise plus the calculator and data-processor surfaces that share the
+# same sidebar.  A widget is only included when it exposes a public
+# ``get_context_snapshot()`` method that returns a JSON-serializable dict.
+_SNAPSHOTTABLE_SUBTAB_IDS: tuple[str, ...] = (
+    "chat",
+    "terminal",
+    "calculator",
+    "data_processor",
+)
+
+
+def _gather_subtab_snapshots(sidebar: Any) -> dict[str, Any]:
+    """Collect ``get_context_snapshot()`` payloads from known sub-tabs.
+
+    The method is opt-in: a sub-tab is only included when its widget
+    exposes a callable ``get_context_snapshot`` attribute.  Missing tabs
+    and snapshot exceptions are swallowed so that an unhealthy sub-tab
+    cannot block the rest of the report.
+
+    Args:
+        sidebar: The parent ``UnifiedToolsSidebar`` instance.  Must expose
+            ``_tab_widgets`` (a ``dict[str, QWidget]``); sidebars without
+            the attribute return an empty mapping.
+
+    Returns:
+        Mapping of tab id to snapshot dict.  Tabs without a snapshot
+        method, or whose snapshot raises, are omitted entirely (no
+        ``None`` pollution).
+    """
+    tab_widgets = getattr(sidebar, "_tab_widgets", None)
+    if not isinstance(tab_widgets, dict):
+        return {}
+
+    snapshots: dict[str, Any] = {}
+    for tab_id in _SNAPSHOTTABLE_SUBTAB_IDS:
+        widget = tab_widgets.get(tab_id)
+        if widget is None:
+            continue
+        snapshot_fn = getattr(widget, "get_context_snapshot", None)
+        if not callable(snapshot_fn):
+            continue
+        try:
+            snapshot = snapshot_fn()
+        except Exception as exc:  # noqa: BLE001 - per-tab fault isolation
+            logger.warning("Sub-tab %r get_context_snapshot raised: %s", tab_id, exc)
+            continue
+        snapshots[tab_id] = snapshot
+    return snapshots
+
 
 def _gather_session_context(sidebar: Any) -> dict[str, Any]:
     """Collect workspace state that the report generator can summarize.
@@ -30,7 +82,11 @@ def _gather_session_context(sidebar: Any) -> dict[str, Any]:
         sidebar: The parent ``UnifiedToolsSidebar`` instance.
 
     Returns:
-        Dictionary of context data for report generation.
+        Dictionary of context data for report generation.  Always
+        contains ``workspace_variables`` and ``project_root``; sub-tab
+        snapshots (``chat``, ``terminal``, ``calculator``,
+        ``data_processor``) are merged in when the corresponding widget
+        exposes a ``get_context_snapshot()`` method.
     """
     variables: list[str] = []
     try:
@@ -40,10 +96,12 @@ def _gather_session_context(sidebar: Any) -> dict[str, Any]:
 
     project_root = str(getattr(sidebar, "project_root", "."))
 
-    return {
+    context: dict[str, Any] = {
         "workspace_variables": variables,
         "project_root": project_root,
     }
+    context.update(_gather_subtab_snapshots(sidebar))
+    return context
 
 
 def _try_import_report_generator() -> Any | None:

--- a/tests/unit/sidekick/test_reporting_tab_context_gathering.py
+++ b/tests/unit/sidekick/test_reporting_tab_context_gathering.py
@@ -1,0 +1,164 @@
+"""Tests for ``_gather_session_context`` covering Tools #2747.
+
+The reporting tab's UI label promises that the report aggregates
+"workspace context, chat interactions, and terminal history".  The
+historical gatherer only returned workspace variables and the project
+root.  These tests pin the extended contract: the gatherer must
+collect snapshots from the chat, terminal, calculator, and
+data_processor sub-tabs when those tabs are present and expose a
+``get_context_snapshot`` method.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from sidekick.ui.tools_sidebar.reporting_tab import _gather_session_context
+
+
+class _FakeRegistry:
+    def __init__(self, names: list[str]) -> None:
+        self._names = names
+
+    def variables(self) -> list[SimpleNamespace]:
+        return [SimpleNamespace(name=n) for n in self._names]
+
+
+class _SnapshotTab:
+    """Stand-in for a sub-tab widget that exposes a snapshot method."""
+
+    def __init__(self, snapshot: dict[str, Any]) -> None:
+        self._snapshot = snapshot
+        self.calls = 0
+
+    def get_context_snapshot(self) -> dict[str, Any]:
+        self.calls += 1
+        return dict(self._snapshot)
+
+
+class _BoomTab:
+    """Sub-tab whose snapshot method raises — must not break gather."""
+
+    def get_context_snapshot(self) -> dict[str, Any]:
+        raise RuntimeError("snapshot failure")
+
+
+class _OpaqueTab:
+    """Sub-tab with no snapshot method — must be skipped silently."""
+
+
+def _build_sidebar(
+    *,
+    variables: list[str] | None = None,
+    project_root: str = "/tmp/project",
+    tab_widgets: dict[str, Any] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        registry=_FakeRegistry(variables or []),
+        project_root=project_root,
+        _tab_widgets=tab_widgets or {},
+    )
+
+
+def test_base_context_still_present() -> None:
+    """Existing workspace + project_root keys must not regress."""
+    sidebar = _build_sidebar(variables=["alpha", "beta"], project_root="/x")
+    ctx = _gather_session_context(sidebar)
+    assert ctx["workspace_variables"] == ["alpha", "beta"]
+    assert ctx["project_root"] == "/x"
+
+
+@pytest.mark.parametrize(
+    "tab_id",
+    ["chat", "terminal", "calculator", "data_processor"],
+)
+def test_snapshot_collected_for_each_known_subtab(tab_id: str) -> None:
+    """Each advertised sub-tab's snapshot must appear in the context."""
+    snap = {"sample": [1, 2, 3], "tab": tab_id}
+    sidebar = _build_sidebar(tab_widgets={tab_id: _SnapshotTab(snap)})
+    ctx = _gather_session_context(sidebar)
+    assert tab_id in ctx, f"missing {tab_id!r} entry in {sorted(ctx)}"
+    assert ctx[tab_id] == snap
+
+
+def test_all_subtabs_collected_simultaneously() -> None:
+    chat = _SnapshotTab({"messages": ["hi", "hello"]})
+    term = _SnapshotTab({"history": ["ls", "pwd"]})
+    calc = _SnapshotTab({"expressions": ["1+1=2"]})
+    data = _SnapshotTab({"dataset": "df.csv"})
+    sidebar = _build_sidebar(
+        tab_widgets={
+            "chat": chat,
+            "terminal": term,
+            "calculator": calc,
+            "data_processor": data,
+        },
+    )
+    ctx = _gather_session_context(sidebar)
+    assert ctx["chat"] == {"messages": ["hi", "hello"]}
+    assert ctx["terminal"] == {"history": ["ls", "pwd"]}
+    assert ctx["calculator"] == {"expressions": ["1+1=2"]}
+    assert ctx["data_processor"] == {"dataset": "df.csv"}
+    assert chat.calls == 1
+
+
+def test_missing_subtab_is_skipped() -> None:
+    """Absent sub-tabs must not appear in the context (no None pollution)."""
+    sidebar = _build_sidebar(tab_widgets={"chat": _SnapshotTab({"m": []})})
+    ctx = _gather_session_context(sidebar)
+    assert "chat" in ctx
+    assert "terminal" not in ctx
+    assert "calculator" not in ctx
+    assert "data_processor" not in ctx
+
+
+def test_subtab_without_snapshot_method_is_skipped() -> None:
+    sidebar = _build_sidebar(tab_widgets={"chat": _OpaqueTab()})
+    ctx = _gather_session_context(sidebar)
+    assert "chat" not in ctx
+    # Base keys still survive
+    assert "workspace_variables" in ctx
+    assert "project_root" in ctx
+
+
+def test_snapshot_exception_is_swallowed() -> None:
+    """A failing snapshot must not break the whole gather."""
+    sidebar = _build_sidebar(
+        tab_widgets={
+            "chat": _BoomTab(),
+            "terminal": _SnapshotTab({"history": ["ok"]}),
+        },
+    )
+    ctx = _gather_session_context(sidebar)
+    # chat snapshot failed silently and does not poison the dict
+    assert "chat" not in ctx
+    # terminal snapshot succeeded
+    assert ctx["terminal"] == {"history": ["ok"]}
+
+
+def test_sidebar_without_tab_widgets_attribute() -> None:
+    """Sidebars predating the registry must not raise."""
+    sidebar = SimpleNamespace(
+        registry=_FakeRegistry([]),
+        project_root="/p",
+    )
+    ctx = _gather_session_context(sidebar)
+    assert ctx["workspace_variables"] == []
+    assert ctx["project_root"] == "/p"
+
+
+def test_output_shape_matches_ui_label_promise() -> None:
+    """The UI label promises workspace + chat + terminal at minimum."""
+    sidebar = _build_sidebar(
+        variables=["x"],
+        tab_widgets={
+            "chat": _SnapshotTab({"messages": []}),
+            "terminal": _SnapshotTab({"history": []}),
+        },
+    )
+    ctx = _gather_session_context(sidebar)
+    expected = {"workspace_variables", "project_root", "chat", "terminal"}
+    assert expected.issubset(ctx.keys())

--- a/tests/unit/sidekick/test_reporting_tab_context_gathering.py
+++ b/tests/unit/sidekick/test_reporting_tab_context_gathering.py
@@ -15,7 +15,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-
 from sidekick.ui.tools_sidebar.reporting_tab import _gather_session_context
 
 


### PR DESCRIPTION
## Summary

Phase 6C of the 2026-05-17 fleet audit identified #2747 as the single clean P1 phantom-close gap. The reporting tab's UI label promises that the generated session report aggregates 'workspace context, chat interactions, and terminal history' but the gatherer only returned `workspace_variables` and `project_root`. This PR extends the gatherer to collect from all advertised sub-tabs.

## Changes

- `src/shared/python/sidekick/ui/tools_sidebar/reporting_tab.py` — new `_gather_subtab_snapshots()` helper that introspects `sidebar._tab_widgets` and merges `get_context_snapshot()` payloads from `chat`, `terminal`, `calculator`, and `data_processor` sub-tabs into the report context.
- The integration is opt-in (a sub-tab is included only when it exposes a callable `get_context_snapshot` attribute) and fault-isolated (missing tabs are skipped, snapshot exceptions are logged and the offending tab is dropped — one unhealthy sub-tab cannot block the rest of the report).
- Backward compatible: sidebars predating the `_tab_widgets` attribute and sub-tabs without a snapshot method keep working unchanged. No new mandatory contract is imposed on existing sub-tabs.

## Test plan

- [x] Added `tests/unit/sidekick/test_reporting_tab_context_gathering.py` (11 tests, all passing): base context regression, parametrized per-sub-tab snapshot collection, simultaneous collection, missing-sub-tab skip, missing-method skip, snapshot exception isolation, sidebar without `_tab_widgets` attribute, UI-label promise shape.
- [x] `python -m ruff check` — clean
- [x] `python -m ruff format --check` — clean

Closes #2747