### PR TITLE
ci(parallelize): fan out tests after pick-runner (~30min savings)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -305,7 +305,11 @@ jobs:
 
   tests:
     timeout-minutes: 30
-    needs: [pick-runner, quality-gate]
+    # Parallelized: tests do not consume any quality-gate outputs (quality-gate
+    # declares no `outputs:` block, and no step in this job references
+    # `needs.quality-gate.*`). Fanning out after pick-runner removes the
+    # inter-job queue wait between quality-gate completion and tests start.
+    needs: [pick-runner]
     runs-on: d-sorg-fleet
     strategy:
       matrix:


### PR DESCRIPTION
Per the audit of run #25980399944 (which took 54-69min wallclock with inter-job queue waits dominating), restructure CI Standard so the `tests` matrix runs in parallel with `quality-gate` after `pick-runner` instead of chaining via `needs: quality-gate`.

## Change

Single edit in `.github/workflows/ci-standard.yml`:
- `tests`: `needs: [pick-runner, quality-gate]` -> `needs: [pick-runner]`

## Final job graph

| Job | needs | Notes |
|-----|-------|-------|
| `pick-runner` | (none) | Dispatcher, declares `runner` output |
| `quality-gate` | `pick-runner` | No `outputs:` declared |
| `tests` (matrix 3.10/3.11/3.12) | `[pick-runner]` | CHANGED - parallelized |
| `rust-quality-gate` | `pick-runner` | Already parallel (no change) |

## Verification

Confirmed before parallelizing `tests`:
- grep `needs\.quality-gate` ci-standard.yml -> zero matches
- `quality-gate` declares no `outputs:` block
- Therefore `tests` has no data dependency on `quality-gate`, only a scheduling/ordering one - which is the inter-job queue wait being removed

Jobs kept on `needs: quality-gate`: none. No job in this file consumes `quality-gate` outputs.

## Expected impact

- Removes 10-21 min inter-job queue waits between quality-gate completion and tests start
- Reduces total wallclock by ~30 min during fleet saturation
- Preserves quality-gate as a separate reported check
- PR still goes red if any single dimension fails

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci-standard.yml'))"` -> passes
- All 4 jobs preserved (`pick-runner`, `quality-gate`, `tests`, `rust-quality-gate`)
- Only `needs:` declarations changed; `runs-on`, `timeout-minutes`, all `steps:` unchanged