### PR TITLE
policy(ci): migrate hosted-runner workflows to d-sorg-fleet (keep guard tripwire on hosted)

### DIFF
--- a/.github/workflows/Jules-Assessment-Generator.yml
+++ b/.github/workflows/Jules-Assessment-Generator.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   generate-assessments:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     # Grant write only at this job level — assessment commits and issue creation
     # happen here.
     permissions:

--- a/.github/workflows/Jules-Assessment-Remediator.yml
+++ b/.github/workflows/Jules-Assessment-Remediator.yml
@@ -75,7 +75,7 @@ env:
 
 jobs:
   remediate:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 45
     # Grant write only at this job level — remediation creates branches, pushes
     # fixes, opens PRs, and closes resolved issues.

--- a/.github/workflows/Jules-Code-Quality-Reviewer.yml
+++ b/.github/workflows/Jules-Code-Quality-Reviewer.yml
@@ -41,7 +41,7 @@ permissions:
 jobs:
   review:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     # Grant write only at this job level — report commits and issue creation
     # happen here. No write needed for runner selection.
     permissions:

--- a/.github/workflows/Jules-Completist.yml
+++ b/.github/workflows/Jules-Completist.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
   audit:
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     # Grant write only at this job level.
     permissions:
       contents: write # push completist fixes to jules/completist-* branch

--- a/.github/workflows/Jules-Comprehensive-Assessment.yml
+++ b/.github/workflows/Jules-Comprehensive-Assessment.yml
@@ -34,7 +34,7 @@ jobs:
   comprehensive-assessment:
     timeout-minutes: 30
     name: Comprehensive Assessment & Audit
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     # Grant write only at this job level.
     permissions:
       contents: write  # commit assessment report to docs/assessments/

--- a/.github/workflows/Jules-Critics-Comments.yml
+++ b/.github/workflows/Jules-Critics-Comments.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   write-critics-comments:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/Jules-Diff-Verifier.yml
+++ b/.github/workflows/Jules-Diff-Verifier.yml
@@ -43,7 +43,7 @@ jobs:
   verify:
     timeout-minutes: 30
     name: Verify Diff Substance
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     # Only gate Jules-generated branches. Other PRs pass through automatically.
     if: >
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/Jules-Laymans-Terms-Writer.yml
+++ b/.github/workflows/Jules-Laymans-Terms-Writer.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   write-laymans-terms:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/file-size-budget.yml
+++ b/.github/workflows/file-size-budget.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   file-size-budget:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/maturin-ai-backend.yml
+++ b/.github/workflows/maturin-ai-backend.yml
@@ -109,7 +109,7 @@ jobs:
   # ── Optional: build with local-embeddings feature (Linux only, heavy) ────────
   build-local-embeddings:
     name: Build wheel with local-embeddings (Linux)
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 45
     # Only on workflow_dispatch to keep PR feedback fast
     if: github.event_name == 'workflow_dispatch'
@@ -160,7 +160,7 @@ jobs:
     timeout-minutes: 60
     name: Wheel build summary
     needs: build-wheels
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     if: always()
     steps:
       - name: Report results

--- a/.github/workflows/nightly-full-repo-quality.yml
+++ b/.github/workflows/nightly-full-repo-quality.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   full-repo-quality:
     name: Full-Repo Quality Audit
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary

Fleet-wide policy enforcement: no jobs may run on GitHub-hosted runners (`ubuntu-latest`, `windows-latest`, `macos-latest`). All work routes to the self-hosted `d-sorg-fleet` pool.

This batch migrates the remaining hosted-runner jobs in Tools that weren't already on the fleet.

## Workflows / jobs migrated (ubuntu-latest -> d-sorg-fleet)

| Workflow | Job |
|----------|-----|
| `file-size-budget.yml` | `file-size-budget` |
| `Jules-Assessment-Generator.yml` | `generate-assessments` |
| `Jules-Assessment-Remediator.yml` | `remediate` |
| `Jules-Code-Quality-Reviewer.yml` | `review` |
| `Jules-Completist.yml` | `audit` |
| `Jules-Comprehensive-Assessment.yml` | `Comprehensive Assessment & Audit` |
| `Jules-Critics-Comments.yml` | `write-critics-comments` |
| `Jules-Diff-Verifier.yml` | `Verify Diff Substance` |
| `Jules-Laymans-Terms-Writer.yml` | `write-laymans-terms` |
| `maturin-ai-backend.yml` | `build-local-embeddings`, `summary` |
| `nightly-full-repo-quality.yml` | `Full-Repo Quality Audit` |

## Intentionally left on GitHub-hosted runners

- `maturin-ai-backend.yml` job `build-wheels` uses `runs-on: ${{ matrix.os }}` with `[ubuntu-latest, windows-latest, macos-latest]` — documented in `CLAUDE.md` as the cross-platform wheel build matrix; the `d-sorg-fleet` label is Linux-only so Windows/macOS wheel builds must remain hosted.

No tripwire workflow exists in Tools requiring an `ubuntu-latest` exception (the `local-only-runner-guard.yml` and `ci-standard.yml` `local-only-workflows` job already run on `d-sorg-fleet`).

## Verification

- Only `runs-on:` lines changed (verified via `git diff`)
- All edited workflow files parse cleanly with `python -c "import yaml; yaml.safe_load(open(f, encoding='utf-8'))"`

## Test plan

- [ ] CI shows the migrated jobs pick up on the `d-sorg-fleet` pool on next trigger
- [ ] No regression in workflow behaviour (only runner label changed)