### PR TITLE
fix(ci): allowlist local-only-runner-guard.yml in tripwire scanner (resolves self-failure)

### DIFF
--- a/scripts/check_local_only_workflows.py
+++ b/scripts/check_local_only_workflows.py
@@ -28,6 +28,7 @@ LEGACY_HOSTED_RUNNER_ALLOWLIST = {
     ".github/workflows/Jules-Critics-Comments.yml",
     ".github/workflows/Jules-Laymans-Terms-Writer.yml",
     ".github/workflows/file-size-budget.yml",
+    ".github/workflows/local-only-runner-guard.yml",
     ".github/workflows/nightly-full-repo-quality.yml",
 }
 


### PR DESCRIPTION
After tonight's tripwire restoration to ubuntu-latest, the tripwire scanner fails on its own file. Adding it to the legacy allowlist so the scanner ignores the tripwire's intentional ubuntu-latest while still catching other hosted-runner drift.