### PR TITLE
ci: replace stub runner guard with real enforcement; fix 4 hosted leaks

### DIFF
--- a/.github/workflows/issue-closure-policy.yml
+++ b/.github/workflows/issue-closure-policy.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 5
     if: github.event.issue.state_reason == 'completed'
     steps:

--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -1,49 +1,141 @@
 name: Local-Only Workflow Runner Guard
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+
+# Enforces that every workflow in this repo routes its jobs to the d-sorg
+# self-hosted fleet. The guard runs on ubuntu-latest because it is the canary
+# that must remain operable when the fleet itself is down. The job is named
+# "Reject hosted runner routing" — together with the workflow name above, these
+# are the only two names allowlisted to run on hosted runners across the org.
 
 on:
   pull_request:
     paths:
       - ".github/workflows/**"
-      - "scripts/check_local_only_workflows.py"
   push:
     branches: [main]
     paths:
       - ".github/workflows/**"
-      - "scripts/check_local_only_workflows.py"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  local-only-workflows:
-    timeout-minutes: 30
+  reject-hosted-runner-routing:
     name: Reject hosted runner routing
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Checkout repository without external actions
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install --disable-pip-version-check pyyaml==6.0.2
+
+      - name: Verify all workflows route to d-sorg-fleet
+        shell: python
         run: |
-          set -euo pipefail
-          auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
-          git init "$GITHUB_WORKSPACE"
-          cd "$GITHUB_WORKSPACE"
-          git remote remove origin 2>/dev/null || true
-          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" fetch --depth=1 origin "$GITHUB_SHA"
-          git checkout --force FETCH_HEAD
-          git clean -ffdx
-      - name: Run local-only workflow guard
-        shell: bash
-        run: |
-          set -euo pipefail
-          if command -v python3 >/dev/null 2>&1; then
-            python3 scripts/check_local_only_workflows.py
-          else
-            python scripts/check_local_only_workflows.py
-          fi
+          import re
+          import sys
+          from pathlib import Path
+
+          import yaml
+
+          # Workflow files allowlisted to run on hosted runners. The guard itself
+          # is here because it is the canary. The runner-health-alert canary in
+          # Repository_Management is allowlisted only in that repo; the entry is
+          # harmless elsewhere.
+          ALLOWLIST_FILES = {
+              "local-only-runner-guard.yml",
+              "runner-health-alert.yml",
+          }
+          # Job names allowlisted to run on hosted runners. Matches the two
+          # human-facing names every repo's CI standard refers to.
+          ALLOWLIST_JOB_NAMES = {
+              "Reject hosted runner routing",
+              "Local-Only Workflow Runner Guard",
+          }
+          HOSTED = re.compile(r"^(ubuntu|macos|windows)(-latest|-\d+)?$")
+
+          def collect_runs_on(job: dict) -> list[str]:
+              runs_on = job.get("runs-on")
+              values: list[str] = []
+              if isinstance(runs_on, str):
+                  values.append(runs_on)
+              elif isinstance(runs_on, list):
+                  values.extend(v for v in runs_on if isinstance(v, str))
+              # Resolve matrix.os: walk strategy.matrix.os and strategy.matrix.include[*].os
+              if any("matrix.os" in v for v in values):
+                  values = []
+                  strategy = job.get("strategy") or {}
+                  matrix = strategy.get("matrix") or {}
+                  if isinstance(matrix, dict):
+                      os_axis = matrix.get("os")
+                      if isinstance(os_axis, list):
+                          values.extend(v for v in os_axis if isinstance(v, str))
+                      include = matrix.get("include")
+                      if isinstance(include, list):
+                          for item in include:
+                              if isinstance(item, dict) and isinstance(item.get("os"), str):
+                                  values.append(item["os"])
+              return values
+
+          violations: list[str] = []
+          wf_dir = Path(".github/workflows")
+          if not wf_dir.is_dir():
+              print("No .github/workflows directory; nothing to check.")
+              sys.exit(0)
+
+          for wf in sorted(wf_dir.glob("*.y*ml")):
+              if wf.name in ALLOWLIST_FILES:
+                  continue
+              try:
+                  data = yaml.safe_load(wf.read_text(encoding="utf-8"))
+              except yaml.YAMLError as exc:
+                  violations.append(f"{wf.name}: failed to parse YAML: {exc}")
+                  continue
+              if not isinstance(data, dict):
+                  continue
+              jobs = data.get("jobs") or {}
+              if not isinstance(jobs, dict):
+                  continue
+              for job_id, job in jobs.items():
+                  if not isinstance(job, dict):
+                      continue
+                  if job.get("name") in ALLOWLIST_JOB_NAMES:
+                      continue
+                  # Reusable workflow callers don't have runs-on; skip
+                  if "uses" in job and "runs-on" not in job:
+                      continue
+                  values = collect_runs_on(job)
+                  if not values:
+                      # Could be an expression like ${{ needs.pick-runner.outputs.runner }};
+                      # treat the raw expression text as the value to inspect.
+                      raw = job.get("runs-on")
+                      if isinstance(raw, str):
+                          values = [raw]
+                  for v in values:
+                      v_clean = v.strip()
+                      # Expressions that resolve at runtime to fleet labels are OK
+                      if "pick-runner" in v_clean or "d-sorg-fleet" in v_clean or "self-hosted" in v_clean:
+                          continue
+                      if HOSTED.match(v_clean):
+                          violations.append(
+                              f"{wf.name}::{job_id}: runs-on '{v_clean}' is a hosted runner; "
+                              f"route to d-sorg-fleet (or `${{{{ needs.pick-runner.outputs.runner }}}}`)."
+                          )
+
+          if violations:
+              print("\n".join(f"::error::{v}" for v in violations))
+              print()
+              print(f"{len(violations)} workflow(s) leak to hosted runners.")
+              print(
+                  "Allowed: local-only-runner-guard.yml, runner-health-alert.yml, "
+                  "and jobs literally named 'Reject hosted runner routing'."
+              )
+              sys.exit(1)
+
+          print("All workflows route to d-sorg-fleet.")

--- a/.github/workflows/maturin-ai-backend.yml
+++ b/.github/workflows/maturin-ai-backend.yml
@@ -42,13 +42,16 @@ concurrency:
 jobs:
   build-wheels:
     name: Build wheel (${{ matrix.os }}, Python ${{ matrix.python-version }})
-    runs-on: ${{ matrix.os }}
+    runs-on: d-sorg-fleet
     timeout-minutes: 30
 
+    # Windows and macOS dropped 2026-05-17 — no fleet equivalent yet, and the
+    # org policy (Runner_Dashboard#641) forbids hosted fallback. Restoring
+    # Windows + macOS wheel builds is tracked in #643 / #642 respectively.
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
Part of #641. Replaces stub guard. Fixes 4 hosted-runner leaks: maturin-ai-backend.yml drops windows-latest + macos-latest from wheel build matrix (#643 / #642 track restoration); issue-closure-policy.yml routed to d-sorg-fleet. Verifier reports CLEAN.
