### PR TITLE
feat(sidekick): add markdown notes tab with color picker and persistence (closes #2931)

### DIFF
--- a/src/shared/python/sidekick/notes_store.py
+++ b/src/shared/python/sidekick/notes_store.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import cast
 
 from notes.card_store import NoteCardStore
 from notes.models import DEFAULT_NOTE_COLOR, NoteCard
@@ -136,7 +137,7 @@ class SidekickNotesStore:
         Returns:
             List of :class:`~notes.models.NoteCard` objects.
         """
-        return self._store.list_notes()
+        return cast(list[NoteCard], self._store.list_notes())
 
     def load_note(self, note_id: str) -> NoteCard | None:
         """Load one note by ID, or ``None`` if it does not exist.

--- a/src/shared/python/sidekick/notes_store.py
+++ b/src/shared/python/sidekick/notes_store.py
@@ -1,0 +1,185 @@
+"""Sidekick notes persistence facade (issue #2931).
+
+Wraps :class:`~notes.card_store.NoteCardStore` with a Sidekick-scoped
+interface so the notes tab does not reach into the ``notes`` package directly.
+
+Design
+------
+- **DbC**: preconditions checked on every public method.
+- **LOD**: only one level of delegation to ``NoteCardStore``.
+- **DRY**: all persistence logic lives in ``NoteCardStore``; this module
+  adds only the Sidekick-specific directory layout and name.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from notes.card_store import NoteCardStore
+from notes.models import DEFAULT_NOTE_COLOR, NoteCard
+
+log = logging.getLogger(__name__)
+
+_NOTES_SUBDIR = ".sidekick_notes"
+
+
+class SidekickNotesStore:
+    """Project-scoped notes store for the Sidekick notes tab.
+
+    Persists :class:`~notes.models.NoteCard` objects under
+    ``<project_root>/.sidekick_notes/`` using :class:`~notes.card_store.NoteCardStore`.
+
+    Args:
+        project_root: Root directory of the current project.
+
+    Raises:
+        TypeError: If *project_root* is ``None``.
+        ValueError: If *project_root* does not exist or is not a directory.
+    """
+
+    def __init__(self, project_root: Path | str) -> None:
+        if project_root is None:
+            raise TypeError("project_root must be provided")
+        self._root = Path(project_root)
+        if not self._root.exists() or not self._root.is_dir():
+            raise ValueError(
+                f"project_root must exist and be a directory: {self._root!r}"
+            )
+        self._root.mkdir(parents=True, exist_ok=True)
+        # Ensure the notes sub-directory exists before constructing the store
+        notes_dir = self._root / _NOTES_SUBDIR
+        notes_dir.mkdir(parents=True, exist_ok=True)
+        self._store = NoteCardStore(
+            project_dir=self._root,
+            notes_dirname=_NOTES_SUBDIR,
+        )
+        log.debug("SidekickNotesStore initialized at %s", self._root)
+
+    # ------------------------------------------------------------------
+    # Public API (thin delegation to NoteCardStore)
+    # ------------------------------------------------------------------
+
+    def create_note(
+        self,
+        title: str,
+        body: str = "",
+        *,
+        color: str = DEFAULT_NOTE_COLOR,
+    ) -> NoteCard:
+        """Create and persist a new note card.
+
+        Args:
+            title: Human-readable note title.
+            body: Markdown body text (may be empty).
+            color: Background color as ``#RRGGBB`` hex string.
+
+        Returns:
+            The newly created :class:`~notes.models.NoteCard`.
+
+        Raises:
+            TypeError: If *title* is not a string.
+            ValueError: If *title* is empty or *color* is not a valid hex color.
+        """
+        if not isinstance(title, str):
+            raise TypeError(f"title must be str, got {type(title).__name__!r}")
+        if not title.strip():
+            raise ValueError("title must not be empty")
+        card = self._store.create_note(title=title, markdown_body=body, color=color)
+        log.debug("Created note %r (color=%r)", card.note_id, card.color)
+        return card
+
+    def update_note(
+        self,
+        note_id: str,
+        *,
+        title: str,
+        body: str,
+        color: str = DEFAULT_NOTE_COLOR,
+    ) -> NoteCard:
+        """Update an existing note card.
+
+        Args:
+            note_id: Stable identifier of the note to update.
+            title: Updated title.
+            body: Updated markdown body.
+            color: Updated background color as ``#RRGGBB`` hex string.
+
+        Returns:
+            The updated :class:`~notes.models.NoteCard`.
+
+        Raises:
+            TypeError: If *note_id* or *title* is not a string.
+            ValueError: If *note_id* or *title* is empty.
+            FileNotFoundError: If no note with *note_id* exists.
+        """
+        if not isinstance(note_id, str):
+            raise TypeError(f"note_id must be str, got {type(note_id).__name__!r}")
+        if not note_id.strip():
+            raise ValueError("note_id must not be empty")
+        if not isinstance(title, str):
+            raise TypeError(f"title must be str, got {type(title).__name__!r}")
+        if not title.strip():
+            raise ValueError("title must not be empty")
+        card = self._store.update_note(
+            note_id,
+            title=title,
+            markdown_body=body,
+            color=color,
+        )
+        log.debug("Updated note %r", note_id)
+        return card
+
+    def list_notes(self) -> list[NoteCard]:
+        """Return all notes sorted by newest update first.
+
+        Returns:
+            List of :class:`~notes.models.NoteCard` objects.
+        """
+        return self._store.list_notes()
+
+    def load_note(self, note_id: str) -> NoteCard | None:
+        """Load one note by ID, or ``None`` if it does not exist.
+
+        Args:
+            note_id: Stable note identifier.
+
+        Returns:
+            :class:`~notes.models.NoteCard` or ``None``.
+
+        Raises:
+            TypeError: If *note_id* is not a string.
+            ValueError: If *note_id* is empty.
+        """
+        if not isinstance(note_id, str):
+            raise TypeError(f"note_id must be str, got {type(note_id).__name__!r}")
+        if not note_id.strip():
+            raise ValueError("note_id must not be empty")
+        return self._store.load_note(note_id)
+
+    def delete_note(self, note_id: str) -> bool:
+        """Move *note_id* to the recycle bin.
+
+        Args:
+            note_id: Stable note identifier.
+
+        Returns:
+            ``True`` when the note was found and recycled.
+
+        Raises:
+            TypeError: If *note_id* is not a string.
+            ValueError: If *note_id* is empty.
+        """
+        if not isinstance(note_id, str):
+            raise TypeError(f"note_id must be str, got {type(note_id).__name__!r}")
+        if not note_id.strip():
+            raise ValueError("note_id must not be empty")
+        try:
+            self._store.delete_note(note_id, reason="user_delete")
+            log.debug("Deleted note %r", note_id)
+            return True
+        except FileNotFoundError:
+            return False
+
+
+__all__ = ["SidekickNotesStore"]

--- a/src/shared/python/sidekick/notes_tab.py
+++ b/src/shared/python/sidekick/notes_tab.py
@@ -1,0 +1,416 @@
+"""Visual markdown notes tab for the Sidekick sidebar (issue #2931).
+
+Provides a card-based notes UI with:
+
+- A scrollable grid of colored note cards
+- Per-card color picker (via :class:`~PyQt6.QtWidgets.QColorDialog`)
+- Markdown rendering in the card preview (CommonMark via ``mistune``)
+- Persistence across sessions via :class:`~sidekick.notes_store.SidekickNotesStore`
+
+Design
+------
+- **DbC**: every public method validates its inputs.
+- **LOD**: the tab only talks to :class:`SidekickNotesStore`; it does not
+  reach into ``NoteCardStore`` directly.
+- **DRY**: card widget creation is delegated to :func:`_make_note_card_widget`.
+
+Dependencies
+------------
+- PyQt6 (required; module raises ``ImportError`` if missing)
+- mistune >= 3.0 (optional; falls back to plain-text when absent)
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+try:
+    from PyQt6.QtCore import Qt, pyqtSignal
+    from PyQt6.QtGui import QColor, QFont
+    from PyQt6.QtWidgets import (
+        QColorDialog,
+        QDialog,
+        QDialogButtonBox,
+        QHBoxLayout,
+        QLabel,
+        QLineEdit,
+        QPlainTextEdit,
+        QPushButton,
+        QScrollArea,
+        QSizePolicy,
+        QTextEdit,
+        QVBoxLayout,
+        QWidget,
+    )
+
+    _QT_AVAILABLE = True
+except ImportError:
+    _QT_AVAILABLE = False
+
+try:
+    import mistune
+
+    _MISTUNE_AVAILABLE = True
+except ImportError:
+    _MISTUNE_AVAILABLE = False
+
+from notes.models import (  # noqa: E402
+    DEFAULT_NOTE_COLOR,
+    NoteCard,
+)
+
+from .notes_store import SidekickNotesStore  # noqa: E402
+
+_CARD_MIN_WIDTH = 220
+_CARD_MAX_WIDTH = 340
+_CARD_MIN_HEIGHT = 160
+
+
+def _render_markdown(text: str) -> str:
+    """Render *text* as HTML via mistune, or fall back to plain text.
+
+    Args:
+        text: Markdown source.
+
+    Returns:
+        HTML string, or escaped plain text when mistune is unavailable.
+    """
+    if _MISTUNE_AVAILABLE:
+        # mistune.create_markdown returns a callable
+        md = mistune.create_markdown(plugins=["strikethrough", "table"])
+        return md(text)
+    # Minimal plain-text fallback
+    return f"<pre>{text}</pre>"
+
+
+def _color_button_style(color: str) -> str:
+    """Return a QSS stylesheet string for a color swatch button."""
+    return (
+        f"QPushButton {{ background: {color}; border: 1px solid #aaa;"
+        f" border-radius: 4px; min-width: 20px; max-width: 20px;"
+        f" min-height: 20px; max-height: 20px; }}"
+    )
+
+
+def _make_note_card_widget(
+    card: NoteCard,
+    on_edit: Any,
+    on_delete: Any,
+    on_color_change: Any,
+    parent: QWidget | None = None,
+) -> QWidget:
+    """Create a single visual note card widget.
+
+    Args:
+        card: The :class:`~notes.models.NoteCard` to display.
+        on_edit: Callable ``(note_id: str) -> None`` invoked when Edit is clicked.
+        on_delete: Callable ``(note_id: str) -> None`` invoked when Delete is clicked.
+        on_color_change: Callable ``(note_id: str, color: str) -> None`` invoked
+            when the color swatch is clicked and a new color is picked.
+        parent: Optional Qt parent.
+
+    Returns:
+        A :class:`~PyQt6.QtWidgets.QWidget` representing the note card.
+    """
+    frame = QWidget(parent)
+    frame.setObjectName(f"NoteCard_{card.note_id}")
+    frame.setMinimumSize(_CARD_MIN_WIDTH, _CARD_MIN_HEIGHT)
+    frame.setMaximumWidth(_CARD_MAX_WIDTH)
+    frame.setSizePolicy(
+        QSizePolicy.Policy.Preferred,
+        QSizePolicy.Policy.Minimum,
+    )
+    frame.setStyleSheet(
+        f"QWidget#NoteCard_{card.note_id} {{"
+        f"  background: {card.color};"
+        f"  border: 1px solid #ccc;"
+        f"  border-radius: 6px;"
+        f"  padding: 6px;"
+        f"}}"
+    )
+
+    layout = QVBoxLayout(frame)
+    layout.setContentsMargins(8, 6, 8, 6)
+    layout.setSpacing(4)
+
+    # ── Title row ───────────────────────────────────────────────────────
+    header = QHBoxLayout()
+
+    title_label = QLabel(card.title, frame)
+    title_label.setObjectName(f"NoteCardTitle_{card.note_id}")
+    title_label.setFont(_bold_font(11))
+    title_label.setWordWrap(True)
+    header.addWidget(title_label, stretch=1)
+
+    # Color swatch
+    color_btn = QPushButton(frame)
+    color_btn.setObjectName(f"NoteCardColor_{card.note_id}")
+    color_btn.setStyleSheet(_color_button_style(card.color))
+    color_btn.setToolTip("Change card color")
+    color_btn.clicked.connect(lambda: on_color_change(card.note_id))
+    header.addWidget(color_btn)
+
+    layout.addLayout(header)
+
+    # ── Markdown body preview ────────────────────────────────────────────
+    body_view = QTextEdit(frame)
+    body_view.setObjectName(f"NoteCardBody_{card.note_id}")
+    body_view.setReadOnly(True)
+    body_view.setHtml(_render_markdown(card.markdown_body))
+    body_view.setMaximumHeight(120)
+    body_view.setStyleSheet("QTextEdit { background: transparent; border: none; }")
+    layout.addWidget(body_view, stretch=1)
+
+    # ── Action row ───────────────────────────────────────────────────────
+    actions = QHBoxLayout()
+
+    edit_btn = QPushButton("Edit", frame)
+    edit_btn.setObjectName(f"NoteCardEdit_{card.note_id}")
+    edit_btn.clicked.connect(lambda: on_edit(card.note_id))
+    actions.addWidget(edit_btn)
+
+    delete_btn = QPushButton("Delete", frame)
+    delete_btn.setObjectName(f"NoteCardDelete_{card.note_id}")
+    delete_btn.clicked.connect(lambda: on_delete(card.note_id))
+    actions.addWidget(delete_btn)
+
+    layout.addLayout(actions)
+
+    return frame
+
+
+def _bold_font(size: int) -> QFont:
+    font = QFont()
+    font.setBold(True)
+    font.setPointSize(size)
+    return font
+
+
+class _NoteEditDialog(QDialog):
+    """Modal dialog for creating / editing a note card.
+
+    Args:
+        card: Existing card to edit, or ``None`` to create a new one.
+        parent: Optional Qt parent.
+    """
+
+    def __init__(
+        self,
+        card: NoteCard | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("NoteEditDialog")
+        self.setWindowTitle("Edit Note" if card else "New Note")
+        self.setMinimumSize(480, 360)
+
+        layout = QVBoxLayout(self)
+
+        title_row = QHBoxLayout()
+        title_row.addWidget(QLabel("Title:", self))
+        self._title_edit = QLineEdit(card.title if card else "", self)
+        self._title_edit.setObjectName("NoteEditTitle")
+        title_row.addWidget(self._title_edit, stretch=1)
+        layout.addLayout(title_row)
+
+        layout.addWidget(QLabel("Body (Markdown):", self))
+        self._body_edit = QPlainTextEdit(card.markdown_body if card else "", self)
+        self._body_edit.setObjectName("NoteEditBody")
+        layout.addWidget(self._body_edit, stretch=1)
+
+        # Color picker row
+        color_row = QHBoxLayout()
+        self._color: str = card.color if card else DEFAULT_NOTE_COLOR
+        color_row.addWidget(QLabel("Card color:", self))
+        self._color_preview = QPushButton(self)
+        self._color_preview.setObjectName("NoteEditColorSwatch")
+        self._color_preview.setStyleSheet(_color_button_style(self._color))
+        self._color_preview.setFixedSize(28, 28)
+        self._color_preview.clicked.connect(self._pick_color)
+        color_row.addWidget(self._color_preview)
+        color_row.addStretch()
+        layout.addLayout(color_row)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+            parent=self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _pick_color(self) -> None:
+        initial = QColor(self._color)
+        picked = QColorDialog.getColor(initial, self, "Pick note color")
+        if picked.isValid():
+            self._color = picked.name()
+            self._color_preview.setStyleSheet(_color_button_style(self._color))
+
+    @property
+    def title_text(self) -> str:
+        return self._title_edit.text().strip()
+
+    @property
+    def body_text(self) -> str:
+        return self._body_edit.toPlainText()
+
+    @property
+    def color(self) -> str:
+        return self._color
+
+
+class NotesTab(QWidget):
+    """Sidekick notes tab with markdown note cards and color pickers.
+
+    Persists notes via :class:`~sidekick.notes_store.SidekickNotesStore`.
+
+    Args:
+        project_root: Root directory for persisting notes.
+        parent: Optional Qt parent widget.
+
+    Raises:
+        TypeError: If *project_root* is ``None``.
+        ValueError: If *project_root* does not exist or is not a directory.
+
+    Signals:
+        notes_changed: Emitted whenever notes are created, updated, or deleted.
+    """
+
+    notes_changed = pyqtSignal()
+
+    def __init__(
+        self,
+        project_root: Path | str,
+        parent: QWidget | None = None,
+    ) -> None:
+        if project_root is None:
+            raise TypeError("project_root must be provided")
+        super().__init__(parent)
+        self.setObjectName("SidekickNotesTab")
+
+        self._store = SidekickNotesStore(project_root)
+        self._build_ui()
+        self.refresh()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(4)
+
+        # ── Toolbar ───────────────────────────────────────────────────────
+        toolbar = QHBoxLayout()
+        new_btn = QPushButton("+ New Note", self)
+        new_btn.setObjectName("NotesTabNewButton")
+        new_btn.clicked.connect(self._on_new_note)
+        toolbar.addWidget(new_btn)
+        toolbar.addStretch()
+        layout.addLayout(toolbar)
+
+        # ── Scrollable card grid ─────────────────────────────────────────
+        self._scroll = QScrollArea(self)
+        self._scroll.setObjectName("NotesTabScrollArea")
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+        self._card_container = QWidget(self._scroll)
+        self._card_container.setObjectName("NotesCardContainer")
+        self._card_layout = QVBoxLayout(self._card_container)
+        self._card_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+        self._scroll.setWidget(self._card_container)
+
+        layout.addWidget(self._scroll, stretch=1)
+
+    def refresh(self) -> None:
+        """Reload all notes from the store and rebuild the card grid."""
+        # Clear existing cards
+        while self._card_layout.count():
+            item = self._card_layout.takeAt(0)
+            if item and item.widget():
+                item.widget().deleteLater()
+
+        cards = self._store.list_notes()
+        for card in cards:
+            widget = _make_note_card_widget(
+                card,
+                on_edit=self._on_edit_note,
+                on_delete=self._on_delete_note,
+                on_color_change=self._on_change_color,
+                parent=self._card_container,
+            )
+            self._card_layout.addWidget(widget)
+
+        if not cards:
+            empty_label = QLabel(
+                "No notes yet. Click '+ New Note' to create one.", self
+            )
+            empty_label.setObjectName("NotesTabEmptyLabel")
+            empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self._card_layout.addWidget(empty_label)
+
+        log.debug("NotesTab refreshed with %d cards", len(cards))
+
+    def _on_new_note(self) -> None:
+        dialog = _NoteEditDialog(parent=self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            title = dialog.title_text
+            if title:
+                self._store.create_note(title, dialog.body_text, color=dialog.color)
+                self.refresh()
+                self.notes_changed.emit()
+
+    def _on_edit_note(self, note_id: str) -> None:
+        card = self._store.load_note(note_id)
+        if card is None:
+            log.warning("Cannot edit: note %r not found", note_id)
+            return
+        dialog = _NoteEditDialog(card=card, parent=self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            title = dialog.title_text
+            if title:
+                self._store.update_note(
+                    note_id,
+                    title=title,
+                    body=dialog.body_text,
+                    color=dialog.color,
+                )
+                self.refresh()
+                self.notes_changed.emit()
+
+    def _on_delete_note(self, note_id: str) -> None:
+        deleted = self._store.delete_note(note_id)
+        if deleted:
+            self.refresh()
+            self.notes_changed.emit()
+        else:
+            log.warning("Cannot delete: note %r not found", note_id)
+
+    def _on_change_color(self, note_id: str) -> None:
+        card = self._store.load_note(note_id)
+        if card is None:
+            return
+        initial = QColor(card.color)
+        picked = QColorDialog.getColor(initial, self, "Pick note color")
+        if picked.isValid():
+            self._store.update_note(
+                note_id,
+                title=card.title,
+                body=card.markdown_body,
+                color=picked.name(),
+            )
+            self.refresh()
+            self.notes_changed.emit()
+
+    # ------------------------------------------------------------------
+    # Public helpers for testing
+    # ------------------------------------------------------------------
+
+    def note_ids(self) -> list[str]:
+        """Return the IDs of all currently displayed note cards."""
+        return [card.note_id for card in self._store.list_notes()]
+
+
+__all__ = ["NotesTab"]

--- a/src/shared/python/sidekick/notes_tab.py
+++ b/src/shared/python/sidekick/notes_tab.py
@@ -80,9 +80,9 @@ def _render_markdown(text: str) -> str:
         HTML string, or escaped plain text when mistune is unavailable.
     """
     if _MISTUNE_AVAILABLE:
-        # mistune.create_markdown returns a callable
+        # mistune.create_markdown returns a callable; cast to str for mypy
         md = mistune.create_markdown(plugins=["strikethrough", "table"])
-        return md(text)
+        return str(md(text))
     # Minimal plain-text fallback
     return f"<pre>{text}</pre>"
 
@@ -329,8 +329,10 @@ class NotesTab(QWidget):
         # Clear existing cards
         while self._card_layout.count():
             item = self._card_layout.takeAt(0)
-            if item and item.widget():
-                item.widget().deleteLater()
+            if item:
+                widget = item.widget()
+                if widget is not None:
+                    widget.deleteLater()
 
         cards = self._store.list_notes()
         for card in cards:

--- a/tests/unit/sidekick/test_notes_tab.py
+++ b/tests/unit/sidekick/test_notes_tab.py
@@ -1,0 +1,268 @@
+"""Tests for sidekick.notes_tab and sidekick.notes_store (issue #2931).
+
+TDD: these tests drove the implementation of notes_tab.py and notes_store.py.
+
+Tests cover:
+- SidekickNotesStore CRUD and color persistence
+- NotesTab widget creation, card display, and persistence across simulated
+  session restart (store re-construction)
+- Markdown rendering (basic CommonMark)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SHARED = Path(__file__).resolve().parents[4] / "src" / "shared" / "python"
+if str(SHARED) not in sys.path:
+    sys.path.insert(0, str(SHARED))
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# SidekickNotesStore — pure-Python tests (no Qt required)
+# ---------------------------------------------------------------------------
+
+
+def test_notes_store_create_and_list(tmp_path: Path) -> None:
+    """create_note persists a card; list_notes returns it."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store = SidekickNotesStore(tmp_path)
+    card = store.create_note("Hello", "# Hello world")
+    assert card.title == "Hello"
+    assert card.markdown_body == "# Hello world"
+    notes = store.list_notes()
+    assert len(notes) == 1
+    assert notes[0].note_id == card.note_id
+
+
+def test_notes_store_default_color(tmp_path: Path) -> None:
+    """Notes get a default color when none is specified."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store = SidekickNotesStore(tmp_path)
+    card = store.create_note("Default color")
+    assert card.color.startswith("#")
+
+
+def test_notes_store_custom_color(tmp_path: Path) -> None:
+    """Notes support a custom background color."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store = SidekickNotesStore(tmp_path)
+    card = store.create_note("Colored", color="#ffaacc")
+    assert card.color == "#ffaacc"
+
+
+def test_notes_store_color_persists(tmp_path: Path) -> None:
+    """Color is preserved when reloading the note from disk."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store = SidekickNotesStore(tmp_path)
+    original = store.create_note("Persist color", color="#aabbcc")
+    reloaded = store.load_note(original.note_id)
+    assert reloaded is not None
+    assert reloaded.color == "#aabbcc"
+
+
+def test_notes_store_update(tmp_path: Path) -> None:
+    """update_note changes title, body, and color."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store = SidekickNotesStore(tmp_path)
+    card = store.create_note("Original", "original body")
+    updated = store.update_note(
+        card.note_id, title="Updated", body="updated body", color="#112233"
+    )
+    assert updated.title == "Updated"
+    assert updated.markdown_body == "updated body"
+    assert updated.color == "#112233"
+
+
+def test_notes_store_delete(tmp_path: Path) -> None:
+    """delete_note removes the card from list_notes."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store = SidekickNotesStore(tmp_path)
+    card = store.create_note("To delete")
+    assert len(store.list_notes()) == 1
+    result = store.delete_note(card.note_id)
+    assert result is True
+    assert len(store.list_notes()) == 0
+
+
+def test_notes_store_delete_missing_returns_false(tmp_path: Path) -> None:
+    """Deleting a non-existent note returns False without raising."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store = SidekickNotesStore(tmp_path)
+    result = store.delete_note("nonexistent-note-id1")
+    assert result is False
+
+
+def test_notes_store_precondition_empty_title(tmp_path: Path) -> None:
+    """create_note with an empty title raises ValueError."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store = SidekickNotesStore(tmp_path)
+    with pytest.raises(ValueError, match="title must not be empty"):
+        store.create_note("")
+
+
+def test_notes_store_precondition_bad_root() -> None:
+    """Constructing store with a non-existent root raises ValueError."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    with pytest.raises(ValueError, match="project_root must exist"):
+        SidekickNotesStore("/this/path/does/not/exist/ever")
+
+
+def test_notes_store_persistence_across_restart(tmp_path: Path) -> None:
+    """Notes created in one store instance are visible in a new instance."""
+    from sidekick.notes_store import SidekickNotesStore
+
+    store1 = SidekickNotesStore(tmp_path)
+    card = store1.create_note("Persisted", "# Persistent body")
+
+    # Simulate session restart: create a new store from the same path
+    store2 = SidekickNotesStore(tmp_path)
+    notes = store2.list_notes()
+    assert len(notes) == 1
+    assert notes[0].note_id == card.note_id
+    assert notes[0].markdown_body == "# Persistent body"
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering helper — no Qt required
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("md_input", "expected_fragment"),
+    [
+        ("# Hello", "<h1>"),
+        ("**bold**", "bold"),
+        ("- item one", "item one"),
+    ],
+)
+def test_render_markdown_html_output(md_input: str, expected_fragment: str) -> None:
+    """_render_markdown produces HTML containing expected fragments."""
+    pytest.importorskip("mistune")
+    from sidekick.notes_tab import _render_markdown
+
+    html = _render_markdown(md_input)
+    assert expected_fragment in html
+
+
+def test_render_markdown_fallback_without_mistune(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_render_markdown falls back to <pre> when mistune is absent."""
+    import sidekick.notes_tab as nt_module
+
+    monkeypatch.setattr(nt_module, "_MISTUNE_AVAILABLE", False)
+    result = nt_module._render_markdown("hello")
+    assert "<pre>" in result
+
+
+# ---------------------------------------------------------------------------
+# NotesTab Qt widget tests (require PyQt6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.gui
+def test_notes_tab_creates_without_error(tmp_path: Path, qtbot) -> None:  # type: ignore[no-untyped-def]
+    """NotesTab can be instantiated and added to qtbot."""
+    pytest.importorskip("PyQt6")
+    from sidekick.notes_tab import NotesTab
+
+    tab = NotesTab(project_root=tmp_path)
+    qtbot.addWidget(tab)
+    assert tab.objectName() == "SidekickNotesTab"
+
+
+@pytest.mark.gui
+def test_notes_tab_shows_empty_label_when_no_notes(tmp_path: Path, qtbot) -> None:  # type: ignore[no-untyped-def]
+    """Empty notes tab shows a helpful empty-state label."""
+    pytest.importorskip("PyQt6")
+    from PyQt6.QtWidgets import QLabel
+    from sidekick.notes_tab import NotesTab
+
+    tab = NotesTab(project_root=tmp_path)
+    qtbot.addWidget(tab)
+    label = tab.findChild(QLabel, "NotesTabEmptyLabel")
+    assert label is not None
+
+
+@pytest.mark.gui
+def test_notes_tab_new_button_exists(tmp_path: Path, qtbot) -> None:  # type: ignore[no-untyped-def]
+    """NotesTab has a '+ New Note' button."""
+    pytest.importorskip("PyQt6")
+    from PyQt6.QtWidgets import QPushButton
+    from sidekick.notes_tab import NotesTab
+
+    tab = NotesTab(project_root=tmp_path)
+    qtbot.addWidget(tab)
+    btn = tab.findChild(QPushButton, "NotesTabNewButton")
+    assert btn is not None
+    assert "New Note" in btn.text()
+
+
+@pytest.mark.gui
+def test_notes_tab_displays_card_after_store_insert(tmp_path: Path, qtbot) -> None:  # type: ignore[no-untyped-def]
+    """NotesTab shows a card widget for each stored note."""
+    pytest.importorskip("PyQt6")
+    from PyQt6.QtWidgets import QWidget
+    from sidekick.notes_store import SidekickNotesStore
+    from sidekick.notes_tab import NotesTab
+
+    store = SidekickNotesStore(tmp_path)
+    card = store.create_note("My Note", "## Body")
+
+    tab = NotesTab(project_root=tmp_path)
+    qtbot.addWidget(tab)
+
+    card_widget = tab.findChild(QWidget, f"NoteCard_{card.note_id}")
+    assert card_widget is not None
+
+
+@pytest.mark.gui
+def test_notes_tab_card_has_color_button(tmp_path: Path, qtbot) -> None:  # type: ignore[no-untyped-def]
+    """Each card widget contains a color-picker button."""
+    pytest.importorskip("PyQt6")
+    from PyQt6.QtWidgets import QPushButton
+    from sidekick.notes_store import SidekickNotesStore
+    from sidekick.notes_tab import NotesTab
+
+    store = SidekickNotesStore(tmp_path)
+    card = store.create_note("Colored Note", color="#aabbcc")
+
+    tab = NotesTab(project_root=tmp_path)
+    qtbot.addWidget(tab)
+
+    color_btn = tab.findChild(QPushButton, f"NoteCardColor_{card.note_id}")
+    assert color_btn is not None
+
+
+@pytest.mark.gui
+def test_notes_tab_persistence_across_session_restart(tmp_path: Path, qtbot) -> None:  # type: ignore[no-untyped-def]
+    """Notes created via store persist when NotesTab is reconstructed."""
+    pytest.importorskip("PyQt6")
+    from PyQt6.QtWidgets import QWidget
+    from sidekick.notes_store import SidekickNotesStore
+    from sidekick.notes_tab import NotesTab
+
+    # Write a note
+    store = SidekickNotesStore(tmp_path)
+    card = store.create_note("Restart note", "persisted body")
+
+    # Create tab in new "session" (new object, same directory)
+    tab2 = NotesTab(project_root=tmp_path)
+    qtbot.addWidget(tab2)
+
+    card_widget = tab2.findChild(QWidget, f"NoteCard_{card.note_id}")
+    assert card_widget is not None


### PR DESCRIPTION
## Summary

- Implements `sidekick/notes_store.py`: a project-scoped facade over `NoteCardStore` with DbC preconditions and LOD (no deep delegation chains)
- Implements `sidekick/notes_tab.py`: a PyQt6 card-grid UI tab with scrollable note cards, per-card color pickers (`QColorDialog`), markdown rendering (mistune with `<pre>` fallback), and a `+ New Note` toolbar button
- 20 unit tests (TDD) cover: CRUD persistence, color round-trips, markdown rendering, session-restart persistence, and Qt widget tree assertions

## Closes

Closes #2931

Original issue #2674 gets a backlink via this PR.

## Test plan

- [x] `python -m pytest tests/unit/sidekick/test_notes_tab.py` - 20 tests pass
- [x] `ruff check` - zero violations
- [x] `ruff format --check` - zero diffs
- [x] Notes created in one store instance visible in a new instance (persistence across restart)
- [x] Color picker changes persisted to disk
- [x] Markdown rendered via mistune; falls back to pre tag when mistune absent
- [x] Qt card widgets have expected objectNames for accessibility/testing

Generated with Claude Code