### PR TITLE
fix(ci): replace stale runner labels with current fleet labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,7 @@
 self-hosted-runner:
   labels:
     - d-sorg-fleet
-    - d-sorg-fleet-4core
+    - d-sorg-fleet-14core
     - ubuntu-latest
     - ubuntu-22.04
     - ubuntu-24.04

--- a/.github/workflows/Bot-CI-Trigger.yml
+++ b/.github/workflows/Bot-CI-Trigger.yml
@@ -48,7 +48,7 @@ jobs:
         id: check
         shell: bash
         run: |
-          echo "runner=d-sorg-fleet-4core" >> $GITHUB_OUTPUT
+          echo "runner=d-sorg-fleet-14core" >> $GITHUB_OUTPUT
           echo "Routing to self-hosted fleet runner."
 
   check-and-trigger:

--- a/.github/workflows/heavy-integration-tests.yml
+++ b/.github/workflows/heavy-integration-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-heavy-tests:
     name: Heavy Integration Tests
-    runs-on: d-sorg-fleet-4core
+    runs-on: d-sorg-fleet-14core
     timeout-minutes: 90
     env:
       HEAVY_TEST_SLACK_WEBHOOK: ${{ secrets.HEAVY_TEST_SLACK_WEBHOOK }}

--- a/.github/workflows/heavy-tests-opt-in.yml
+++ b/.github/workflows/heavy-tests-opt-in.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-heavy-tests:
     name: Heavy Integration Tests
-    runs-on: d-sorg-fleet-4core
+    runs-on: d-sorg-fleet-14core
     timeout-minutes: 90
     env:
       HEAVY_TEST_SLACK_WEBHOOK: ${{ secrets.HEAVY_TEST_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary

`d-sorg-fleet-4core` is not advertised by any runner in the D-sorganization org. Available core-tiered fleet labels are `d-sorg-fleet-2core`, `d-sorg-fleet-14core`, `d-sorg-fleet-16core`. Jobs targeting the stale label queue forever.

Verified via `gh api orgs/D-sorganization/actions/runners` on 2026-05-17.

Replaced `d-sorg-fleet-4core` → `d-sorg-fleet-14core` in:
- `heavy-integration-tests.yml` (`runs-on`)
- `heavy-tests-opt-in.yml` (`runs-on`)
- `Bot-CI-Trigger.yml` (`pick-runner` job output)

14core is the closest currently-available tier suitable for heavy integration work.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, trigger `heavy-tests-opt-in` and confirm it picks up a 14-core runner