### PR TITLE
ci(tauri-build): drop unreachable macOS matrix leg

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -174,8 +174,9 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: [self-hosted, Windows]
             target: x86_64-pc-windows-msvc
-          - os: [self-hosted, macOS]
-            target: x86_64-apple-darwin
+          # macOS leg removed: org has no `[self-hosted, macOS]` runners. Jobs
+          # with this label queued indefinitely. Re-add when macOS runner
+          # capacity is provisioned and macOS becomes an active deliverable.
 
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 30


### PR DESCRIPTION
## Summary

The `build` job in `.github/workflows/tauri-build.yml` declared a
`[self-hosted, macOS]` platform matrix entry, but the org has zero
macOS runners (self-hosted or hosted). Jobs queued indefinitely.

## What changed
- `tauri-build.yml`: remove `[self-hosted, macOS]` / `x86_64-apple-darwin` matrix entry, with a comment explaining when to re-add.

## What was deliberately NOT changed
- `maturin-ai-backend.yml` uses `macos-latest` which is fine (currently macos-14 under the hood).
- 150+ action references using tag pins (`@v4`, `@v5`, `@v6`) rather than SHAs. Tools pins **zero** actions to SHAs today — converting all of them is a large coordinated change that belongs in its own PR, not bundled with a one-line runner fix.

## Test plan
- [ ] CI runs Linux + Windows build legs only on next push to main
- [ ] No queued macOS jobs in Actions tab