### PR TITLE
chore(deps): bump postcss to 8.5.14 across web workspaces (security)

### DIFF
--- a/src/data_processing/data_processor/web/package.json
+++ b/src/data_processing/data_processor/web/package.json
@@ -32,7 +32,7 @@
                             "eslint":  "^8.50.0",
                             "eslint-plugin-react":  "^7.33.2",
                             "eslint-plugin-react-hooks":  "^4.6.0",
-                            "postcss":  "latest",
+                            "postcss":  "^8.5.14",
                             "tailwindcss":  "^3.3.3",
                             "typescript":  "^5.2.2",
                             "vite":  "^7.3.2"

--- a/src/financial_calculator/web/package-lock.json
+++ b/src/financial_calculator/web/package-lock.json
@@ -2061,9 +2061,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/src/function_generator/web/package-lock.json
+++ b/src/function_generator/web/package-lock.json
@@ -2523,9 +2523,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/src/media_processing/video_processor/apps/web/package.json
+++ b/src/media_processing/video_processor/apps/web/package.json
@@ -47,7 +47,7 @@
         "eslint": "^8.54.0",
         "eslint-config-next": "^15.5.12",
         "jsdom": "^28.1.0",
-        "postcss": "latest",
+        "postcss": "^8.5.14",
         "tailwindcss": "^3.3.0",
         "typescript": "^5.3.0",
         "vitest": "^4.0.18"

--- a/src/ode_solver/web/package-lock.json
+++ b/src/ode_solver/web/package-lock.json
@@ -2336,9 +2336,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/src/pendulum_simulator/pendulum-web/package-lock.json
+++ b/src/pendulum_simulator/pendulum-web/package-lock.json
@@ -2322,9 +2322,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/src/pressure_drop_calculator/web/package-lock.json
+++ b/src/pressure_drop_calculator/web/package-lock.json
@@ -2336,9 +2336,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/src/rotation_converter/web/package-lock.json
+++ b/src/rotation_converter/web/package-lock.json
@@ -4189,9 +4189,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Closes 11 of the 18 open Dependabot alerts on `main` by bumping postcss to 8.5.14 across all per-workspace `package-lock.json` files and pinning two `"latest"` entries in `package.json` to `^8.5.14`. Surgical lockfile edits — only the postcss entry is touched in each lockfile, avoiding incidental transitive churn.

## Alerts closed

`postcss` XSS (#254/#251/#219/#217/#216/#210/#209/#208/#207/#206) and line-return parsing (#253/#250) — all medium severity. See commit message for the per-file mapping.

## Test plan

- [ ] `npm ci` succeeds in each workspace package
- [ ] Vite/Tailwind builds still produce identical-ish output (postcss 8.5.x is fully backward compatible)

Wave 6 — Dependabot triage.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>