### PR TITLE
fix(ci): de-templatize ${{ }} literals in runner-guard run block

### DIFF
--- a/.github/workflows/local-only-runner-guard.yml
+++ b/.github/workflows/local-only-runner-guard.yml
@@ -112,7 +112,7 @@ jobs:
                       continue
                   values = collect_runs_on(job)
                   if not values:
-                      # Could be an expression like ${{ needs.pick-runner.outputs.runner }};
+                      # Could be an expression like the pick-runner.outputs.runner runtime value;
                       # treat the raw expression text as the value to inspect.
                       raw = job.get("runs-on")
                       if isinstance(raw, str):
@@ -125,7 +125,7 @@ jobs:
                       if HOSTED.match(v_clean):
                           violations.append(
                               f"{wf.name}::{job_id}: runs-on '{v_clean}' is a hosted runner; "
-                              f"route to d-sorg-fleet (or `${{{{ needs.pick-runner.outputs.runner }}}}`)."
+                              "route to d-sorg-fleet (or use the pick-runner.outputs.runner expression)."
                           )
 
           if violations:


### PR DESCRIPTION
## Summary

The local-only runner guard workflow has been startup-failing on every push to `main` with:

```
failed to parse workflow: (Line: 40, Col: 14): Unexpected symbol: '{{'.
Located at position 1 within expression: {{ needs.pick-runner.outputs.runner
```

Root cause: GitHub Actions interpolates `${{ }}` inside `run: |` blocks at parse time, even when those tokens are inside Python comments or f-strings. The guard's Python source referenced `${{ needs.pick-runner.outputs.runner }}` literally in a comment and again (4x-braced) in an f-string error message — but this workflow has no `pick-runner` job, so parsing fails.

Fix: reword the comment and error message in plain prose. The `${{ }}` tokens are removed entirely, so the YAML parser no longer trips. Guard logic is unchanged.

## Test plan

- [x] `yaml.safe_load` succeeds locally
- [x] Manual `gh workflow run` previously rejected with HTTP 422 — should succeed after merge
- [ ] After merge, next push to `main` does not produce a startup_failure for this workflow