### PR TITLE
feat(ops): runner capacity planning script

### DIFF
--- a/docs/ops/runners.md
+++ b/docs/ops/runners.md
@@ -1,0 +1,94 @@
+# Fleet Runner Capacity — Steady-State Documentation
+
+## Overview
+
+The Tools CI fleet uses self-hosted GitHub Actions runners.  
+Runner-pool saturation is a P0 issue: when the queue depth spikes, multiple
+unrelated repos timeout simultaneously, creating misleading failures that
+obscure real bugs.
+
+## Steady-State Configuration
+
+| Parameter                    | Value         | Notes                            |
+| ---------------------------- | ------------- | -------------------------------- |
+| Self-hosted runner count     | 4+            | Minimum; scale up as fleet grows |
+| Queue-depth alert threshold  | 10 jobs       | Trigger `ALERT` advisory         |
+| Target queue-wait SLO        | 300 s (5 min) | Jobs should not wait > 5 min     |
+| Average job runtime estimate | 120 s         | Used for capacity math           |
+
+## Capacity Math (Little's Law approximation)
+
+To drain `Q` queued jobs within `T` seconds, given jobs averaging `J` seconds:
+
+```
+needed_runners = ceil(Q × J / T)
+```
+
+Example: `Q=30, J=120s, T=300s` → `ceil(30 × 120 / 300) = ceil(12) = 12 runners`
+
+## Tooling
+
+`scripts/runner_capacity_check.py` — capacity planning and alert CLI.
+
+```bash
+# Check queue depth and get advisory
+python scripts/runner_capacity_check.py \
+    --token "$GITHUB_TOKEN" \
+    --org D-sorganization \
+    --current-runners 4
+
+# JSON output for machine consumption
+python scripts/runner_capacity_check.py \
+    --token "$GITHUB_TOKEN" \
+    --org D-sorganization \
+    --current-runners 4 \
+    --json
+```
+
+Output levels:
+
+- `OK` — queue is empty
+- `WARN: ...` — queue is non-zero but below alert threshold
+- `ALERT: ...` — queue depth ≥ alert threshold; add runners immediately
+
+## Alerting
+
+Wire `scripts/runner_capacity_check.py` into a cron job or GitHub Actions
+scheduled workflow (on a GitHub-hosted runner, not self-hosted, to avoid
+circular dependency):
+
+```yaml
+# .github/workflows/runner-capacity-alert.yml  (do NOT add — example only)
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          python scripts/runner_capacity_check.py \
+            --token "${{ secrets.GITHUB_TOKEN }}" \
+            --current-runners ${{ vars.RUNNER_COUNT }} \
+            --alert-threshold 10
+```
+
+## Overflow Strategy
+
+When self-hosted runners are saturated, short-term relief options:
+
+1. **GitHub-hosted runners** — add `runs-on: ubuntu-latest` to non-sensitive jobs
+2. **Increase concurrency limit** — raise `concurrency.group` limits in workflow YAML
+3. **Add runners** — provision additional self-hosted runners (contact @dieterolson)
+
+## Historical Context
+
+Root cause of 2026-05-17 fleet-wide CI timeout:
+
+- Maxwell_Daemon, Tools, and Pinocchio_Models hit runner-pool saturation
+  simultaneously during a busy push window
+- All three showed "runner did not start within 10 minutes" errors
+- Unrelated to code changes in those PRs (infrastructure issue)
+
+See also: `docs/audits/2026-05-17_fleet_audit.md`

--- a/scripts/runner_capacity_check.py
+++ b/scripts/runner_capacity_check.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python
+"""Fleet runner capacity planning and alerting tool.
+
+Queries the GitHub Actions API to measure current queue depth and recommend
+runner count adjustments to keep queued workflow runs bounded.
+
+Usage:
+    python scripts/runner_capacity_check.py --token $GITHUB_TOKEN \
+        --org D-sorganization --current-runners 4
+
+DbC preconditions are enforced on all public functions via assert statements.
+
+See also: docs/ops/runners.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GITHUB_API_BASE = "https://api.github.com"
+DEFAULT_TARGET_WAIT_SEC = 300  # 5 minutes queue-wait budget
+DEFAULT_SECONDS_PER_JOB = 120  # average job runtime assumption
+DEFAULT_ALERT_THRESHOLD_JOBS = 10  # alert when queue exceeds this
+ALERT_SUSTAINED_MINUTES = 5  # alert when threshold exceeded > N minutes
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunnerStats:
+    """Current state of the self-hosted runner pool.
+
+    Attributes:
+        online: Number of runners currently online and accepting jobs.
+        offline: Number of runners registered but offline.
+        busy: Number of runners currently executing a job.
+        idle: Number of runners online and waiting for work.
+    """
+
+    online: int
+    offline: int
+    busy: int
+    idle: int
+    total_registered: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.total_registered = self.online + self.offline
+
+
+@dataclass
+class QueueReport:
+    """Summary of current workflow queue state.
+
+    Attributes:
+        queued_runs: Total workflow runs in ``queued`` status across the org.
+        in_progress_runs: Workflow runs currently executing.
+        org: GitHub organisation queried.
+    """
+
+    queued_runs: int
+    in_progress_runs: int
+    org: str
+
+
+@dataclass
+class CapacityRecommendation:
+    """Output of :func:`calculate_needed_runners`.
+
+    Attributes:
+        current_runners: Runners available at the time of measurement.
+        recommended_runners: Recommended total runner count.
+        delta: ``recommended_runners - current_runners`` (positive means add).
+        queue_depth: The queue depth used for the calculation.
+        target_wait_sec: The wait-time SLO the recommendation targets.
+        rationale: Human-readable explanation.
+    """
+
+    current_runners: int
+    recommended_runners: int
+    delta: int
+    queue_depth: int
+    target_wait_sec: int
+    rationale: str
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+
+def _github_get(path: str, token: str) -> Any:
+    """Make an authenticated GET request to the GitHub API.
+
+    Precondition:
+        ``path`` must be a non-empty string starting with ``/``.
+        ``token`` must be a non-empty string.
+
+    Args:
+        path: API path relative to ``GITHUB_API_BASE`` (must start with ``/``).
+        token: GitHub personal access token or Actions token.
+
+    Returns:
+        Parsed JSON response body.
+
+    Raises:
+        urllib.error.HTTPError: On non-2xx responses.
+        ValueError: If the response body is not valid JSON.
+    """
+    assert isinstance(path, str) and path, "path must be a non-empty string"
+    assert path.startswith("/"), f"path must start with '/': {path!r}"
+    assert isinstance(token, str) and token, "token must be a non-empty string"
+
+    url = GITHUB_API_BASE + path
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    logger.debug("GET %s", url)
+    with urllib.request.urlopen(req, timeout=30) as resp:  # noqa: S310
+        return json.loads(resp.read().decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def get_queue_depth(token: str, org: str = "D-sorganization") -> int:
+    """Return the number of workflow runs currently in ``queued`` status.
+
+    Queries all repositories in *org* and sums workflow runs with status
+    ``queued``.  Uses the ``/orgs/{org}/actions/runs`` endpoint with a
+    ``status=queued`` filter.
+
+    Precondition:
+        ``token`` must be a non-empty string.
+        ``org`` must be a non-empty string.
+
+    Args:
+        token: GitHub personal access token with ``actions:read`` scope.
+        org: GitHub organisation name.
+
+    Returns:
+        Total count of queued workflow runs across the organisation.
+
+    Raises:
+        urllib.error.HTTPError: On API error.
+    """
+    assert isinstance(token, str) and token, "token must be a non-empty string"
+    assert isinstance(org, str) and org, "org must be a non-empty string"
+
+    data = _github_get(
+        f"/orgs/{org}/actions/runs?status=queued&per_page=100",
+        token,
+    )
+    total = int(data.get("total_count", 0))
+    logger.info("Queue depth for org %s: %d", org, total)
+    return total
+
+
+def get_runner_stats(token: str, org: str = "D-sorganization") -> RunnerStats:
+    """Return statistics about self-hosted runners registered to *org*.
+
+    Precondition:
+        ``token`` must be a non-empty string.
+        ``org`` must be a non-empty string.
+
+    Args:
+        token: GitHub personal access token with ``admin:org`` scope.
+        org: GitHub organisation name.
+
+    Returns:
+        :class:`RunnerStats` populated from the GitHub API.
+
+    Raises:
+        urllib.error.HTTPError: On API error.
+    """
+    assert isinstance(token, str) and token, "token must be a non-empty string"
+    assert isinstance(org, str) and org, "org must be a non-empty string"
+
+    data = _github_get(f"/orgs/{org}/actions/runners?per_page=100", token)
+    runners: list[dict[str, Any]] = data.get("runners", [])
+
+    online = sum(1 for r in runners if r.get("status") == "online")
+    offline = sum(1 for r in runners if r.get("status") == "offline")
+    busy = sum(
+        1 for r in runners if r.get("busy") is True and r.get("status") == "online"
+    )
+    idle = online - busy
+
+    stats = RunnerStats(online=online, offline=offline, busy=busy, idle=idle)
+    logger.info(
+        "Runner stats — online=%d offline=%d busy=%d idle=%d",
+        online,
+        offline,
+        busy,
+        idle,
+    )
+    return stats
+
+
+def calculate_needed_runners(
+    queue_depth: int,
+    current_runners: int,
+    target_wait_sec: int = DEFAULT_TARGET_WAIT_SEC,
+    avg_job_sec: int = DEFAULT_SECONDS_PER_JOB,
+) -> CapacityRecommendation:
+    """Calculate the recommended runner count to keep queue wait bounded.
+
+    Uses a simple Little's-Law approximation:
+
+        needed = ceil(queue_depth / (target_wait_sec / avg_job_sec))
+
+    The recommendation is never less than ``current_runners`` (we do not
+    recommend removing runners unless the queue is empty and ``current_runners``
+    is significantly over-provisioned — that case is reported as ``delta == 0``).
+
+    Precondition:
+        ``queue_depth`` must be a non-negative integer.
+        ``current_runners`` must be a positive integer.
+        ``target_wait_sec`` must be a positive integer.
+        ``avg_job_sec`` must be a positive integer.
+
+    Args:
+        queue_depth: Number of workflow runs currently queued.
+        current_runners: Number of runners currently available.
+        target_wait_sec: Maximum acceptable queue wait time in seconds.
+        avg_job_sec: Average job runtime used for throughput estimation.
+
+    Returns:
+        :class:`CapacityRecommendation` with suggested runner count.
+    """
+    assert isinstance(queue_depth, int) and queue_depth >= 0, (
+        f"queue_depth must be a non-negative int, got {queue_depth!r}"
+    )
+    assert isinstance(current_runners, int) and current_runners > 0, (
+        f"current_runners must be a positive int, got {current_runners!r}"
+    )
+    assert isinstance(target_wait_sec, int) and target_wait_sec > 0, (
+        f"target_wait_sec must be a positive int, got {target_wait_sec!r}"
+    )
+    assert isinstance(avg_job_sec, int) and avg_job_sec > 0, (
+        f"avg_job_sec must be a positive int, got {avg_job_sec!r}"
+    )
+
+    if queue_depth == 0:
+        return CapacityRecommendation(
+            current_runners=current_runners,
+            recommended_runners=current_runners,
+            delta=0,
+            queue_depth=0,
+            target_wait_sec=target_wait_sec,
+            rationale="Queue is empty — no capacity change needed.",
+        )
+
+    # Throughput = runners * (1 / avg_job_sec) jobs/sec
+    # To drain queue_depth jobs in target_wait_sec seconds:
+    #   needed_runners * (target_wait_sec / avg_job_sec) >= queue_depth
+    #   needed_runners >= queue_depth / (target_wait_sec / avg_job_sec)
+    #   needed_runners >= queue_depth * avg_job_sec / target_wait_sec
+    import math
+
+    needed = math.ceil(queue_depth * avg_job_sec / target_wait_sec)
+    recommended = max(needed, current_runners)
+    delta = recommended - current_runners
+
+    if delta > 0:
+        rationale = (
+            f"Queue depth {queue_depth} exceeds capacity. "
+            f"Add {delta} runner(s) to drain queue within "
+            f"{target_wait_sec}s (assuming {avg_job_sec}s avg job time)."
+        )
+    else:
+        rationale = (
+            f"Queue depth {queue_depth} is within capacity "
+            f"({current_runners} runners, {avg_job_sec}s avg job time, "
+            f"{target_wait_sec}s target wait). No change needed."
+        )
+
+    logger.info(
+        "Capacity recommendation: current=%d recommended=%d delta=%+d",
+        current_runners,
+        recommended,
+        delta,
+    )
+    return CapacityRecommendation(
+        current_runners=current_runners,
+        recommended_runners=recommended,
+        delta=delta,
+        queue_depth=queue_depth,
+        target_wait_sec=target_wait_sec,
+        rationale=rationale,
+    )
+
+
+def check_and_alert(
+    token: str,
+    current_runners: int,
+    org: str = "D-sorganization",
+    alert_threshold: int = DEFAULT_ALERT_THRESHOLD_JOBS,
+    target_wait_sec: int = DEFAULT_TARGET_WAIT_SEC,
+) -> str:
+    """Check queue depth and return an advisory message.
+
+    Combines :func:`get_queue_depth` and :func:`calculate_needed_runners`
+    into a single convenience call suitable for alerting pipelines.
+
+    Precondition:
+        ``token`` must be a non-empty string.
+        ``current_runners`` must be a positive integer.
+        ``org`` must be a non-empty string.
+        ``alert_threshold`` must be a positive integer.
+        ``target_wait_sec`` must be a positive integer.
+
+    Args:
+        token: GitHub personal access token with ``actions:read`` scope.
+        current_runners: Number of self-hosted runners currently provisioned.
+        org: GitHub organisation to query.
+        alert_threshold: Queue depth above which an ALERT is emitted.
+        target_wait_sec: Queue-wait SLO in seconds for capacity calculation.
+
+    Returns:
+        Advisory string: one of ``"OK"``, ``"WARN: ..."``, or ``"ALERT: ..."``.
+    """
+    assert isinstance(token, str) and token, "token must be a non-empty string"
+    assert isinstance(current_runners, int) and current_runners > 0, (
+        f"current_runners must be a positive int, got {current_runners!r}"
+    )
+    assert isinstance(org, str) and org, "org must be a non-empty string"
+    assert isinstance(alert_threshold, int) and alert_threshold > 0, (
+        f"alert_threshold must be a positive int, got {alert_threshold!r}"
+    )
+    assert isinstance(target_wait_sec, int) and target_wait_sec > 0, (
+        f"target_wait_sec must be a positive int, got {target_wait_sec!r}"
+    )
+
+    queue_depth = get_queue_depth(token=token, org=org)
+    rec = calculate_needed_runners(
+        queue_depth=queue_depth,
+        current_runners=current_runners,
+        target_wait_sec=target_wait_sec,
+    )
+
+    if queue_depth == 0:
+        return "OK"
+    if queue_depth >= alert_threshold:
+        return (
+            f"ALERT: queue depth {queue_depth} exceeds threshold {alert_threshold}. "
+            f"{rec.rationale}"
+        )
+    return f"WARN: queue depth {queue_depth}. {rec.rationale}"
+
+
+# ---------------------------------------------------------------------------
+# CLI entry-point
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> Any:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        description="Fleet runner capacity check and alerting tool.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--token", required=True, help="GitHub PAT with actions:read scope")
+    p.add_argument("--org", default="D-sorganization", help="GitHub organisation")
+    p.add_argument(
+        "--current-runners",
+        type=int,
+        required=True,
+        help="Number of self-hosted runners currently provisioned",
+    )
+    p.add_argument(
+        "--alert-threshold",
+        type=int,
+        default=DEFAULT_ALERT_THRESHOLD_JOBS,
+        help="Queue depth that triggers ALERT level",
+    )
+    p.add_argument(
+        "--target-wait-sec",
+        type=int,
+        default=DEFAULT_TARGET_WAIT_SEC,
+        help="Maximum acceptable queue wait in seconds",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit JSON output suitable for machine consumption",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry-point for the runner capacity checker."""
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    message = check_and_alert(
+        token=args.token,
+        current_runners=args.current_runners,
+        org=args.org,
+        alert_threshold=args.alert_threshold,
+        target_wait_sec=args.target_wait_sec,
+    )
+    queue_depth = get_queue_depth(token=args.token, org=args.org)
+    rec = calculate_needed_runners(
+        queue_depth=queue_depth,
+        current_runners=args.current_runners,
+        target_wait_sec=args.target_wait_sec,
+    )
+
+    if args.json:
+        output = {
+            "status": message.split(":")[0],
+            "message": message,
+            "queue_depth": rec.queue_depth,
+            "current_runners": rec.current_runners,
+            "recommended_runners": rec.recommended_runners,
+            "delta": rec.delta,
+            "rationale": rec.rationale,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print(message)
+        if rec.delta > 0:
+            print(f"  Recommendation: add {rec.delta} runner(s)")
+            print(f"  Rationale: {rec.rationale}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ops/test_runner_capacity_check.py
+++ b/tests/ops/test_runner_capacity_check.py
@@ -1,0 +1,379 @@
+"""Tests for scripts/runner_capacity_check.py (TDD — issue #2946).
+
+Validates:
+- get_queue_depth() returns correct int from mocked API response
+- calculate_needed_runners() applies Little's Law correctly
+- check_and_alert() combines both and produces correct advisory strings
+- DbC preconditions reject invalid inputs
+- Edge cases: zero queue, exact-capacity match, large backlog
+
+Mocking strategy: patch ``runner_capacity_check._github_get`` to avoid
+real network calls. All tests are deterministic.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# Ensure scripts/ is on the path
+_SCRIPTS_DIR = Path(__file__).parent.parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import runner_capacity_check as rcc  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _queued_runs_response(total_count: int) -> dict[str, Any]:
+    """Build a fake GitHub /orgs/{org}/actions/runs response."""
+    return {
+        "total_count": total_count,
+        "workflow_runs": [{"id": i, "status": "queued"} for i in range(total_count)],
+    }
+
+
+def _runners_response(online: int, offline: int, busy: int) -> dict[str, Any]:
+    """Build a fake GitHub /orgs/{org}/actions/runners response."""
+    runners: list[dict[str, Any]] = []
+    for i in range(online):
+        runners.append(
+            {
+                "id": i,
+                "name": f"runner-{i}",
+                "status": "online",
+                "busy": i < busy,
+            }
+        )
+    for i in range(offline):
+        runners.append(
+            {
+                "id": online + i,
+                "name": f"runner-offline-{i}",
+                "status": "offline",
+                "busy": False,
+            }
+        )
+    return {"total_count": online + offline, "runners": runners}
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_queue_depth
+# ---------------------------------------------------------------------------
+
+
+class TestGetQueueDepth:
+    """Unit tests for get_queue_depth()."""
+
+    def test_returns_total_count_from_api(self) -> None:
+        """Happy path: API returns total_count=7 → function returns 7."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(7)):
+            result = rcc.get_queue_depth(token="tok", org="myorg")
+        assert result == 7
+
+    def test_returns_zero_when_no_queued_runs(self) -> None:
+        """Queue depth is 0 when no runs are queued."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(0)):
+            result = rcc.get_queue_depth(token="tok", org="myorg")
+        assert result == 0
+
+    def test_returns_large_count(self) -> None:
+        """Handles large queue depths (> 100) correctly."""
+        with patch.object(rcc, "_github_get", return_value={"total_count": 250}):
+            result = rcc.get_queue_depth(token="tok", org="myorg")
+        assert result == 250
+
+    def test_missing_total_count_defaults_to_zero(self) -> None:
+        """If total_count is absent from API response, return 0."""
+        with patch.object(rcc, "_github_get", return_value={}):
+            result = rcc.get_queue_depth(token="tok", org="myorg")
+        assert result == 0
+
+    def test_passes_correct_path_to_api(self) -> None:
+        """Verifies the correct API path is used (queued status filter)."""
+        with patch.object(
+            rcc, "_github_get", return_value=_queued_runs_response(1)
+        ) as mock_get:
+            rcc.get_queue_depth(token="mytoken", org="testorg")
+        call_args = mock_get.call_args
+        path_arg = call_args[0][0]
+        assert "testorg" in path_arg
+        assert "status=queued" in path_arg
+
+    def test_passes_token_to_api(self) -> None:
+        """Token is forwarded to the API helper."""
+        with patch.object(
+            rcc, "_github_get", return_value=_queued_runs_response(0)
+        ) as mock_get:
+            rcc.get_queue_depth(token="secret-token", org="org")
+        call_args = mock_get.call_args
+        token_arg = call_args[0][1]
+        assert token_arg == "secret-token"
+
+    # DbC tests
+    def test_rejects_empty_token(self) -> None:
+        """Empty token raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.get_queue_depth(token="", org="org")
+
+    def test_rejects_empty_org(self) -> None:
+        """Empty org raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.get_queue_depth(token="tok", org="")
+
+
+# ---------------------------------------------------------------------------
+# Tests: calculate_needed_runners
+# ---------------------------------------------------------------------------
+
+
+class TestCalculateNeededRunners:
+    """Unit tests for calculate_needed_runners()."""
+
+    def test_zero_queue_returns_no_change(self) -> None:
+        """Zero queue depth → delta is 0, recommended == current."""
+        rec = rcc.calculate_needed_runners(
+            queue_depth=0, current_runners=4, target_wait_sec=300
+        )
+        assert rec.delta == 0
+        assert rec.recommended_runners == 4
+        assert rec.queue_depth == 0
+
+    def test_small_queue_within_capacity_no_delta(self) -> None:
+        """Queue well within runner capacity → no additional runners needed."""
+        # 4 runners, 120s avg, 300s target → can drain 10 jobs in 300s
+        # queue_depth=5 → needed=ceil(5*120/300)=2 → max(2,4)=4 → delta=0
+        rec = rcc.calculate_needed_runners(
+            queue_depth=5,
+            current_runners=4,
+            target_wait_sec=300,
+            avg_job_sec=120,
+        )
+        assert rec.delta == 0
+        assert rec.recommended_runners == 4
+
+    def test_large_queue_recommends_more_runners(self) -> None:
+        """Large queue backlog → positive delta recommended."""
+        # queue_depth=60, avg_job_sec=120, target=300 → needed=ceil(60*120/300)=24
+        rec = rcc.calculate_needed_runners(
+            queue_depth=60,
+            current_runners=4,
+            target_wait_sec=300,
+            avg_job_sec=120,
+        )
+        assert rec.recommended_runners == 24
+        assert rec.delta == 20
+
+    def test_recommendation_never_below_current_runners(self) -> None:
+        """Recommended count is always at least current_runners."""
+        rec = rcc.calculate_needed_runners(
+            queue_depth=1, current_runners=10, target_wait_sec=300, avg_job_sec=120
+        )
+        assert rec.recommended_runners >= 10
+
+    def test_rationale_mentions_delta(self) -> None:
+        """Rationale string mentions the runner count change."""
+        rec = rcc.calculate_needed_runners(
+            queue_depth=30,
+            current_runners=2,
+            target_wait_sec=300,
+            avg_job_sec=120,
+        )
+        assert rec.delta > 0
+        assert str(rec.delta) in rec.rationale or "Add" in rec.rationale
+
+    def test_rationale_for_zero_queue(self) -> None:
+        """Rationale for empty queue says no change needed."""
+        rec = rcc.calculate_needed_runners(
+            queue_depth=0, current_runners=4, target_wait_sec=300
+        )
+        assert "empty" in rec.rationale.lower() or "no" in rec.rationale.lower()
+
+    def test_exact_capacity_boundary(self) -> None:
+        """Queue at exact capacity boundary → delta is 0."""
+        # needed=ceil(10*120/300)=4 → max(4,4)=4 → delta=0
+        rec = rcc.calculate_needed_runners(
+            queue_depth=10, current_runners=4, target_wait_sec=300, avg_job_sec=120
+        )
+        assert rec.delta == 0
+
+    def test_one_over_capacity_boundary(self) -> None:
+        """Queue one job over capacity → recommend one additional runner."""
+        # needed=ceil(11*120/300)=5 → max(5,4)=5 → delta=1
+        rec = rcc.calculate_needed_runners(
+            queue_depth=11, current_runners=4, target_wait_sec=300, avg_job_sec=120
+        )
+        assert rec.delta == 1
+
+    def test_target_wait_sec_field_populated(self) -> None:
+        """CapacityRecommendation stores target_wait_sec."""
+        rec = rcc.calculate_needed_runners(
+            queue_depth=0, current_runners=2, target_wait_sec=600
+        )
+        assert rec.target_wait_sec == 600
+
+    # DbC tests
+    def test_rejects_negative_queue_depth(self) -> None:
+        """Negative queue_depth raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.calculate_needed_runners(queue_depth=-1, current_runners=4)
+
+    def test_rejects_zero_current_runners(self) -> None:
+        """Zero current_runners raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.calculate_needed_runners(queue_depth=5, current_runners=0)
+
+    def test_rejects_zero_target_wait_sec(self) -> None:
+        """Zero target_wait_sec raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.calculate_needed_runners(
+                queue_depth=5, current_runners=4, target_wait_sec=0
+            )
+
+    def test_rejects_zero_avg_job_sec(self) -> None:
+        """Zero avg_job_sec raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.calculate_needed_runners(
+                queue_depth=5, current_runners=4, avg_job_sec=0
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tests: check_and_alert
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAndAlert:
+    """Unit tests for check_and_alert()."""
+
+    def test_ok_when_queue_empty(self) -> None:
+        """Returns 'OK' when no jobs are queued."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(0)):
+            result = rcc.check_and_alert(token="tok", current_runners=4)
+        assert result == "OK"
+
+    def test_warn_below_threshold(self) -> None:
+        """Returns WARN advisory when queue is non-empty but below threshold."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(3)):
+            result = rcc.check_and_alert(
+                token="tok", current_runners=4, alert_threshold=10
+            )
+        assert result.startswith("WARN")
+
+    def test_alert_at_threshold(self) -> None:
+        """Returns ALERT when queue depth equals the alert threshold."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(10)):
+            result = rcc.check_and_alert(
+                token="tok", current_runners=4, alert_threshold=10
+            )
+        assert result.startswith("ALERT")
+
+    def test_alert_above_threshold(self) -> None:
+        """Returns ALERT when queue depth exceeds the alert threshold."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(50)):
+            result = rcc.check_and_alert(
+                token="tok", current_runners=4, alert_threshold=10
+            )
+        assert result.startswith("ALERT")
+
+    def test_alert_contains_queue_depth(self) -> None:
+        """Alert message includes the current queue depth."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(25)):
+            result = rcc.check_and_alert(
+                token="tok", current_runners=4, alert_threshold=10
+            )
+        assert "25" in result
+
+    def test_warn_contains_queue_depth(self) -> None:
+        """Warn message includes the current queue depth."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(5)):
+            result = rcc.check_and_alert(
+                token="tok", current_runners=4, alert_threshold=10
+            )
+        assert "5" in result
+
+    def test_return_type_is_string(self) -> None:
+        """Return value is always a str regardless of queue state."""
+        with patch.object(rcc, "_github_get", return_value=_queued_runs_response(0)):
+            result = rcc.check_and_alert(token="tok", current_runners=2)
+        assert isinstance(result, str)
+
+    # DbC tests
+    def test_rejects_empty_token(self) -> None:
+        """Empty token raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.check_and_alert(token="", current_runners=4)
+
+    def test_rejects_zero_current_runners(self) -> None:
+        """Zero current_runners raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.check_and_alert(token="tok", current_runners=0)
+
+    def test_rejects_zero_alert_threshold(self) -> None:
+        """Zero alert_threshold raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.check_and_alert(token="tok", current_runners=4, alert_threshold=0)
+
+
+# ---------------------------------------------------------------------------
+# Tests: RunnerStats dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestRunnerStats:
+    """Validate RunnerStats dataclass invariants."""
+
+    def test_total_registered_is_online_plus_offline(self) -> None:
+        """total_registered == online + offline."""
+        stats = rcc.RunnerStats(online=3, offline=2, busy=1, idle=2)
+        assert stats.total_registered == 5
+
+    def test_idle_is_online_minus_busy(self) -> None:
+        """Caller sets idle = online - busy; dataclass stores it as given."""
+        stats = rcc.RunnerStats(online=5, offline=1, busy=3, idle=2)
+        assert stats.idle == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_runner_stats
+# ---------------------------------------------------------------------------
+
+
+class TestGetRunnerStats:
+    """Unit tests for get_runner_stats()."""
+
+    def test_counts_online_offline_runners(self) -> None:
+        """Correctly counts online and offline runners."""
+        mock_resp = _runners_response(online=3, offline=1, busy=0)
+        with patch.object(rcc, "_github_get", return_value=mock_resp):
+            stats = rcc.get_runner_stats(token="tok", org="org")
+        assert stats.online == 3
+        assert stats.offline == 1
+
+    def test_counts_busy_runners(self) -> None:
+        """Correctly identifies busy vs idle runners."""
+        mock_resp = _runners_response(online=4, offline=0, busy=2)
+        with patch.object(rcc, "_github_get", return_value=mock_resp):
+            stats = rcc.get_runner_stats(token="tok", org="org")
+        assert stats.busy == 2
+        assert stats.idle == 2
+
+    def test_all_idle_when_busy_zero(self) -> None:
+        """All online runners are idle when none are busy."""
+        mock_resp = _runners_response(online=3, offline=0, busy=0)
+        with patch.object(rcc, "_github_get", return_value=mock_resp):
+            stats = rcc.get_runner_stats(token="tok", org="org")
+        assert stats.idle == 3
+        assert stats.busy == 0
+
+    # DbC tests
+    def test_rejects_empty_token(self) -> None:
+        """Empty token raises AssertionError (DbC)."""
+        with pytest.raises(AssertionError):
+            rcc.get_runner_stats(token="", org="org")


### PR DESCRIPTION
## Summary

- Adds `scripts/runner_capacity_check.py` — capacity planning CLI for the self-hosted runner pool
- Three public functions with full DbC preconditions:
  - `get_queue_depth(token, org)` — queries GitHub API for queued workflow runs
  - `calculate_needed_runners(queue_depth, current_runners, target_wait_sec)` — Little's Law calculation
  - `check_and_alert(token, current_runners)` — returns OK / WARN / ALERT advisory string
- 37 tests in `tests/ops/test_runner_capacity_check.py` (all mocked, zero network calls)
- Documents steady-state capacity config in `docs/ops/runners.md`

## Root cause (from 2026-05-17 fleet audit)

Maxwell_Daemon, Tools, and Pinocchio_Models saw simultaneous CI timeouts — runner-pool saturation, not real per-repo failures. This tool surfaces queue depth before it becomes a fleet-wide problem.

## Test plan

- [x] 37 unit tests pass (`pytest tests/ops/test_runner_capacity_check.py`)
- [x] `ruff check` and `ruff format --check` clean
- [x] Pre-commit hooks pass
- [ ] CI quality-gate passes

Closes #2946