### PR TITLE
🎨 Palette: [spec-exempt] Add accessible labels to reusable UnitSelector component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2026-05-20 - Toggle Button Accessibility
 **Learning:** Custom toggle buttons implemented via class changes (e.g., `.active`) lack semantic state for screen readers, hiding the active mode from assistive technologies.
 **Action:** Always pair visual active class toggles with `aria-pressed="true|false"` dynamic attribute updates.
+## 2024-05-30 - Accessible Reusable Form Controls
+**Learning:** When creating reusable form controls (like unit selectors or dropdowns) that require linking `<label>` elements to inputs using `id` and `htmlFor`, hardcoded IDs can cause collisions if the component is rendered multiple times. Using `React.useId()` generates unique IDs per component instance, ensuring screen readers can correctly associate the label with the input without collisions.
+**Action:** Always use `React.useId()` for `id` and `htmlFor` attributes when creating reusable React components that involve form labels.

--- a/src/pendulum_simulator/pendulum-web/src/components/UnitSelector.tsx
+++ b/src/pendulum_simulator/pendulum-web/src/components/UnitSelector.tsx
@@ -2,7 +2,7 @@
  * Reusable unit selector dropdown (DRY).
  * Renders a compact dropdown for selecting units on any quantity.
  */
-import React from 'react';
+import React, { useId } from 'react';
 
 interface UnitSelectorProps<T extends string> {
     label: string;
@@ -14,10 +14,12 @@ interface UnitSelectorProps<T extends string> {
 export function UnitSelector<T extends string>({
     label, value, options, onChange,
 }: UnitSelectorProps<T>): React.ReactElement {
+    const id = useId();
     return (
         <div className="unit-row">
-            <span className="unit-label">{label}</span>
+            <label className="unit-label" htmlFor={id}>{label}</label>
             <select
+                id={id}
                 className="unit-select"
                 value={value}
                 onChange={e => onChange(e.target.value as T)}


### PR DESCRIPTION
💡 What: Replaced the generic `span` with an accessible `label` linked to the `select` element using `React.useId()`.
🎯 Why: To improve screen reader support by properly associating the label text with the dropdown control and prevent ID collisions when the component is rendered multiple times.
📸 Before/After: Visuals remain unchanged, but screen reader experience is improved (verified via playwright script querying `for` attributes mapping to `id`).
♿ Accessibility: Screen readers will now announce the correct label when a user focuses on any of the unit selectors on the page without ID collision errors.

---
*PR created automatically by Jules for task [13522476165603375248](https://jules.google.com/task/13522476165603375248) started by @dieterolson*