### PR TITLE
🎨 Palette: Add ARIA state announcements to toggle and Play/Pause buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -8,3 +8,6 @@
 ## 2024-05-30 - Accessible Reusable Form Controls
 **Learning:** When creating reusable form controls (like unit selectors or dropdowns) that require linking `<label>` elements to inputs using `id` and `htmlFor`, hardcoded IDs can cause collisions if the component is rendered multiple times. Using `React.useId()` generates unique IDs per component instance, ensuring screen readers can correctly associate the label with the input without collisions.
 **Action:** Always use `React.useId()` for `id` and `htmlFor` attributes when creating reusable React components that involve form labels.
+## 2024-05-22 - Add ARIA Labels to Icon-like Toggle Buttons and Play/Pause Button
+**Learning:** React toggle buttons implemented with custom class changes (like `.active`) or inline style changes (like changing font-weight to bold) often lack explicit semantic announcements for screen reader users. Adding `aria-pressed="true|false"` explicitly updates the state appropriately. Also, icon-only or dynamic text buttons like the "Play/Pause" simulation toggle benefit from explicit `aria-label`s.
+**Action:** Always add explicit `aria-pressed={condition}` for toggles relying on class/style changes, and explicit `aria-label` for buttons where the visible text simply switches between states (like Play/Pause).

--- a/src/pendulum_simulator/pendulum-web/src/App.tsx
+++ b/src/pendulum_simulator/pendulum-web/src/App.tsx
@@ -387,6 +387,7 @@ export default function App() {
               <button
                 key={m}
                 onClick={() => { setModelType(m); setResult(null); setPlaying(false); }}
+                aria-pressed={modelType === m}
                 style={{
                   padding: '8px 16px',
                   backgroundColor: modelType === m ? '#0066cc' : '#333',
@@ -482,6 +483,7 @@ export default function App() {
                     id="btn-play-pause"
                     className="btn btn-secondary"
                     onClick={() => setPlaying(p => !p)}
+                    aria-label={playing ? "Pause simulation" : "Play simulation"}
                   >
                     {playing ? 'Pause' : 'Play'}
                   </button>
@@ -562,7 +564,7 @@ export default function App() {
               <div className="panel-section">
                 <button id="btn-run" className="btn btn-primary" onClick={runSimTriple}>Run Simulation</button>
                 {result && (
-                  <button id="btn-play-pause" className="btn btn-secondary" onClick={() => setPlaying(p => !p)}>
+                  <button id="btn-play-pause" className="btn btn-secondary" onClick={() => setPlaying(p => !p)} aria-label={playing ? "Pause simulation" : "Play simulation"}>
                     {playing ? 'Pause' : 'Play'}
                   </button>
                 )}
@@ -615,7 +617,7 @@ export default function App() {
               <div className="panel-section">
                 <button id="btn-run-golfer" className="btn btn-primary" onClick={runSimGolfer}>Run Simulation</button>
                 {result && (
-                  <button id="btn-play-pause-golfer" className="btn btn-secondary" onClick={() => setPlaying(p => !p)}>
+                  <button id="btn-play-pause-golfer" className="btn btn-secondary" onClick={() => setPlaying(p => !p)} aria-label={playing ? "Pause simulation" : "Play simulation"}>
                     {playing ? 'Pause' : 'Play'}
                   </button>
                 )}


### PR DESCRIPTION
💡 **What**
Added `aria-pressed` to the model selection toggle buttons (Double Pendulum, Triple Pendulum, Golfer) and explicit `aria-label`s to the Play/Pause simulation buttons.

🎯 **Why**
Toggle buttons that rely exclusively on visual changes (like an active class or inline styling changes to font weight/color) are not announced properly by screen readers when activated. Adding `aria-pressed={condition}` explicitly informs assistive technologies of their state. Additionally, buttons where the visible text simply switches between words like "Play" and "Pause" benefit from contextual `aria-label`s like "Play simulation" to provide clarity to screen reader users about what is actually being played.

📸 **Before/After**
(No visual changes; purely semantic HTML updates)

♿ **Accessibility**
- Screen readers now announce the selected Pendulum model correctly.
- Screen readers now announce the Play/Pause button with context (e.g. "Pause simulation").

---
*PR created automatically by Jules for task [6195568520974486231](https://jules.google.com/task/6195568520974486231) started by @dieterolson*