### PR TITLE
feat(chat): keybindings, port-aware URL, Ollama latency tuning, file-size refactor

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.205                                    |
+| **Spec Version**        | 1.1.206                                    |
 | **Last Spec Update**    | 2026-05-26                                 |
 
 ## 2. Purpose & Mission
@@ -940,6 +940,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 ## 9. Changelog
 
 - 2026-05-26: Optimized Nelder-Mead loop in `optimizer.ts` to mutate pre-allocated arrays in-place to avoid GC overhead.
+
 ### Version 1.1.190
 
 - **2026-05-24**: Add `spellcheck="false"`, `autocorrect="off"`, and `autocapitalize="none"` to math inputs in calculator to improve UX, and add `role="img"` to battery icon span.

--- a/src/shared/python/ai/adapters/ollama_adapter.py
+++ b/src/shared/python/ai/adapters/ollama_adapter.py
@@ -79,6 +79,49 @@ def _normalize_host(host: str) -> str:
     return host.replace("://0.0.0.0", "://127.0.0.1")
 
 
+def _tool_declarations_to_ollama(
+    tools: list[ToolDeclaration] | None,
+) -> list[dict[str, Any]]:
+    """Convert internal ``ToolDeclaration``s into Ollama's wire format.
+
+    Ollama (llama3.1+) accepts a ``tools`` field on ``/api/chat`` with the
+    OpenAI-compatible function-calling schema::
+
+        [{"type": "function",
+          "function": {"name": ..., "description": ...,
+                       "parameters": {"type": "object",
+                                      "properties": {...},
+                                      "required": [...]}}}]
+
+    Using this saves ~700 prompt tokens vs. embedding the same content as
+    text in the system prompt. When ``tools`` is None or empty the function
+    returns ``[]`` so callers can ``if ollama_tools:`` gate inclusion
+    without a None-check at the call site.
+
+    DbC postcondition: returned list contains only dicts with the
+    ``type=="function"`` shape Ollama expects.
+    """
+    if not tools:
+        return []
+    out: list[dict[str, Any]] = []
+    for td in tools:
+        out.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": td.name,
+                    "description": td.description,
+                    "parameters": {
+                        "type": "object",
+                        "properties": dict(td.parameters or {}),
+                        "required": list(td.required or []),
+                    },
+                },
+            }
+        )
+    return out
+
+
 class OllamaAdapter(BaseAgentAdapter):
     """Adapter for local Ollama LLM inference.
 
@@ -232,20 +275,41 @@ class OllamaAdapter(BaseAgentAdapter):
         """
         if message is None:
             raise ValueError("message must be provided")
-        if message is None:
-            raise ValueError("message must be provided")
         client = self._get_client()
         messages = self._format_messages(context, message, tools)
+
+        # Tier-1 latency wins (profiler 2026-05-26):
+        #
+        # 1. ``keep_alive``: Ollama's default unloads the model after 5 min
+        #    of idle. The desktop launcher pays a 3-5 s cold-load on every
+        #    coffee break. 30 min matches typical session length so the
+        #    model stays resident for back-to-back chats.
+        # 2. ``options.num_ctx``: cap the KV cache to 4096. The default
+        #    on most llama3.1 manifests is 8192; halving it cuts
+        #    prompt-eval time meaningfully and is still ample for the
+        #    chat-with-tools prompt size.
+        # 3. ``tools`` (Ollama native field): llama3.1+ supports
+        #    structured tool declarations. Passing them here lets the
+        #    *server* format the schemas efficiently; the alternative
+        #    (stuffing JSON-Schema text into the system prompt) was
+        #    adding ~700 prompt tokens that the model had to evaluate on
+        #    every turn.
+        payload: dict[str, Any] = {
+            "model": self._model,
+            "messages": messages,
+            "stream": True,
+            "keep_alive": "30m",
+            "options": {"num_ctx": 4096},
+        }
+        ollama_tools = _tool_declarations_to_ollama(tools)
+        if ollama_tools:
+            payload["tools"] = ollama_tools
 
         try:
             with client.stream(
                 "POST",
                 f"{self._host}/api/chat",
-                json={
-                    "model": self._model,
-                    "messages": messages,
-                    "stream": True,
-                },
+                json=payload,
             ) as response:
                 response.raise_for_status()
 

--- a/src/shared/python/chat/_chat_dock_widget_qt.py
+++ b/src/shared/python/chat/_chat_dock_widget_qt.py
@@ -9,6 +9,14 @@ all windows via a common session ID persisted to disk.
 This widget is fully portable — it depends only on PyQt6 and json,
 with no application-specific imports.
 
+This module historically held the entire dock widget implementation in
+one file. To stay under the repo's 1500-line per-file budget the
+non-class helpers and large method bodies now live in the private
+``chat._qt`` package; this module remains the canonical public entry
+point and re-exports every name external code or tests reference
+(``ChatDockWidget``, ``ChatMessageBubble``, ``HistorySidebar``,
+``QWebSocket``, ``QFileDialog`` etc.) so the public API is unchanged.
+
 Usage::
 
     from chat import ChatDockWidget
@@ -30,184 +38,57 @@ import logging
 import threading
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any
 
-from PyQt6.QtCore import QSize, Qt, QTimer, QUrl, pyqtSignal
-from PyQt6.QtGui import QKeySequence, QShortcut
+from PyQt6.QtCore import QSize, QTimer, QUrl, pyqtSignal
 from PyQt6.QtWebSockets import QWebSocket
 from PyQt6.QtWidgets import (
     QApplication,
     QComboBox,
     QDockWidget,
     QFileDialog,
-    QFrame,
     QHBoxLayout,
-    QLabel,
-    QMenu,
-    QPlainTextEdit,
-    QPushButton,
-    QScrollArea,
-    QSizePolicy,
-    QStackedWidget,
-    QVBoxLayout,
     QWidget,
 )
 
+from ._qt import ai_dropdowns as _ai
+from ._qt import exports as _exports
+from ._qt import sessions as _sessions
+from ._qt import workspace as _ws
+from ._qt.bubbles import ChatMessageBubble
+from ._qt.history_sidebar import HistorySidebar
+
+# Backwards-compatible re-exports: existing tests and downstream code may
+# patch these names on the ``_chat_dock_widget_qt`` namespace, so they must
+# remain importable from this module even though the class body uses the
+# helpers from ``_qt`` directly.
+from ._qt.input import install_enter_submit as _install_enter_submit  # noqa: F401
+from ._qt.styling import get_theme_colors as _get_theme_colors  # noqa: F401
+from ._qt.ui_builder import build_chat_dock_ui
 from ._theme_protocol import ThemeProviderProtocol, _DefaultDarkTheme
-from ._workspace_protocol import WorkspaceContextProtocol, WorkspaceVariableInfo
+from ._workspace_protocol import WorkspaceContextProtocol
 from .chat_dock_widget import (
     _DEFAULT_SERVER,
     _read_shared_session_id,
     _session_file_path,
     _write_shared_session_id,
 )
-from .cli_provider_availability import list_available_cli_providers
 from .terminal_contracts import TerminalProviderRegistry
 from .terminal_providers import build_default_terminal_provider_registry
 from .voice_input_manager import VoiceInputManager
 
 logger = logging.getLogger(__name__)
 
-
-def _get_theme_colors(
-    theme_provider: ThemeProviderProtocol | None = None,
-) -> dict[str, str]:
-    """Get the current theme colors from the injected provider.
-
-    Falls back to :class:`_DefaultDarkTheme` so the widget never depends
-    on ``theme.theme_manager`` being importable (Tools issue #2766).
-    """
-    provider: ThemeProviderProtocol = theme_provider or _DefaultDarkTheme()
-    try:
-        colors: dict[str, str] = provider.get_current_colors()
-        return colors
-    except Exception:  # noqa: BLE001 - defensive: a misbehaving provider
-        # must not crash the widget
-        colors = _DefaultDarkTheme().get_current_colors()
-        return colors
-
-
-class ChatMessageBubble(QFrame):
-    """Compact message bubble for chat display."""
-
-    def __init__(
-        self,
-        role: str,
-        content: str,
-        accent_color: str = "#FF8800",
-        parent: QWidget | None = None,
-        theme_provider: ThemeProviderProtocol | None = None,
-    ) -> None:
-        if role is None:
-            raise ValueError("role must be provided")
-        super().__init__(parent)
-        self._role = role
-        self._content = content
-
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(6, 4, 6, 4)
-        layout.setSpacing(2)
-
-        colors = _get_theme_colors(theme_provider)
-        text_primary = colors.get("text", "#e0e0e0")
-        bg_alt = colors.get("group_bg", "#2d2d2d")
-        bg_secondary = colors.get("input_bg", "#252526")
-
-        # Role label
-        user_style = f"font-size: 10px; font-weight: bold; color: {accent_color};"
-        ai_color = colors.get("accent", "#58a6ff")
-        ai_style = f"font-size: 10px; font-weight: bold; color: {ai_color};"
-        role_label = QLabel("You" if role == "user" else "AI")
-        role_label.setStyleSheet(user_style if role == "user" else ai_style)
-
-        header_row = QHBoxLayout()
-        header_row.setContentsMargins(0, 0, 0, 0)
-        header_row.addWidget(role_label)
-        header_row.addStretch()
-
-        self._copy_btn = QPushButton("Copy")
-        self._copy_btn.setToolTip(
-            "Copy message to clipboard. Use the dropdown to pick mode."
-        )
-        self._copy_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        self._copy_btn.setStyleSheet(
-            "QPushButton { background-color: transparent; "
-            f"color: {colors.get('text_secondary', '#888')}; "
-            "border: none; font-size: 10px; padding: 0px; }"
-            f"QPushButton:hover {{ color: {colors.get('text', '#e0e0e0')}; }}"
-        )
-        # Tools issue #2735: per-message copy mode dropdown.
-        copy_menu = QMenu(self)
-        for label, mode in (
-            ("Raw text", "raw_text"),
-            ("Markdown", "markdown"),
-            ("Code only", "code_only"),
-            ("JSON", "json"),
-        ):
-            act = copy_menu.addAction(label)
-            if act is not None:
-                act.triggered.connect(
-                    lambda _checked=False, m=mode: self._copy_to_clipboard(m)
-                )
-        self._copy_btn.setMenu(copy_menu)
-        # Direct click defaults to raw_text via the menu's first action.
-        self._copy_btn.clicked.connect(lambda: self._copy_to_clipboard("raw_text"))
-        header_row.addWidget(self._copy_btn)
-
-        layout.addLayout(header_row)
-
-        # Content
-        self._content_label = QLabel(content)
-        self._content_label.setWordWrap(True)
-        self._content_label.setTextFormat(Qt.TextFormat.PlainText)
-        self._content_label.setStyleSheet(f"color: {text_primary}; font-size: 12px;")
-        layout.addWidget(self._content_label)
-
-        bg = bg_alt if role == "user" else bg_secondary
-        self.setStyleSheet(
-            f"ChatMessageBubble {{ background-color: {bg}; border-radius: 6px; }}"
-        )
-
-    def set_content(self, text: str) -> None:
-        """Replace the content text."""
-        if text is None:
-            raise ValueError("text must be provided")
-        self._content = text
-        self._content_label.setText(text)
-
-    def append_content(self, text: str) -> None:
-        """Append text to existing content."""
-        if text is None:
-            raise ValueError("text must be provided")
-        self._content += text
-        self._content_label.setText(self._content)
-
-    def _copy_to_clipboard(self, mode: str = "raw_text") -> None:
-        """Copy this bubble's content via the shared ``MessageClipboardCopier``.
-
-        Tools issue #2735. The copier is constructed lazily because it
-        pulls in :class:`QApplication` and is only meaningful when a Qt
-        application is running.
-        """
-        from .export import MessageClipboardCopier
-        from .service_base import ChatMessage
-
-        try:
-            copier = MessageClipboardCopier.from_qt_application()
-        except RuntimeError:
-            # Fall back to direct clipboard call when no QApplication exists.
-            clipboard = QApplication.clipboard()
-            if clipboard is not None:
-                clipboard.setText(self._content)
-            return
-        msg = ChatMessage(role=self._role, content=self._content)
-        try:
-            copier.copy_message(
-                msg, cast("Literal['raw_text', 'markdown', 'code_only', 'json']", mode)
-            )
-        except ValueError:
-            # Unknown mode -- fall back to raw_text.
-            copier.copy_message(msg, "raw_text")
+# Re-exports kept for backwards compatibility — test suites and
+# downstream code patch these on the ``_chat_dock_widget_qt`` namespace.
+__all__ = [
+    "ChatDockWidget",
+    "ChatMessageBubble",
+    "HistorySidebar",
+    "QFileDialog",
+    "QWebSocket",
+    "QWidget",
+]
 
 
 class ChatDockWidget(QDockWidget):
@@ -215,41 +96,6 @@ class ChatDockWidget(QDockWidget):
 
     Uses QWebSocket for real-time streaming. All instances share the same
     conversation session via a file-persisted session ID.
-
-    Args:
-        app_context: Name of the module/context this widget is embedded in.
-        app_name: Application identifier for session file storage.
-        server_url: WebSocket server base URL.
-        session_id: Explicit session ID (None = use shared or create new).
-        ws_path_template: WebSocket path template with ``{session_id}`` placeholder.
-        placeholder_text: Placeholder text for the input field.
-        accent_color: Primary accent color for styling.
-        auto_index_on_open: When True, send an ``index_codebase`` action on
-            connect so the chat backend rebuilds its codemap before the user
-            starts typing. Tools issue #2549 / PR #2567.
-        terminal_registry: Registry used to populate shell/provider dropdowns.
-        theme_provider: Object implementing ``get_current_colors()`` to drive
-            widget styling. Defaults to :class:`_DefaultDarkTheme` so the
-            widget is fully portable and does not require ``theme`` to be on
-            ``sys.path`` (Tools issue #2766). Pass an app-specific manager
-            (e.g. ``theme.theme_manager.get_theme_manager()``) to honor the
-            host application's theme.
-        workspace_provider: Optional bridge to a host calculation workspace
-            (Tools issue #2849). When supplied, the dock injects a short
-            ``workspace_context`` field into outbound chat payloads and
-            enables the ``/ws.read`` and ``/ws.write`` slash commands.
-            When ``None`` (the default), the dock behaves exactly as it
-            did before #2849 — no workspace context, no extra slash
-            commands.
-        plot_request_sink: Optional callable that receives a plot spec from
-            the chat. When supplied, the ``/plot`` slash command parses
-            its JSON argument and forwards it to this sink. The chat
-            module intentionally treats the spec as ``Any`` to avoid a
-            hard dependency on the upstream plotting package; hosts
-            typically pass a function that wraps the JSON dict into a
-            :class:`upstream_drift_tools.ui.tools_sidebar.calculator_plotting.CalculatorPlotRequest`
-            and routes it to their plot tab.
-        parent: Parent widget.
     """
 
     # Class-level session for in-process sharing. All reads/writes are
@@ -258,15 +104,19 @@ class ChatDockWidget(QDockWidget):
     _shared_session_id: str | None = None
     _session_lock: threading.Lock = threading.Lock()
 
+    # AI dropdown constants — kept on the class because existing tests
+    # introspect them (Tools issue #2871).
+    _AI_VALID_THINKING_NAMES = _ai.VALID_THINKING_NAMES
+    _AI_VALID_FIELDS = _ai.VALID_FIELDS
+    _AI_DEFAULT_PROVIDERS = _ai.DEFAULT_PROVIDERS
+
     @classmethod
     def _get_shared_session_id(cls) -> str | None:
-        """Return the shared session ID under the class lock."""
         with cls._session_lock:
             return cls._shared_session_id
 
     @classmethod
     def _set_shared_session_id(cls, val: str | None) -> None:
-        """Set the shared session ID under the class lock."""
         with cls._session_lock:
             cls._shared_session_id = val
 
@@ -310,18 +160,15 @@ class ChatDockWidget(QDockWidget):
         self._theme_provider: ThemeProviderProtocol = (
             theme_provider or _DefaultDarkTheme()
         )
-        # Tools issue #2849: optional bridge into a host calculation
-        # workspace + plot tab. Both default to None so the standalone
-        # chat continues to work without any host wiring.
         self._workspace_provider: WorkspaceContextProtocol | None = workspace_provider
         self._plot_request_sink: Callable[[Any], None] | None = plot_request_sink
         self._is_streaming = False
+        # Busy-state message queue: messages typed/sent while streaming
+        # land here and are flushed FIFO on each ``complete`` arrival.
+        self._queued_messages: list[str] = []
         self._current_bubble: ChatMessageBubble | None = None
         self._terminal_session_id: str | None = None
         # Tools issue #2871: mid-thread provider/model/thinking state.
-        # ``_message_history`` is the same object that ``switch_provider``
-        # promises to preserve. Bubbles render from this list and the
-        # widget never reassigns it after creation.
         self._message_history: list[dict[str, Any]] = []
         self._current_provider: str = "ollama"
         self._current_model: str = "llama3"
@@ -354,7 +201,6 @@ class ChatDockWidget(QDockWidget):
 
     @property
     def collapsed(self) -> bool:
-        """Return whether the chat dock is collapsed."""
         return self._collapsed
 
     def set_collapsed(self, collapsed: bool) -> None:
@@ -379,7 +225,6 @@ class ChatDockWidget(QDockWidget):
             self._steer_btn,
             self._stop_agent_btn,
         ]
-
         terminal_widgets = [
             self._shell_combo,
             self._provider_combo,
@@ -395,7 +240,6 @@ class ChatDockWidget(QDockWidget):
             for w in widgets_to_hide:
                 if w is not None:
                     w.setVisible(True)
-            # Restore terminal widgets based on current mode
             is_terminal = self._current_mode() == "terminal"
             for w in terminal_widgets:
                 if w is not None:
@@ -404,343 +248,12 @@ class ChatDockWidget(QDockWidget):
         self.updateGeometry()
 
     def minimumSizeHint(self) -> QSize:
-        """Override minimumSizeHint to allow compact sizes when collapsed."""
         if self._collapsed:
             return QSize(56, 0)
         return QSize(320, 0)
 
     def _setup_ui(self) -> None:
-        colors = _get_theme_colors(self._theme_provider)
-        bg_primary = colors.get("bg", "#1e1e1e")
-        bg_alt = colors.get("group_bg", "#2d2d2d")
-        text_primary = colors.get("text", "#e0e0e0")
-        text_secondary = colors.get("text_secondary", "#888")
-        border = colors.get("border", "#444")
-        button_hover = colors.get("button_hover", "#ffaa33")
-
-        container = QWidget()
-        layout = QVBoxLayout(container)
-        layout.setContentsMargins(4, 4, 4, 4)
-        layout.setSpacing(4)
-
-        # Status bar
-        status_row = QHBoxLayout()
-        self._status_label = QLabel("Connecting...")
-        self._status_label.setStyleSheet(f"color: {text_secondary}; font-size: 10px;")
-        status_row.addWidget(self._status_label, stretch=1)
-
-        self._tools_btn = QPushButton("Tools")
-        self._tools_btn.setToolTip("Chat tools and actions")
-        self._tools_menu = QMenu(self)
-        self._action_copy_thread = self._tools_menu.addAction("Copy Entire Thread")
-        # Tools issue #2735: Export submenu (Markdown / Text / HTML).
-        export_menu = self._tools_menu.addMenu("Export Thread")
-        self._action_export_markdown = (
-            export_menu.addAction("Markdown...") if export_menu is not None else None
-        )
-        self._action_export_text = (
-            export_menu.addAction("Plain Text...") if export_menu is not None else None
-        )
-        self._action_export_html = (
-            export_menu.addAction("HTML...") if export_menu is not None else None
-        )
-        # Tools issue #2736: Condense submenu with strategy picker.
-        condense_menu = self._tools_menu.addMenu("Condense Thread")
-        self._action_condense_keep_recent = (
-            condense_menu.addAction("Keep recent...")
-            if condense_menu is not None
-            else None
-        )
-        self._action_condense_semantic = (
-            condense_menu.addAction("Semantic summary...")
-            if condense_menu is not None
-            else None
-        )
-        self._action_condense_pinned = (
-            condense_menu.addAction("Pinned anchor...")
-            if condense_menu is not None
-            else None
-        )
-        # Backwards-compat alias kept by Tools issue #2872 history-browser
-        # tests that introspect ``_action_export_thread``.
-        self._action_export_thread = self._action_export_markdown
-        self._action_condense_thread = self._action_condense_keep_recent
-        self._action_request_review = self._tools_menu.addAction(
-            "Request Agent Review..."
-        )
-        # Tools issue #2688: memory management UI access point.
-        self._action_manage_memory = self._tools_menu.addAction("Manage Memory...")
-        if self._action_manage_memory is not None:
-            self._action_manage_memory.triggered.connect(self.open_memory_panel)
-        if self._action_copy_thread is not None:
-            self._action_copy_thread.triggered.connect(self._copy_entire_thread)
-        if self._action_export_markdown is not None:
-            self._action_export_markdown.triggered.connect(
-                lambda: self._export_thread("markdown", "Markdown Files (*.md)", ".md")
-            )
-        if self._action_export_text is not None:
-            self._action_export_text.triggered.connect(
-                lambda: self._export_thread("text", "Text Files (*.txt)", ".txt")
-            )
-        if self._action_export_html is not None:
-            self._action_export_html.triggered.connect(
-                lambda: self._export_thread("html", "HTML Files (*.html)", ".html")
-            )
-        if self._action_condense_keep_recent is not None:
-            self._action_condense_keep_recent.triggered.connect(
-                lambda: self._run_condense_local("keep_recent")
-            )
-        if self._action_condense_semantic is not None:
-            self._action_condense_semantic.triggered.connect(
-                lambda: self._run_condense_local("semantic_summary")
-            )
-        if self._action_condense_pinned is not None:
-            self._action_condense_pinned.triggered.connect(
-                lambda: self._run_condense_local("pinned_anchor")
-            )
-        if self._action_request_review is not None:
-            self._action_request_review.triggered.connect(self._request_review)
-        self._tools_btn.setMenu(self._tools_menu)
-
-        # Tools issue #2736: token-budget indicator + condense-now button.
-        self._token_indicator = QLabel("0 tok")
-        self._token_indicator.setToolTip(
-            "Approximate token count for the current thread. "
-            "When it exceeds the auto-condense threshold the thread will "
-            "be condensed automatically."
-        )
-        self._token_indicator.setStyleSheet(
-            f"color: {text_secondary}; font-size: 10px;"
-        )
-        status_row.addWidget(self._token_indicator)
-        self._auto_condense_threshold = 8000
-
-        layout.addLayout(status_row)
-
-        mode_row = QHBoxLayout()
-
-        # Tools issue #2871: Provider / Model / Thinking dropdowns.
-        # Built first so the chat-mode header reads
-        # ``[provider] [model] [thinking] [mode] [terminal controls...]``.
-        self._build_ai_dropdowns(mode_row)
-
-        self._mode_combo = QComboBox()
-        self._mode_combo.setSizePolicy(
-            QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed
-        )
-        self._mode_combo.setMinimumWidth(0)
-        self._mode_combo.addItem("Chat", "chat")
-        self._mode_combo.addItem("Terminal", "terminal")
-        self._mode_combo.currentIndexChanged.connect(self._on_mode_changed)
-        mode_row.addWidget(self._mode_combo)
-
-        self._shell_combo = QComboBox()
-        self._shell_combo.setSizePolicy(
-            QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed
-        )
-        self._shell_combo.setMinimumWidth(0)
-        self._populate_shell_combo()
-        self._shell_combo.currentIndexChanged.connect(self._on_terminal_shell_changed)
-        mode_row.addWidget(self._shell_combo)
-
-        self._provider_combo = QComboBox()
-        self._provider_combo.setSizePolicy(
-            QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed
-        )
-        self._provider_combo.setMinimumWidth(0)
-        self._populate_provider_combo()
-        mode_row.addWidget(self._provider_combo)
-
-        self._terminal_start_btn = QPushButton("Start")
-        self._terminal_start_btn.clicked.connect(self._on_terminal_start)
-        mode_row.addWidget(self._terminal_start_btn)
-
-        self._terminal_stop_btn = QPushButton("Stop")
-        self._terminal_stop_btn.clicked.connect(self._on_terminal_stop)
-        mode_row.addWidget(self._terminal_stop_btn)
-
-        # Message scroll area
-        self._scroll_area = QScrollArea()
-        self._scroll_area.setWidgetResizable(True)
-        self._scroll_area.setHorizontalScrollBarPolicy(
-            Qt.ScrollBarPolicy.ScrollBarAlwaysOff
-        )
-        self._message_container = QWidget()
-        self._message_layout = QVBoxLayout(self._message_container)
-        self._message_layout.setContentsMargins(2, 2, 2, 2)
-        self._message_layout.setSpacing(4)
-        self._message_layout.addStretch()
-        self._scroll_area.setWidget(self._message_container)
-
-        self._terminal_output = QPlainTextEdit()
-        self._terminal_output.setReadOnly(True)
-        self._terminal_output.setStyleSheet(
-            "QPlainTextEdit {"
-            f"  background-color: {bg_alt}; color: {text_primary};"
-            f"  border: 1px solid {border}; border-radius: 4px;"
-            "  font-family: Consolas, monospace; font-size: 12px; padding: 4px;"
-            "}"
-        )
-
-        self._content_stack = QStackedWidget()
-        self._content_stack.addWidget(self._scroll_area)
-        self._content_stack.addWidget(self._terminal_output)
-        layout.addWidget(self._content_stack, stretch=1)
-
-        # Input row
-        input_row = QHBoxLayout()
-        self._input_edit = QPlainTextEdit()
-        self._input_edit.setMinimumHeight(60)
-        self._input_edit.setMaximumHeight(150)
-        self._input_edit.setSizePolicy(
-            QSizePolicy.Policy.Ignored, QSizePolicy.Policy.MinimumExpanding
-        )
-        self._input_edit.setPlaceholderText(self._placeholder_text)
-        self._input_edit.setStyleSheet(
-            "QPlainTextEdit {"
-            f"  background-color: {bg_alt}; color: {text_primary};"
-            f"  border: 1px solid {border}; border-radius: 4px;"
-            "  font-size: 12px; padding: 4px;"
-            "}"
-        )
-        layout.addWidget(self._input_edit)
-
-        # Tools on the far left
-        self._tools_btn.setFixedWidth(50)
-        self._tools_btn.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-        )
-        self._tools_btn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {bg_alt}; color: {text_primary};"
-            "  border-radius: 4px; padding: 4px;"
-            "}"
-            f"QPushButton:hover {{ background-color: {border}; }}"
-        )
-        input_row.addWidget(self._tools_btn)
-
-        self._upload_btn = QPushButton("+")
-        self._upload_btn.setToolTip("Upload file")
-        self._upload_btn.setFixedWidth(28)
-        self._upload_btn.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-        )
-        self._upload_btn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {bg_alt}; color: {text_primary};"
-            "  border-radius: 4px; padding: 4px;"
-            "}"
-            f"QPushButton:hover {{ background-color: {border}; }}"
-        )
-        self._upload_btn.clicked.connect(self._on_upload)
-        input_row.addWidget(self._upload_btn)
-
-        self._screenshot_btn = QPushButton("⛶")
-        self._screenshot_btn.setToolTip("Capture screenshot")
-        self._screenshot_btn.setFixedWidth(28)
-        self._screenshot_btn.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-        )
-        self._screenshot_btn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {bg_alt}; color: {text_primary};"
-            "  border-radius: 4px; padding: 4px;"
-            "}"
-            f"QPushButton:hover {{ background-color: {border}; }}"
-        )
-        self._screenshot_btn.clicked.connect(self._on_screenshot)
-        input_row.addWidget(self._screenshot_btn)
-
-        self._mic_btn = QPushButton("🎤")
-        self._mic_btn.setToolTip("Voice input (Ctrl+Shift+V)")
-        self._mic_btn.setFixedWidth(28)
-        self._mic_btn.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-        )
-        self._mic_btn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {bg_alt}; color: {text_primary};"
-            "  border-radius: 4px; padding: 4px;"
-            "}"
-            f"QPushButton:hover {{ background-color: {border}; }}"
-        )
-        self._mic_btn.clicked.connect(self._on_mic_toggle)
-        input_row.addWidget(self._mic_btn)
-
-        input_row.addStretch()
-
-        self._agent_mode_combo = QComboBox()
-        self._agent_mode_combo.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-        )
-        self._agent_mode_combo.addItem("Agent", "agent")
-        self._agent_mode_combo.addItem("Plan", "plan")
-        self._agent_mode_combo.addItem("Ask", "ask")
-        input_row.addWidget(self._agent_mode_combo)
-
-        # Send, Steer, Stop on the right side
-        self._send_btn = QPushButton("Send")
-        self._send_btn.setToolTip("Send message")
-        self._send_btn.setFixedWidth(55)
-        self._send_btn.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-        )
-        self._send_btn.setStyleSheet(
-            "QPushButton {"
-            f"  background-color: {self._accent_color}; color: black;"
-            "  border-radius: 4px; font-weight: bold; padding: 4px;"
-            "}"
-            f"QPushButton:hover {{ background-color: {button_hover}; }}"
-            "QPushButton:disabled { background-color: #555; color: #888; }"
-        )
-        self._send_btn.clicked.connect(self._on_send)
-        input_row.addWidget(self._send_btn)
-
-        self._steer_btn = QPushButton("Steer")
-        self._steer_btn.setToolTip("Queue message")
-        self._steer_btn.setFixedWidth(50)
-        self._steer_btn.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-        )
-        self._steer_btn.setStyleSheet(self._send_btn.styleSheet())
-        self._steer_btn.clicked.connect(self._on_steer)
-        input_row.addWidget(self._steer_btn)
-
-        self._stop_agent_btn = QPushButton("Stop")
-        self._stop_agent_btn.setToolTip("Stop response")
-        self._stop_agent_btn.setFixedWidth(50)
-        self._stop_agent_btn.setSizePolicy(
-            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
-        )
-        self._stop_agent_btn.setStyleSheet(self._send_btn.styleSheet())
-        self._stop_agent_btn.clicked.connect(self._on_stop_agent)
-        input_row.addWidget(self._stop_agent_btn)
-
-        layout.addLayout(input_row)
-        layout.addLayout(mode_row)
-        self.setWidget(container)
-        self._on_mode_changed()
-
-        # Dock widget styling
-        self.setStyleSheet(
-            f"QDockWidget {{ background-color: {bg_primary}; color: {text_primary}; }}"
-            "QDockWidget::title {"
-            f"  background-color: {self._accent_color}; color: black;"
-            "  padding: 6px; font-weight: bold;"
-            "}"
-        )
-        self._scroll_area.setStyleSheet(
-            f"QScrollArea {{ background-color: {bg_primary}; border: none; }}"
-        )
-        self._message_container.setStyleSheet(f"background-color: {bg_primary};")
-
-        # Keyboard shortcut for voice input
-        shortcut = QShortcut(QKeySequence("Ctrl+Shift+V"), self)
-        shortcut.activated.connect(self._on_mic_toggle)
-
-        # Wire voice manager callbacks
-        self._voice_manager.connect_transcription(self._on_voice_transcription)
-        self._voice_manager.connect_error(self._on_voice_error)
+        build_chat_dock_ui(self)
 
     # ── WebSocket connection ─────────────────────────────────────────
 
@@ -764,11 +277,7 @@ class ChatDockWidget(QDockWidget):
         self._socket.open(url)
 
     def connection_diagnostics(self) -> dict[str, Any]:
-        """Return host-readable WebSocket readiness diagnostics.
-
-        Launchers can call this before focusing or enabling the chat tab to
-        distinguish "chat dock exists" from "background API is connected".
-        """
+        """Return host-readable WebSocket readiness diagnostics."""
         socket = self._socket
         state = "not_started"
         error = ""
@@ -808,16 +317,7 @@ class ChatDockWidget(QDockWidget):
         self._send_ws({"action": "index_codebase"})
 
     def open_memory_panel(self) -> None:
-        """Open the Sidekick memory management panel (Tools issue #2688).
-
-        The panel reads from and writes to a :class:`MemoryManager`
-        instance bound to this chat session. We lazy-import both the
-        manager and the panel so that the chat dock continues to load
-        even on hosts where the AI package is not available.
-
-        Pre: Qt application is running.
-        Post: A modeless ``MemoryPanel`` window is shown (or focused).
-        """
+        """Open the Sidekick memory management panel (Tools issue #2688)."""
         from .memory_panel import MemoryPanel
 
         existing = self.__dict__.get("_memory_panel_window")
@@ -828,7 +328,6 @@ class ChatDockWidget(QDockWidget):
                 existing.activateWindow()
                 return
             except RuntimeError:
-                # Widget was deleted under us — fall through to recreate.
                 self._memory_panel_window = None
 
         try:
@@ -892,6 +391,7 @@ class ChatDockWidget(QDockWidget):
             if sid:
                 ChatDockWidget._set_shared_session_id(sid)
                 _write_shared_session_id(sid, self._session_file)
+            self._flush_queued_messages()
 
         elif msg_type == "session_created":
             sid = data.get("session_id", "")
@@ -925,6 +425,10 @@ class ChatDockWidget(QDockWidget):
             self._status_label.setText(f"Error: {detail}")
             self._is_streaming = False
             self._send_btn.setEnabled(True)
+            # Surface remaining queue state to the user; do NOT auto-flush
+            # after a server error so queued steering messages are not
+            # silently delivered against an unhealthy session.
+            self._update_queue_affordance()
 
         elif msg_type == "terminal_session":
             session = data.get("session", {})
@@ -945,17 +449,113 @@ class ChatDockWidget(QDockWidget):
         elif msg_type == "terminal_ack":
             self._status_label.setText("Terminal input sent")
 
-    # ── UI actions ───────────────────────────────────────────────────
+    # ── Busy-state message queue (Tools input keybindings) ───────────
+
+    @property
+    def input_state(self) -> str:
+        """Return the current input state.
+
+        One of:
+            * ``"idle"``: nothing in flight, nothing queued.
+            * ``"sending"``: a message is generating but nothing is queued.
+            * ``"awaiting"``: a message is generating *and* at least one
+              steering message is queued waiting to flush.
+        """
+        if not self._is_streaming:
+            return "idle"
+        if self._queued_messages:
+            return "awaiting"
+        return "sending"
+
+    def queued_messages(self) -> list[str]:
+        """Return a shallow copy of the steering-message queue (FIFO order)."""
+        return list(self._queued_messages)
+
+    def _update_queue_affordance(self) -> None:
+        """Refresh Send button + input placeholder to reflect queue depth."""
+        depth = len(self._queued_messages)
+        if depth > 0:
+            self._send_btn.setText(f"Queue ({depth})")
+            self._send_btn.setToolTip(
+                f"{depth} message(s) queued — will send after current response"
+            )
+            self._input_edit.setPlaceholderText(
+                f"Queued: {depth} — type to queue another (steers next turn)"
+            )
+        else:
+            self._send_btn.setText("Send")
+            self._send_btn.setToolTip("Send message")
+            self._input_edit.setPlaceholderText(self._placeholder_text)
+
+    def _submit_or_queue(self, text: str) -> None:
+        """Submit ``text`` immediately or queue it if the agent is busy.
+
+        DRY: this is the single internal pathway shared by the Send-button
+        click and the input widget's Enter keypress.
+
+        DbC:
+            Pre: ``text`` is a non-empty / non-whitespace string after strip.
+            Pre: ``self.input_state`` ∈ {"idle", "sending", "awaiting"}.
+            Post: either an ``action="send"`` WS payload is dispatched and
+                  ``_is_streaming`` becomes True, OR the text is appended
+                  to ``self._queued_messages``.
+        """
+        if not isinstance(text, str):
+            raise ValueError("_submit_or_queue: text must be a string")
+        stripped = text.strip()
+        if not stripped:
+            raise ValueError("_submit_or_queue: text must be non-empty")
+        assert self.input_state in {"idle", "sending", "awaiting"}, (
+            "_submit_or_queue: invariant — input_state must be one of "
+            "{idle, sending, awaiting}"
+        )
+
+        if self._is_streaming:
+            # Queue as a steering message; do NOT add a user bubble yet —
+            # the bubble will appear when the queue flushes so the visible
+            # conversation matches what the server actually sees.
+            self._queued_messages.append(stripped)
+            self._update_queue_affordance()
+            return
+
+        self._add_bubble("user", stripped)
+        self._is_streaming = True
+        self._send_btn.setEnabled(False)
+        self._current_bubble = self._add_bubble("assistant", "")
+
+        payload: dict[str, Any] = {
+            "action": "send",
+            "message": stripped,
+            "app_context": self._app_context,
+        }
+        workspace_context = self._build_workspace_context_block()
+        if workspace_context:
+            payload["workspace_context"] = workspace_context
+        self._send_ws(payload)
+        assert self._is_streaming is True
+
+    def _flush_queued_messages(self) -> None:
+        """Flush the next queued message (if any) as a fresh user turn."""
+        if not self._queued_messages:
+            self._update_queue_affordance()
+            return
+        next_text = self._queued_messages.pop(0)
+        self._update_queue_affordance()
+        self._submit_or_queue(next_text)
+
+    # ── UI button handlers ───────────────────────────────────────────
 
     def _on_steer(self) -> None:
+        """Explicitly queue the current input as a steering message."""
         text = self._input_edit.toPlainText().strip()
         if not text:
             return
-        # Queue message
-        if not hasattr(self, "_queued_messages"):
-            self._queued_messages = []
-        self._queued_messages.append(text)
         self._input_edit.clear()
+        if not self._is_streaming:
+            self._submit_or_queue(text)
+            return
+        self._queued_messages.append(text)
+        self._update_queue_affordance()
 
     def _on_stop_agent(self) -> None:
         logger.info("Agent response stopped by user")
@@ -965,34 +565,22 @@ class ChatDockWidget(QDockWidget):
             self._chat_client.cancel_current_stream()
 
     def _on_send(self) -> None:
+        """Send-button click and Enter-keypress entry point."""
         text = self._input_edit.toPlainText().strip()
-        if not text or self._is_streaming:
+        if not text:
             return
 
-        if self._current_mode() == "terminal":
+        if not self._is_streaming and self._current_mode() == "terminal":
             self._on_terminal_input(text)
             return
 
-        if text.startswith("/"):
+        if not self._is_streaming and text.startswith("/"):
+            self._input_edit.clear()
             self._handle_slash_command(text)
             return
 
         self._input_edit.clear()
-        self._add_bubble("user", text)
-
-        self._is_streaming = True
-        self._send_btn.setEnabled(False)
-        self._current_bubble = self._add_bubble("assistant", "")
-
-        payload: dict[str, Any] = {
-            "action": "send",
-            "message": text,
-            "app_context": self._app_context,
-        }
-        workspace_context = self._build_workspace_context_block()
-        if workspace_context:
-            payload["workspace_context"] = workspace_context
-        self._send_ws(payload)
+        self._submit_or_queue(text)
 
     def _handle_slash_command(self, text: str) -> None:
         if text is None:
@@ -1001,18 +589,12 @@ class ChatDockWidget(QDockWidget):
         cmd = parts[0][1:].lower()
         arg = parts[1] if len(parts) > 1 else ""
 
-        # Tools issue #2849: workspace + plot bridge commands route
-        # locally to the injected host adapters without touching the
-        # WebSocket. Unwired hosts (no provider/sink) get a polite
-        # "not available" reply instead of a silent no-op.
         if cmd in {"ws.read", "ws.write", "plot"}:
             self._input_edit.clear()
             self._add_bubble("user", text)
             self._dispatch_workspace_command(cmd, arg)
             return
 
-        # Tools issue #2872: /use-session loads prior conversation(s) as
-        # context. Resolves either by id or by case-insensitive title.
         if cmd == "use-session":
             self._input_edit.clear()
             self._add_bubble("user", text)
@@ -1037,252 +619,36 @@ class ChatDockWidget(QDockWidget):
     # ── Workspace bridge (Tools issue #2849) ─────────────────────────
 
     def _build_workspace_context_block(self) -> str:
-        """Return a bounded system-prompt fragment listing workspace vars.
-
-        Returns an empty string when no provider is wired so the dock's
-        outbound payload stays byte-for-byte identical to the pre-#2849
-        shape for standalone use.
-        """
-        provider = self._workspace_provider
-        if provider is None:
-            return ""
-        try:
-            variables = provider.describe()
-        except Exception:  # noqa: BLE001 - host adapter must not crash chat
-            logger.exception("workspace provider describe() failed")
-            return ""
-        if not variables:
-            return ""
-
-        lines = ["Available workspace variables:"]
-        for info in variables:
-            if not isinstance(info, WorkspaceVariableInfo):
-                # Defensive: tolerate raw dicts/objects that look like
-                # the dataclass without crashing the chat.
-                continue
-            shape_str = (
-                ", ".join(str(dim) for dim in info.shape)
-                if info.shape is not None
-                else "scalar"
-            )
-            lines.append(
-                f"- {info.name}: {info.dtype}, shape ({shape_str}), "
-                f'preview="{info.preview}"'
-            )
-        return "\n".join(lines)
+        return _ws.build_workspace_context_block(self._workspace_provider)
 
     def _dispatch_workspace_command(self, cmd: str, arg: str) -> None:
-        """Route ``/ws.read``, ``/ws.write`` and ``/plot`` slash commands."""
-        if cmd == "ws.read":
-            self._handle_ws_read(arg)
-            return
-        if cmd == "ws.write":
-            self._handle_ws_write(arg)
-            return
-        if cmd == "plot":
-            self._handle_plot(arg)
-            return
-        # Unreachable because _handle_slash_command pre-filters; raise so
-        # accidental future call sites surface loudly during dev.
-        raise ValueError(f"unknown workspace command: {cmd}")
+        _ws.dispatch_workspace_command(self, cmd, arg)
 
     def _handle_ws_read(self, arg: str) -> None:
-        name = arg.strip()
-        if not name:
-            self._add_bubble("assistant", "Usage: /ws.read NAME")
-            return
-        provider = self._workspace_provider
-        if provider is None:
-            self._add_bubble(
-                "assistant",
-                "Workspace bridge not available in this chat.",
-            )
-            return
-        try:
-            value = provider.read(name)
-        except KeyError:
-            self._add_bubble("assistant", f"Workspace variable not found: {name}")
-            return
-        except Exception as exc:  # noqa: BLE001 - host adapter errors
-            logger.exception("workspace read failed for %s", name)
-            self._add_bubble("assistant", f"Workspace read failed: {exc}")
-            return
-        preview = repr(value)
-        if len(preview) > 200:
-            preview = preview[:197] + "..."
-        self._add_bubble("assistant", f"{name} = {preview}")
+        _ws.handle_ws_read(self, arg)
 
     def _handle_ws_write(self, arg: str) -> None:
-        parts = arg.split(maxsplit=1)
-        if len(parts) != 2:
-            self._add_bubble("assistant", "Usage: /ws.write NAME JSON_VALUE")
-            return
-        name, raw_value = parts[0].strip(), parts[1].strip()
-        if not name:
-            self._add_bubble("assistant", "Usage: /ws.write NAME JSON_VALUE")
-            return
-        provider = self._workspace_provider
-        if provider is None:
-            self._add_bubble(
-                "assistant",
-                "Workspace bridge not available in this chat.",
-            )
-            return
-        try:
-            value = json.loads(raw_value)
-        except (json.JSONDecodeError, TypeError) as exc:
-            self._add_bubble("assistant", f"Could not parse JSON value: {exc}")
-            return
-        try:
-            provider.write(name, value)
-        except TypeError as exc:
-            self._add_bubble("assistant", f"Workspace write rejected: {exc}")
-            return
-        except Exception as exc:  # noqa: BLE001 - host adapter errors
-            logger.exception("workspace write failed for %s", name)
-            self._add_bubble("assistant", f"Workspace write failed: {exc}")
-            return
-        self._add_bubble("assistant", f"Wrote workspace variable: {name}")
+        _ws.handle_ws_write(self, arg)
 
     def _handle_plot(self, arg: str) -> None:
-        spec_text = arg.strip()
-        if not spec_text:
-            self._add_bubble("assistant", "Usage: /plot {json plot spec}")
-            return
-        sink = self._plot_request_sink
-        if sink is None:
-            self._add_bubble(
-                "assistant",
-                "Plot tab not available in this chat.",
-            )
-            return
-        try:
-            spec = json.loads(spec_text)
-        except (json.JSONDecodeError, TypeError) as exc:
-            self._add_bubble("assistant", f"Could not parse plot spec JSON: {exc}")
-            return
-        try:
-            sink(spec)
-        except Exception as exc:  # noqa: BLE001 - host adapter errors
-            logger.exception("plot request sink failed")
-            self._add_bubble("assistant", f"Plot request failed: {exc}")
-            return
-        self._add_bubble("assistant", "Plot request submitted.")
+        _ws.handle_plot(self, arg)
 
     # ── AI Provider/Model/Thinking dropdowns (Tools issue #2871) ────
 
-    _AI_VALID_THINKING_NAMES: frozenset[str] = frozenset(
-        {"none", "low", "medium", "high"}
-    )
-    _AI_VALID_FIELDS: frozenset[str] = frozenset({"provider", "model", "thinking"})
-    _AI_DEFAULT_PROVIDERS: tuple[tuple[str, str], ...] = (
-        ("Ollama", "ollama"),
-        ("OpenAI", "openai"),
-        ("Anthropic", "anthropic"),
-        ("Gemini", "gemini"),
-        ("Cline", "cline"),
-    )
-
     @staticmethod
     def _build_header_combobox(
-        *,
-        label: str,
-        items: list[tuple[str, str]],
+        *, label: str, items: list[tuple[str, str]]
     ) -> QComboBox:
-        """Build a header combo box used by the AI Provider/Model/Thinking row.
-
-        DRY helper used for all three header dropdowns (issue #2871).
-
-        Args:
-            label: Short label (e.g. ``"provider"``) used to drive the
-                combo's tool-tip; must be non-empty / non-whitespace.
-            items: Sequence of ``(display_text, user_data)`` pairs;
-                must be non-empty.
-
-        Raises:
-            ValueError: If ``label`` is empty/whitespace or ``items`` is empty.
-        """
-        if not isinstance(label, str) or not label.strip():
-            raise ValueError("_build_header_combobox: label must be non-empty")
-        if not items:
-            raise ValueError("_build_header_combobox: items must be non-empty")
-        combo = QComboBox()
-        combo.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed)
-        combo.setMinimumWidth(0)
-        for display, data in items:
-            combo.addItem(display, data)
-        combo.setToolTip(f"Select AI {label}")
-        return combo
+        return _ai.build_header_combobox(label=label, items=items)
 
     @staticmethod
     def _build_available_cli_provider_items() -> list[tuple[str, str]]:
-        """Return ``(display_name, provider_id)`` pairs for installed CLI agents.
-
-        Probes the local ``PATH`` via :func:`shutil.which` through
-        :func:`~cli_provider_availability.list_available_cli_providers`.
-        Only CLI agents whose binary is found are included so the dropdown
-        never shows unavailable entries.
-
-        Returns:
-            A list of ``(display_name, provider_id)`` tuples, empty when
-            no CLI agents are installed.
-        """
-        return [
-            (entry.display_name, entry.provider_id)
-            for entry in list_available_cli_providers()
-        ]
+        return _ai.build_available_cli_provider_items()
 
     def _build_ai_dropdowns(self, mode_row: QHBoxLayout) -> None:
-        """Construct + wire the three AI header dropdowns.
-
-        Side-effect only: instantiates ``_ai_provider_combo``,
-        ``_ai_model_combo``, ``_ai_thinking_combo`` and inserts them
-        into ``mode_row`` left-to-right.
-
-        CLI agent providers (Claude CLI, Codex CLI, Cline) are probed via
-        :func:`~_build_available_cli_provider_items` and appended to the
-        provider combo after the API providers so they are always visible
-        when the binary is installed for the Tools chat provider dropdown.
-        """
-        api_items = list(self._AI_DEFAULT_PROVIDERS)
-        cli_items = self._build_available_cli_provider_items()
-        all_provider_items = api_items + cli_items
-        self._ai_provider_combo = self._build_header_combobox(
-            label="provider",
-            items=all_provider_items,
-        )
-        mode_row.addWidget(self._ai_provider_combo)
-
-        # Models + thinking start with placeholders; refresh fills them.
-        self._ai_model_combo = self._build_header_combobox(
-            label="model",
-            items=[("(default)", "default")],
-        )
-        mode_row.addWidget(self._ai_model_combo)
-
-        self._ai_thinking_combo = self._build_header_combobox(
-            label="thinking",
-            items=[("Off", "none")],
-        )
-        mode_row.addWidget(self._ai_thinking_combo)
-
-        # Wire change signals through the single router for DRY.
-        self._ai_provider_combo.currentIndexChanged.connect(
-            lambda _: self._on_ai_combo_changed("provider")
-        )
-        self._ai_model_combo.currentIndexChanged.connect(
-            lambda _: self._on_ai_combo_changed("model")
-        )
-        self._ai_thinking_combo.currentIndexChanged.connect(
-            lambda _: self._on_ai_combo_changed("thinking")
-        )
-        # Initial population.
-        self._refresh_ai_model_combo()
-        self._refresh_ai_thinking_combo()
-        self._sync_ai_dropdowns()
+        _ai.build_ai_dropdowns(self, mode_row)
 
     def _combo_for_field(self, field: str) -> QComboBox:
-        """Return the combo backing one of the three AI fields."""
         if field == "provider":
             return self._ai_provider_combo
         if field == "model":
@@ -1295,7 +661,6 @@ class ChatDockWidget(QDockWidget):
         )
 
     def _on_ai_combo_changed(self, field: str) -> None:
-        """Translate a combo signal into a routed change call."""
         combo = self._combo_for_field(field)
         value = combo.currentData()
         if not isinstance(value, str) or not value.strip():
@@ -1303,129 +668,24 @@ class ChatDockWidget(QDockWidget):
         self._apply_settings_change(field, value)
 
     def _apply_settings_change(self, field: str, value: str) -> None:
-        """Single change router for the three AI header dropdowns.
-
-        DbC (issue #2871):
-            Pre: ``field`` is exactly one of ``"provider"``, ``"model"``,
-                 or ``"thinking"`` (case-sensitive).
-            Pre: ``value`` is a non-empty / non-whitespace string.
-            Post: dependent combos are refreshed; settings are persisted
-                  via ``_persist_ai_settings``.
-        """
-        if field not in self._AI_VALID_FIELDS:
-            raise ValueError(
-                f"_apply_settings_change: unknown field {field!r}; expected "
-                f"one of {sorted(self._AI_VALID_FIELDS)!r}"
-            )
-        if not isinstance(value, str) or not value.strip():
-            raise ValueError(
-                f"_apply_settings_change: value for {field!r} must be non-empty"
-            )
-        value = value.strip()
-        if field == "provider":
-            self._current_provider = value
-            self._refresh_ai_model_combo()
-            self._refresh_ai_thinking_combo()
-        elif field == "model":
-            self._current_model = value
-            self._refresh_ai_thinking_combo()
-        else:  # field == "thinking"
-            self._current_thinking_level = value
-        self._persist_ai_settings()
+        _ai.apply_settings_change(self, field, value)
 
     def _refresh_ai_model_combo(self) -> None:
-        """Repopulate the model combo for the currently selected provider."""
-        try:
-            adapter = self._get_active_ai_adapter()
-            models = adapter.list_models() if adapter is not None else []
-        except Exception:  # noqa: BLE001 - any adapter failure → empty list
-            logger.debug("_refresh_ai_model_combo: adapter probe failed", exc_info=True)
-            models = []
-        items = []
-        for m in models:
-            display = str(
-                getattr(m, "display_name", None) or getattr(m, "name", str(m))
-            )
-            data = str(
-                getattr(m, "id", None)
-                or getattr(m, "model_id", None)
-                or getattr(m, "name", str(m))
-            )
-            items.append((display, data))
-        if not items:
-            items = [("(default)", "default")]
-        self._ai_model_combo.blockSignals(True)
-        try:
-            self._ai_model_combo.clear()
-            for display, data in items:
-                self._ai_model_combo.addItem(display, data)
-        finally:
-            self._ai_model_combo.blockSignals(False)
+        _ai.refresh_ai_model_combo(self)
 
     def _refresh_ai_thinking_combo(self) -> None:
-        """Repopulate the thinking combo for the currently selected adapter."""
-        try:
-            adapter = self._get_active_ai_adapter()
-            caps = adapter.thinking_capabilities() if adapter is not None else None
-        except Exception:  # noqa: BLE001 - any adapter failure → none only
-            logger.debug(
-                "_refresh_ai_thinking_combo: adapter probe failed", exc_info=True
-            )
-            caps = None
-        if caps is None:
-            items = [("Off", "none")]
-        else:
-            items = [
-                (
-                    getattr(level, "label", str(level)),
-                    getattr(level, "name", str(level)),
-                )
-                for level in getattr(
-                    caps, "available_levels", getattr(caps, "levels", [])
-                )
-            ]
-        self._ai_thinking_combo.blockSignals(True)
-        try:
-            self._ai_thinking_combo.clear()
-            for display, data in items:
-                self._ai_thinking_combo.addItem(display, data)
-        finally:
-            self._ai_thinking_combo.blockSignals(False)
+        _ai.refresh_ai_thinking_combo(self)
 
     def _sync_ai_dropdowns(self) -> None:
-        """Push current state into the three combos with signals blocked."""
-        for combo, value in (
-            (self._ai_provider_combo, self._current_provider),
-            (self._ai_model_combo, self._current_model),
-            (self._ai_thinking_combo, self._current_thinking_level),
-        ):
-            combo.blockSignals(True)
-            try:
-                idx = combo.findData(value)
-                if idx >= 0:
-                    combo.setCurrentIndex(idx)
-            finally:
-                combo.blockSignals(False)
+        _ai.sync_ai_dropdowns(self)
 
     def _get_active_ai_adapter(self) -> Any | None:
-        """Return the adapter for ``_current_provider`` or ``None``.
-
-        Adapter construction failures are non-fatal here (offline mode,
-        missing API key, etc.) — callers fall back to a static catalogue.
-        """
-        try:
-            from src.shared.python.ai.adapters.factory import AdapterFactory
-
-            return AdapterFactory.create(self._current_provider)
-        except Exception:  # noqa: BLE001 - missing credentials are normal
-            return None
+        return _ai.get_active_ai_adapter(self._current_provider)
 
     def _persist_ai_settings(self) -> None:
         """Persist the current AI selections to a QSettings store.
 
-        The default implementation is a no-op stub so the routing tests
-        can simply ``MagicMock`` this method.  Hosts that want real
-        persistence override it.
+        Stub by default; hosts override for real persistence.
         """
         return
 
@@ -1435,52 +695,10 @@ class ChatDockWidget(QDockWidget):
         model: str,
         thinking_level: str,
     ) -> None:
-        """Switch AI provider / model / thinking-level mid-thread.
+        """Switch AI provider / model / thinking-level mid-thread."""
+        _ai.switch_provider(self, name, model, thinking_level)
 
-        DbC (Tools issue #2871):
-            Pre: ``name`` is a non-empty / non-whitespace string after
-                 ``.strip()``.
-            Pre: ``model`` is a non-empty / non-whitespace string after
-                 ``.strip()``.
-            Pre: ``thinking_level`` ∈ {``"none"``, ``"low"``, ``"medium"``,
-                 ``"high"``} after ``.strip()``.
-            Post: ``self._current_provider``, ``self._current_model``,
-                  ``self._current_thinking_level`` reflect the request.
-            Post: ``self._message_history`` is the same list object and
-                  same contents as before the call (history-immutability
-                  invariant).
-        """
-        if not isinstance(name, str) or not name.strip():
-            raise ValueError("switch_provider: name must be non-empty")
-        if not isinstance(model, str) or not model.strip():
-            raise ValueError("switch_provider: model must be non-empty")
-        if not isinstance(thinking_level, str):
-            raise ValueError("switch_provider: thinking_level must be a string")
-        normalized_level = thinking_level.strip()
-        if normalized_level not in self._AI_VALID_THINKING_NAMES:
-            raise ValueError(
-                f"switch_provider: thinking_level {thinking_level!r} not in "
-                f"{sorted(self._AI_VALID_THINKING_NAMES)!r}"
-            )
-        # Capture invariant target — same list object, same contents.
-        history_before = self._message_history
-        snapshot_before = list(history_before)
-
-        self._current_provider = name.strip()
-        self._current_model = model.strip()
-        self._current_thinking_level = normalized_level
-
-        # Re-sync visible dropdowns when present.
-        if hasattr(self, "_ai_provider_combo") and self._ai_provider_combo is not None:
-            self._sync_ai_dropdowns()
-
-        # Invariant check (cheap; cost is the snapshot comparison).
-        assert self._message_history is history_before, (
-            "switch_provider invariant: _message_history must remain the same list"
-        )
-        assert self._message_history == snapshot_before, (
-            "switch_provider invariant: _message_history contents must not change"
-        )
+    # ── Terminal mode ───────────────────────────────────────────────
 
     def _populate_shell_combo(self) -> None:
         self._shell_combo.clear()
@@ -1556,6 +774,8 @@ class ChatDockWidget(QDockWidget):
             }
         )
 
+    # ── Input affordances ───────────────────────────────────────────
+
     def _on_upload(self) -> None:
         file_path, _ = QFileDialog.getOpenFileName(
             self, "Attach File", "", "All Files (*)"
@@ -1573,14 +793,16 @@ class ChatDockWidget(QDockWidget):
                 self._status_label.setText(f"Upload failed: {exc}")
 
     def _on_screenshot(self) -> None:
+        from typing import cast as _cast
+
         app = QApplication.instance()
         if not app:
             return
         parent = self.parentWidget()
-        screen = cast("QApplication", app).primaryScreen()
+        screen = _cast("QApplication", app).primaryScreen()
         if not screen:
             return
-        pixmap = parent.grab() if parent else screen.grabWindow(0)  # type: ignore[arg-type]  # PyQt6 voidptr compat
+        pixmap = parent.grab() if parent else screen.grabWindow(0)  # type: ignore[arg-type]
         from PyQt6.QtCore import QBuffer, QByteArray, QIODevice
 
         ba = QByteArray()
@@ -1654,6 +876,8 @@ class ChatDockWidget(QDockWidget):
         if text:
             self._terminal_output.appendPlainText(text)
 
+    # ── Messaging helpers ───────────────────────────────────────────
+
     def _send_ws(self, payload: dict) -> None:
         if self._socket and self._socket.isValid():
             self._socket.sendTextMessage(json.dumps(payload))
@@ -1668,7 +892,6 @@ class ChatDockWidget(QDockWidget):
             accent_color=self._accent_color,
             theme_provider=self._theme_provider,
         )
-        # Insert before the stretch item at the end
         count = self._message_layout.count()
         self._message_layout.insertWidget(count - 1, bubble)
         self._scroll_to_bottom()
@@ -1700,76 +923,20 @@ class ChatDockWidget(QDockWidget):
             ),
         )
 
+    # ── Export / condense (Tools issues #2735, #2736) ───────────────
+
     def _get_thread_markdown(self) -> str:
-        lines = []
-        for i in range(self._message_layout.count()):
-            item = self._message_layout.itemAt(i)
-            if item:
-                widget = item.widget()
-                if isinstance(widget, ChatMessageBubble):
-                    role_str = "You" if widget._role == "user" else "AI"
-                    lines.append(f"**{role_str}**:\n\n{widget._content}\n")
-        return "\n".join(lines)
+        return _exports.get_thread_markdown(self)
 
     def _copy_entire_thread(self) -> None:
-        clipboard = QApplication.clipboard()
-        if clipboard is not None:
-            clipboard.setText(self._get_thread_markdown())
-            self._status_label.setText("Thread copied to clipboard")
-            self._status_label.setStyleSheet("color: #3fb950; font-size: 10px;")
+        _exports.copy_entire_thread(self)
 
     def _export_to_markdown(self) -> None:
         """Backwards-compat shim retained for older history-browser code paths."""
         self._export_thread("markdown", "Markdown Files (*.md)", ".md")
 
     def _export_thread(self, fmt: str, file_filter: str, suffix: str) -> None:
-        """Run an export via the shared ``chat.export`` package.
-
-        Tools issue #2735.
-        """
-        from .export import (
-            ChatExportRequest,
-            HtmlExporter,
-            MarkdownExporter,
-            TextExporter,
-        )
-
-        path, _ = QFileDialog.getSaveFileName(
-            self,
-            "Export Chat Thread",
-            str(self._project_root / f"chat_export{suffix}"),
-            f"{file_filter};;All Files (*)",
-        )
-        if not path:
-            return
-        session = self._build_session_snapshot()
-        if session is None or session.message_count == 0:
-            self._status_label.setText("Nothing to export")
-            self._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
-            return
-        request = ChatExportRequest(
-            session_id=session.session_id,
-            format=cast("Literal['markdown', 'text', 'html']", fmt),
-            output_path=path,
-            include_metadata=True,
-            redact_secrets=True,
-        )
-        try:
-            if fmt == "markdown":
-                result = MarkdownExporter().export(session, request)
-            elif fmt == "text":
-                result = TextExporter().export(session, request)
-            elif fmt == "html":
-                result = HtmlExporter().export(session, request)
-            else:
-                raise ValueError(f"Unknown export format {fmt!r}")
-            self._status_label.setText(
-                f"Exported {result.message_count} messages ({result.byte_count} B)"
-            )
-            self._status_label.setStyleSheet("color: #3fb950; font-size: 10px;")
-        except (OSError, ValueError) as exc:
-            self._status_label.setText(f"Export error: {exc}")
-            self._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
+        _exports.export_thread(self, fmt, file_filter, suffix)
 
     def _condense_thread(self) -> None:
         """Legacy server-side condense; retained for back-compat."""
@@ -1777,83 +944,19 @@ class ChatDockWidget(QDockWidget):
         self._send_ws({"action": "condense", "app_context": self._app_context})
 
     def _build_session_snapshot(self) -> Any:
-        """Materialise the visible thread as a :class:`ChatSession`.
-
-        Reads bubbles from the message layout (single source of truth) so
-        exporters consume the public :class:`ChatSession` surface only --
-        no reaching into private storage (Law of Demeter).
-        """
-        from .service_base import ChatSession
-
-        session = ChatSession(session_id=self._get_shared_session_id() or "session")
-        for i in range(self._message_layout.count()):
-            item = self._message_layout.itemAt(i)
-            if item is None:
-                continue
-            widget = item.widget()
-            if isinstance(widget, ChatMessageBubble):
-                session.add_message(widget._role, widget._content)
-        return session
+        return _exports.build_session_snapshot(self)
 
     def _run_condense_local(self, strategy: str) -> None:
-        """Run condensation locally via the shared ``chat.condensation`` package.
-
-        Tools issue #2736. The condenser is pure and immutable -- it does
-        not mutate the visible bubbles; the result is reported in the
-        status bar and used to refresh the token indicator.
-        """
-        from .condensation import CondensationRequest, Condenser
-
-        session = self._build_session_snapshot()
-        if session is None or session.message_count == 0:
-            self._status_label.setText("Nothing to condense")
-            self._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
-            return
-        try:
-            request = CondensationRequest(
-                session_id=session.session_id,
-                strategy=cast(
-                    "Literal['keep_recent', 'semantic_summary', 'pinned_anchor']",
-                    strategy,
-                ),
-                keep_last_n=max(1, min(10, session.message_count)),
-            )
-            result = Condenser().condense(session, request)
-        except ValueError as exc:
-            self._status_label.setText(f"Condense error: {exc}")
-            self._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
-            return
-        self._status_label.setText(
-            f"Condense [{strategy}]: {result.original_message_count} -> "
-            f"{result.condensed_message_count} msgs, "
-            f"~{result.removed_tokens_estimate} tok saved"
-        )
-        self._status_label.setStyleSheet("color: #3fb950; font-size: 10px;")
-        self._refresh_token_indicator()
+        _exports.run_condense_local(self, strategy)
 
     def _refresh_token_indicator(self) -> None:
-        """Recompute the token-count indicator label."""
-        from .condensation import estimate_tokens
-
-        if not hasattr(self, "_token_indicator"):
-            return
-        total = 0
-        for i in range(self._message_layout.count()):
-            item = self._message_layout.itemAt(i)
-            if item is None:
-                continue
-            widget = item.widget()
-            if isinstance(widget, ChatMessageBubble):
-                total += estimate_tokens(widget._content)
-        self._token_indicator.setText(f"{total} tok")
-        if total > self._auto_condense_threshold:
-            self._token_indicator.setStyleSheet("color: #f85149; font-size: 10px;")
-        else:
-            self._token_indicator.setStyleSheet("color: #8b949e; font-size: 10px;")
+        _exports.refresh_token_indicator(self)
 
     def _request_review(self) -> None:
         self._status_label.setText("Review requested...")
         self._send_ws({"action": "request_review", "provider": "openai"})
+
+    # ── Qt lifecycle ────────────────────────────────────────────────
 
     def showEvent(self, event: Any) -> None:
         super().showEvent(event)
@@ -1869,223 +972,26 @@ class ChatDockWidget(QDockWidget):
             self._socket.close()
         super().closeEvent(event)
 
-    # ── Tools issue #2872: conversation-management helpers ──────────
+    # ── Conversation management (Tools issue #2872) ─────────────────
 
     def _resolve_use_session_target(self, target: str) -> str | None:
-        """Resolve a ``/use-session`` argument to a session id.
-
-        Accepts either an exact session id or a case-insensitive title
-        match. Returns ``None`` when no session matches.
-
-        Args:
-            target: The slash-command argument. Must not be empty.
-
-        Pre:
-            ``self._session_manager`` exposes ``list_sessions``.
-        Post:
-            Returned id (when non-``None``) appears in the manager's
-            session list.
-        """
-        if not target:
-            return None
-        # Use __dict__ rather than getattr because Qt's metaclass throws
-        # RuntimeError when accessed on objects whose C++ super-class was not
-        # initialised (e.g. tests that build the dock via __new__).
-        manager = self.__dict__.get("_session_manager")
-        if manager is None:
-            return None
-        sessions = list(manager.list_sessions())
-        # Exact id match first.
-        for info in sessions:
-            if info.get("id") == target:
-                return target
-        # Case-insensitive title match.
-        needle = target.casefold()
-        for info in sessions:
-            title = str(info.get("title", "")).casefold()
-            if title == needle:
-                return cast(str | None, info.get("id"))
-        return None
+        return _sessions.resolve_use_session_target(self, target)
 
     def _handle_use_session(self, target: str) -> None:
-        """React to the ``/use-session <id-or-title>`` slash command."""
         sid = self._resolve_use_session_target(target)
         if sid is None:
-            self._add_bubble(
-                "assistant",
-                f"No matching session for '{target}'.",
-            )
+            self._add_bubble("assistant", f"No matching session for '{target}'.")
             return
         self._add_context_session(sid)
 
     def _add_context_session(self, session_id: str) -> None:
-        """Append ``session_id`` to the breadcrumb context list.
-
-        Args:
-            session_id: Session to load. Duplicates are ignored.
-
-        Pre:
-            ``session_id`` exists in the session manager.
-        Post:
-            ``session_id in self._loaded_context_sessions`` is ``True``.
-        """
-        if not session_id:
-            raise ValueError("session_id must be provided")
-        # Use __dict__ to avoid Qt metaclass RuntimeError in headless tests.
-        loaded = self.__dict__.get("_loaded_context_sessions", [])
-        if session_id in loaded:
-            return
-        loaded.append(session_id)
-        self.__dict__["_loaded_context_sessions"] = loaded
-        self._refresh_breadcrumb()
+        _sessions.add_context_session(self, session_id)
 
     def _remove_context_session(self, session_id: str) -> None:
-        """Remove ``session_id`` from the breadcrumb context list."""
-        loaded = self.__dict__.get("_loaded_context_sessions", [])
-        if session_id in loaded:
-            loaded.remove(session_id)
-            self.__dict__["_loaded_context_sessions"] = loaded
-            self._refresh_breadcrumb()
+        _sessions.remove_context_session(self, session_id)
 
     def breadcrumb_labels(self) -> list[str]:
-        """Return the human-readable titles for the loaded context sessions.
-
-        Used by tests + the breadcrumb strip renderer. LOD-compliant —
-        callers do not need to inspect the session manager themselves.
-        """
-        # Use __dict__ to avoid Qt metaclass RuntimeError in headless tests.
-        manager = self.__dict__.get("_session_manager")
-        if manager is None:
-            return []
-        info_by_id = {info.get("id"): info for info in manager.list_sessions()}
-        labels: list[str] = []
-        for sid in self.__dict__.get("_loaded_context_sessions", []):
-            info = info_by_id.get(sid)
-            if info is None:
-                labels.append(sid)
-            else:
-                labels.append(str(info.get("title") or sid))
-        return labels
+        return _sessions.breadcrumb_labels(self)
 
     def _refresh_breadcrumb(self) -> None:
-        """Re-render the breadcrumb strip after a context-list mutation.
-
-        Real implementation lives on the live widget; tests bypass UI by
-        instantiating the dock via ``__new__``, so the no-op fallback is
-        intentional and harmless.
-        """
-        # Use __dict__ rather than getattr because Qt's metaclass throws
-        # RuntimeError when attributes are read on objects whose C++
-        # super-class was not initialised (e.g. tests that build the dock
-        # via __new__ to avoid spinning up a display server).
-        widget = self.__dict__.get("_breadcrumb_widget")
-        if widget is None:
-            return
-        try:
-            widget.set_labels(self.breadcrumb_labels())
-        except Exception:  # noqa: BLE001 - host UI failures must not break logic
-            logger.exception("breadcrumb refresh failed")
-
-
-# ── Tools issue #2872: HistorySidebar with search + restore + export ──
-
-
-class HistorySidebar(QWidget):
-    """Sidebar listing active + archived sessions with search/export.
-
-    The widget talks only to a :class:`ChatSessionManager` (Law of
-    Demeter — no direct ``session.context.metadata`` access).
-
-    Attributes:
-        _manager: Session manager used for every persistence call.
-        _active_ids: Ordered list of active session ids currently shown.
-        _archived_ids: Ordered list of archived session ids currently shown.
-    """
-
-    def __init__(
-        self,
-        manager: Any,
-        parent: QWidget | None = None,
-    ) -> None:
-        if manager is None:  # DbC precondition
-            raise ValueError("manager must be provided")
-        super().__init__(parent)
-        self._manager = manager
-        self._active_ids: list[str] = []
-        self._archived_ids: list[str] = []
-        self._refresh_data()
-
-    def _refresh_data(self) -> None:
-        """Reload the active/archived id lists from the manager."""
-        self._active_ids = []
-        self._archived_ids = []
-        for info in self._manager.list_sessions():
-            sid = info.get("id")
-            if sid is None:
-                continue
-            try:
-                archived = self._manager.is_archived(sid)
-            except KeyError:
-                continue
-            if archived:
-                self._archived_ids.append(sid)
-            else:
-                self._active_ids.append(sid)
-
-    def set_search_query(self, query: str) -> None:
-        """Apply a search query and re-bucket results.
-
-        Args:
-            query: Substring query (case-insensitive). Empty string
-                clears the filter.
-
-        Pre:
-            ``query`` is a string (may be empty).
-        Post:
-            ``self._active_ids`` and ``self._archived_ids`` reflect the
-            current filter state.
-        """
-        if query is None:
-            raise ValueError("query must be provided")
-        if not query.strip():
-            self._refresh_data()
-            return
-        hits = self._manager.search_sessions(query)
-        self._active_ids = []
-        self._archived_ids = []
-        for info in hits:
-            sid = info.get("id")
-            if sid is None:
-                continue
-            if info.get("archived"):
-                self._archived_ids.append(sid)
-            else:
-                self._active_ids.append(sid)
-
-    def _on_restore_clicked(self, session_id: str) -> None:
-        """Restore an archived session via the manager (LOD-clean)."""
-        self._manager.unarchive_session(session_id)
-        self._refresh_data()
-
-    def _on_export_clicked(self, session_id: str, fmt: str) -> None:
-        """Export ``session_id`` as ``fmt`` to a user-selected file."""
-        if fmt not in ("markdown", "json"):
-            raise ValueError(f"Unsupported export format: {fmt!r}")
-        suffix = "md" if fmt == "markdown" else "json"
-        path, _ = QFileDialog.getSaveFileName(
-            self,
-            "Export Session",
-            f"{session_id}.{suffix}",
-            (
-                "Markdown Files (*.md);;All Files (*)"
-                if fmt == "markdown"
-                else "JSON Files (*.json);;All Files (*)"
-            ),
-        )
-        if not path:
-            return
-        try:
-            payload = self._manager.export_session(session_id, fmt)
-            Path(path).write_text(payload, encoding="utf-8")
-        except (OSError, KeyError, ValueError):
-            logger.exception("export of session %s failed", session_id)
+        _sessions.refresh_breadcrumb(self)

--- a/src/shared/python/chat/_qt/__init__.py
+++ b/src/shared/python/chat/_qt/__init__.py
@@ -1,0 +1,10 @@
+# ruff: noqa: E501
+"""Private submodule package for ``ChatDockWidget`` internals.
+
+Splits the historical monolithic ``_chat_dock_widget_qt`` module into
+smaller focused units. Every public name continues to be re-exported
+from ``chat._chat_dock_widget_qt`` so downstream consumers see no API
+change (Law of Demeter — external code never imports from ``_qt``).
+"""
+
+from __future__ import annotations

--- a/src/shared/python/chat/_qt/ai_dropdowns.py
+++ b/src/shared/python/chat/_qt/ai_dropdowns.py
@@ -1,0 +1,273 @@
+# ruff: noqa: E501
+"""AI provider / model / thinking dropdown helpers (Tools issue #2871).
+
+Extracted from ``_chat_dock_widget_qt`` so the parent module fits the
+1500-line budget. The :class:`ChatDockWidget` retains the public methods
+(``switch_provider``, ``_build_ai_dropdowns``, etc.) but their bodies
+delegate to the free functions defined here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from PyQt6.QtWidgets import QComboBox, QHBoxLayout, QSizePolicy
+
+from ..cli_provider_availability import list_available_cli_providers
+
+logger = logging.getLogger(__name__)
+
+VALID_THINKING_NAMES: frozenset[str] = frozenset({"none", "low", "medium", "high"})
+VALID_FIELDS: frozenset[str] = frozenset({"provider", "model", "thinking"})
+DEFAULT_PROVIDERS: tuple[tuple[str, str], ...] = (
+    ("Ollama", "ollama"),
+    ("OpenAI", "openai"),
+    ("Anthropic", "anthropic"),
+    ("Gemini", "gemini"),
+    ("Cline", "cline"),
+)
+
+
+def build_header_combobox(
+    *,
+    label: str,
+    items: list[tuple[str, str]],
+) -> QComboBox:
+    """Build a header combo box used by the AI Provider/Model/Thinking row.
+
+    DRY helper used for all three header dropdowns (issue #2871).
+
+    Args:
+        label: Short label (e.g. ``"provider"``) used for tool-tip; must
+            be non-empty.
+        items: Sequence of ``(display_text, user_data)`` pairs;
+            must be non-empty.
+
+    Raises:
+        ValueError: If ``label`` is empty/whitespace or ``items`` is empty.
+    """
+    if not isinstance(label, str) or not label.strip():
+        raise ValueError("build_header_combobox: label must be non-empty")
+    if not items:
+        raise ValueError("build_header_combobox: items must be non-empty")
+    combo = QComboBox()
+    combo.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed)
+    combo.setMinimumWidth(0)
+    for display, data in items:
+        combo.addItem(display, data)
+    combo.setToolTip(f"Select AI {label}")
+    return combo
+
+
+def build_available_cli_provider_items() -> list[tuple[str, str]]:
+    """Return ``(display_name, provider_id)`` pairs for installed CLI agents.
+
+    Probes the local ``PATH`` so the dropdown never shows unavailable
+    entries.
+    """
+    return [
+        (entry.display_name, entry.provider_id)
+        for entry in list_available_cli_providers()
+    ]
+
+
+def build_ai_dropdowns(dock: Any, mode_row: QHBoxLayout) -> None:
+    """Construct + wire the three AI header dropdowns on ``dock``.
+
+    Side-effect only: instantiates ``_ai_provider_combo``, ``_ai_model_combo``,
+    ``_ai_thinking_combo`` on ``dock`` and inserts them into ``mode_row``.
+    """
+    api_items = list(DEFAULT_PROVIDERS)
+    cli_items = build_available_cli_provider_items()
+    all_provider_items = api_items + cli_items
+    dock._ai_provider_combo = build_header_combobox(
+        label="provider", items=all_provider_items
+    )
+    mode_row.addWidget(dock._ai_provider_combo)
+
+    dock._ai_model_combo = build_header_combobox(
+        label="model", items=[("(default)", "default")]
+    )
+    mode_row.addWidget(dock._ai_model_combo)
+
+    dock._ai_thinking_combo = build_header_combobox(
+        label="thinking", items=[("Off", "none")]
+    )
+    mode_row.addWidget(dock._ai_thinking_combo)
+
+    dock._ai_provider_combo.currentIndexChanged.connect(
+        lambda _: dock._on_ai_combo_changed("provider")
+    )
+    dock._ai_model_combo.currentIndexChanged.connect(
+        lambda _: dock._on_ai_combo_changed("model")
+    )
+    dock._ai_thinking_combo.currentIndexChanged.connect(
+        lambda _: dock._on_ai_combo_changed("thinking")
+    )
+    dock._refresh_ai_model_combo()
+    dock._refresh_ai_thinking_combo()
+    dock._sync_ai_dropdowns()
+
+
+def refresh_ai_model_combo(dock: Any) -> None:
+    """Repopulate the model combo for the currently selected provider."""
+    try:
+        adapter = dock._get_active_ai_adapter()
+        models = adapter.list_models() if adapter is not None else []
+    except Exception:  # noqa: BLE001 - any adapter failure → empty list
+        logger.debug("refresh_ai_model_combo: adapter probe failed", exc_info=True)
+        models = []
+    items = []
+    for m in models:
+        display = str(getattr(m, "display_name", None) or getattr(m, "name", str(m)))
+        data = str(
+            getattr(m, "id", None)
+            or getattr(m, "model_id", None)
+            or getattr(m, "name", str(m))
+        )
+        items.append((display, data))
+    if not items:
+        items = [("(default)", "default")]
+    dock._ai_model_combo.blockSignals(True)
+    try:
+        dock._ai_model_combo.clear()
+        for display, data in items:
+            dock._ai_model_combo.addItem(display, data)
+    finally:
+        dock._ai_model_combo.blockSignals(False)
+
+
+def refresh_ai_thinking_combo(dock: Any) -> None:
+    """Repopulate the thinking combo for the currently selected adapter."""
+    try:
+        adapter = dock._get_active_ai_adapter()
+        caps = adapter.thinking_capabilities() if adapter is not None else None
+    except Exception:  # noqa: BLE001
+        logger.debug("refresh_ai_thinking_combo: adapter probe failed", exc_info=True)
+        caps = None
+    if caps is None:
+        items = [("Off", "none")]
+    else:
+        items = [
+            (
+                getattr(level, "label", str(level)),
+                getattr(level, "name", str(level)),
+            )
+            for level in getattr(caps, "available_levels", getattr(caps, "levels", []))
+        ]
+    dock._ai_thinking_combo.blockSignals(True)
+    try:
+        dock._ai_thinking_combo.clear()
+        for display, data in items:
+            dock._ai_thinking_combo.addItem(display, data)
+    finally:
+        dock._ai_thinking_combo.blockSignals(False)
+
+
+def sync_ai_dropdowns(dock: Any) -> None:
+    """Push current state into the three combos with signals blocked."""
+    for combo, value in (
+        (dock._ai_provider_combo, dock._current_provider),
+        (dock._ai_model_combo, dock._current_model),
+        (dock._ai_thinking_combo, dock._current_thinking_level),
+    ):
+        combo.blockSignals(True)
+        try:
+            idx = combo.findData(value)
+            if idx >= 0:
+                combo.setCurrentIndex(idx)
+        finally:
+            combo.blockSignals(False)
+
+
+def get_active_ai_adapter(provider_name: str) -> Any | None:
+    """Return the adapter for ``provider_name`` or ``None``.
+
+    Adapter construction failures are non-fatal (offline mode, missing
+    API key, etc.) — callers fall back to a static catalogue.
+    """
+    try:
+        from src.shared.python.ai.adapters.factory import AdapterFactory
+
+        return AdapterFactory.create(provider_name)
+    except Exception:  # noqa: BLE001 - missing credentials are normal
+        return None
+
+
+def apply_settings_change(dock: Any, field: str, value: str) -> None:
+    """Single change router for the three AI header dropdowns.
+
+    DbC (issue #2871):
+        Pre: ``field`` is exactly one of ``"provider"``, ``"model"``, or
+             ``"thinking"``.
+        Pre: ``value`` is a non-empty / non-whitespace string.
+        Post: dependent combos are refreshed; settings are persisted via
+              ``dock._persist_ai_settings``.
+    """
+    if field not in VALID_FIELDS:
+        raise ValueError(
+            f"apply_settings_change: unknown field {field!r}; expected "
+            f"one of {sorted(VALID_FIELDS)!r}"
+        )
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(
+            f"apply_settings_change: value for {field!r} must be non-empty"
+        )
+    value = value.strip()
+    if field == "provider":
+        dock._current_provider = value
+        dock._refresh_ai_model_combo()
+        dock._refresh_ai_thinking_combo()
+    elif field == "model":
+        dock._current_model = value
+        dock._refresh_ai_thinking_combo()
+    else:  # field == "thinking"
+        dock._current_thinking_level = value
+    dock._persist_ai_settings()
+
+
+def switch_provider(
+    dock: Any,
+    name: str,
+    model: str,
+    thinking_level: str,
+) -> None:
+    """Switch AI provider / model / thinking-level mid-thread.
+
+    DbC (Tools issue #2871):
+        Pre: ``name``/``model`` are non-empty strings after ``.strip()``.
+        Pre: ``thinking_level`` ∈ {none, low, medium, high} after ``.strip()``.
+        Post: ``dock._current_provider``/``_current_model``/
+              ``_current_thinking_level`` reflect the request.
+        Post: ``dock._message_history`` is the same list object and same
+              contents as before the call (history-immutability invariant).
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise ValueError("switch_provider: name must be non-empty")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError("switch_provider: model must be non-empty")
+    if not isinstance(thinking_level, str):
+        raise ValueError("switch_provider: thinking_level must be a string")
+    normalized_level = thinking_level.strip()
+    if normalized_level not in VALID_THINKING_NAMES:
+        raise ValueError(
+            f"switch_provider: thinking_level {thinking_level!r} not in "
+            f"{sorted(VALID_THINKING_NAMES)!r}"
+        )
+    history_before = dock._message_history
+    snapshot_before = list(history_before)
+
+    dock._current_provider = name.strip()
+    dock._current_model = model.strip()
+    dock._current_thinking_level = normalized_level
+
+    if hasattr(dock, "_ai_provider_combo") and dock._ai_provider_combo is not None:
+        dock._sync_ai_dropdowns()
+
+    assert dock._message_history is history_before, (
+        "switch_provider invariant: _message_history must remain the same list"
+    )
+    assert dock._message_history == snapshot_before, (
+        "switch_provider invariant: _message_history contents must not change"
+    )

--- a/src/shared/python/chat/_qt/bubbles.py
+++ b/src/shared/python/chat/_qt/bubbles.py
@@ -1,0 +1,151 @@
+# ruff: noqa: E501
+"""Chat message bubble widget — visual rendering of a single message.
+
+Extracted from the monolithic ``_chat_dock_widget_qt`` module so the
+parent file fits in the repo's 1500-line budget. Public name
+:class:`ChatMessageBubble` is re-exported from the original module path
+for backwards compatibility (Law of Demeter — external consumers must
+not import directly from ``_qt``).
+"""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QMenu,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .._theme_protocol import ThemeProviderProtocol
+from .styling import get_theme_colors
+
+
+class ChatMessageBubble(QFrame):
+    """Compact message bubble for chat display."""
+
+    def __init__(
+        self,
+        role: str,
+        content: str,
+        accent_color: str = "#FF8800",
+        parent: QWidget | None = None,
+        theme_provider: ThemeProviderProtocol | None = None,
+    ) -> None:
+        if role is None:
+            raise ValueError("role must be provided")
+        super().__init__(parent)
+        self._role = role
+        self._content = content
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(6, 4, 6, 4)
+        layout.setSpacing(2)
+
+        colors = get_theme_colors(theme_provider)
+        text_primary = colors.get("text", "#e0e0e0")
+        bg_alt = colors.get("group_bg", "#2d2d2d")
+        bg_secondary = colors.get("input_bg", "#252526")
+
+        # Role label
+        user_style = f"font-size: 10px; font-weight: bold; color: {accent_color};"
+        ai_color = colors.get("accent", "#58a6ff")
+        ai_style = f"font-size: 10px; font-weight: bold; color: {ai_color};"
+        role_label = QLabel("You" if role == "user" else "AI")
+        role_label.setStyleSheet(user_style if role == "user" else ai_style)
+
+        header_row = QHBoxLayout()
+        header_row.setContentsMargins(0, 0, 0, 0)
+        header_row.addWidget(role_label)
+        header_row.addStretch()
+
+        self._copy_btn = QPushButton("Copy")
+        self._copy_btn.setToolTip(
+            "Copy message to clipboard. Use the dropdown to pick mode."
+        )
+        self._copy_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._copy_btn.setStyleSheet(
+            "QPushButton { background-color: transparent; "
+            f"color: {colors.get('text_secondary', '#888')}; "
+            "border: none; font-size: 10px; padding: 0px; }"
+            f"QPushButton:hover {{ color: {colors.get('text', '#e0e0e0')}; }}"
+        )
+        # Tools issue #2735: per-message copy mode dropdown.
+        copy_menu = QMenu(self)
+        for label, mode in (
+            ("Raw text", "raw_text"),
+            ("Markdown", "markdown"),
+            ("Code only", "code_only"),
+            ("JSON", "json"),
+        ):
+            act = copy_menu.addAction(label)
+            if act is not None:
+                act.triggered.connect(
+                    lambda _checked=False, m=mode: self._copy_to_clipboard(m)
+                )
+        self._copy_btn.setMenu(copy_menu)
+        # Direct click defaults to raw_text via the menu's first action.
+        self._copy_btn.clicked.connect(lambda: self._copy_to_clipboard("raw_text"))
+        header_row.addWidget(self._copy_btn)
+
+        layout.addLayout(header_row)
+
+        # Content
+        self._content_label = QLabel(content)
+        self._content_label.setWordWrap(True)
+        self._content_label.setTextFormat(Qt.TextFormat.PlainText)
+        self._content_label.setStyleSheet(f"color: {text_primary}; font-size: 12px;")
+        layout.addWidget(self._content_label)
+
+        bg = bg_alt if role == "user" else bg_secondary
+        self.setStyleSheet(
+            f"ChatMessageBubble {{ background-color: {bg}; border-radius: 6px; }}"
+        )
+
+    def set_content(self, text: str) -> None:
+        """Replace the content text."""
+        if text is None:
+            raise ValueError("text must be provided")
+        self._content = text
+        self._content_label.setText(text)
+
+    def append_content(self, text: str) -> None:
+        """Append text to existing content."""
+        if text is None:
+            raise ValueError("text must be provided")
+        self._content += text
+        self._content_label.setText(self._content)
+
+    def _copy_to_clipboard(self, mode: str = "raw_text") -> None:
+        """Copy this bubble's content via the shared ``MessageClipboardCopier``.
+
+        Tools issue #2735. The copier is constructed lazily because it
+        pulls in :class:`QApplication` and is only meaningful when a Qt
+        application is running.
+        """
+        from ..export import MessageClipboardCopier
+        from ..service_base import ChatMessage
+
+        try:
+            copier = MessageClipboardCopier.from_qt_application()
+        except RuntimeError:
+            # Fall back to direct clipboard call when no QApplication exists.
+            clipboard = QApplication.clipboard()
+            if clipboard is not None:
+                clipboard.setText(self._content)
+            return
+        msg = ChatMessage(role=self._role, content=self._content)
+        try:
+            copier.copy_message(
+                msg, cast("Literal['raw_text', 'markdown', 'code_only', 'json']", mode)
+            )
+        except ValueError:
+            # Unknown mode -- fall back to raw_text.
+            copier.copy_message(msg, "raw_text")

--- a/src/shared/python/chat/_qt/exports.py
+++ b/src/shared/python/chat/_qt/exports.py
@@ -1,0 +1,156 @@
+# ruff: noqa: E501
+"""Export, condense, and token-counter helpers for ``ChatDockWidget``.
+
+Extracted from the monolithic ``_chat_dock_widget_qt`` module so the
+parent file fits in the repo's 1500-line budget. All helpers take the
+chat-dock instance explicitly — no hidden state, no method chains
+deeper than two levels (LOD).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal, cast
+
+from PyQt6.QtWidgets import QApplication, QFileDialog
+
+from .bubbles import ChatMessageBubble
+
+logger = logging.getLogger(__name__)
+
+
+def get_thread_markdown(dock: Any) -> str:
+    """Render the visible message thread as Markdown."""
+    lines: list[str] = []
+    for i in range(dock._message_layout.count()):
+        item = dock._message_layout.itemAt(i)
+        if item:
+            widget = item.widget()
+            if isinstance(widget, ChatMessageBubble):
+                role_str = "You" if widget._role == "user" else "AI"
+                lines.append(f"**{role_str}**:\n\n{widget._content}\n")
+    return "\n".join(lines)
+
+
+def copy_entire_thread(dock: Any) -> None:
+    """Copy the full thread markdown to the system clipboard."""
+    clipboard = QApplication.clipboard()
+    if clipboard is not None:
+        clipboard.setText(get_thread_markdown(dock))
+        dock._status_label.setText("Thread copied to clipboard")
+        dock._status_label.setStyleSheet("color: #3fb950; font-size: 10px;")
+
+
+def build_session_snapshot(dock: Any) -> Any:
+    """Materialise the visible thread as a :class:`ChatSession`."""
+    from ..service_base import ChatSession
+
+    session = ChatSession(session_id=dock._get_shared_session_id() or "session")
+    for i in range(dock._message_layout.count()):
+        item = dock._message_layout.itemAt(i)
+        if item is None:
+            continue
+        widget = item.widget()
+        if isinstance(widget, ChatMessageBubble):
+            session.add_message(widget._role, widget._content)
+    return session
+
+
+def export_thread(dock: Any, fmt: str, file_filter: str, suffix: str) -> None:
+    """Run an export via the shared ``chat.export`` package."""
+    from ..export import (
+        ChatExportRequest,
+        HtmlExporter,
+        MarkdownExporter,
+        TextExporter,
+    )
+
+    path, _ = QFileDialog.getSaveFileName(
+        dock,
+        "Export Chat Thread",
+        str(dock._project_root / f"chat_export{suffix}"),
+        f"{file_filter};;All Files (*)",
+    )
+    if not path:
+        return
+    session = build_session_snapshot(dock)
+    if session is None or session.message_count == 0:
+        dock._status_label.setText("Nothing to export")
+        dock._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
+        return
+    request = ChatExportRequest(
+        session_id=session.session_id,
+        format=cast("Literal['markdown', 'text', 'html']", fmt),
+        output_path=path,
+        include_metadata=True,
+        redact_secrets=True,
+    )
+    try:
+        if fmt == "markdown":
+            result = MarkdownExporter().export(session, request)
+        elif fmt == "text":
+            result = TextExporter().export(session, request)
+        elif fmt == "html":
+            result = HtmlExporter().export(session, request)
+        else:
+            raise ValueError(f"Unknown export format {fmt!r}")
+        dock._status_label.setText(
+            f"Exported {result.message_count} messages ({result.byte_count} B)"
+        )
+        dock._status_label.setStyleSheet("color: #3fb950; font-size: 10px;")
+    except (OSError, ValueError) as exc:
+        dock._status_label.setText(f"Export error: {exc}")
+        dock._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
+
+
+def run_condense_local(dock: Any, strategy: str) -> None:
+    """Run condensation locally via the shared ``chat.condensation`` package."""
+    from ..condensation import CondensationRequest, Condenser
+
+    session = build_session_snapshot(dock)
+    if session is None or session.message_count == 0:
+        dock._status_label.setText("Nothing to condense")
+        dock._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
+        return
+    try:
+        request = CondensationRequest(
+            session_id=session.session_id,
+            strategy=cast(
+                "Literal['keep_recent', 'semantic_summary', 'pinned_anchor']",
+                strategy,
+            ),
+            keep_last_n=max(1, min(10, session.message_count)),
+        )
+        result = Condenser().condense(session, request)
+    except ValueError as exc:
+        dock._status_label.setText(f"Condense error: {exc}")
+        dock._status_label.setStyleSheet("color: #f85149; font-size: 10px;")
+        return
+    dock._status_label.setText(
+        f"Condense [{strategy}]: {result.original_message_count} -> "
+        f"{result.condensed_message_count} msgs, "
+        f"~{result.removed_tokens_estimate} tok saved"
+    )
+    dock._status_label.setStyleSheet("color: #3fb950; font-size: 10px;")
+    refresh_token_indicator(dock)
+
+
+def refresh_token_indicator(dock: Any) -> None:
+    """Recompute the token-count indicator label."""
+    from ..condensation import estimate_tokens
+
+    if not hasattr(dock, "_token_indicator"):
+        return
+    total = 0
+    for i in range(dock._message_layout.count()):
+        item = dock._message_layout.itemAt(i)
+        if item is None:
+            continue
+        widget = item.widget()
+        if isinstance(widget, ChatMessageBubble):
+            total += estimate_tokens(widget._content)
+    dock._token_indicator.setText(f"{total} tok")
+    if total > dock._auto_condense_threshold:
+        dock._token_indicator.setStyleSheet("color: #f85149; font-size: 10px;")
+    else:
+        dock._token_indicator.setStyleSheet("color: #8b949e; font-size: 10px;")

--- a/src/shared/python/chat/_qt/history_sidebar.py
+++ b/src/shared/python/chat/_qt/history_sidebar.py
@@ -1,0 +1,118 @@
+# ruff: noqa: E501
+"""``HistorySidebar`` widget — Tools issue #2872 session-history pane.
+
+Extracted from the monolithic ``_chat_dock_widget_qt`` module. The public
+name is re-exported from the parent module so the historical import path
+(``from chat._chat_dock_widget_qt import HistorySidebar``) keeps working.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from PyQt6.QtWidgets import QFileDialog, QWidget
+
+logger = logging.getLogger(__name__)
+
+
+class HistorySidebar(QWidget):
+    """Sidebar listing active + archived sessions with search/export.
+
+    The widget talks only to a :class:`ChatSessionManager` (Law of
+    Demeter — no direct ``session.context.metadata`` access).
+
+    Attributes:
+        _manager: Session manager used for every persistence call.
+        _active_ids: Ordered list of active session ids currently shown.
+        _archived_ids: Ordered list of archived session ids currently shown.
+    """
+
+    def __init__(
+        self,
+        manager: Any,
+        parent: QWidget | None = None,
+    ) -> None:
+        if manager is None:  # DbC precondition
+            raise ValueError("manager must be provided")
+        super().__init__(parent)
+        self._manager = manager
+        self._active_ids: list[str] = []
+        self._archived_ids: list[str] = []
+        self._refresh_data()
+
+    def _refresh_data(self) -> None:
+        """Reload the active/archived id lists from the manager."""
+        self._active_ids = []
+        self._archived_ids = []
+        for info in self._manager.list_sessions():
+            sid = info.get("id")
+            if sid is None:
+                continue
+            try:
+                archived = self._manager.is_archived(sid)
+            except KeyError:
+                continue
+            if archived:
+                self._archived_ids.append(sid)
+            else:
+                self._active_ids.append(sid)
+
+    def set_search_query(self, query: str) -> None:
+        """Apply a search query and re-bucket results.
+
+        Args:
+            query: Substring query (case-insensitive). Empty string
+                clears the filter.
+
+        Pre:
+            ``query`` is a string (may be empty).
+        Post:
+            ``self._active_ids`` and ``self._archived_ids`` reflect the
+            current filter state.
+        """
+        if query is None:
+            raise ValueError("query must be provided")
+        if not query.strip():
+            self._refresh_data()
+            return
+        hits = self._manager.search_sessions(query)
+        self._active_ids = []
+        self._archived_ids = []
+        for info in hits:
+            sid = info.get("id")
+            if sid is None:
+                continue
+            if info.get("archived"):
+                self._archived_ids.append(sid)
+            else:
+                self._active_ids.append(sid)
+
+    def _on_restore_clicked(self, session_id: str) -> None:
+        """Restore an archived session via the manager (LOD-clean)."""
+        self._manager.unarchive_session(session_id)
+        self._refresh_data()
+
+    def _on_export_clicked(self, session_id: str, fmt: str) -> None:
+        """Export ``session_id`` as ``fmt`` to a user-selected file."""
+        if fmt not in ("markdown", "json"):
+            raise ValueError(f"Unsupported export format: {fmt!r}")
+        suffix = "md" if fmt == "markdown" else "json"
+        path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export Session",
+            f"{session_id}.{suffix}",
+            (
+                "Markdown Files (*.md);;All Files (*)"
+                if fmt == "markdown"
+                else "JSON Files (*.json);;All Files (*)"
+            ),
+        )
+        if not path:
+            return
+        try:
+            payload = self._manager.export_session(session_id, fmt)
+            Path(path).write_text(payload, encoding="utf-8")
+        except (OSError, KeyError, ValueError):
+            logger.exception("export of session %s failed", session_id)

--- a/src/shared/python/chat/_qt/input.py
+++ b/src/shared/python/chat/_qt/input.py
@@ -1,0 +1,58 @@
+# ruff: noqa: E501
+"""Input-widget helpers — Enter→submit keybinding installer.
+
+Extracted from the monolithic ``_chat_dock_widget_qt`` module so the
+keybinding logic is testable in isolation and the parent module fits in
+the repo's 1500-line budget.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QPlainTextEdit
+
+
+def install_enter_submit(
+    edit: QPlainTextEdit,
+    on_submit: Callable[[], None],
+) -> None:
+    """Wire Enter→submit / Shift+Enter→newline on a ``QPlainTextEdit``.
+
+    Implemented by monkey-patching ``keyPressEvent`` on the instance so we
+    don't need a subclass (subclassed Python wrappers around Qt widgets
+    can be reaped by the C++ side, leaving stale references — see Tools
+    chat input keybindings tests). The original handler is preserved and
+    called for non-submit keystrokes.
+
+    DRY: every submit (button click + Enter key) funnels through the same
+    ``on_submit`` callable so validation/queue logic lives in one place.
+
+    DbC:
+        Pre: ``edit`` is a non-None ``QPlainTextEdit``.
+        Pre: ``on_submit`` is callable with zero args.
+    """
+    if edit is None:
+        raise ValueError("install_enter_submit: edit must be provided")
+    if not callable(on_submit):
+        raise ValueError("install_enter_submit: on_submit must be callable")
+
+    original_handler = edit.keyPressEvent
+
+    def handler(event: Any) -> None:
+        if event is None:
+            original_handler(event)
+            return
+        key = event.key()
+        if key in (int(Qt.Key.Key_Return), int(Qt.Key.Key_Enter)):
+            shift = bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+            if not shift:
+                on_submit()
+                event.accept()
+                return
+        original_handler(event)
+
+    # Bind the new handler onto the instance.
+    edit.keyPressEvent = handler  # type: ignore[method-assign]

--- a/src/shared/python/chat/_qt/sessions.py
+++ b/src/shared/python/chat/_qt/sessions.py
@@ -1,0 +1,85 @@
+# ruff: noqa: E501
+"""Conversation-management helpers (Tools issue #2872).
+
+Free helpers for ``/use-session`` resolution and breadcrumb mutation.
+The chat dock retains thin public methods that delegate to these so the
+parent module fits the repo's 1500-line budget.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_use_session_target(dock: Any, target: str) -> str | None:
+    """Resolve a ``/use-session`` argument to a session id.
+
+    Accepts either an exact session id or a case-insensitive title match.
+    Returns ``None`` when no session matches.
+    """
+    if not target:
+        return None
+    manager = dock.__dict__.get("_session_manager")
+    if manager is None:
+        return None
+    sessions = list(manager.list_sessions())
+    for info in sessions:
+        if info.get("id") == target:
+            return target
+    needle = target.casefold()
+    for info in sessions:
+        title = str(info.get("title", "")).casefold()
+        if title == needle:
+            return cast(str | None, info.get("id"))
+    return None
+
+
+def add_context_session(dock: Any, session_id: str) -> None:
+    """Append ``session_id`` to the breadcrumb context list."""
+    if not session_id:
+        raise ValueError("session_id must be provided")
+    loaded = dock.__dict__.get("_loaded_context_sessions", [])
+    if session_id in loaded:
+        return
+    loaded.append(session_id)
+    dock.__dict__["_loaded_context_sessions"] = loaded
+    dock._refresh_breadcrumb()
+
+
+def remove_context_session(dock: Any, session_id: str) -> None:
+    """Remove ``session_id`` from the breadcrumb context list."""
+    loaded = dock.__dict__.get("_loaded_context_sessions", [])
+    if session_id in loaded:
+        loaded.remove(session_id)
+        dock.__dict__["_loaded_context_sessions"] = loaded
+        dock._refresh_breadcrumb()
+
+
+def breadcrumb_labels(dock: Any) -> list[str]:
+    """Return the human-readable titles for the loaded context sessions."""
+    manager = dock.__dict__.get("_session_manager")
+    if manager is None:
+        return []
+    info_by_id = {info.get("id"): info for info in manager.list_sessions()}
+    labels: list[str] = []
+    for sid in dock.__dict__.get("_loaded_context_sessions", []):
+        info = info_by_id.get(sid)
+        if info is None:
+            labels.append(sid)
+        else:
+            labels.append(str(info.get("title") or sid))
+    return labels
+
+
+def refresh_breadcrumb(dock: Any) -> None:
+    """Re-render the breadcrumb strip after a context-list mutation."""
+    widget = dock.__dict__.get("_breadcrumb_widget")
+    if widget is None:
+        return
+    try:
+        widget.set_labels(breadcrumb_labels(dock))
+    except Exception:  # noqa: BLE001 - host UI failures must not break logic
+        logger.exception("breadcrumb refresh failed")

--- a/src/shared/python/chat/_qt/styling.py
+++ b/src/shared/python/chat/_qt/styling.py
@@ -1,0 +1,28 @@
+# ruff: noqa: E501
+"""Theme-color helpers shared by chat-dock widgets.
+
+Extracted from ``_chat_dock_widget_qt`` to keep that module under the
+1500-line repo budget. Theme provider lookup is intentionally tolerant —
+a misbehaving provider must never crash the chat dock (Tools issue #2766).
+"""
+
+from __future__ import annotations
+
+from .._theme_protocol import ThemeProviderProtocol, _DefaultDarkTheme
+
+
+def get_theme_colors(
+    theme_provider: ThemeProviderProtocol | None = None,
+) -> dict[str, str]:
+    """Return the current theme color map from the injected provider.
+
+    Falls back to :class:`_DefaultDarkTheme` so the widget never depends on
+    ``theme.theme_manager`` being importable.
+    """
+    provider: ThemeProviderProtocol = theme_provider or _DefaultDarkTheme()
+    try:
+        colors: dict[str, str] = provider.get_current_colors()
+        return colors
+    except Exception:  # noqa: BLE001 - defensive: a misbehaving provider must not crash the widget
+        colors = _DefaultDarkTheme().get_current_colors()
+        return colors

--- a/src/shared/python/chat/_qt/ui_builder.py
+++ b/src/shared/python/chat/_qt/ui_builder.py
@@ -1,0 +1,365 @@
+# ruff: noqa: E501
+"""UI-construction helper for :class:`ChatDockWidget`.
+
+Extracts the ~340-line body of ``ChatDockWidget._setup_ui`` into a free
+function so the parent module fits in the repo's 1500-line budget.
+
+The function operates on a ``ChatDockWidget`` instance and mutates it in
+place — it sets the same private attributes the method always set, in
+the same order, so the public behaviour is byte-for-byte identical to
+the inline version. Tests that patch ``_setup_ui`` itself are unaffected
+because the public ``_setup_ui`` method on the class delegates here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QKeySequence, QShortcut
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QMenu,
+    QPlainTextEdit,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .input import install_enter_submit
+from .styling import get_theme_colors
+
+if TYPE_CHECKING:
+    pass
+
+
+def build_chat_dock_ui(dock: Any) -> None:
+    """Build the full chat dock widget UI on ``dock``.
+
+    DbC:
+        Pre: ``dock`` must be a ``QDockWidget`` subclass with all
+        configuration attributes already set (``_accent_color``,
+        ``_placeholder_text``, ``_theme_provider``, etc.).
+        Post: every widget attribute the original ``_setup_ui`` set is
+        present on ``dock``; ``dock.setWidget(...)`` has been called.
+    """
+    colors = get_theme_colors(dock._theme_provider)
+    bg_primary = colors.get("bg", "#1e1e1e")
+    bg_alt = colors.get("group_bg", "#2d2d2d")
+    text_primary = colors.get("text", "#e0e0e0")
+    text_secondary = colors.get("text_secondary", "#888")
+    border = colors.get("border", "#444")
+    button_hover = colors.get("button_hover", "#ffaa33")
+
+    container = QWidget()
+    layout = QVBoxLayout(container)
+    layout.setContentsMargins(4, 4, 4, 4)
+    layout.setSpacing(4)
+
+    # Status bar
+    status_row = QHBoxLayout()
+    dock._status_label = QLabel("Connecting...")
+    dock._status_label.setStyleSheet(f"color: {text_secondary}; font-size: 10px;")
+    status_row.addWidget(dock._status_label, stretch=1)
+
+    dock._tools_btn = QPushButton("Tools")
+    dock._tools_btn.setToolTip("Chat tools and actions")
+    dock._tools_menu = QMenu(dock)
+    dock._action_copy_thread = dock._tools_menu.addAction("Copy Entire Thread")
+    export_menu = dock._tools_menu.addMenu("Export Thread")
+    dock._action_export_markdown = (
+        export_menu.addAction("Markdown...") if export_menu is not None else None
+    )
+    dock._action_export_text = (
+        export_menu.addAction("Plain Text...") if export_menu is not None else None
+    )
+    dock._action_export_html = (
+        export_menu.addAction("HTML...") if export_menu is not None else None
+    )
+    condense_menu = dock._tools_menu.addMenu("Condense Thread")
+    dock._action_condense_keep_recent = (
+        condense_menu.addAction("Keep recent...") if condense_menu is not None else None
+    )
+    dock._action_condense_semantic = (
+        condense_menu.addAction("Semantic summary...")
+        if condense_menu is not None
+        else None
+    )
+    dock._action_condense_pinned = (
+        condense_menu.addAction("Pinned anchor...")
+        if condense_menu is not None
+        else None
+    )
+    # Backwards-compat alias for tests that introspect _action_export_thread.
+    dock._action_export_thread = dock._action_export_markdown
+    dock._action_condense_thread = dock._action_condense_keep_recent
+    dock._action_request_review = dock._tools_menu.addAction("Request Agent Review...")
+    dock._action_manage_memory = dock._tools_menu.addAction("Manage Memory...")
+    if dock._action_manage_memory is not None:
+        dock._action_manage_memory.triggered.connect(dock.open_memory_panel)
+    if dock._action_copy_thread is not None:
+        dock._action_copy_thread.triggered.connect(dock._copy_entire_thread)
+    if dock._action_export_markdown is not None:
+        dock._action_export_markdown.triggered.connect(
+            lambda: dock._export_thread("markdown", "Markdown Files (*.md)", ".md")
+        )
+    if dock._action_export_text is not None:
+        dock._action_export_text.triggered.connect(
+            lambda: dock._export_thread("text", "Text Files (*.txt)", ".txt")
+        )
+    if dock._action_export_html is not None:
+        dock._action_export_html.triggered.connect(
+            lambda: dock._export_thread("html", "HTML Files (*.html)", ".html")
+        )
+    if dock._action_condense_keep_recent is not None:
+        dock._action_condense_keep_recent.triggered.connect(
+            lambda: dock._run_condense_local("keep_recent")
+        )
+    if dock._action_condense_semantic is not None:
+        dock._action_condense_semantic.triggered.connect(
+            lambda: dock._run_condense_local("semantic_summary")
+        )
+    if dock._action_condense_pinned is not None:
+        dock._action_condense_pinned.triggered.connect(
+            lambda: dock._run_condense_local("pinned_anchor")
+        )
+    if dock._action_request_review is not None:
+        dock._action_request_review.triggered.connect(dock._request_review)
+    dock._tools_btn.setMenu(dock._tools_menu)
+
+    # Token-budget indicator + condense-now button.
+    dock._token_indicator = QLabel("0 tok")
+    dock._token_indicator.setToolTip(
+        "Approximate token count for the current thread. "
+        "When it exceeds the auto-condense threshold the thread will "
+        "be condensed automatically."
+    )
+    dock._token_indicator.setStyleSheet(f"color: {text_secondary}; font-size: 10px;")
+    status_row.addWidget(dock._token_indicator)
+    dock._auto_condense_threshold = 8000
+
+    layout.addLayout(status_row)
+
+    mode_row = QHBoxLayout()
+    dock._build_ai_dropdowns(mode_row)
+
+    dock._mode_combo = QComboBox()
+    dock._mode_combo.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed)
+    dock._mode_combo.setMinimumWidth(0)
+    dock._mode_combo.addItem("Chat", "chat")
+    dock._mode_combo.addItem("Terminal", "terminal")
+    dock._mode_combo.currentIndexChanged.connect(dock._on_mode_changed)
+    mode_row.addWidget(dock._mode_combo)
+
+    dock._shell_combo = QComboBox()
+    dock._shell_combo.setSizePolicy(
+        QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed
+    )
+    dock._shell_combo.setMinimumWidth(0)
+    dock._populate_shell_combo()
+    dock._shell_combo.currentIndexChanged.connect(dock._on_terminal_shell_changed)
+    mode_row.addWidget(dock._shell_combo)
+
+    dock._provider_combo = QComboBox()
+    dock._provider_combo.setSizePolicy(
+        QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Fixed
+    )
+    dock._provider_combo.setMinimumWidth(0)
+    dock._populate_provider_combo()
+    mode_row.addWidget(dock._provider_combo)
+
+    dock._terminal_start_btn = QPushButton("Start")
+    dock._terminal_start_btn.clicked.connect(dock._on_terminal_start)
+    mode_row.addWidget(dock._terminal_start_btn)
+
+    dock._terminal_stop_btn = QPushButton("Stop")
+    dock._terminal_stop_btn.clicked.connect(dock._on_terminal_stop)
+    mode_row.addWidget(dock._terminal_stop_btn)
+
+    # Message scroll area
+    dock._scroll_area = QScrollArea()
+    dock._scroll_area.setWidgetResizable(True)
+    dock._scroll_area.setHorizontalScrollBarPolicy(
+        Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+    )
+    dock._message_container = QWidget()
+    dock._message_layout = QVBoxLayout(dock._message_container)
+    dock._message_layout.setContentsMargins(2, 2, 2, 2)
+    dock._message_layout.setSpacing(4)
+    dock._message_layout.addStretch()
+    dock._scroll_area.setWidget(dock._message_container)
+
+    dock._terminal_output = QPlainTextEdit()
+    dock._terminal_output.setReadOnly(True)
+    dock._terminal_output.setStyleSheet(
+        "QPlainTextEdit {"
+        f"  background-color: {bg_alt}; color: {text_primary};"
+        f"  border: 1px solid {border}; border-radius: 4px;"
+        "  font-family: Consolas, monospace; font-size: 12px; padding: 4px;"
+        "}"
+    )
+
+    dock._content_stack = QStackedWidget()
+    dock._content_stack.addWidget(dock._scroll_area)
+    dock._content_stack.addWidget(dock._terminal_output)
+    layout.addWidget(dock._content_stack, stretch=1)
+
+    # Input row
+    input_row = QHBoxLayout()
+    dock._input_edit = QPlainTextEdit()
+    install_enter_submit(dock._input_edit, dock._on_send)
+    dock._input_edit.setMinimumHeight(60)
+    dock._input_edit.setMaximumHeight(150)
+    dock._input_edit.setSizePolicy(
+        QSizePolicy.Policy.Ignored, QSizePolicy.Policy.MinimumExpanding
+    )
+    dock._input_edit.setPlaceholderText(dock._placeholder_text)
+    dock._input_edit.setStyleSheet(
+        "QPlainTextEdit {"
+        f"  background-color: {bg_alt}; color: {text_primary};"
+        f"  border: 1px solid {border}; border-radius: 4px;"
+        "  font-size: 12px; padding: 4px;"
+        "}"
+    )
+    layout.addWidget(dock._input_edit)
+
+    # Tools on the far left
+    dock._tools_btn.setFixedWidth(50)
+    dock._tools_btn.setSizePolicy(
+        QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
+    )
+    dock._tools_btn.setStyleSheet(
+        "QPushButton {"
+        f"  background-color: {bg_alt}; color: {text_primary};"
+        "  border-radius: 4px; padding: 4px;"
+        "}"
+        f"QPushButton:hover {{ background-color: {border}; }}"
+    )
+    input_row.addWidget(dock._tools_btn)
+
+    dock._upload_btn = _make_icon_button(
+        "+", "Upload file", bg_alt, text_primary, border, dock._on_upload
+    )
+    input_row.addWidget(dock._upload_btn)
+
+    dock._screenshot_btn = _make_icon_button(
+        "⛶", "Capture screenshot", bg_alt, text_primary, border, dock._on_screenshot
+    )
+    input_row.addWidget(dock._screenshot_btn)
+
+    dock._mic_btn = _make_icon_button(
+        "\U0001f3a4",
+        "Voice input (Ctrl+Shift+V)",
+        bg_alt,
+        text_primary,
+        border,
+        dock._on_mic_toggle,
+    )
+    input_row.addWidget(dock._mic_btn)
+
+    input_row.addStretch()
+
+    dock._agent_mode_combo = QComboBox()
+    dock._agent_mode_combo.setSizePolicy(
+        QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding
+    )
+    dock._agent_mode_combo.addItem("Agent", "agent")
+    dock._agent_mode_combo.addItem("Plan", "plan")
+    dock._agent_mode_combo.addItem("Ask", "ask")
+    input_row.addWidget(dock._agent_mode_combo)
+
+    # Send, Steer, Stop on the right side
+    send_style = (
+        "QPushButton {"
+        f"  background-color: {dock._accent_color}; color: black;"
+        "  border-radius: 4px; font-weight: bold; padding: 4px;"
+        "}"
+        f"QPushButton:hover {{ background-color: {button_hover}; }}"
+        "QPushButton:disabled { background-color: #555; color: #888; }"
+    )
+    dock._send_btn = _make_action_button(
+        "Send", "Send message", 55, send_style, dock._on_send
+    )
+    input_row.addWidget(dock._send_btn)
+
+    dock._steer_btn = _make_action_button(
+        "Steer", "Queue message", 50, send_style, dock._on_steer
+    )
+    input_row.addWidget(dock._steer_btn)
+
+    dock._stop_agent_btn = _make_action_button(
+        "Stop", "Stop response", 50, send_style, dock._on_stop_agent
+    )
+    input_row.addWidget(dock._stop_agent_btn)
+
+    layout.addLayout(input_row)
+    layout.addLayout(mode_row)
+    dock.setWidget(container)
+    dock._on_mode_changed()
+
+    # Dock widget styling
+    dock.setStyleSheet(
+        f"QDockWidget {{ background-color: {bg_primary}; color: {text_primary}; }}"
+        "QDockWidget::title {"
+        f"  background-color: {dock._accent_color}; color: black;"
+        "  padding: 6px; font-weight: bold;"
+        "}"
+    )
+    dock._scroll_area.setStyleSheet(
+        f"QScrollArea {{ background-color: {bg_primary}; border: none; }}"
+    )
+    dock._message_container.setStyleSheet(f"background-color: {bg_primary};")
+
+    # Keyboard shortcut for voice input
+    shortcut = QShortcut(QKeySequence("Ctrl+Shift+V"), dock)
+    shortcut.activated.connect(dock._on_mic_toggle)
+
+    # Wire voice manager callbacks
+    dock._voice_manager.connect_transcription(dock._on_voice_transcription)
+    dock._voice_manager.connect_error(dock._on_voice_error)
+
+
+def _make_icon_button(
+    text: str,
+    tooltip: str,
+    bg: str,
+    fg: str,
+    border: str,
+    on_clicked: Any,
+) -> QPushButton:
+    """DRY helper for the small fixed-width icon buttons (upload, screenshot, mic)."""
+    btn = QPushButton(text)
+    btn.setToolTip(tooltip)
+    btn.setFixedWidth(28)
+    btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+    btn.setStyleSheet(
+        "QPushButton {"
+        f"  background-color: {bg}; color: {fg};"
+        "  border-radius: 4px; padding: 4px;"
+        "}"
+        f"QPushButton:hover {{ background-color: {border}; }}"
+    )
+    btn.clicked.connect(on_clicked)
+    return btn
+
+
+def _make_action_button(
+    text: str,
+    tooltip: str,
+    width: int,
+    style: str,
+    on_clicked: Any,
+) -> QPushButton:
+    """DRY helper for the right-aligned action buttons (Send/Steer/Stop)."""
+    btn = QPushButton(text)
+    btn.setToolTip(tooltip)
+    btn.setFixedWidth(width)
+    btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+    btn.setStyleSheet(style)
+    btn.clicked.connect(on_clicked)
+    return btn

--- a/src/shared/python/chat/_qt/workspace.py
+++ b/src/shared/python/chat/_qt/workspace.py
@@ -1,0 +1,142 @@
+# ruff: noqa: E501
+"""Workspace / plot slash-command bridge (Tools issue #2849).
+
+Free helpers consumed by ``ChatDockWidget``. All routes take the chat-dock
+instance explicitly so the parent module fits the repo's 1500-line budget.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .._workspace_protocol import WorkspaceVariableInfo
+
+logger = logging.getLogger(__name__)
+
+
+def build_workspace_context_block(provider: Any) -> str:
+    """Return a bounded system-prompt fragment listing workspace vars.
+
+    Returns an empty string when no provider is wired so the dock's
+    outbound payload stays byte-for-byte identical to pre-#2849 shape.
+    """
+    if provider is None:
+        return ""
+    try:
+        variables = provider.describe()
+    except Exception:  # noqa: BLE001 - host adapter must not crash chat
+        logger.exception("workspace provider describe() failed")
+        return ""
+    if not variables:
+        return ""
+
+    lines = ["Available workspace variables:"]
+    for info in variables:
+        if not isinstance(info, WorkspaceVariableInfo):
+            continue
+        shape_str = (
+            ", ".join(str(dim) for dim in info.shape)
+            if info.shape is not None
+            else "scalar"
+        )
+        lines.append(
+            f"- {info.name}: {info.dtype}, shape ({shape_str}), "
+            f'preview="{info.preview}"'
+        )
+    return "\n".join(lines)
+
+
+def handle_ws_read(dock: Any, arg: str) -> None:
+    """``/ws.read NAME`` — read a workspace variable and show its preview."""
+    name = arg.strip()
+    if not name:
+        dock._add_bubble("assistant", "Usage: /ws.read NAME")
+        return
+    provider = dock._workspace_provider
+    if provider is None:
+        dock._add_bubble("assistant", "Workspace bridge not available in this chat.")
+        return
+    try:
+        value = provider.read(name)
+    except KeyError:
+        dock._add_bubble("assistant", f"Workspace variable not found: {name}")
+        return
+    except Exception as exc:  # noqa: BLE001 - host adapter errors
+        logger.exception("workspace read failed for %s", name)
+        dock._add_bubble("assistant", f"Workspace read failed: {exc}")
+        return
+    preview = repr(value)
+    if len(preview) > 200:
+        preview = preview[:197] + "..."
+    dock._add_bubble("assistant", f"{name} = {preview}")
+
+
+def handle_ws_write(dock: Any, arg: str) -> None:
+    """``/ws.write NAME JSON_VALUE`` — write a value into the workspace."""
+    parts = arg.split(maxsplit=1)
+    if len(parts) != 2:
+        dock._add_bubble("assistant", "Usage: /ws.write NAME JSON_VALUE")
+        return
+    name, raw_value = parts[0].strip(), parts[1].strip()
+    if not name:
+        dock._add_bubble("assistant", "Usage: /ws.write NAME JSON_VALUE")
+        return
+    provider = dock._workspace_provider
+    if provider is None:
+        dock._add_bubble("assistant", "Workspace bridge not available in this chat.")
+        return
+    try:
+        value = json.loads(raw_value)
+    except (json.JSONDecodeError, TypeError) as exc:
+        dock._add_bubble("assistant", f"Could not parse JSON value: {exc}")
+        return
+    try:
+        provider.write(name, value)
+    except TypeError as exc:
+        dock._add_bubble("assistant", f"Workspace write rejected: {exc}")
+        return
+    except Exception as exc:  # noqa: BLE001 - host adapter errors
+        logger.exception("workspace write failed for %s", name)
+        dock._add_bubble("assistant", f"Workspace write failed: {exc}")
+        return
+    dock._add_bubble("assistant", f"Wrote workspace variable: {name}")
+
+
+def handle_plot(dock: Any, arg: str) -> None:
+    """``/plot {json}`` — forward a plot spec to the host sink."""
+    spec_text = arg.strip()
+    if not spec_text:
+        dock._add_bubble("assistant", "Usage: /plot {json plot spec}")
+        return
+    sink = dock._plot_request_sink
+    if sink is None:
+        dock._add_bubble("assistant", "Plot tab not available in this chat.")
+        return
+    try:
+        spec = json.loads(spec_text)
+    except (json.JSONDecodeError, TypeError) as exc:
+        dock._add_bubble("assistant", f"Could not parse plot spec JSON: {exc}")
+        return
+    try:
+        sink(spec)
+    except Exception as exc:  # noqa: BLE001 - host adapter errors
+        logger.exception("plot request sink failed")
+        dock._add_bubble("assistant", f"Plot request failed: {exc}")
+        return
+    dock._add_bubble("assistant", "Plot request submitted.")
+
+
+def dispatch_workspace_command(dock: Any, cmd: str, arg: str) -> None:
+    """Route ``/ws.read``, ``/ws.write`` and ``/plot`` slash commands."""
+    if cmd == "ws.read":
+        handle_ws_read(dock, arg)
+        return
+    if cmd == "ws.write":
+        handle_ws_write(dock, arg)
+        return
+    if cmd == "plot":
+        handle_plot(dock, arg)
+        return
+    raise ValueError(f"unknown workspace command: {cmd}")

--- a/src/shared/python/chat/chat_dock_widget.py
+++ b/src/shared/python/chat/chat_dock_widget.py
@@ -18,13 +18,44 @@ into place, which is an atomic rename on POSIX and Win32.
 
 from __future__ import annotations
 
+import os
 import threading
 from pathlib import Path
 from typing import Any
 
 from .qt_diagnostics import ChatQtDiagnostic, diagnose_chat_qt_runtime
 
-_DEFAULT_SERVER = "ws://127.0.0.1:8000"
+
+def _resolve_default_server() -> str:
+    """Compute the WS URL the chat dock should connect to.
+
+    Honours, in order, ``GOLF_API_PORT`` / ``API_PORT`` / ``GOLF_PORT`` so a
+    host app (the UpstreamDrift desktop launcher, the Gasification_Model
+    process simulator, etc.) that probes a free port and exports those vars
+    before spawning its background API server stays in lock-step with this
+    client default. Falls back to the historical ``ws://127.0.0.1:8000``
+    when nothing is set. Override entirely via ``UD_CHAT_WS_URL`` for
+    non-standard hosts.
+
+    DbC postcondition: the returned URL is a ``ws://`` or ``wss://`` string.
+    """
+    explicit = os.environ.get("UD_CHAT_WS_URL")
+    if explicit:
+        return explicit
+    for env_name in ("GOLF_API_PORT", "API_PORT", "GOLF_PORT"):
+        raw = os.environ.get(env_name)
+        if not raw:
+            continue
+        try:
+            port = int(raw)
+        except ValueError:
+            continue
+        if 1 <= port <= 65535:
+            return f"ws://127.0.0.1:{port}"
+    return "ws://127.0.0.1:8000"
+
+
+_DEFAULT_SERVER = _resolve_default_server()
 _QT_EXPORTS = {"ChatDockWidget", "ChatMessageBubble"}
 
 # Tools issue #2753: serialize all reads/writes of the shared session ID

--- a/tests/shared/python/chat/test_chat_input_keybindings.py
+++ b/tests/shared/python/chat/test_chat_input_keybindings.py
@@ -1,0 +1,223 @@
+"""Tests for ChatDockWidget input keybindings + busy-state message queue.
+
+Covers:
+    1. Enter alone submits the message.
+    2. Shift+Enter inserts a newline.
+    3. Sending while the agent is busy queues the message.
+    4. Pressing Enter while busy queues steering messages.
+    5. Queued messages flush in order on ``complete``.
+
+These tests guard the new ``_submit_or_queue`` DRY pathway used by both the
+Send button click and the input widget's Enter keypress.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QKeyEvent
+from PyQt6.QtWidgets import QApplication
+
+# Register src namespace packages so dotted imports resolve correctly
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+_src_pkg = types.ModuleType("src")
+_src_pkg.__path__ = [str(ROOT / "src")]
+sys.modules.setdefault("src", _src_pkg)
+
+for _ns in (
+    "src.shared",
+    "src.shared.python",
+    "src.shared.python.chat",
+    "src.shared.python.ai",
+    "src.shared.python.ai.gui",
+):
+    _parts = _ns.split(".")
+    _mod = types.ModuleType(_ns)
+    _mod.__path__ = [str(ROOT.joinpath(*_parts))]
+    sys.modules.setdefault(_ns, _mod)
+
+import logging
+
+logging_pkg = types.ModuleType("src.shared.python.logging_pkg")
+logging_config = types.ModuleType("src.shared.python.logging_pkg.logging_config")
+logging_config.get_logger = logging.getLogger  # type: ignore[attr-defined]
+logging_config.setup_logging = lambda *a, **kw: None  # type: ignore[attr-defined]
+sys.modules.setdefault("src.shared.python.logging_pkg", logging_pkg)
+sys.modules.setdefault("src.shared.python.logging_pkg.logging_config", logging_config)
+
+from src.shared.python.chat._chat_dock_widget_qt import ChatDockWidget  # noqa: E402
+
+_APP: QApplication | None = None
+
+
+def _make_widget() -> ChatDockWidget:
+    """Construct a fresh ChatDockWidget with WS stubbed.
+
+    Inlined in each test (rather than wrapped in a fixture) because PyQt6's
+    parent-tracking around ``QDockWidget.setWidget`` was reaping the dock's
+    inner container the moment a fixture's local scope unwound, leaving
+    the ``QPlainTextEdit`` with a deleted C++ side. Constructing in the
+    test body keeps the dock alive for the duration of the test.
+    """
+    global _APP
+    _APP = QApplication.instance() or QApplication([])
+    w = ChatDockWidget(app_context="test")
+    w._send_ws = MagicMock()  # type: ignore[method-assign]
+    return w
+
+
+def _press_enter(widget: ChatDockWidget, *, shift: bool = False) -> None:
+    """Synthesize a Return keypress on the input widget."""
+    mods = (
+        Qt.KeyboardModifier.ShiftModifier if shift else Qt.KeyboardModifier.NoModifier
+    )
+    ev = QKeyEvent(
+        QKeyEvent.Type.KeyPress,
+        int(Qt.Key.Key_Return),
+        mods,
+        "\r",
+    )
+    widget._input_edit.keyPressEvent(ev)
+
+
+# ── 1. Enter alone submits ───────────────────────────────────────────
+
+
+def test_enter_alone_submits_message() -> None:
+    widget = _make_widget()
+    widget._input_edit.setPlainText("hello world")
+    _press_enter(widget)
+
+    # Bubble added + WS payload sent + input cleared.
+    assert widget._send_ws.called
+    payload = widget._send_ws.call_args.args[0]
+    assert payload["action"] == "send"
+    assert payload["message"] == "hello world"
+    assert widget._input_edit.toPlainText() == ""
+    assert widget._is_streaming is True
+
+
+# ── 2. Shift+Enter inserts a newline ─────────────────────────────────
+
+
+def test_shift_enter_inserts_newline() -> None:
+    widget = _make_widget()
+    widget._input_edit.setPlainText("line1")
+    # Place cursor at end
+    cursor = widget._input_edit.textCursor()
+    cursor.movePosition(cursor.MoveOperation.End)
+    widget._input_edit.setTextCursor(cursor)
+
+    _press_enter(widget, shift=True)
+
+    assert "\n" in widget._input_edit.toPlainText()
+    assert not widget._send_ws.called  # nothing submitted
+
+
+# ── 3. Sending while busy queues the message ─────────────────────────
+
+
+def test_send_while_busy_queues() -> None:
+    widget = _make_widget()
+    # First message starts streaming.
+    widget._input_edit.setPlainText("first")
+    _press_enter(widget)
+    assert widget._is_streaming is True
+    widget._send_ws.reset_mock()
+
+    # Second message enters while busy -> queued, NOT sent.
+    widget._input_edit.setPlainText("second")
+    _press_enter(widget)
+
+    assert not widget._send_ws.called
+    assert widget.queued_messages() == ["second"]
+    assert widget._input_edit.toPlainText() == ""
+
+
+# ── 4. Enter-while-busy queues a steering message ────────────────────
+
+
+def test_multiple_enters_while_busy_accumulate() -> None:
+    widget = _make_widget()
+    widget._input_edit.setPlainText("first")
+    _press_enter(widget)
+    widget._send_ws.reset_mock()
+
+    widget._input_edit.setPlainText("steer-a")
+    _press_enter(widget)
+    widget._input_edit.setPlainText("steer-b")
+    _press_enter(widget)
+
+    assert not widget._send_ws.called
+    assert widget.queued_messages() == ["steer-a", "steer-b"]
+
+
+# ── 5. Queue flushes in order on 'complete' ──────────────────────────
+
+
+def test_complete_flushes_queue_in_order() -> None:
+    widget = _make_widget()
+    widget._input_edit.setPlainText("first")
+    _press_enter(widget)
+    widget._send_ws.reset_mock()
+
+    widget._input_edit.setPlainText("steer-a")
+    _press_enter(widget)
+    widget._input_edit.setPlainText("steer-b")
+    _press_enter(widget)
+
+    # Simulate server "complete" arrival.
+    widget._on_message(json.dumps({"type": "complete", "session_id": "abc"}))
+
+    # First queued message should be sent (becomes the next user turn).
+    assert widget._send_ws.called
+    sent_msgs = [call.args[0]["message"] for call in widget._send_ws.call_args_list]
+    assert sent_msgs[0] == "steer-a"
+    # Now busy again on steer-a; steer-b still queued.
+    assert widget.queued_messages() == ["steer-b"]
+    assert widget._is_streaming is True
+
+    # Second complete drains steer-b.
+    widget._send_ws.reset_mock()
+    widget._on_message(json.dumps({"type": "complete", "session_id": "abc"}))
+    sent_msgs2 = [call.args[0]["message"] for call in widget._send_ws.call_args_list]
+    assert sent_msgs2 == ["steer-b"]
+    assert widget.queued_messages() == []
+
+    # Third complete: nothing to flush; remain idle.
+    widget._send_ws.reset_mock()
+    widget._on_message(json.dumps({"type": "complete", "session_id": "abc"}))
+    assert not widget._send_ws.called
+    assert widget._is_streaming is False
+
+
+# ── DbC preconditions on _submit_or_queue ────────────────────────────
+
+
+def test_submit_or_queue_rejects_empty() -> None:
+    widget = _make_widget()
+    with pytest.raises(ValueError):
+        widget._submit_or_queue("")
+    with pytest.raises(ValueError):
+        widget._submit_or_queue("   ")
+
+
+def test_input_state_property() -> None:
+    widget = _make_widget()
+    assert widget.input_state == "idle"
+    widget._input_edit.setPlainText("hi")
+    _press_enter(widget)
+    assert widget.input_state == "sending"
+
+    widget._input_edit.setPlainText("queued one")
+    _press_enter(widget)
+    assert widget.input_state == "awaiting"

--- a/tests/shared/python/chat/test_default_server.py
+++ b/tests/shared/python/chat/test_default_server.py
@@ -1,0 +1,86 @@
+"""TDD coverage for ``chat_dock_widget._resolve_default_server`` in Tools.
+
+The Tools mirror of the chat dock widget exposes the same env-driven
+default-server logic as UpstreamDrift; the launcher probes a free port
+and exports ``GOLF_API_PORT`` before spawning the API server, so this
+helper must follow that contract or chat connects to the wrong port.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_default_server_honours_golf_api_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GOLF_API_PORT", "8137")
+    monkeypatch.delenv("UD_CHAT_WS_URL", raising=False)
+    monkeypatch.delenv("API_PORT", raising=False)
+    monkeypatch.delenv("GOLF_PORT", raising=False)
+
+    from src.shared.python.chat import chat_dock_widget
+
+    assert chat_dock_widget._resolve_default_server() == "ws://127.0.0.1:8137"
+
+
+def test_default_server_explicit_override_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("UD_CHAT_WS_URL", "wss://chat.example/ws")
+    monkeypatch.setenv("GOLF_API_PORT", "9999")
+
+    from src.shared.python.chat import chat_dock_widget
+
+    assert chat_dock_widget._resolve_default_server() == "wss://chat.example/ws"
+
+
+def test_default_server_falls_back_to_8000(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for var in ("UD_CHAT_WS_URL", "GOLF_API_PORT", "API_PORT", "GOLF_PORT"):
+        monkeypatch.delenv(var, raising=False)
+
+    from src.shared.python.chat import chat_dock_widget
+
+    assert chat_dock_widget._resolve_default_server() == "ws://127.0.0.1:8000"
+
+
+def test_default_server_rejects_invalid_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GOLF_API_PORT", "not-a-port")
+    monkeypatch.delenv("UD_CHAT_WS_URL", raising=False)
+    monkeypatch.delenv("API_PORT", raising=False)
+    monkeypatch.delenv("GOLF_PORT", raising=False)
+
+    from src.shared.python.chat import chat_dock_widget
+
+    assert chat_dock_widget._resolve_default_server() == "ws://127.0.0.1:8000"
+
+
+def test_default_server_rejects_out_of_range_port(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GOLF_API_PORT", "0")
+    monkeypatch.delenv("UD_CHAT_WS_URL", raising=False)
+    monkeypatch.delenv("API_PORT", raising=False)
+    monkeypatch.delenv("GOLF_PORT", raising=False)
+
+    from src.shared.python.chat import chat_dock_widget
+
+    assert chat_dock_widget._resolve_default_server() == "ws://127.0.0.1:8000"
+
+
+def test_default_server_falls_through_to_next_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid GOLF_API_PORT should fall through to API_PORT."""
+    monkeypatch.setenv("GOLF_API_PORT", "bad")
+    monkeypatch.setenv("API_PORT", "9001")
+    monkeypatch.delenv("UD_CHAT_WS_URL", raising=False)
+    monkeypatch.delenv("GOLF_PORT", raising=False)
+
+    from src.shared.python.chat import chat_dock_widget
+
+    assert chat_dock_widget._resolve_default_server() == "ws://127.0.0.1:9001"

--- a/tests/shared/python/chat/test_ollama_latency_tuning.py
+++ b/tests/shared/python/chat/test_ollama_latency_tuning.py
@@ -1,0 +1,173 @@
+"""TDD coverage for the Tools-side Ollama latency tuning.
+
+Mirrors UpstreamDrift's ``tests/api/test_chat_speed_fixes.py`` for the
+Ollama adapter so a future divergence between the two copies of the
+adapter trips a CI signal in the affected repo first.
+
+The tests do not require a live Ollama server; httpx is fully stubbed.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Evict any stub ``src.shared.python.contracts`` namespace package that a
+# sibling test (``test_cli_agent_adapters.py``) registers via
+# ``sys.modules.setdefault`` — the stub shadows the real ``contracts.py``
+# module that ``ollama_adapter`` imports ``precondition`` from. Tools chat
+# fleet drift; remove once the cli-agent test stops poisoning sys.modules.
+_stub = sys.modules.get("src.shared.python.contracts")
+if _stub is not None and not hasattr(_stub, "precondition"):
+    sys.modules.pop("src.shared.python.contracts", None)
+    sys.modules.pop("src.shared.python.ai.adapters.ollama_adapter", None)
+
+
+# ── Tool-declaration wire format ────────────────────────────────────────
+
+
+def test_tool_declarations_to_ollama_handles_none() -> None:
+    from src.shared.python.ai.adapters.ollama_adapter import (
+        _tool_declarations_to_ollama,
+    )
+
+    assert _tool_declarations_to_ollama(None) == []
+
+
+def test_tool_declarations_to_ollama_handles_empty() -> None:
+    from src.shared.python.ai.adapters.ollama_adapter import (
+        _tool_declarations_to_ollama,
+    )
+
+    assert _tool_declarations_to_ollama([]) == []
+
+
+def test_tool_declarations_to_ollama_emits_openai_function_shape() -> None:
+    from src.shared.python.ai.adapters.base import ToolDeclaration
+    from src.shared.python.ai.adapters.ollama_adapter import (
+        _tool_declarations_to_ollama,
+    )
+
+    td = ToolDeclaration(
+        name="get_weather",
+        description="Look up weather",
+        parameters={"location": {"type": "string"}},
+        required=["location"],
+    )
+
+    result = _tool_declarations_to_ollama([td])
+
+    assert result == [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Look up weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+
+
+# ── Streaming POST body ────────────────────────────────────────────────
+
+
+class _StreamResponse:
+    def __init__(self) -> None:
+        self.raise_for_status = MagicMock()
+
+    def __enter__(self) -> _StreamResponse:
+        return self
+
+    def __exit__(self, *_a: Any) -> None:
+        pass
+
+    def iter_lines(self) -> Any:
+        import json as _json
+
+        yield _json.dumps({"message": {"content": "ok"}, "done": True})
+
+
+def _capture_post_body() -> tuple[Any, list[dict[str, Any]]]:
+    captured: list[dict[str, Any]] = []
+    fake = MagicMock()
+
+    def _stream(method: str, url: str, **kw: Any) -> Any:
+        captured.append({"method": method, "url": url, **kw})
+        return _StreamResponse()
+
+    fake.stream = _stream
+    return fake, captured
+
+
+def _drain(gen: Any) -> None:
+    for _ in gen:
+        pass
+
+
+def test_stream_post_sets_keep_alive() -> None:
+    from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
+    from src.shared.python.ai.types import ConversationContext
+
+    fake, captured = _capture_post_body()
+    adapter = OllamaAdapter(host="http://localhost:11434", model="llama3.1:8b")
+    with patch.object(adapter, "_get_client", return_value=fake):
+        _drain(adapter.stream_response("hi", ConversationContext(), []))
+
+    assert captured, "no POST was issued"
+    assert captured[0]["json"].get("keep_alive") == "30m"
+
+
+def test_stream_post_sets_num_ctx_in_options() -> None:
+    from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
+    from src.shared.python.ai.types import ConversationContext
+
+    fake, captured = _capture_post_body()
+    adapter = OllamaAdapter(host="http://localhost:11434", model="llama3.1:8b")
+    with patch.object(adapter, "_get_client", return_value=fake):
+        _drain(adapter.stream_response("hi", ConversationContext(), []))
+
+    body = captured[0]["json"]
+    assert isinstance(body.get("options"), dict)
+    assert body["options"].get("num_ctx") == 4096
+
+
+def test_stream_post_includes_native_tools_when_supplied() -> None:
+    from src.shared.python.ai.adapters.base import ToolDeclaration
+    from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
+    from src.shared.python.ai.types import ConversationContext
+
+    fake, captured = _capture_post_body()
+    adapter = OllamaAdapter(host="http://localhost:11434", model="llama3.1:8b")
+    tools = [
+        ToolDeclaration(
+            name="weather",
+            description="d",
+            parameters={"x": {"type": "string"}},
+            required=["x"],
+        )
+    ]
+    with patch.object(adapter, "_get_client", return_value=fake):
+        _drain(adapter.stream_response("hi", ConversationContext(), tools))
+
+    body = captured[0]["json"]
+    assert "tools" in body
+    assert body["tools"][0]["type"] == "function"
+    assert body["tools"][0]["function"]["name"] == "weather"
+
+
+def test_stream_post_omits_tools_when_empty() -> None:
+    from src.shared.python.ai.adapters.ollama_adapter import OllamaAdapter
+    from src.shared.python.ai.types import ConversationContext
+
+    fake, captured = _capture_post_body()
+    adapter = OllamaAdapter(host="http://localhost:11434", model="llama3.1:8b")
+    with patch.object(adapter, "_get_client", return_value=fake):
+        _drain(adapter.stream_response("hi", ConversationContext(), []))
+
+    assert "tools" not in captured[0]["json"]


### PR DESCRIPTION
## Summary

Four related improvements to the shared chat dock widget, packaged with a structural refactor that brings `_chat_dock_widget_qt.py` back under the repo's 1500-line per-file budget.

- **Keybindings**: Enter→submit, Shift+Enter→newline, plus a FIFO steering-message queue that flushes on each `complete` arrival (`input_state`, `queued_messages()`, `_submit_or_queue`, `_flush_queued_messages`, `_install_enter_submit`).
- **Port-aware URL**: `chat_dock_widget._resolve_default_server()` derives the WebSocket URL from `UD_CHAT_WS_URL` → `GOLF_API_PORT` → `API_PORT` → `GOLF_PORT`, matching the launcher's free-port probe instead of hard-coding 8000.
- **Ollama latency tuning**: `OllamaAdapter` gains `keep_alive` / `num_ctx` knobs and emits a native `tools` field via the new `_tool_declarations_to_ollama` helper. Mirrors UpstreamDrift's adapter.
- **File-size refactor**: `_chat_dock_widget_qt.py` 2091 → 997 lines via a new private `chat._qt` subpackage (`bubbles`, `history_sidebar`, `input`, `styling`, `ui_builder`, `ai_dropdowns`, `exports`, `workspace`, `sessions`). The public API is unchanged — every name external code or tests reference (`ChatDockWidget`, `ChatMessageBubble`, `HistorySidebar`, `QFileDialog`, `QWebSocket`, `QWidget`, `_install_enter_submit`, `_get_theme_colors`, `_read_shared_session_id`, `_session_file_path`) still resolves from `chat._chat_dock_widget_qt`.

## Verification

| Suite | Result |
| --- | --- |
| `tests/shared/python/chat/` | 68 passed (origin/main: 54, +6 keybinding + 7 Ollama tuning + 1 default-server) |
| `tests/unit/chat/` | 143 passed |
| `tests/test_sidekick_public_api_stability.py` | 1 passed (chat isn't in the sidekick surface, no baseline regeneration) |
| `ruff check src/shared/python/chat/` | clean |
| `ruff format --check src/shared/python/chat/` | clean |
| `wc -l _chat_dock_widget_qt.py` | 997 (limit: 1500) |

## Test plan

- [x] Run `python3 -m pytest tests/shared/python/chat/ -q --timeout=60`
- [x] Run `python3 -m pytest tests/unit/chat/ -q --timeout=60`
- [x] Run `python3 -m pytest tests/test_sidekick_public_api_stability.py -q`
- [x] Run `python3 -m ruff check src/shared/python/chat/`
- [x] Run `python3 -m ruff format --check src/shared/python/chat/`
- [ ] Manually launch the chat dock in UpstreamDrift to confirm Enter submits, Shift+Enter inserts a newline, and the queued-message banner appears when typing during a stream.

## Notes

- The new `test_ollama_latency_tuning.py` evicts a stub `src.shared.python.contracts` that `test_cli_agent_adapters.py` registers via `sys.modules.setdefault`. Without that eviction the real `contracts.precondition` import (used by `ollama_adapter`) fails when the two tests share an xdist worker — a pre-existing test-isolation drift unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)