### PR TITLE
fix(fleet-hooks): drop ls-files fallback that scanned the whole tree

### DIFF
--- a/shared_scripts/fleet_hooks.py
+++ b/shared_scripts/fleet_hooks.py
@@ -82,6 +82,25 @@ def staged_files() -> list[str]:
 
 
 def changed_files() -> list[str]:
+    """Return files changed in the current event scope.
+
+    Scope, in priority order:
+
+    1. Staged (``git diff --cached``) — pre-commit.
+    2. Working-tree diff vs ``HEAD`` (``git diff HEAD``) — pre-commit when
+       the user did ``git add -p`` and left some changes unstaged.
+    3. ``@{upstream}..HEAD`` — pre-push when the tracking ref is set.
+    4. ``origin/main...HEAD`` — pre-push fallback when no upstream is set.
+
+    Returns an empty list when no scope is detectable (clean tree, no
+    upstream, etc.). Callers must treat empty as "nothing to check".
+
+    The historical ``ls-files`` fallback that scanned the entire working
+    tree was the leading cause of agents reaching for ``--no-verify``:
+    it surfaced pre-existing grandfathered violations on every clean
+    commit. It is intentionally removed — if your diff is empty, the
+    hook is a no-op.
+    """
     files = set(staged_files())
     files.update(_git_files(["diff", "--name-only", "--diff-filter=ACMR", "HEAD"]))
     if not files:
@@ -96,8 +115,6 @@ def changed_files() -> list[str]:
                 ["diff", "--name-only", "--diff-filter=ACMR", "origin/main...HEAD"]
             )
         )
-    if not files:
-        files.update(_git_files(["ls-files"]))
     return sorted(files)
 
 


### PR DESCRIPTION
## Summary

Surgical fix to \`changed_files()\` in \`shared_scripts/fleet_hooks.py\`: remove the \`ls-files\` fallback that walked the entire working tree when no diff was detectable. That fallback was the leading cause of agents reaching for \`--no-verify\` — on a clean tree the hook would report pre-existing grandfathered violations (legacy \`.m\` files, large generated \`.tsx\`, archived JPGs).

After this change, if your diff is empty the hook is a no-op.

## Coordination

Mirrors the canonical fix in [Repository_Management#1253](https://github.com/D-sorganization/Repository_Management/pull/1253). Gasification_Model gets the same patch in a sibling PR.

## Test plan
- [ ] CI green (only \`quality-gate\` is required).
- [ ] \`pre-commit run --files <some-file>\` on a clean tree no longer reports legacy violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)