### PR TITLE
🎨 Palette: Add accessible tab roles to AnalyticsSuite

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-23 - Interactive Element Hover States
 **Learning:** Interactive elements like copy buttons, mode buttons, action buttons, and regular keys in this calculator app are missing hover state styling. Only `.soft-key` currently has a defined hover style.
 **Action:** Always verify consistent hover state styling on all interactive elements across the application to ensure visual feedback when hovered.
+## 2024-05-28 - Add accessible roles to mapped tab components
+**Learning:** When generating tabs via a map loop in React, dynamic components often lack essential accessibility structure, leaving screen reader users without proper context (e.g. knowing it's a tab, which is selected).
+**Action:** Always ensure any tab list mapped dynamically explicitly receives `role="tablist"` on the wrapper, and `role="tab"`, `aria-selected`, `aria-controls`, and an `id` on each button. Wrap corresponding sections with `role="tabpanel"`.

--- a/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
+++ b/src/data_processing/data_processor/web/src/components/AnalyticsSuite.tsx
@@ -614,11 +614,19 @@ export const AnalyticsSuite = memo(function AnalyticsSuite({ data, signals, sele
   return (
     <div className="space-y-4">
       {/* Tab Selector */}
-      <div className="flex border-b border-dark-700 text-sm">
+      <div
+        className="flex border-b border-dark-700 text-sm"
+        role="tablist"
+        aria-label="Analytics tools"
+      >
         {(['correlation', 'pca', 'regression'] as const).map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
+            role="tab"
+            aria-selected={tab === t}
+            aria-controls={`panel-${t}`}
+            id={`tab-${t}`}
             className={`px-4 py-2 capitalize ${
               tab === t
                 ? 'border-b-2 border-blue-500 text-blue-400'
@@ -632,7 +640,12 @@ export const AnalyticsSuite = memo(function AnalyticsSuite({ data, signals, sele
 
       {/* --- Correlation Matrix --- */}
       {tab === 'correlation' && correlation && (
-        <div className="card">
+        <div
+          className="card"
+          role="tabpanel"
+          id="panel-correlation"
+          aria-labelledby="tab-correlation"
+        >
           <div className="card-header">Correlation Matrix</div>
           <div className="card-body overflow-x-auto">
             <table className="text-xs w-full">
@@ -674,7 +687,12 @@ export const AnalyticsSuite = memo(function AnalyticsSuite({ data, signals, sele
 
       {/* --- PCA --- */}
       {tab === 'pca' && pca && (
-        <div className="space-y-4">
+        <div
+          className="space-y-4"
+          role="tabpanel"
+          id="panel-pca"
+          aria-labelledby="tab-pca"
+        >
           {/* Scree Plot */}
           <div className="card">
             <div className="card-header">Scree Plot (Variance Explained)</div>
@@ -762,7 +780,12 @@ export const AnalyticsSuite = memo(function AnalyticsSuite({ data, signals, sele
 
       {/* --- Regression --- */}
       {tab === 'regression' && (
-        <div className="space-y-4">
+        <div
+          className="space-y-4"
+          role="tabpanel"
+          id="panel-regression"
+          aria-labelledby="tab-regression"
+        >
           {/* Controls */}
           <div className="card">
             <div className="card-header">Regression Setup</div>


### PR DESCRIPTION
💡 What: Added accessible `role="tablist"`, `role="tab"`, and `role="tabpanel"` attributes, along with their corresponding ARIA controls/labels to the dynamically rendered tab components in the `AnalyticsSuite`.

🎯 Why: The original tab buttons lacked accessibility roles and state indicators (`aria-selected`), making them inaccessible to screen readers. This update improves the component's compliance and usability for assistive technologies.

📸 Before/After: Visual UI is unaffected (pure HTML semantic additions).

♿ Accessibility:
- Added `role="tablist"` to the tab navigation container.
- Added `role="tab"`, `aria-selected`, `aria-controls`, and `id` to each generated tab button.
- Wrapped corresponding visual content blocks with `role="tabpanel"`, `id`, and `aria-labelledby`.

---
*PR created automatically by Jules for task [9220231963183003260](https://jules.google.com/task/9220231963183003260) started by @dieterolson*