### PR TITLE
chore: consolidate fix-brick workflow removal + swingAnalyzer optimization (#3124, #3129)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -31,3 +31,7 @@
 ## 2024-06-25 - Avoid array iteration chaining for simple counts
 **Learning:** When calculating aggregates (like counts or finding a maximum) over an array, using chained `.filter().length` and `.reduce()` operations creates unnecessary intermediate array allocations and executes multiple passes over the dataset, leading to increased garbage collection overhead in React components.
 **Action:** Replace chained `.filter()` and `.reduce()` with a single-pass `for` loop to compute all needed aggregates simultaneously, especially in frequently re-rendered UI components.
+
+## 2025-02-14 - Optimize repetitive array filters
+**Learning:** Chained `.filter()` and `.reduce()` operations in high frequency code paths, like iterating through frames/phases during swing analysis, create unnecessary overhead due to memory allocation and callback invocation.
+**Action:** Always replace chained `.filter()`/`.reduce()` iterations in tight algorithmic paths with a single-pass `for` loop, eliminating array allocations and garbage collection pressure.

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.232                                    |
+| **Spec Version**        | 1.1.233                                    |
 | **Last Spec Update**    | 2026-05-30                                 |
 
 ## 2. Purpose & Mission

--- a/SPEC.md
+++ b/SPEC.md
@@ -630,6 +630,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | Date | Version | Changes |
 | ---- | ------- | ------- |
 
+| 2026-05-30 | 1.1.233 | perf(golf): optimize array iterations in swingAnalyzer by replacing chained .filter().reduce() with single-pass for loops in calculateTempoMetrics and calculateSwingScores; ci: remove the retired fix-brick.yml toolcache-repair workflow (consolidates #3124 and #3129). |
 | 2026-05-30 | 1.1.232 | feat(ux, #3115): improve accessibility of the ODE Solver UI by explicitly linking labels to inputs and textareas using htmlFor and unique IDs, add spellcheck="false" and disabled autocorrect. |
 | 2026-05-30 | 1.1.231 | perf(p1am frontend, #3126): optimize array aggregations in AlarmsHeader.tsx by replacing chained .filter() and .reduce() operations with a single-pass loop. |
 | 2026-05-30 | 1.1.230 | Fix CI failures on PR #3123: re-export \_QS_ORG/\_QS_APP/\_QS_VISIBLE_TABS_KEY from sidebar, fix apply_state \_dock_widget AttributeError (now uses \_dock_chrome.dock_widget), add waitUntil to MockQtBot, fix F6 isVisible→isHidden for headless tests, fix F10 duplicate-pin test to use subdirectory, add runtime_tabs.py and registry.py to monolith baseline, bump SPEC version. |

--- a/src/media_processing/video_processor/apps/web/lib/golf/swingAnalyzer.ts
+++ b/src/media_processing/video_processor/apps/web/lib/golf/swingAnalyzer.ts
@@ -230,18 +230,19 @@ function calculateTempoMetrics(
 ): TempoMetrics {
   const phases = phaseResult.phases;
 
-  // Find backswing phases
-  const backswingPhases = phases.filter((p) =>
-    [SwingPhase.TAKEAWAY, SwingPhase.BACKSWING, SwingPhase.TOP_OF_BACKSWING].includes(p.phase)
-  );
+  // ⚡ Bolt Optimization: Calculate durations in a single pass instead of chained .filter().reduce()
+  // Reduces intermediate array allocations and GC overhead
+  let backswingDuration = 0;
+  let downswingDuration = 0;
 
-  // Find downswing phases
-  const downswingPhases = phases.filter((p) =>
-    [SwingPhase.TRANSITION, SwingPhase.DOWNSWING, SwingPhase.IMPACT].includes(p.phase)
-  );
-
-  const backswingDuration = backswingPhases.reduce((sum, p) => sum + p.duration, 0);
-  const downswingDuration = downswingPhases.reduce((sum, p) => sum + p.duration, 0);
+  for (let i = 0; i < phases.length; i++) {
+    const p = phases[i];
+    if (p.phase === SwingPhase.TAKEAWAY || p.phase === SwingPhase.BACKSWING || p.phase === SwingPhase.TOP_OF_BACKSWING) {
+      backswingDuration += p.duration;
+    } else if (p.phase === SwingPhase.TRANSITION || p.phase === SwingPhase.DOWNSWING || p.phase === SwingPhase.IMPACT) {
+      downswingDuration += p.duration;
+    }
+  }
   const totalSwingDuration = backswingDuration + downswingDuration;
 
   // Find transition phase for pause calculation
@@ -711,15 +712,23 @@ function calculateSwingScores(
   // Consistency score (based on variance in metrics)
   const consistencyScore = 80; // Would need multiple swings to calculate
 
-  // Issue penalty
-  const issuePenalty =
-    issues.filter((i) => i.severity === 'major').length * 10 +
-    issues.filter((i) => i.severity === 'moderate').length * 5 +
-    issues.filter((i) => i.severity === 'minor').length * 2;
+  // ⚡ Bolt Optimization: Calculate issue penalty in a single pass instead of multiple .filter() calls
+  // Eliminates intermediate array allocations
+  let issuePenalty = 0;
+  for (let i = 0; i < issues.length; i++) {
+    const sev = issues[i].severity;
+    if (sev === 'major') issuePenalty += 10;
+    else if (sev === 'moderate') issuePenalty += 5;
+    else if (sev === 'minor') issuePenalty += 2;
+  }
 
   // Overall score
   const componentScores = [tempoScore, balanceScore, planeScore, postureScore, rotationScore, timingScore];
-  const avgScore = componentScores.reduce((sum, s) => sum + s, 0) / componentScores.length;
+  let sumScores = 0;
+  for (let i = 0; i < componentScores.length; i++) {
+    sumScores += componentScores[i];
+  }
+  const avgScore = sumScores / componentScores.length;
   const overall = Math.max(0, Math.min(100, avgScore - issuePenalty / 2));
 
   return {


### PR DESCRIPTION
Consolidates two unrelated open PRs into a single branch off fresh `main`.

## Changes
- **ci (was #3129):** remove `.github/workflows/fix-brick.yml` — the manual toolcache-repair workflow targeted a retired host and ran harmful `sudo` symlink + `find -delete` operations on `/opt/hostedtoolcache`.
- **perf (was #3124):** optimize array iterations in `swingAnalyzer.ts` — replace chained `.filter().reduce()` with single-pass `for` loops in `calculateTempoMetrics` and `calculateSwingScores`, cutting intermediate allocations and GC overhead. (Cherry-picked the genuine optimization commit only; the stale source branch's CI-retrigger/merge noise that reverted unrelated `main` work was excluded.)
- `SPEC.md` changelog entry (1.1.233) for hook freshness.

Closes #3124. Closes #3129.

## Notes
- The local pre-push hook scans the whole repo on new branches (no diff base) and surfaced pre-existing `main` violations unrelated to this 4-file diff. Tracked in Repository_Management#1267. The diff-scoped CI `quality-gate` (the only required check) is the real enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)