### PR TITLE
🎨 Palette: Add aria-pressed to custom toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,6 @@
 ## 2026-05-31 - Link form labels to inputs dynamically
 **Learning:** Using React's `useId()` to dynamically link `<label htmlFor>` with `<input id>` ensures proper semantic accessibility mapping without the risk of duplicate hard-coded IDs if a component is used multiple times.
 **Action:** When adding labels to complex form structures in React applications, utilize `useId()` to automatically coordinate standard accessible connections.
+## 2026-05-31 - aria-pressed on Custom Toggles
+**Learning:** When using custom toggle buttons in React that rely on dynamic styling (`className` or inline `style`) rather than standard HTML checkbox/radio inputs, screen readers have no way of knowing the button's active state.
+**Action:** Always pair custom state styling (like `.active` classes or dynamic background colors) with a dynamic `aria-pressed={isActive}` attribute on the `<button>` element to ensure the semantic state is announced to assistive technologies.

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.233                                    |
-| **Last Spec Update**    | 2026-05-30                                 |
+| **Spec Version**        | 1.1.234                                    |
+| **Last Spec Update**    | 2026-05-31                                 |
 
 ## 2. Purpose & Mission
 
@@ -634,6 +634,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | Date | Version | Changes |
 | ---- | ------- | ------- |
 
+| 2026-05-31 | 1.1.234 | feat(a11y, p1am frontend): add `aria-pressed` to custom toggle buttons in ControlDashboard (PID loop selector) and RoutingMatrix (input/output route cells) so screen readers announce active state. |
 | 2026-05-30 | 1.1.233 | perf(golf): optimize array iterations in swingAnalyzer by replacing chained .filter().reduce() with single-pass for loops in calculateTempoMetrics and calculateSwingScores; ci: remove the retired fix-brick.yml toolcache-repair workflow (consolidates #3124 and #3129). |
 | 2026-05-30 | 1.1.232 | feat(ux, #3115): improve accessibility of the ODE Solver UI by explicitly linking labels to inputs and textareas using htmlFor and unique IDs, add spellcheck="false" and disabled autocorrect. |
 | 2026-05-30 | 1.1.231 | perf(p1am frontend, #3126): optimize array aggregations in AlarmsHeader.tsx by replacing chained .filter() and .reduce() operations with a single-pass loop. |

--- a/src/p1am_control_system/frontend/src/components/ControlDashboard.tsx
+++ b/src/p1am_control_system/frontend/src/components/ControlDashboard.tsx
@@ -117,6 +117,7 @@ export const ControlDashboard: React.FC<ControlDashboardProps> = ({
                     background: selectedPidIdx === idx ? "rgba(0, 242, 254, 0.1)" : "rgba(0,0,0,0.2)",
                     color: selectedPidIdx === idx ? "var(--accent-cyan)" : "var(--text-secondary)",
                   }}
+                  aria-pressed={selectedPidIdx === idx}
                 >
                   Loop {idx + 1}
                 </button>

--- a/src/p1am_control_system/frontend/src/components/RoutingMatrix.tsx
+++ b/src/p1am_control_system/frontend/src/components/RoutingMatrix.tsx
@@ -77,6 +77,7 @@ export const RoutingMatrix: React.FC<RoutingMatrixProps> = ({
                           className={`matrix-cell ${isActive ? "active-input" : ""}`}
                           onClick={() => handleInputRoute(rowIdx, colIdx)}
                           title={`Route ${label} to Tag ${colIdx} (Current val: ${tagValues[colIdx]?.toFixed(2) ?? "0.00"})`}
+                          aria-pressed={isActive}
                         >
                           {isActive && <div style={{ width: "6px", height: "6px", borderRadius: "50%", background: "#0b0d12" }} />}
                         </button>
@@ -127,6 +128,7 @@ export const RoutingMatrix: React.FC<RoutingMatrixProps> = ({
                           className={`matrix-cell ${isActive ? "active-output" : ""}`}
                           onClick={() => handleOutputRoute(rowIdx, colIdx)}
                           title={`Route Tag ${colIdx} (Current val: ${tagValues[colIdx]?.toFixed(2) ?? "0.00"}) to ${label}`}
+                          aria-pressed={isActive}
                         >
                           {isActive && <div style={{ width: "6px", height: "6px", borderRadius: "50%", background: "#0b0d12" }} />}
                         </button>


### PR DESCRIPTION
💡 What: Added dynamic `aria-pressed` attributes to custom toggle buttons in the RoutingMatrix and ControlDashboard components.
🎯 Why: These buttons act as stateful toggles (turning routing on/off or selecting active PID loops), but previously only conveyed their state visually through CSS/styles. This ensures screen readers can announce the correct active/inactive state.
📸 Before/After: Visuals remain unchanged, but the accessibility tree now accurately reflects the toggle state.
♿ Accessibility: `aria-pressed` added to matrix-cell buttons and PID loop selector buttons, drastically improving screen reader navigation.

---
*PR created automatically by Jules for task [12339707680112710047](https://jules.google.com/task/12339707680112710047) started by @dieterolson*