### PR TITLE
🎨 Palette: Improve accessibility of model selector tabs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-05-31 - aria-pressed on Custom Toggles
 **Learning:** When using custom toggle buttons in React that rely on dynamic styling (`className` or inline `style`) rather than standard HTML checkbox/radio inputs, screen readers have no way of knowing the button's active state.
 **Action:** Always pair custom state styling (like `.active` classes or dynamic background colors) with a dynamic `aria-pressed={isActive}` attribute on the `<button>` element to ensure the semantic state is announced to assistive technologies.
+## 2024-05-31 - Tab Roles vs aria-pressed
+**Learning:** When adding `role="tab"` to buttons to form an accessible tab list, existing `aria-pressed` attributes must be removed, as `aria-pressed` is intended for toggle buttons and creates conflicting semantics on tab elements. Furthermore, dynamically updating `aria-controls` with missing IDs creates broken reference validations.
+**Action:** When implementing tab semantics, ensure `role="tab"` is paired strictly with `aria-selected` (not `aria-pressed`), and verify `aria-controls` points to a statically identifiable and valid `role="tabpanel"` container whose `aria-labelledby` points back to the selected tab.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,7 +2,7 @@
 
 <!--
   TEMPLATE VERSION: 1.0.0
-  LAST_UPDATED: 2026-05-31
+  LAST_UPDATED: 2026-06-01
 
   This is the canonical specification template for all repositories in the
   D-sorganization fleet. Every repo MUST have a SPEC.md at its root.
@@ -968,6 +968,10 @@ Active development with stable core, continuous tool expansion, and web API in p
 - **Reliability**: Restored source-tree `src.shared.python.logging_pkg` and `src.shared.python.config` compatibility modules so shared AI adapter factories and chat service connection code import cleanly from a Tools source checkout or vendored shared-module install.
 
 ## 9. Changelog
+
+### Version 1.1.233
+
+- 2026-06-01: fix(ux) — improve accessibility of pendulum simulator model selector tabs by removing conflicting `aria-pressed` attributes and replacing them with standard `role="tablist"`, `role="tab"`, `role="tabpanel"`, and `aria-selected` attributes.
 
 ### Version 1.1.232
 

--- a/src/pendulum_simulator/pendulum-web/src/App.tsx
+++ b/src/pendulum_simulator/pendulum-web/src/App.tsx
@@ -379,15 +379,18 @@ export default function App() {
         <span className="app-status">{status}</span>
       </header>
 
-      <div className="app-body">
+      <div className="app-body" role="tabpanel" id="main-panel" aria-labelledby={`tab-${modelType}`}>
         {/* ── Model selector tabs ── */}
         <div style={{ padding: '10px', backgroundColor: '#222', borderBottom: '2px solid #444' }}>
-          <div style={{ display: 'flex', gap: '10px', marginBottom: '10px' }}>
+          <div role="tablist" aria-label="Model Types" style={{ display: 'flex', gap: '10px', marginBottom: '10px' }}>
             {(['double', 'triple', 'golfer'] as ModelType[]).map(m => (
               <button
                 key={m}
+                id={`tab-${m}`}
+                role="tab"
+                aria-selected={modelType === m}
+                aria-controls="main-panel"
                 onClick={() => { setModelType(m); setResult(null); setPlaying(false); }}
-                aria-pressed={modelType === m}
                 style={{
                   padding: '8px 16px',
                   backgroundColor: modelType === m ? '#0066cc' : '#333',


### PR DESCRIPTION
💡 What: Added standard ARIA roles (`role="tablist"`, `role="tab"`, `role="tabpanel"`) and state attributes (`aria-selected`, `aria-controls`) to the model selector tab UI, while properly removing the conflicting `aria-pressed` attributes.
🎯 Why: Screen readers now correctly announce the selector as a tabbed interface, enabling users to understand they are switching views and know which view is currently selected without semantic conflicts.
📸 Before/After: Visuals unchanged, semantics upgraded.
♿ Accessibility: Added proper `tablist`, `tab`, and `tabpanel` ARIA patterns.

---
*PR created automatically by Jules for task [1454799343054321144](https://jules.google.com/task/1454799343054321144) started by @dieterolson*