### PR TITLE
fix(ai): repair ShellTool, bitnet read-timeout, gemini error-contract + branding (#3175, #3176, #3179)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.272                                    |
+| **Spec Version**        | 1.1.273                                    |
 | **Last Spec Update**    | 2026-06-02                                 |
 
 ## 2. Purpose & Mission
@@ -634,6 +634,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | Date | Version | Changes |
 | ---- | ------- | ------- |
 
+| 2026-06-02 | 1.1.273 | fix(ai): ShellTool runs allowlisted argv via `shlex.split` (was `["","-c",cmd]` → always FileNotFoundError) with the operator blocklist retained and the misleading "sandboxed" docstring corrected (#3176); BitNet adapter enforces a wall-clock read deadline (daemon reader thread + bounded `queue.get`, killing a hung `llama-cli`) and forwards `timeout=` → `AITimeoutError` (#3175); gemini adapter raises typed `AIProviderError` via `_classify_error` instead of leaking `"Error: {e}"`, openai/anthropic system prompts route through `build_system_prompt(app_context)` (no hardcoded "Golf Modeling Suite"), `tool_bridge` fails CLOSED when confirmation is required but no callback is configured, and `rust_adapter` replaces the busy-poll fallback with a bounded `queue.get` (#3179). |
 | 2026-06-02 | 1.1.272 | test(plot-engine): add focused headless coverage for the Matplotlib renderer, including line/scatter styling, trendline success and failure paths, 3D surface rendering, contour and heatmap options, histogram styling, filter-comparison difference plots, PNG export, validation guards, and helper defaults, raising `src/shared/python/plot_engine/matplotlib_renderer.py` focused coverage from 8.38% to 100.00% without changing production behavior. |
 | 2026-06-02 | 1.1.271 | test(plot-engine): add focused headless coverage for the Plotly converter JSON contract, including typed dispatch for line/scatter, surface, contour, heatmap, histogram, and filter-comparison specs, style/layout serialization, trendline naming and failure handling, required-input guards, and helper defaults, raising `src/shared/python/plot_engine/plotly_converter.py` focused coverage from 0% to 94.77% without changing production behavior. |
 | 2026-06-02 | 1.1.270 | fix(calc_backend,signal_toolkit): iterate the scrubber router's column area -> liquid flux -> flooding velocity -> diameter solve to convergence so `liquid_mass_flux` is self-consistent with the solved cross-section instead of an assumed 1 m2 basis (#3181); and restore Design-by-Contract `ValueError` guards on `Integrator.integrate`/`compute_integral` that reject NaN, inverted (`lower > upper`), and out-of-range integration bounds via explicit checks that survive `python -O` (#3182). Regression tests live in dedicated, fully type-annotated files (`calc_backend/tests/test_scrubber_convergence_3181.py`, `signal_toolkit/tests/test_bound_validation_3182.py`) to keep the delta-CI mypy surface clean. |

--- a/src/shared/python/ai/adapters/anthropic_adapter.py
+++ b/src/shared/python/ai/adapters/anthropic_adapter.py
@@ -86,6 +86,7 @@ class AnthropicAdapter(BaseAgentAdapter):
         api_key: str,
         model: str | None = None,
         timeout: float | None = None,
+        app_context: str = "assistant",
     ) -> None:
         """Initialize Anthropic adapter.
 
@@ -97,6 +98,10 @@ class AnthropicAdapter(BaseAgentAdapter):
             api_key: Anthropic API key (required).
             model: Model name. Uses ANTHROPIC_MODEL env var or default.
             timeout: Request timeout [s]. Uses ANTHROPIC_TIMEOUT env var or default.
+            app_context: Registry key for the consuming application's system
+                prompt preamble (e.g. ``"upstream_drift"``, ``"gasification"``).
+                Defaults to ``"assistant"``, a brand-neutral preamble. See
+                :mod:`src.shared.python.ai.system_prompts` (issue #3179).
         """
         if api_key is None:
             raise ValueError("api_key must be provided")
@@ -105,6 +110,7 @@ class AnthropicAdapter(BaseAgentAdapter):
         self._api_key = api_key
         self._model = model or get_anthropic_model()
         self._timeout = timeout if timeout is not None else get_anthropic_timeout()
+        self._app_context = app_context
         self._client: Any = None  # Lazy-loaded Anthropic client
 
         logger.info("Initialized AnthropicAdapter: model=%s", self._model)
@@ -488,28 +494,18 @@ class AnthropicAdapter(BaseAgentAdapter):
             raise ValueError("context must be provided")
         if context is None:
             raise ValueError("context must be provided")
+        from src.shared.python.ai.system_prompts import build_system_prompt
+
         expertise = context.user_expertise.name.lower()
         context_instructions = self.build_context_instruction_section(context)
 
-        return (
-            f"You are Claude, an AI assistant for the Golf Modeling Suite, a "
-            f"research-grade biomechanics simulation platform for analyzing "
-            f"golf swings.\n\n"
-            f"Current user expertise level: {expertise}\n\n"
-            f"Your capabilities include:\n"
-            f"- Analyzing C3D motion capture data\n"
-            f"- Running physics simulations (MuJoCo, Drake, Pinocchio)\n"
-            f"- Computing inverse dynamics and joint torques\n"
-            f"- Performing drift-control decomposition\n"
-            f"- Generating visualizations and reports\n\n"
-            f"{context_instructions}\n\n"
-            f"Guidelines:\n"
-            f"1. Use tools to perform analyses - never fabricate numerical results\n"
-            f"2. Explain concepts at the {expertise} level\n"
-            f"3. Validate scientific claims before presenting them\n"
-            f"4. Guide users through workflows step by step\n"
-            f"5. Acknowledge uncertainty and cite limitations\n"
-            f"6. Be precise about physical units (SI: m, kg, s, rad, N, N·m)"
+        # Brand-neutral preamble + capabilities are injected by app_context
+        # rather than hardcoded here (issue #3179). Persisted-memory context
+        # is appended as extra instructions when present.
+        return build_system_prompt(
+            app_context=self._app_context,
+            expertise_level=expertise,
+            extra_instructions=context_instructions or None,
         )
 
     def _parse_response(self, response: Any) -> AgentResponse:

--- a/src/shared/python/ai/adapters/bitnet_adapter.py
+++ b/src/shared/python/ai/adapters/bitnet_adapter.py
@@ -9,10 +9,15 @@ from __future__ import annotations
 
 import os
 import subprocess
+import time
 from collections.abc import Iterator
 
 from src.shared.python.ai.adapters.base import BaseAgentAdapter, ToolDeclaration
-from src.shared.python.ai.exceptions import AIConnectionError, AIProviderError
+from src.shared.python.ai.exceptions import (
+    AIConnectionError,
+    AIProviderError,
+    AITimeoutError,
+)
 from src.shared.python.ai.types import (
     AgentChunk,
     AgentResponse,
@@ -25,6 +30,11 @@ from src.shared.python.logging_pkg.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+# Default wall-clock budget for a single llama-cli invocation. Local
+# inference of 512 tokens on CPU can be slow, so this is generous; a hung
+# or stalled process is killed once the deadline elapses (issue #3175).
+DEFAULT_BITNET_TIMEOUT: float = 300.0
+
 
 class BitnetAdapter(BaseAgentAdapter):
     """Adapter for running local BitNet models via direct subprocess.
@@ -34,14 +44,25 @@ class BitnetAdapter(BaseAgentAdapter):
     """
 
     def __init__(
-        self, model: str | None = None, bitnet_root: str | None = None
+        self,
+        model: str | None = None,
+        bitnet_root: str | None = None,
+        timeout: float | None = None,
     ) -> None:
         """Initialize the BitNet adapter.
 
         Args:
             model: Name or path to the model file to run.
             bitnet_root: Path to the root of the bitnet installation.
+            timeout: Wall-clock budget [s] for a single ``llama-cli``
+                invocation (both ``send_message`` and ``stream_response``).
+                Defaults to :data:`DEFAULT_BITNET_TIMEOUT`. Must be > 0.
         """
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be a positive number of seconds")
+        self.timeout: float = (
+            float(timeout) if timeout is not None else DEFAULT_BITNET_TIMEOUT
+        )
         self.model = model or "bitnet-1.58b-q4_0.gguf"
         self.bitnet_root = bitnet_root or os.environ.get("BITNET_ROOT", "")
         self.llama_cli = (
@@ -95,6 +116,12 @@ class BitnetAdapter(BaseAgentAdapter):
             raise AIConnectionError(
                 f"Failed to run BitNet: llama-cli not found at {self.llama_cli}",
                 provider="bitnet",
+            ) from error
+        if isinstance(error, subprocess.TimeoutExpired):
+            raise AITimeoutError(
+                f"BitNet timed out after {self.timeout}s",
+                provider="bitnet",
+                timeout=self.timeout,
             ) from error
         if isinstance(error, subprocess.CalledProcessError):
             raise AIProviderError(
@@ -162,6 +189,7 @@ class BitnetAdapter(BaseAgentAdapter):
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=self.timeout,
             )
 
             output = result.stdout.replace(prompt, "").strip()
@@ -197,6 +225,7 @@ class BitnetAdapter(BaseAgentAdapter):
             "--log-disable",
         ]
 
+        process: subprocess.Popen | None = None
         try:
             process = subprocess.Popen(
                 cmd,
@@ -211,16 +240,65 @@ class BitnetAdapter(BaseAgentAdapter):
                     "BitNet process stdout is unavailable", provider="bitnet"
                 )
 
-            for index, line in enumerate(process.stdout):
-                yield AgentChunk(
-                    content=line,
-                    is_final=False,
-                    index=index,
-                )
+            # Drain stdout on a daemon reader thread so the main loop can
+            # enforce a wall-clock deadline. A hung llama-cli that never
+            # emits EOF would otherwise block ``for line in stdout`` forever
+            # (issue #3175). The sentinel ``None`` marks normal EOF.
+            import queue as _queue
+            import threading as _threading
 
-            process.wait()
+            line_queue: _queue.Queue[str | None] = _queue.Queue()
+            stdout = process.stdout
+
+            def _pump() -> None:
+                try:
+                    for raw_line in stdout:
+                        line_queue.put(raw_line)
+                finally:
+                    line_queue.put(None)
+
+            reader = _threading.Thread(target=_pump, daemon=True)
+            reader.start()
+
+            deadline = time.monotonic() + self.timeout
+            index = 0
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise subprocess.TimeoutExpired(cmd, self.timeout)
+                try:
+                    line = line_queue.get(timeout=remaining)
+                except _queue.Empty as exc:
+                    raise subprocess.TimeoutExpired(cmd, self.timeout) from exc
+                if line is None:  # EOF sentinel
+                    break
+                yield AgentChunk(content=line, is_final=False, index=index)
+                index += 1
+
+            process.wait(timeout=max(0.0, deadline - time.monotonic()))
             yield AgentChunk(content="", is_final=True)
 
+        except subprocess.TimeoutExpired:
+            logger.error("BitNet stream timed out after %ss", self.timeout)
+            self._terminate(process)
+            yield AgentChunk(
+                content=f"\n[Error: BitNet stream timed out after {self.timeout}s]",
+                is_final=True,
+            )
         except Exception as e:
             logger.error("Failed to stream BitNet: %s", e)
+            self._terminate(process)
             yield AgentChunk(content=f"\n[Error: {e}]", is_final=True)
+
+    @staticmethod
+    def _terminate(process: subprocess.Popen | None) -> None:
+        """Kill and reap a (possibly hung) child process; never raises."""
+        if process is None:
+            return
+        if process.poll() is not None:  # already exited
+            return
+        try:
+            process.kill()
+            process.wait(timeout=5.0)
+        except Exception:  # noqa: BLE001 - best-effort reaping
+            logger.warning("Failed to fully reap BitNet child process", exc_info=True)

--- a/src/shared/python/ai/adapters/gemini_adapter.py
+++ b/src/shared/python/ai/adapters/gemini_adapter.py
@@ -202,7 +202,9 @@ class GeminiAdapter(BaseAgentAdapter):
             return AgentResponse(content=response.text, usage=canonical_usage)
         except (RuntimeError, ValueError, OSError) as e:
             logger.error(f"Gemini API error: {e}")
-            return AgentResponse(content=f"Error: {e}", usage=canonical_usage)
+            # Raise a typed error rather than leaking the raw exception
+            # string as model content (issue #3179).
+            raise self._classify_error(e, provider="gemini") from e
 
     def stream_response(
         self,
@@ -238,8 +240,11 @@ class GeminiAdapter(BaseAgentAdapter):
 
         except (RuntimeError, ValueError, OSError) as e:
             logger.error(f"Gemini streaming error: {e}")
-            yield AgentChunk(content=f"\n[Error: {e}]", is_final=True)
-            emitted_final = True
+            # Raise a typed error rather than leaking the raw exception
+            # string as a chunk's content (issue #3179). Callers consuming
+            # the generator observe an AIProviderError, consistent with the
+            # synchronous send_message path and the base adapter contract.
+            raise self._classify_error(e, provider="gemini") from e
 
         # Guarantee: every stream MUST end with is_final=True (issue #2763).
         if not emitted_final:

--- a/src/shared/python/ai/adapters/openai_adapter.py
+++ b/src/shared/python/ai/adapters/openai_adapter.py
@@ -90,6 +90,7 @@ class OpenAIAdapter(BaseAgentAdapter):
         model: str | None = None,
         timeout: float | None = None,
         organization: str | None = None,
+        app_context: str = "assistant",
     ) -> None:
         """Initialize OpenAI adapter.
 
@@ -103,6 +104,10 @@ class OpenAIAdapter(BaseAgentAdapter):
             model: Model name. Uses OPENAI_MODEL env var or default.
             timeout: Request timeout [s]. Uses OPENAI_TIMEOUT env var or default.
             organization: Organization ID. Uses OPENAI_ORGANIZATION env var if not set.
+            app_context: Registry key for the consuming application's system
+                prompt preamble (e.g. ``"upstream_drift"``, ``"gasification"``).
+                Defaults to ``"assistant"``, a brand-neutral preamble. See
+                :mod:`src.shared.python.ai.system_prompts` (issue #3179).
         """
         if api_key is None:
             raise ValueError("api_key must be provided")
@@ -112,6 +117,7 @@ class OpenAIAdapter(BaseAgentAdapter):
         self._model = model or get_openai_model()
         self._timeout = timeout if timeout is not None else get_openai_timeout()
         self._organization = organization or get_openai_organization()
+        self._app_context = app_context
         self._client: Any = None  # Lazy-loaded OpenAI client
 
         logger.info("Initialized OpenAIAdapter: model=%s", self._model)
@@ -458,31 +464,29 @@ class OpenAIAdapter(BaseAgentAdapter):
             raise ValueError("context must be provided")
         if context is None:
             raise ValueError("context must be provided")
+        from src.shared.python.ai.system_prompts import build_system_prompt
+
         expertise = context.user_expertise.name.lower()
         context_instructions = self.build_context_instruction_section(context)
 
-        return (
-            f"You are an AI assistant for the Golf Modeling Suite, a research-grade "
-            f"biomechanics simulation platform for analyzing golf swings.\n\n"
-            f"Current user expertise level: {expertise}\n\n"
-            f"Your capabilities include:\n"
-            f"- Analyzing C3D motion capture data\n"
-            f"- Running physics simulations (MuJoCo, Drake, Pinocchio)\n"
-            f"- Computing inverse dynamics and joint torques\n"
-            f"- Performing drift-control decomposition\n"
-            f"- Generating visualizations and reports\n\n"
-            f"{context_instructions}\n\n"
-            f"Guidelines:\n"
-            f"1. Use tools to perform analyses - never make up numerical results\n"
-            f"2. Explain concepts at the {expertise} level\n"
-            f"3. Validate scientific claims before presenting them\n"
-            f"4. Guide users through workflows step by step\n"
-            f"5. Acknowledge uncertainty and cite limitations\n\n"
-            f"When the user asks about analysis:\n"
-            f"1. First, understand what data they have\n"
-            f"2. Suggest appropriate analyses for their goals\n"
-            f"3. Execute using available tools\n"
-            f"4. Interpret results with scientific rigor"
+        # Brand-neutral preamble + capabilities are injected by app_context
+        # rather than hardcoded here (issue #3179). OpenAI-specific workflow
+        # guidance and persisted-memory context are appended.
+        extra_parts = []
+        if context_instructions:
+            extra_parts.append(context_instructions)
+        extra_parts.append(
+            "When the user asks about analysis:\n"
+            "1. First, understand what data they have\n"
+            "2. Suggest appropriate analyses for their goals\n"
+            "3. Execute using available tools\n"
+            "4. Interpret results with scientific rigor"
+        )
+
+        return build_system_prompt(
+            app_context=self._app_context,
+            expertise_level=expertise,
+            extra_instructions="\n\n".join(extra_parts),
         )
 
     def _parse_response(self, response: Any) -> AgentResponse:

--- a/src/shared/python/ai/adapters/rust_adapter.py
+++ b/src/shared/python/ai/adapters/rust_adapter.py
@@ -23,6 +23,11 @@ _WHEEL_MISSING_HINT = (
     "`cd rust_core/ai_backend && maturin develop --features python`."
 )
 
+# Wall-clock budget for the headless threaded streaming fallback. Bounds
+# the wait on the worker thread's result so a stalled Rust engine cannot
+# hang the generator indefinitely (issue #3179).
+_STREAM_THREAD_TIMEOUT_S: float = 120.0
+
 
 def _make_rust_stream_worker_class() -> type | None:
     """Return _RustStreamWorker(QThread), or None when PyQt6 is absent or uninitialized.
@@ -268,7 +273,6 @@ class RustAgentAdapter(BaseAgentAdapter):
     ) -> Iterator[AgentChunk]:
         """Stream via a plain daemon thread (headless / no PyQt6 fallback)."""
         import threading
-        import time
 
         def _fetch() -> None:
             try:
@@ -278,10 +282,25 @@ class RustAgentAdapter(BaseAgentAdapter):
 
         t = threading.Thread(target=_fetch, daemon=True)
         t.start()
-        while t.is_alive() and result_queue.empty():
-            time.sleep(0.01)
 
-        result = result_queue.get()
+        # Bounded blocking wait instead of a 10ms busy-poll (issue #3179):
+        # block on the queue up to the deadline so a stalled worker cannot
+        # spin the CPU or hang forever.
+        try:
+            result: Any = result_queue.get(timeout=_STREAM_THREAD_TIMEOUT_S)
+        except queue.Empty:
+            logger.error(
+                "Rust stream worker did not produce a result within %ss",
+                _STREAM_THREAD_TIMEOUT_S,
+            )
+            yield AgentChunk(
+                content=(
+                    f"Error: Rust stream timed out after {_STREAM_THREAD_TIMEOUT_S}s"
+                ),
+                is_final=True,
+            )
+            return
+
         if isinstance(result, Exception):
             try:
                 response = self.engine.generate_response(full_prompt)

--- a/src/shared/python/ai/tool_bridge.py
+++ b/src/shared/python/ai/tool_bridge.py
@@ -152,10 +152,20 @@ class ChatToolBridge:
                         error="User declined confirmation for destructive tool",
                     )
             else:
+                # Fail closed: a tool that requires confirmation must not run
+                # when no confirmation mechanism is configured (issue #3179).
                 logger.warning(
                     "Tool %s requires confirmation but no callback set — "
-                    "proceeding without confirmation",
+                    "refusing execution (fail-closed)",
                     tool_name,
+                )
+                return _result(
+                    success=False,
+                    error=(
+                        f"Tool '{tool_name}' requires confirmation but no "
+                        "confirmation callback is configured; refusing to "
+                        "execute."
+                    ),
                 )
 
         # Execute the tool

--- a/src/shared/python/ai/tools/cli_tools.py
+++ b/src/shared/python/ai/tools/cli_tools.py
@@ -280,10 +280,17 @@ class CodexCLITool(CLIToolBase):
 
 
 class ShellTool(CLIToolBase):
-    """Adapter for secure shell command execution.
+    """Adapter for allowlisted shell command execution.
 
-    Provides sandboxed shell command execution for the AI agent.
-    Use with caution - implements allowlist-based command filtering.
+    Runs commands directly (``shell=False``) after tokenizing with
+    :func:`shlex.split`. This is **not** an OS-level sandbox: the only
+    guarantees are (1) the first token must be in ``allowed_commands``,
+    (2) no token may be a known-dangerous command, and (3) any shell
+    metacharacter/operator (``&&``, ``||``, ``;``, ``|``, redirection,
+    substitution, etc.) causes the command to be rejected. Because the
+    argv is executed without a shell, those operators are inert even if
+    they slipped through, but they are blocked defensively. Use with
+    caution.
 
     Example:
         >>> tool = ShellTool(allowed_commands=["ls", "pwd", "cat"])
@@ -301,6 +308,9 @@ class ShellTool(CLIToolBase):
             working_dir: Working directory for command execution.
             allowed_commands: List of allowed command prefixes.
         """
+        # No base command: ShellTool builds the full argv from the
+        # allowlisted user command itself (see ``execute``), so the
+        # inherited ``_command`` prefix is unused and left empty.
         super().__init__("", working_dir)
         self._allowed_commands = allowed_commands or [
             "ls",
@@ -353,7 +363,12 @@ class ShellTool(CLIToolBase):
             return False
 
     def execute(self, command: str, timeout: int = 60) -> CLIExecutionResult:
-        """Execute a shell command.
+        """Execute an allowlisted command.
+
+        The command string is tokenized with :func:`shlex.split` and the
+        resulting argv is run directly with ``shell=False`` — there is no
+        intermediate shell and no ``-c`` wrapper, so shell operators are
+        inert (and additionally rejected by :meth:`_is_command_allowed`).
 
         Args:
             command: Command to execute.
@@ -370,7 +385,48 @@ class ShellTool(CLIToolBase):
                 command=command,
             )
 
-        return self._execute_command(["-c", command], timeout=timeout)
+        # ``_is_command_allowed`` already validated that shlex.split
+        # succeeds and yields a non-empty token list whose first token is
+        # in the allowlist; re-split here to obtain the argv to execute.
+        tokens = shlex.split(command)
+
+        try:
+            result = subprocess.run(
+                tokens,
+                capture_output=True,
+                text=True,
+                cwd=self._working_dir,
+                timeout=timeout,
+                shell=False,
+            )
+            return CLIExecutionResult(
+                success=result.returncode == 0,
+                output=result.stdout,
+                error=result.stderr,
+                return_code=result.returncode,
+                command=command,
+            )
+        except subprocess.TimeoutExpired:
+            return CLIExecutionResult(
+                success=False,
+                error=f"Command timed out after {timeout} seconds",
+                return_code=-1,
+                command=command,
+            )
+        except FileNotFoundError:
+            return CLIExecutionResult(
+                success=False,
+                error=f"Command '{tokens[0]}' not found. Please install it.",
+                return_code=-1,
+                command=command,
+            )
+        except OSError as e:
+            return CLIExecutionResult(
+                success=False,
+                error=str(e),
+                return_code=-1,
+                command=command,
+            )
 
 
 @dataclass

--- a/tests/shared/python/ai/test_ai_hardening_3179.py
+++ b/tests/shared/python/ai/test_ai_hardening_3179.py
@@ -1,0 +1,216 @@
+"""Tests for issue #3179 hardening fixes.
+
+Covers:
+- Gemini error-contract: ``send_message``/``stream_response`` raise a typed
+  ``AIProviderError`` (via ``_classify_error``) instead of leaking the raw
+  exception string as model content.
+- Adapter branding: ``_build_system_message`` no longer hardcodes the
+  "Golf Modeling Suite" literal and routes through the configurable
+  ``app_context`` preamble (brand-neutral by default).
+- tool_bridge fail-closed: a tool that requires confirmation with no
+  confirmation callback configured is refused, not executed.
+- rust_adapter: the headless threaded fallback uses a bounded queue wait
+  (no unbounded busy-poll) and times out cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.shared.python.ai.exceptions import AIProviderError  # noqa: E402
+from src.shared.python.ai.types import (  # noqa: E402
+    ConversationContext,
+    ExpertiseLevel,
+)
+
+
+def _make_context() -> ConversationContext:
+    return ConversationContext(messages=[], user_expertise=ExpertiseLevel.INTERMEDIATE)
+
+
+# ---------------------------------------------------------------------------
+# Gemini error-contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def gemini_adapter():  # type: ignore[no-untyped-def]
+    """A GeminiAdapter built without running the SDK-requiring __init__.
+
+    The error-contract path only needs ``_classify_error`` (inherited) and a
+    stubbed ``_build_chat_session`` / ``_with_configured_sdk``; constructing
+    via ``object.__new__`` avoids importing the optional google SDK.
+
+    The class is imported lazily under a ``sys.modules`` stub so this test
+    file does not force the gemini_adapter module to import before other
+    tests can stub the optional ``google.generativeai`` package (which would
+    leave the module's ``genai`` global unbound and break sibling tests).
+    """
+    with patch.dict(
+        sys.modules,
+        {
+            "google": MagicMock(),
+            "google.generativeai": MagicMock(),
+            "google.generativeai.types": MagicMock(),
+        },
+    ):
+        from src.shared.python.ai.adapters.gemini_adapter import GeminiAdapter
+
+    adapter = object.__new__(GeminiAdapter)
+    adapter._api_key = "fake-key"  # type: ignore[attr-defined]
+    adapter._model_name = "gemini-pro"  # type: ignore[attr-defined]
+    adapter._client = None  # type: ignore[attr-defined]
+    adapter._model = MagicMock()  # type: ignore[attr-defined]
+    return adapter
+
+
+class TestGeminiErrorContract:
+    """send_message / stream_response must raise, not leak error strings."""
+
+    @pytest.mark.unit
+    def test_send_message_raises_ai_provider_error(
+        self, gemini_adapter: object
+    ) -> None:
+        """A SDK RuntimeError is classified and raised, not returned as content."""
+        boom = MagicMock()
+        boom.send_message.side_effect = RuntimeError("upstream 500")
+        with (
+            patch.object(gemini_adapter, "_with_configured_sdk"),
+            patch.object(gemini_adapter, "_build_chat_session", return_value=boom),
+        ):
+            with pytest.raises(AIProviderError) as info:
+                gemini_adapter.send_message("hi", _make_context(), [])
+        assert info.value.provider == "gemini"
+        # The raw exception text must not be presented as model output.
+        assert "upstream 500" not in str(info.value) or "gemini" in str(info.value)
+
+    @pytest.mark.unit
+    def test_stream_response_raises_ai_provider_error(
+        self, gemini_adapter: object
+    ) -> None:
+        """Streaming failure raises AIProviderError instead of an error chunk."""
+        boom = MagicMock()
+        boom.send_message.side_effect = ValueError("bad request")
+        with (
+            patch.object(gemini_adapter, "_with_configured_sdk"),
+            patch.object(gemini_adapter, "_build_chat_session", return_value=boom),
+        ):
+            with pytest.raises(AIProviderError):
+                list(gemini_adapter.stream_response("hi", _make_context(), []))
+
+
+# ---------------------------------------------------------------------------
+# Branding / configurable preamble
+# ---------------------------------------------------------------------------
+
+
+class TestBranding:
+    """No hardcoded product literal; preamble injectable via app_context."""
+
+    @pytest.mark.unit
+    def test_no_golf_literal_in_adapter_source(self) -> None:
+        """The 'Golf Modeling Suite' literal is gone from adapter sources."""
+        import inspect
+
+        import src.shared.python.ai.adapters.anthropic_adapter as a_mod
+        import src.shared.python.ai.adapters.openai_adapter as o_mod
+
+        for mod in (a_mod, o_mod):
+            src = inspect.getsource(mod)
+            assert "Golf Modeling Suite" not in src
+
+    @pytest.mark.unit
+    def test_default_preamble_is_brand_neutral(self) -> None:
+        """Default app_context produces a neutral preamble (no product literal)."""
+        from src.shared.python.ai.adapters.openai_adapter import OpenAIAdapter
+
+        adapter = OpenAIAdapter(api_key="x")
+        msg = adapter._build_system_message(_make_context())
+        assert "Golf Modeling Suite" not in msg
+        assert "AI assistant" in msg
+
+    @pytest.mark.unit
+    def test_app_context_injects_branding(self) -> None:
+        """A non-default app_context changes the preamble (injectable)."""
+        from src.shared.python.ai.adapters.anthropic_adapter import AnthropicAdapter
+
+        adapter = AnthropicAdapter(api_key="x", app_context="gasification")
+        msg = adapter._build_system_message(_make_context())
+        assert "Integrated Process Simulator" in msg
+
+
+# ---------------------------------------------------------------------------
+# tool_bridge fail-closed
+# ---------------------------------------------------------------------------
+
+
+class TestToolBridgeFailClosed:
+    """A confirmation-required tool with no callback must NOT execute."""
+
+    @pytest.mark.unit
+    def test_confirmation_required_no_callback_is_refused(self) -> None:
+        from src.shared.python.ai.tool_bridge import ChatToolBridge
+
+        tool = MagicMock()
+        tool.requires_confirmation = True
+        tool.validate_arguments.return_value = []
+
+        registry = MagicMock()
+        registry.get_tool.return_value = tool
+
+        bridge = ChatToolBridge(registry=registry)  # no confirmation callback
+
+        result = asyncio.run(
+            bridge.handle_tool_call(session_id="s1", tool_name="danger", arguments={})
+        )
+
+        assert result["success"] is False
+        assert "confirmation" in result["error"].lower()
+        tool.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# rust_adapter bounded wait
+# ---------------------------------------------------------------------------
+
+
+class TestRustBoundedWait:
+    """The threaded fallback must not busy-poll and must honor a deadline."""
+
+    @pytest.mark.unit
+    def test_no_busy_poll_sleep_in_source(self) -> None:
+        """Regression: the 10ms busy-poll loop is gone from the source."""
+        import inspect
+
+        from src.shared.python.ai.adapters.rust_adapter import RustAgentAdapter
+
+        src = inspect.getsource(RustAgentAdapter._stream_with_thread)
+        assert "time.sleep(0.01)" not in src
+
+    @pytest.mark.unit
+    def test_stream_with_thread_times_out_cleanly(self) -> None:
+        """A worker that never produces a result yields a final timeout chunk."""
+        import queue
+
+        from src.shared.python.ai.adapters import rust_adapter as r_mod
+
+        # Build a bare adapter instance without running __init__ (which needs
+        # the ai_backend wheel); we only exercise the threaded helper.
+        adapter = object.__new__(r_mod.RustAgentAdapter)
+        # engine.stream_response blocks forever -> never enqueues a result.
+        engine = MagicMock()
+        blocker = __import__("threading").Event()
+        engine.stream_response.side_effect = lambda *_a, **_k: blocker.wait()
+        adapter.engine = engine  # type: ignore[attr-defined]
+
+        q: queue.Queue = queue.Queue()
+        with patch.object(r_mod, "_STREAM_THREAD_TIMEOUT_S", 0.3):
+            chunks = list(adapter._stream_with_thread("prompt", q))
+
+        blocker.set()
+        assert chunks[-1].is_final is True
+        assert "timed out" in chunks[-1].content.lower()

--- a/tests/shared/python/ai/test_bitnet_adapter.py
+++ b/tests/shared/python/ai/test_bitnet_adapter.py
@@ -11,6 +11,7 @@ importing the adapter module directly works in a plain pytest run.
 from __future__ import annotations
 
 import subprocess
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,6 +23,7 @@ from src.shared.python.ai.adapters.bitnet_adapter import BitnetAdapter  # noqa: 
 from src.shared.python.ai.exceptions import (  # noqa: E402
     AIConnectionError,
     AIProviderError,
+    AITimeoutError,
 )
 from src.shared.python.ai.types import ConversationContext, ExpertiseLevel  # noqa: E402
 
@@ -348,3 +350,105 @@ class TestSendMessageSuccess:
         call_args = mock_run.call_args[0][0]  # positional cmd list
         assert "-m" in call_args
         assert adapter.model in call_args
+
+
+# ---------------------------------------------------------------------------
+# Timeout enforcement (issue #3175)
+# ---------------------------------------------------------------------------
+
+
+class TestTimeouts:
+    """A hung llama-cli must be bounded by a wall-clock deadline."""
+
+    @pytest.mark.unit
+    def test_send_message_passes_timeout_to_subprocess(
+        self, adapter: BitnetAdapter
+    ) -> None:
+        """send_message forwards self.timeout to subprocess.run."""
+        mock_result = MagicMock()
+        mock_result.stdout = "ok"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+        with patch("subprocess.run", return_value=mock_result) as run:
+            adapter.send_message("hi", _make_context(), [])
+        assert run.call_args.kwargs["timeout"] == adapter.timeout
+
+    @pytest.mark.unit
+    def test_send_message_timeout_raises_ai_timeout_error(
+        self, adapter: BitnetAdapter
+    ) -> None:
+        """subprocess.TimeoutExpired maps to AITimeoutError (issue #3175)."""
+        exc = subprocess.TimeoutExpired(cmd=["llama-cli"], timeout=adapter.timeout)
+        with patch("subprocess.run", side_effect=exc):
+            with pytest.raises(AITimeoutError) as info:
+                adapter.send_message("hi", _make_context(), [])
+        assert info.value.provider == "bitnet"
+
+    @pytest.mark.unit
+    def test_ai_timeout_error_is_ai_provider_error(
+        self, adapter: BitnetAdapter
+    ) -> None:
+        """AITimeoutError IS-A AIProviderError (hierarchy contract)."""
+        exc = subprocess.TimeoutExpired(cmd=["llama-cli"], timeout=adapter.timeout)
+        with patch("subprocess.run", side_effect=exc):
+            with pytest.raises(AIProviderError):
+                adapter.send_message("hi", _make_context(), [])
+
+    @pytest.mark.unit
+    def test_constructor_rejects_nonpositive_timeout(self) -> None:
+        """timeout <= 0 is a precondition violation (DbC)."""
+        with pytest.raises(ValueError):
+            BitnetAdapter(timeout=0)
+        with pytest.raises(ValueError):
+            BitnetAdapter(timeout=-1)
+
+    @pytest.mark.unit
+    def test_stream_terminates_hung_process_within_timeout(self) -> None:
+        """A stub process that emits a banner then never EOFs is killed.
+
+        The fake stdout yields one banner line, then blocks forever on the
+        next ``__next__`` (simulating a CLI that never reaches EOF). With a
+        tiny timeout the stream must terminate, kill the child, and yield a
+        final error chunk — all well within a few seconds.
+        """
+        adapter = BitnetAdapter(
+            model="test-model.gguf", bitnet_root="/fake/root", timeout=0.3
+        )
+
+        import threading
+
+        never_eof = threading.Event()  # never set -> blocks forever
+
+        class _HangingStdout:
+            def __init__(self) -> None:
+                self._emitted = False
+
+            def __iter__(self) -> _HangingStdout:
+                return self
+
+            def __next__(self) -> str:
+                if not self._emitted:
+                    self._emitted = True
+                    return "banner: loading model\n"
+                # Block until the (never-set) event fires.
+                never_eof.wait()
+                raise StopIteration
+
+        mock_process = MagicMock()
+        mock_process.stdout = _HangingStdout()
+        mock_process.poll.return_value = None  # appears alive
+        mock_process.wait.return_value = 0
+
+        start = time.monotonic()
+        with patch("subprocess.Popen", return_value=mock_process):
+            chunks = list(adapter.stream_response("hi", _make_context(), []))
+        elapsed = time.monotonic() - start
+
+        # Unblock the reader thread so it can exit cleanly post-assert.
+        never_eof.set()
+
+        assert elapsed < 5.0, "stream did not honor the deadline"
+        assert chunks[-1].is_final is True
+        assert "timed out" in chunks[-1].content.lower()
+        # The hung child must have been killed/reaped.
+        mock_process.kill.assert_called_once()

--- a/tests/shared/python/ai/test_cli_tools_shell.py
+++ b/tests/shared/python/ai/test_cli_tools_shell.py
@@ -1,0 +1,125 @@
+"""Tests for ShellTool allowlisted command execution (issue #3176).
+
+Verifies that:
+- An allowlisted command runs end-to-end and returns real output with
+  ``return_code == 0`` (regression for the empty-executable bug that made
+  every invocation raise FileNotFoundError).
+- The allow/deny matrix is enforced: allowlisted commands pass; denied
+  commands and any command containing a shell operator are rejected with
+  ``success=False`` and are never executed.
+- ShellTool runs the argv directly (``shell=False``) without an empty
+  executable or a ``-c`` wrapper.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.shared.python.ai.tools.cli_tools import ShellTool  # noqa: E402
+
+
+@pytest.fixture()
+def tool(tmp_path: Path) -> ShellTool:
+    """ShellTool whose working dir is a temp dir, default allowlist."""
+    return ShellTool(working_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: a real allowlisted command actually runs
+# ---------------------------------------------------------------------------
+
+
+class TestRealExecution:
+    """A real allowlisted command must run and return output."""
+
+    @pytest.mark.unit
+    def test_allowlisted_command_runs_and_returns_output(self) -> None:
+        """A custom-allowlisted real command produces output, rc==0.
+
+        Uses the running Python interpreter (cross-platform) rather than a
+        POSIX-only binary so the test runs on Windows CI too. The path is
+        normalized to forward slashes so ``shlex.split`` (posix mode) does
+        not strip backslashes on Windows.
+        """
+        exe = sys.executable.replace("\\", "/")
+        tool = ShellTool(allowed_commands=[exe])
+        result = tool.execute(f"{exe} -c 'print(42)'")
+
+        assert result.success is True, result.error
+        assert result.return_code == 0
+        assert "42" in result.output
+
+    @pytest.mark.unit
+    def test_not_empty_executable_regression(self) -> None:
+        """Regression: execute must not invoke an empty-string executable."""
+        import subprocess as _sp
+
+        exe = sys.executable.replace("\\", "/")
+        tool = ShellTool(allowed_commands=[exe])
+        with patch("subprocess.run", wraps=_sp.run) as run:
+            tool.execute(f"{exe} --version")
+        argv = run.call_args[0][0]
+        assert argv[0] == exe  # not "" and not "-c"
+        assert "-c" not in argv  # no shell -c wrapper
+
+
+# ---------------------------------------------------------------------------
+# Allow / deny matrix
+# ---------------------------------------------------------------------------
+
+
+class TestAllowDenyMatrix:
+    """Parametrized allow/deny matrix for _is_command_allowed/execute."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "command",
+        ["ls", "ls -la", "pwd", "cat file.txt", "head -n 5 x", "wc -l y"],
+    )
+    def test_allowlisted_commands_pass_gate(
+        self, tool: ShellTool, command: str
+    ) -> None:
+        """Allowlisted base commands pass the allow gate."""
+        assert tool._is_command_allowed(command) is True
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "rm -rf /",  # dangerous + not allowlisted
+            "sudo ls",  # dangerous
+            "ls; rm x",  # operator ;
+            "ls && cat y",  # operator &&
+            "ls | grep x",  # operator |
+            "cat < f",  # redirection
+            "echo $HOME",  # substitution
+            "git status",  # not in allowlist
+            "",  # empty
+        ],
+    )
+    def test_denied_commands_rejected(self, tool: ShellTool, command: str) -> None:
+        """Denied/operator/unknown commands are rejected and not executed."""
+        assert tool._is_command_allowed(command) is False
+
+        with patch("subprocess.run") as run:
+            result = tool.execute(command)
+
+        assert result.success is False
+        run.assert_not_called()
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "command",
+        ["rm -rf /", "ls; rm x", "ls && cat y"],
+    )
+    def test_acceptance_criteria_rejections(
+        self, tool: ShellTool, command: str
+    ) -> None:
+        """Explicit AC examples from issue #3176 are rejected."""
+        result = tool.execute(command)
+        assert result.success is False
+        assert "not allowed" in result.error.lower()


### PR DESCRIPTION
Closes #3175
Closes #3176
Closes #3179

## Summary
Hardens three AI subsystems, all verified against current `main`.

### #3176 — ShellTool always FileNotFoundError + misnamed "sandboxed"
`__init__` set `_command=""`, so `execute` ran `["", "-c", cmd]` → the executable was the empty string → every call raised `FileNotFoundError`. Now `execute` tokenizes with `shlex.split` and runs the argv directly with `shell=False` (no empty executable, no `-c` wrapper). The operator/dangerous-command blocklist in `_is_command_allowed` is preserved, and the misleading "sandboxed" docstring is rewritten to describe the actual guarantee (allowlist + operator block, no OS-level sandbox).

### #3175 — BitNet subprocess streaming has no read timeout
`send_message` now passes `timeout=self.timeout` to `subprocess.run` and maps `subprocess.TimeoutExpired` → `AITimeoutError`. `stream_response` drains stdout on a daemon reader thread and enforces a wall-clock deadline via a bounded `queue.get(timeout=...)`; on expiry it raises internally, kills+reaps the child, and yields a final error chunk. New `timeout` constructor arg (default 300s, DbC-validated > 0).

### #3179 — gemini leak + branding + tool_bridge fail-open + rust busy-wait
- **gemini**: `send_message`/`stream_response` now raise a typed `AIProviderError` via `_classify_error(provider="gemini")` instead of returning/yielding `"Error: {e}"` as model content.
- **branding**: `openai`/`anthropic` `_build_system_message` route through the existing shared `system_prompts.build_system_prompt` with a new `app_context` constructor arg (brand-neutral default); the hardcoded "Golf Modeling Suite" literal is removed from both adapter sources.
- **tool_bridge**: a tool that `requires_confirmation` with no callback configured now fails closed (returns an error, does not execute).
- **rust_adapter**: the headless threaded fallback replaces the 10ms busy-poll with a bounded `queue.get(timeout=_STREAM_THREAD_TIMEOUT_S)` and yields a clean timeout chunk on expiry.

## Tests
- New `test_cli_tools_shell.py`: allow/deny matrix (incl. the AC examples `rm -rf /`, `ls; rm x`, `ls && cat`) + a real allowlisted command running end-to-end with `return_code == 0`.
- `test_bitnet_adapter.py`: timeout forwarded to `subprocess.run`, `TimeoutExpired → AITimeoutError`, non-positive-timeout precondition, and a stub process that emits a banner then never EOFs is killed within the deadline.
- New `test_ai_hardening_3179.py`: gemini error-contract raises (no leaked string), no "Golf Modeling Suite" literal in adapter sources + injectable preamble, tool_bridge fail-closed, rust bounded-wait timeout.

Local: touched-module pytest green; full `tests/shared/python/ai` + `tests/unit/ai` green (pre-existing Qt-fixture errors only). ruff check/format, mypy, bandit, pip-audit all pass in pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)