### PR TITLE
🎨 Palette: Enhance accessibility for theme toggle and custom unit validation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,6 @@
 ## 2024-05-31 - Tab Roles vs aria-pressed
 **Learning:** When adding `role="tab"` to buttons to form an accessible tab list, existing `aria-pressed` attributes must be removed, as `aria-pressed` is intended for toggle buttons and creates conflicting semantics on tab elements. Furthermore, dynamically updating `aria-controls` with missing IDs creates broken reference validations.
 **Action:** When implementing tab semantics, ensure `role="tab"` is paired strictly with `aria-selected` (not `aria-pressed`), and verify `aria-controls` points to a statically identifiable and valid `role="tabpanel"` container whose `aria-labelledby` points back to the selected tab.
+## 2024-06-05 - Preserving existing aria-describedby for dynamic validation
+**Learning:** When dynamically associating a validation error message with an input field using `aria-describedby`, setting the attribute blindly will overwrite any existing helpful associations (like an input hint ID).
+**Action:** Always concatenate the error message ID with any existing hint IDs (e.g., `aria-describedby="errorId hintId"`) to ensure screen readers announce both the validation error and the original helper text. When clearing the error, restore the `aria-describedby` to just the hint ID.

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.280                                    |
+| **Spec Version**        | 1.1.281                                    |
 | **Last Spec Update**    | 2026-06-02                                 |
 
 ## 2. Purpose & Mission
@@ -634,6 +634,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | Date | Version | Changes |
 | ---- | ------- | ------- |
 
+| 2026-06-02 | 1.1.281 | feat(a11y): improve the Unit Converter web app's theme-toggle and custom-unit validation accessibility. The theme button now keeps `aria-pressed` synchronized with the active dark/light state, and custom unit validation messages are announced via dynamic `aria-describedby` while preserving existing input hints. |
 | 2026-06-02 | 1.1.280 | fix(tools): consolidated A–O review fixes resolving issues #3173/#3174/#3175/#3176/#3179/#3183/#3184/#3185/#3186/#3187/#3188 — AI adapter/tool-bridge/CLI-tools hardening, model_generation FastAPI/URDF roundtrip fixes, sidekick syngas_compression calculator de-duplication, theme color fallback drift guard, UI headless import safety, plus chat routing lifecycle, programmatic PID pipeline, and humanoid builder assembly coverage. |
 | 2026-06-02 | 1.1.279 | test(codemap): add focused headless coverage for the codemap parser dispatcher, including case-insensitive extension mapping, unsupported-path handling, all registered language dispatch routes, missing-extractor fallback, and public re-export registry stability, raising `src/shared/python/codemap/parsers.py` focused coverage from 58.06% to 100.00% without changing production behavior. |
 | 2026-06-02 | 1.1.278 | test(codemap): add focused headless coverage for shared tree-sitter parser helpers, including byte/text extraction helpers, child lookup, line range conversion, unsupported-language handling, successful parser construction/cache reuse, missing optional-language caching, and initialization-failure warning behavior, raising `src/shared/python/codemap/_ts_common.py` focused coverage from 66.18% to 100.00% without changing production behavior. |

--- a/src/web_applications/unit_converter/unit-converter-app/app.js
+++ b/src/web_applications/unit_converter/unit-converter-app/app.js
@@ -76,6 +76,9 @@ function init() {
 function loadTheme() {
   const savedTheme = localStorage.getItem('theme') || 'light';
   document.documentElement.setAttribute('data-theme', savedTheme);
+  if (themeToggle) {
+    themeToggle.setAttribute('aria-pressed', savedTheme === 'dark' ? 'true' : 'false');
+  }
 }
 
 function toggleTheme() {
@@ -83,6 +86,9 @@ function toggleTheme() {
   const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
   document.documentElement.setAttribute('data-theme', newTheme);
   localStorage.setItem('theme', newTheme);
+  if (themeToggle) {
+    themeToggle.setAttribute('aria-pressed', newTheme === 'dark' ? 'true' : 'false');
+  }
 }
 
 // Standard Condition Preference Management
@@ -615,6 +621,7 @@ function addCustomUnit() {
     if (!unit) {
       customUnitInput.classList.add('has-error');
       customUnitInput.setAttribute('aria-invalid', 'true');
+      customUnitInput.setAttribute('aria-describedby', 'modalMessage');
       customUnitInput.focus();
       showModalError('Please enter a unit symbol');
       return;
@@ -623,6 +630,7 @@ function addCustomUnit() {
     if (isNaN(factor) || factor <= 0) {
       conversionFactorInput.classList.add('has-error');
       conversionFactorInput.setAttribute('aria-invalid', 'true');
+      conversionFactorInput.setAttribute('aria-describedby', 'modalMessage conversionFactorHint');
       conversionFactorInput.focus();
       showModalError('Please enter a valid positive conversion factor');
       return;
@@ -1043,6 +1051,11 @@ function setupEventListeners() {
     input.addEventListener('input', () => {
       input.classList.remove('has-error');
       input.removeAttribute('aria-invalid');
+      if (input === conversionFactorInput) {
+        input.setAttribute('aria-describedby', 'conversionFactorHint');
+      } else {
+        input.removeAttribute('aria-describedby');
+      }
       hideModalMessage();
     });
   });

--- a/src/web_applications/unit_converter/unit-converter-app/index.html
+++ b/src/web_applications/unit_converter/unit-converter-app/index.html
@@ -54,7 +54,8 @@
           <button
             class="icon-button"
             id="themeToggle"
-            aria-label="Toggle dark mode"
+            aria-label="Dark mode"
+            aria-pressed="false"
             title="Toggle dark mode"
           >
             <svg


### PR DESCRIPTION
💡 **What:** 
- Updated the Theme Toggle button to dynamically set `aria-pressed="true|false"` when dark mode is activated/deactivated.
- Enhanced the Custom Unit modal form validation so error messages are linked to their respective inputs using `aria-describedby`.
- Ensured existing `aria-describedby` hints (like the `conversionFactorHint`) are preserved when appending dynamic error message IDs.

🎯 **Why:** 
- The theme toggle lacked a way to communicate its state to screen reader users (it only switched CSS classes).
- When a user submitted an invalid custom unit (e.g., empty symbol or invalid factor), the error message was displayed visually, but screen readers were only told the input was `aria-invalid="true"` without reading the actual error text.

📸 **Before/After:** 
- Before: Theme button had no state attribute. Custom Unit validation simply set `.has-error` and `aria-invalid="true"`.
- After: Theme button uses `aria-pressed`. Validation dynamically applies `aria-describedby="modalMessage"` (and concatenates for inputs that already have hints).

♿ **Accessibility:** 
- State announcements for custom toggle buttons using standard ARIA patterns.
- Clear association between dynamic error messages and the inputs that triggered them, ensuring users relying on assistive technologies understand *why* their input was rejected and how to fix it without having to manually hunt for the error text.

---
*PR created automatically by Jules for task [12469331113886756650](https://jules.google.com/task/12469331113886756650) started by @dieterolson*