### PR TITLE
fix(p1am): correct AO/AI slot, channel, and scaling — three bench-found bugs

### DIFF
--- a/src/p1am_control_system/firmware/P1AMHardware.cpp
+++ b/src/p1am_control_system/firmware/P1AMHardware.cpp
@@ -29,14 +29,27 @@ float P1AMHardware::ReadThermocouple(int channel) {
   if (channel < 0 || channel >= 4) {
     return 0.0f;
   }
-  return P1.readTemperature(kSlotThm, channel);
+  // P1AM library channels are 1-indexed; broker uses 0-indexed.
+  return P1.readTemperature(kSlotThm, channel + 1);
 }
 
 float P1AMHardware::ReadAnalogInput(int channel) {
   if (channel < 0 || channel >= 2) {
     return 0.0f;
   }
-  return P1.readAnalog(kSlotAna, channel);
+  // P1.readAnalog returns raw ADC counts. For the P1-4ADL2DAL-1 the AI is
+  // 13-bit over a 0-20 mA span: 0 counts -> 0 mA, 8191 counts -> 20 mA.
+  // Convert to percent of the 4-20 mA process span: 4 mA -> 0 %, 20 mA -> 100 %.
+  // Library channels are 1-indexed; broker uses 0-indexed.
+  uint32_t counts = P1.readAnalog(kSlotAna, channel + 1);
+  float mA = static_cast<float>(counts) * (20.0f / 8191.0f);
+  float percent = (mA - 4.0f) * (100.0f / 16.0f);
+  if (percent < 0.0f) {
+    percent = 0.0f;
+  } else if (percent > 100.0f) {
+    percent = 100.0f;
+  }
+  return percent;
 }
 
 void P1AMHardware::WriteAnalogOutput(int channel, float value) {
@@ -48,7 +61,12 @@ void P1AMHardware::WriteAnalogOutput(int channel, float value) {
   } else if (value > 100.0f) {
     value = 100.0f;
   }
-  P1.writeAnalog(value, kSlotAna, channel);
+  // P1.writeAnalog takes raw DAC counts (uint32_t). For the P1-4ADL2DAL-1
+  // the AO is 12-bit over the 4-20 mA span: 0 counts -> 4 mA,
+  // 4095 counts -> 20 mA. Scale the 0-100 % broker value to counts.
+  // Library channels are 1-indexed; broker uses 0-indexed.
+  uint32_t counts = static_cast<uint32_t>(value * (4095.0f / 100.0f));
+  P1.writeAnalog(counts, kSlotAna, channel + 1);
 }
 
 void P1AMHardware::WriteInhibit(bool active) {

--- a/src/p1am_control_system/firmware/P1AMHardware.h
+++ b/src/p1am_control_system/firmware/P1AMHardware.h
@@ -16,8 +16,11 @@ class P1AMHardware : public HardwareInterface {
   void WriteInhibit(bool active) override;
 
  private:
-  static const int kSlotThm = 1;    // P1-04THM is in slot 1
-  static const int kSlotAna = 2;    // P1-4ADL2DAL-1 is in slot 2
+  // Actual bench-verified slot order via P1.printModules() on 2026-06-01:
+  //   Slot 1 = P1-4ADL2DAL-1   (analog combo, 4 AI + 2 AO, 4-20 mA)
+  //   Slot 2 = P1-04THM        (4-channel thermocouple)
+  static const int kSlotAna = 1;
+  static const int kSlotThm = 2;
   // Inhibit GPIO. MUST NOT be pin 5 — the P1AM-ETH shield hardwires the W5500
   // chip-select to D5, so driving D5 from this firmware breaks Ethernet SPI.
   // D6 is free on the P1AM-100 / P1AM-ETH stack.

--- a/src/p1am_control_system/firmware/firmware.ino
+++ b/src/p1am_control_system/firmware/firmware.ino
@@ -144,6 +144,12 @@ void setup() {
   Serial.println(F("[hw] P1AMHardware::Begin (backplane init)..."));
   hw.Begin();
   Serial.println(F("[hw] hardware init complete"));
+  // Diagnostic: dump the signed-on module list so we can confirm the
+  // P1-04THM and P1-4ADL2DAL-1 are present on the backplane. If the AO
+  // module is missing, P1.writeAnalog silently returns and outputs hold
+  // at their DAC power-on default of 4 mA.
+  Serial.println(F("[hw] signed-on modules:"));
+  P1.printModules();
 
   // Initialize Ethernet. The P1AM-ETH shield wires W5500 CS to pin 5.
   Ethernet.init(5);


### PR DESCRIPTION
## Summary

Three independent bugs in the P1AM firmware → P1-4ADL2DAL-1 hardware path, all stacked. AO commands had no observable physical effect (DMM stayed at ~4 mA regardless of commanded percent). Discovered and fixed live at the bench. End-to-end loopback now works on both channels with **<0.2 % error**.

## The three bugs

1. **Slot reversal.** \`P1AMHardware.h\` had \`kSlotThm = 1, kSlotAna = 2\` but \`P1.printModules()\` from a fresh boot shows \`Slot 1: P1-4ADL2DAL-1, Slot 2: P1-04THM\`. Every \`P1.writeAnalog(..., 2, ...)\` went to the thermocouple module which has no AO bytes — library returns silently with \`"Slot 2: This module has no Analog Output bytes"\`.
2. **Channel 0-indexing.** Broker uses 0-indexed channels; P1AM library rejects \`channel <= 0\`. Channels were passed straight through. The library silently dropped every write/read for what it thought was channel 0.
3. **Percent vs raw counts.** \`P1.writeAnalog\` takes raw DAC counts (0..4095 over 4..20 mA for this module). We passed the 0..100 % broker value directly, getting 100 counts = ~4.4 mA at \"100 %\". Symmetric problem on read.

## Fix

- [P1AMHardware.h](src/p1am_control_system/firmware/P1AMHardware.h): swap \`kSlotAna / kSlotThm\` constants with bench-verified comment.
- [P1AMHardware.cpp](src/p1am_control_system/firmware/P1AMHardware.cpp): add \`channel + 1\` at each library boundary; on AO write scale percent → counts; on AI read convert counts → mA → percent of the 4..20 mA process span (with clamping).
- [firmware.ino](src/p1am_control_system/firmware/firmware.ino): add one-shot \`P1.printModules()\` after \`hw.Begin()\` so future bring-ups spot a slot reversal in the first 5 seconds via boot serial.

## Bench-verified end-to-end loopback (2026-06-02)

Both PLC channels wired through ABB CC-E/STD signal conditioners (4-20 mA → 0-5 V → 4-20 mA) back to the PLC AIs. Sweep both AOs simultaneously:

\`\`\`
sp%   | AO1%   AI1%   err  | AO2%   AI2%   err
------+--------------------+--------------------
  0.0 |  0.00   0.00  +0.00 |  0.00   0.09  +0.09
 10.0 | 10.00   9.96  -0.04 | 10.00  10.07  +0.07
 25.0 | 25.00  24.95  -0.05 | 25.00  25.12  +0.12
 50.0 | 50.00  50.08  +0.08 | 50.00  50.13  +0.13
 75.0 | 75.00  75.19  +0.19 | 75.00  75.13  +0.13
 90.0 | 90.00  90.17  +0.17 | 90.00  90.02  +0.02
100.0 | 100.00 100.00 +0.00 | 100.00 100.00 +0.00

AO1->AI1 max error: 0.19 %  (target <1.0)
AO2->AI2 max error: 0.13 %  (target <1.0)
\`\`\`

Both channels: 4 mA → 0 % on AI, 20 mA → 100 % on AI, max error well inside ±1 % spec.

## Build / flash note for the next agent

Correct FQBN: \`P1AM-100:samd:P1AM-100_native\` from Facts Engineering's board package — not \`arduino:samd:arduino_zero_native\`. Documented in [firmware/README.md](src/p1am_control_system/firmware/README.md) from PR #3081.

## Stacks on top of

This branch was cut from \`fix-interlock-contract\` (PR #3081). If #3081 merges first this rebases cleanly; if this merges first #3081 needs a small rebase.

## Test plan

- [x] Compiles under correct FQBN (P1AM-100:samd:P1AM-100_native) — 22 % flash, 17 % RAM
- [x] DMM-verified AO endpoints at both 4 mA and 20 mA on both channels
- [x] Live loopback through ABB CC-E/STD conditioners both ways
- [x] Backend + dashboard + historian capturing the verification sweep (85 M rows in dcs_scada.db at time of PR)
- [ ] CI lint + tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)