### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/src/function_generator/web/src/components/FunctionGenerator.tsx
+++ b/src/function_generator/web/src/components/FunctionGenerator.tsx
@@ -686,6 +686,7 @@ export function FunctionGenerator() {
                       <button
                         onClick={(e) => { e.stopPropagation(); removeLayer(layer.id); }}
                         className="px-2 py-0.5 bg-red-600 text-white rounded text-xs hover:bg-red-500"
+                        aria-label="Remove layer"
                       >
                         ×
                       </button>

--- a/src/p1am_control_system/frontend/src/App.tsx
+++ b/src/p1am_control_system/frontend/src/App.tsx
@@ -1591,6 +1591,7 @@ export const App: React.FC = () => {
                   type="button"
                   onClick={() => setInspectorView({ type: "none" })}
                   style={{ background: "none", border: "none", color: "var(--text-secondary)", cursor: "pointer" }}
+                  aria-label="Close inspector panel"
                 >
                   <X size={16} />
                 </button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons (the `X` close button in the inspector panel and the `×` remove layer button in the function generator).
🎯 Why: These buttons consisted entirely of visual icons/characters without any text label, making them inaccessible and unintuitive for screen reader users. The newly added labels clearly define their actions ("Close inspector panel" and "Remove layer").
📸 Before/After: Visuals remain unchanged, but screen readers will now announce the specific action of the buttons instead of "button" or reading out the raw "X" character.
♿ Accessibility: Improves WCAG compliance for non-text interactive elements, making the applications significantly more usable for visually impaired individuals relying on assistive technology.

---
*PR created automatically by Jules for task [18439579279798202418](https://jules.google.com/task/18439579279798202418) started by @dieterolson*