### PR TITLE
feat(power-supply): operator-controlled current/power tab with safety interlocks

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.308                                    |
+| **Spec Version**        | 1.1.309                                    |
 | **Last Spec Update**    | 2026-06-03                                 |
 
 ## 2. Purpose & Mission
@@ -92,6 +92,9 @@ Tools is the central utility hub for the D-sorganization fleet. Other repos depe
 - P1AM SCADA firmware control-loop contracts fail closed on corrupt SCADA or
   flash routing, non-finite process values, invalid PID timing, and non-finite
   analog outputs instead of invoking runtime `assert()` abort paths on the PLC
+- P1AM power-supply control owns its PLC PID-pass-through writes, tag scaling,
+  state-machine controller, and REST routes in a dedicated backend integration
+  module so `backend/main.py` remains below the module-size budget
 - Sidekick tabs declare versioned per-tab settings schemas and persist
   materialized settings by stable tab or duplicate instance id behind the
   selected-tab settings action
@@ -638,6 +641,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | Date | Version | Changes |
 | ---- | ------- | ------- |
 
+| 2026-06-03 | 1.1.309 | fix(p1am-power-supply): move the power-supply controller/router and PID-pass-through integration out of `backend/main.py`, keep the split power-supply tests importable under pytest importlib mode, make the controller enums Python 3.10-compatible and mypy-clean, remove stale mypy suppressions from the invalid-input tests, and preserve the module-size budget without relaxing CI gates. |
 | 2026-06-03 | 1.1.308 | test(folder-packer): add focused workflow coverage for `folder_packer_pro.operations`, including pack/unpack start validation, worker dispatch, scan dispatch, filesystem exception handling, failed unpack results, encrypted package inspection, and missing package warnings; raises focused module coverage from 74.27% to 92.95% without changing production behavior. |
 | 2026-06-03 | 1.1.307 | test(model_generation): add focused edge-case coverage for `model_generation.library.unified_loader`, including load-result naming, preference corruption and persistence failures, manifest cache fallbacks, bundled missing-file reporting, unknown-extension fallback ordering, inline XML conversion dispatch, and malformed MJCF `LoadResult` handling; fixes malformed MJCF loads so they return a failed `LoadResult` instead of escaping parse exceptions, while keeping the loader source under the file-size budget. |
 | 2026-06-03 | 1.1.306 | test(upstream-drift): ratchet the legacy `upstream_drift_tools` compatibility shim coverage gate to 100% after focused shim contract tests verified full line and branch coverage, and update the coverage-policy regression tests so the high-water mark is enforced in CI without changing production behavior. |

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -46,12 +46,7 @@ from models import (
 )
 from plant_model import TagDefinition
 from plc_factory import PLCFactory
-from power_supply import (
-    PowerSupplyConfig,
-    PowerSupplyController,
-    PowerSupplyMode,
-    PowerSupplyStatus,
-)
+from power_supply_integration import PowerSupplyService, create_power_supply_router
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from simulator_client import SimulatedPLCClient
@@ -62,23 +57,16 @@ AlarmEngine = scada.AlarmEngine
 exponential_smoothing = scada.exponential_smoothing
 moving_average = scada.moving_average
 
-# Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("dcs_backend.main")
 
-# Instantiate active PLC client and backup simulator for offline fallback
 plc_client = PLCFactory.create_client()
 modbus_manager = plc_client  # Compatibility alias
 backup_simulator = SimulatedPLCClient()
 
-# Power-supply controller: state machine + safety interlocks for AO1-driven
-# current command, V/I feedback on AI1/AI2, HH-temp on TC1. The polling loop
-# feeds it measured values each tick and applies the resulting command to the
-# PLC (via the PID-0 setpoint pass-through that drives AO1).
-power_supply_controller = PowerSupplyController(PowerSupplyConfig())
+power_supply_service = PowerSupplyService(plc_client=plc_client, logger=logger)
 
 
-# WebSocket Connection Manager
 class ConnectionManager:
     """Manages WebSocket client connections and broadcasts live updates."""
 
@@ -204,17 +192,13 @@ def build_alarm_engine(config: RoutingConfig) -> Any:
     return AlarmEngine(limits_dict)
 
 
-# Global Alarm Engine
 alarm_engine = build_alarm_engine(active_config)
 
-# Active alarms tracking
 active_alarms: dict[str, dict[str, Any]] = {}
 e_stop_active: bool = False
 
-# PID Tuning sessions state
 tuning_sessions: dict[int, dict[str, Any]] = {}
 
-# Bind references
 plc_client.tuning_sessions = tuning_sessions
 backup_simulator.tuning_sessions = tuning_sessions
 plc_client.active_config = active_config
@@ -234,60 +218,6 @@ async def modbus_connect_background() -> None:
             except Exception as e:
                 logger.debug(f"Background PLC connect attempt failed: {e}")
         await asyncio.sleep(5.0)
-
-
-async def _write_pid_setpoint(pid_index: int, value: float) -> bool:
-    """Write a PID setpoint as float to its dedicated register.
-
-    PID i has its setpoint at register 200 + i*10 + 2 (low, high). With
-    the existing pass-through configuration (PID 0 -> TAG_10 -> AO1,
-    PID 1 -> TAG_11 -> AO2, kp=1, ki=kd=0), changing the setpoint changes
-    the commanded analog output value in percent.
-    """
-    if not plc_client.connected:
-        return False
-    if pid_index < 0 or pid_index >= 4:
-        logger.warning("PID index %d out of range", pid_index)
-        return False
-    import struct as _struct
-
-    lo, hi = _struct.unpack("<HH", _struct.pack("<f", float(value)))
-    base = 200 + pid_index * 10
-    try:
-        async with plc_client.lock:
-            resp = await plc_client._get_client().write_registers(
-                address=base + 2, values=[lo, hi]
-            )
-        if resp.isError():
-            logger.error(
-                "write_pid_setpoint(%d, %f) failed: %s", pid_index, value, resp
-            )
-            return False
-        return True
-    except Exception as e:
-        logger.error("write_pid_setpoint(%d, %f) exception: %s", pid_index, value, e)
-        return False
-
-
-def _power_supply_inputs_from_tags(
-    tags: dict[str, float] | None,
-) -> tuple[float, float, float]:
-    """Extract (measured_current_a, measured_voltage_v, measured_temp_c) from
-    a tag snapshot, using the controller's configured tag map plus the
-    PS-supply scaling (full-scale current/voltage are in *engineering* units,
-    while AI tags are 0..100 % of the 4-20 mA span).
-
-    Returns zeros when tags are unavailable (safe behavior).
-    """
-    if not tags:
-        return 0.0, 0.0, 0.0
-    cfg = power_supply_controller.config
-    i_pct = float(tags.get(cfg.current_feedback_tag, 0.0))
-    v_pct = float(tags.get(cfg.voltage_feedback_tag, 0.0))
-    temp_c = float(tags.get(cfg.temp_tag, 0.0))
-    measured_current_a = i_pct * cfg.current_full_scale_a / 100.0
-    measured_voltage_v = v_pct * cfg.voltage_full_scale_v / 100.0
-    return measured_current_a, measured_voltage_v, temp_c
 
 
 async def poll_plc_loop() -> None:
@@ -314,17 +244,7 @@ async def poll_plc_loop() -> None:
                 if tags is not None
                 else []
             )
-            # Power-supply controller tick: feed in measured V/I/T (already
-            # scaled from 0..100 % to engineering units via configured
-            # full-scale), then push the resulting AO command to PID 0 setpoint.
-            ps_i_a, ps_v_v, ps_t_c = _power_supply_inputs_from_tags(tags)
-            ps_command_percent = power_supply_controller.tick(
-                measured_current_a=ps_i_a,
-                measured_voltage_v=ps_v_v,
-                measured_temp_c=ps_t_c,
-            )
-            await _write_pid_setpoint(0, ps_command_percent)
-            ps_status = power_supply_controller.status()
+            ps_status = await power_supply_service.poll(tags)
 
             payload = {
                 "tags": tag_list,
@@ -413,6 +333,7 @@ app = FastAPI(
     description="Middleware bridging the P1AM PLC and HMI Dashboard.",
     lifespan=lifespan,
 )
+app.include_router(create_power_supply_router(power_supply_service))
 
 # Restrict CORS to a configured allowlist (no wildcard with credentials).
 # See cors_config.resolve_cors_settings for env-driven configuration.
@@ -1175,97 +1096,6 @@ async def stream_websocket(websocket: WebSocket) -> None:
     except Exception as e:
         logger.error(f"WebSocket connection exception: {e}")
         ws_manager.disconnect(websocket)
-
-
-# ---------------------------------------------------------------------------
-# Power-supply control endpoints
-# ---------------------------------------------------------------------------
-
-
-class PowerSupplySetpointRequest(BaseModel):
-    """Operator-facing setpoint command.
-
-    Use mode='current' with value_a, or mode='power' with value_w. Server
-    will clamp out-of-range setpoints and return the actual applied value.
-    """
-
-    mode: PowerSupplyMode
-    value_a: float | None = None
-    value_w: float | None = None
-
-
-class PowerSupplyPermissiveRequest(BaseModel):
-    enabled: bool
-
-
-@app.get("/api/power_supply/config", response_model=PowerSupplyConfig)
-async def get_power_supply_config() -> PowerSupplyConfig:
-    """Return the operator-configurable parameters currently in use."""
-    return power_supply_controller.config
-
-
-@app.put("/api/power_supply/config", response_model=PowerSupplyConfig)
-async def update_power_supply_config(
-    new_config: PowerSupplyConfig,
-) -> PowerSupplyConfig:
-    """Replace the operator-configurable parameters.
-
-    Pydantic validates field constraints and the cross-field invariants at
-    parse-time, so any 4xx error here is caused by a bad payload from the UI.
-    """
-    power_supply_controller.update_config(new_config)
-    return power_supply_controller.config
-
-
-@app.get("/api/power_supply/status", response_model=PowerSupplyStatus)
-async def get_power_supply_status() -> PowerSupplyStatus:
-    """Snapshot of controller state, measured values, and active trips."""
-    return power_supply_controller.status()
-
-
-@app.post("/api/power_supply/setpoint")
-async def apply_power_supply_setpoint(
-    req: PowerSupplySetpointRequest,
-) -> dict[str, Any]:
-    """Apply a current or power setpoint. Returns the clamped value used."""
-    if req.mode == PowerSupplyMode.CURRENT:
-        if req.value_a is None:
-            raise HTTPException(
-                status_code=400,
-                detail="value_a is required when mode='current'",
-            )
-        try:
-            applied = power_supply_controller.set_current_setpoint(req.value_a)
-        except (TypeError, ValueError) as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
-        return {"mode": "current", "applied_a": applied}
-
-    if req.value_w is None:
-        raise HTTPException(
-            status_code=400,
-            detail="value_w is required when mode='power'",
-        )
-    try:
-        achievable = power_supply_controller.set_power_setpoint(req.value_w)
-    except (TypeError, ValueError) as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-    return {"mode": "power", "achievable_w": achievable}
-
-
-@app.post("/api/power_supply/permissive")
-async def set_power_supply_permissive(
-    req: PowerSupplyPermissiveRequest,
-) -> PowerSupplyStatus:
-    """Enable/disable permissive. Disabling clears setpoint and returns to IDLE."""
-    power_supply_controller.set_permissive(req.enabled)
-    return power_supply_controller.status()
-
-
-@app.post("/api/power_supply/acknowledge_trip")
-async def acknowledge_power_supply_trip() -> PowerSupplyStatus:
-    """Clear latched trips and return to ARMED (or IDLE if permissive off)."""
-    power_supply_controller.acknowledge_trip()
-    return power_supply_controller.status()
 
 
 @app.post("/api/project/import")

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -46,6 +46,12 @@ from models import (
 )
 from plant_model import TagDefinition
 from plc_factory import PLCFactory
+from power_supply import (
+    PowerSupplyConfig,
+    PowerSupplyController,
+    PowerSupplyMode,
+    PowerSupplyStatus,
+)
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from simulator_client import SimulatedPLCClient
@@ -64,6 +70,12 @@ logger = logging.getLogger("dcs_backend.main")
 plc_client = PLCFactory.create_client()
 modbus_manager = plc_client  # Compatibility alias
 backup_simulator = SimulatedPLCClient()
+
+# Power-supply controller: state machine + safety interlocks for AO1-driven
+# current command, V/I feedback on AI1/AI2, HH-temp on TC1. The polling loop
+# feeds it measured values each tick and applies the resulting command to the
+# PLC (via the PID-0 setpoint pass-through that drives AO1).
+power_supply_controller = PowerSupplyController(PowerSupplyConfig())
 
 
 # WebSocket Connection Manager
@@ -224,6 +236,60 @@ async def modbus_connect_background() -> None:
         await asyncio.sleep(5.0)
 
 
+async def _write_pid_setpoint(pid_index: int, value: float) -> bool:
+    """Write a PID setpoint as float to its dedicated register.
+
+    PID i has its setpoint at register 200 + i*10 + 2 (low, high). With
+    the existing pass-through configuration (PID 0 -> TAG_10 -> AO1,
+    PID 1 -> TAG_11 -> AO2, kp=1, ki=kd=0), changing the setpoint changes
+    the commanded analog output value in percent.
+    """
+    if not plc_client.connected:
+        return False
+    if pid_index < 0 or pid_index >= 4:
+        logger.warning("PID index %d out of range", pid_index)
+        return False
+    import struct as _struct
+
+    lo, hi = _struct.unpack("<HH", _struct.pack("<f", float(value)))
+    base = 200 + pid_index * 10
+    try:
+        async with plc_client.lock:
+            resp = await plc_client._get_client().write_registers(
+                address=base + 2, values=[lo, hi]
+            )
+        if resp.isError():
+            logger.error(
+                "write_pid_setpoint(%d, %f) failed: %s", pid_index, value, resp
+            )
+            return False
+        return True
+    except Exception as e:
+        logger.error("write_pid_setpoint(%d, %f) exception: %s", pid_index, value, e)
+        return False
+
+
+def _power_supply_inputs_from_tags(
+    tags: dict[str, float] | None,
+) -> tuple[float, float, float]:
+    """Extract (measured_current_a, measured_voltage_v, measured_temp_c) from
+    a tag snapshot, using the controller's configured tag map plus the
+    PS-supply scaling (full-scale current/voltage are in *engineering* units,
+    while AI tags are 0..100 % of the 4-20 mA span).
+
+    Returns zeros when tags are unavailable (safe behavior).
+    """
+    if not tags:
+        return 0.0, 0.0, 0.0
+    cfg = power_supply_controller.config
+    i_pct = float(tags.get(cfg.current_feedback_tag, 0.0))
+    v_pct = float(tags.get(cfg.voltage_feedback_tag, 0.0))
+    temp_c = float(tags.get(cfg.temp_tag, 0.0))
+    measured_current_a = i_pct * cfg.current_full_scale_a / 100.0
+    measured_voltage_v = v_pct * cfg.voltage_full_scale_v / 100.0
+    return measured_current_a, measured_voltage_v, temp_c
+
+
 async def poll_plc_loop() -> None:
     """Background loop polling the PLC tags at 10Hz.
 
@@ -248,12 +314,25 @@ async def poll_plc_loop() -> None:
                 if tags is not None
                 else []
             )
+            # Power-supply controller tick: feed in measured V/I/T (already
+            # scaled from 0..100 % to engineering units via configured
+            # full-scale), then push the resulting AO command to PID 0 setpoint.
+            ps_i_a, ps_v_v, ps_t_c = _power_supply_inputs_from_tags(tags)
+            ps_command_percent = power_supply_controller.tick(
+                measured_current_a=ps_i_a,
+                measured_voltage_v=ps_v_v,
+                measured_temp_c=ps_t_c,
+            )
+            await _write_pid_setpoint(0, ps_command_percent)
+            ps_status = power_supply_controller.status()
+
             payload = {
                 "tags": tag_list,
                 "tags_dict": tags if tags is not None else {},
                 "alicats": alicat_manager.get_devices_data(),
                 "active_alarms": active_alarms,
                 "e_stop_active": e_stop_active,
+                "power_supply": ps_status.model_dump(),
             }
             await ws_manager.broadcast(payload)
             if tags is not None:
@@ -1096,6 +1175,97 @@ async def stream_websocket(websocket: WebSocket) -> None:
     except Exception as e:
         logger.error(f"WebSocket connection exception: {e}")
         ws_manager.disconnect(websocket)
+
+
+# ---------------------------------------------------------------------------
+# Power-supply control endpoints
+# ---------------------------------------------------------------------------
+
+
+class PowerSupplySetpointRequest(BaseModel):
+    """Operator-facing setpoint command.
+
+    Use mode='current' with value_a, or mode='power' with value_w. Server
+    will clamp out-of-range setpoints and return the actual applied value.
+    """
+
+    mode: PowerSupplyMode
+    value_a: float | None = None
+    value_w: float | None = None
+
+
+class PowerSupplyPermissiveRequest(BaseModel):
+    enabled: bool
+
+
+@app.get("/api/power_supply/config", response_model=PowerSupplyConfig)
+async def get_power_supply_config() -> PowerSupplyConfig:
+    """Return the operator-configurable parameters currently in use."""
+    return power_supply_controller.config
+
+
+@app.put("/api/power_supply/config", response_model=PowerSupplyConfig)
+async def update_power_supply_config(
+    new_config: PowerSupplyConfig,
+) -> PowerSupplyConfig:
+    """Replace the operator-configurable parameters.
+
+    Pydantic validates field constraints and the cross-field invariants at
+    parse-time, so any 4xx error here is caused by a bad payload from the UI.
+    """
+    power_supply_controller.update_config(new_config)
+    return power_supply_controller.config
+
+
+@app.get("/api/power_supply/status", response_model=PowerSupplyStatus)
+async def get_power_supply_status() -> PowerSupplyStatus:
+    """Snapshot of controller state, measured values, and active trips."""
+    return power_supply_controller.status()
+
+
+@app.post("/api/power_supply/setpoint")
+async def apply_power_supply_setpoint(
+    req: PowerSupplySetpointRequest,
+) -> dict[str, Any]:
+    """Apply a current or power setpoint. Returns the clamped value used."""
+    if req.mode == PowerSupplyMode.CURRENT:
+        if req.value_a is None:
+            raise HTTPException(
+                status_code=400,
+                detail="value_a is required when mode='current'",
+            )
+        try:
+            applied = power_supply_controller.set_current_setpoint(req.value_a)
+        except (TypeError, ValueError) as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        return {"mode": "current", "applied_a": applied}
+
+    if req.value_w is None:
+        raise HTTPException(
+            status_code=400,
+            detail="value_w is required when mode='power'",
+        )
+    try:
+        achievable = power_supply_controller.set_power_setpoint(req.value_w)
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return {"mode": "power", "achievable_w": achievable}
+
+
+@app.post("/api/power_supply/permissive")
+async def set_power_supply_permissive(
+    req: PowerSupplyPermissiveRequest,
+) -> PowerSupplyStatus:
+    """Enable/disable permissive. Disabling clears setpoint and returns to IDLE."""
+    power_supply_controller.set_permissive(req.enabled)
+    return power_supply_controller.status()
+
+
+@app.post("/api/power_supply/acknowledge_trip")
+async def acknowledge_power_supply_trip() -> PowerSupplyStatus:
+    """Clear latched trips and return to ARMED (or IDLE if permissive off)."""
+    power_supply_controller.acknowledge_trip()
+    return power_supply_controller.status()
 
 
 @app.post("/api/project/import")

--- a/src/p1am_control_system/backend/power_supply.py
+++ b/src/p1am_control_system/backend/power_supply.py
@@ -1,0 +1,468 @@
+"""Power-supply controller — state machine, safety interlocks, control law.
+
+Provides the operator-facing model and control logic that the FastAPI layer
+and the React tab wrap. Designed so it can be tested completely without a
+PLC connection by feeding measured values into `tick()` and observing the
+state changes and commanded output.
+
+State machine:
+    IDLE     -- permissive off; output forced to 0 %
+    ARMED    -- permissive on, no setpoint applied; output 0 %
+    RUNNING  -- commanding output at setpoint, no trip active
+    TRIPPED  -- HH-temp or HH-power trip latched; output 0 % until ack
+
+Tripping is one-way until `acknowledge_trip()` is called. A trip latches even
+if the underlying signal returns to the safe band on the next tick.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+logger = logging.getLogger("dcs_backend.power_supply")
+
+
+class PowerSupplyMode(StrEnum):
+    """Operator-selected control mode."""
+
+    CURRENT = "current"
+    POWER = "power"
+
+
+class PowerSupplyState(StrEnum):
+    """Controller state machine state."""
+
+    IDLE = "idle"
+    ARMED = "armed"
+    RUNNING = "running"
+    TRIPPED = "tripped"
+
+
+class PowerSupplyConfig(BaseModel):
+    """Operator-configurable parameters for the power supply controller.
+
+    All numeric fields are validated by Pydantic at construction (Pydantic's
+    Field constraints raise ValidationError on bad input). The
+    `_check_invariants` validator enforces the cross-field invariants:
+        current_setpoint_min_a < current_setpoint_max_a
+        current_setpoint_max_a <= current_full_scale_a
+    """
+
+    command_tag: str = Field(
+        default="TAG_10",
+        description="Modbus tag that drives the current-command AO (AO1).",
+    )
+    current_feedback_tag: str = Field(
+        default="TAG_12",
+        description="Modbus tag carrying measured I_out from the PS (AI1).",
+    )
+    voltage_feedback_tag: str = Field(
+        default="TAG_13",
+        description="Modbus tag carrying measured V_out from the PS (AI2).",
+    )
+    temp_tag: str = Field(
+        default="TAG_0",
+        description="Modbus tag carrying the HH-monitored thermocouple (TC1).",
+    )
+
+    current_full_scale_a: float = Field(
+        default=100.0,
+        gt=0.0,
+        description="Amps at 100 % AO command (5 V on PS input after conditioner).",
+    )
+    voltage_full_scale_v: float = Field(
+        default=50.0,
+        gt=0.0,
+        description="Volts at 100 % AI reading from PS V feedback.",
+    )
+
+    current_setpoint_min_a: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Lower clamp for operator current setpoint (A).",
+    )
+    current_setpoint_max_a: float = Field(
+        default=50.0,
+        gt=0.0,
+        description="Upper clamp for operator current setpoint (A).",
+    )
+
+    power_alarm_max_w: float = Field(
+        default=1000.0,
+        gt=0.0,
+        description="Power trip threshold in watts (HH_POWER).",
+    )
+    temp_alarm_max_c: float = Field(
+        default=1200.0,
+        gt=0.0,
+        description="Temperature trip threshold in degrees Celsius (HH_TEMP).",
+    )
+
+    @model_validator(mode="after")
+    def _check_invariants(self) -> PowerSupplyConfig:
+        if self.current_setpoint_min_a >= self.current_setpoint_max_a:
+            raise ValueError(
+                "current_setpoint_min_a "
+                f"({self.current_setpoint_min_a}) must be less than "
+                f"current_setpoint_max_a ({self.current_setpoint_max_a})"
+            )
+        if self.current_setpoint_max_a > self.current_full_scale_a:
+            raise ValueError(
+                f"current_setpoint_max_a ({self.current_setpoint_max_a}) must not "
+                f"exceed current_full_scale_a ({self.current_full_scale_a})"
+            )
+        return self
+
+
+class PowerSupplyStatus(BaseModel):
+    """Snapshot of controller state for the UI / WebSocket stream."""
+
+    state: PowerSupplyState
+    mode: PowerSupplyMode
+    permissive: bool
+
+    setpoint_a: float
+    setpoint_w: float | None
+
+    measured_current_a: float
+    measured_voltage_v: float
+    measured_power_w: float
+    measured_temp_c: float
+
+    commanded_output_percent: float
+    trips: list[str]
+
+
+class PowerSupplyController:
+    """State machine + control law for the power supply.
+
+    The controller is fed measured feedback values via `tick()`. Each tick:
+        1. Updates internal feedback snapshot
+        2. Computes measured power (V * I)
+        3. Evaluates trip conditions (HH_POWER, HH_TEMP) and latches trips
+        4. Recomputes the implied current setpoint when in POWER mode
+        5. Returns the AO command percentage (0..100) to apply
+
+    Invariants:
+        - In IDLE / ARMED / TRIPPED state, returned command is 0.0.
+        - When permissive is False, returned command is 0.0.
+        - When any trip is latched, returned command is 0.0.
+        - When state is RUNNING, returned command tracks setpoint clamped to
+          [current_setpoint_min_a, current_setpoint_max_a] then scaled to
+          a percent of current_full_scale_a.
+    """
+
+    def __init__(self, config: PowerSupplyConfig) -> None:
+        if not isinstance(config, PowerSupplyConfig):
+            raise TypeError(
+                f"config must be PowerSupplyConfig, got {type(config).__name__}"
+            )
+        self._config = config
+        self._state = PowerSupplyState.IDLE
+        self._mode = PowerSupplyMode.CURRENT
+        self._permissive = False
+        self._setpoint_a = 0.0
+        self._setpoint_w: float | None = None
+        self._trips: set[str] = set()
+        self._last_v = 0.0
+        self._last_i = 0.0
+        self._last_t = 0.0
+        self._last_commanded_percent = 0.0
+
+    @property
+    def state(self) -> PowerSupplyState:
+        return self._state
+
+    @property
+    def mode(self) -> PowerSupplyMode:
+        return self._mode
+
+    @property
+    def permissive(self) -> bool:
+        return self._permissive
+
+    @property
+    def config(self) -> PowerSupplyConfig:
+        return self._config
+
+    @property
+    def trips(self) -> list[str]:
+        return sorted(self._trips)
+
+    def update_config(self, new_config: PowerSupplyConfig) -> None:
+        """Replace operator-configurable parameters.
+
+        Precondition: new_config is a fully-validated PowerSupplyConfig.
+        Postcondition: subsequent commands and trip checks use new_config.
+
+        Raises:
+            TypeError: if new_config is not a PowerSupplyConfig instance.
+        """
+        if not isinstance(new_config, PowerSupplyConfig):
+            raise TypeError(
+                f"new_config must be PowerSupplyConfig, got {type(new_config).__name__}"
+            )
+        self._config = new_config
+        # Re-clamp current setpoint to new bounds without changing state.
+        self._setpoint_a = max(
+            new_config.current_setpoint_min_a,
+            min(self._setpoint_a, new_config.current_setpoint_max_a),
+        )
+
+    def set_permissive(self, on: bool) -> None:
+        """Toggle permissive. A trip latch is not cleared by a permissive change.
+
+        Precondition: on is a bool (no truthy coercion to catch caller bugs).
+        Postcondition:
+            - permissive == on
+            - If on goes False and state was RUNNING / ARMED, state -> IDLE,
+              setpoint -> 0
+            - If on goes True and state was IDLE, state -> ARMED
+            - If state was TRIPPED, state remains TRIPPED
+
+        Raises:
+            TypeError: if on is not exactly bool.
+        """
+        if not isinstance(on, bool):
+            raise TypeError(f"on must be bool, got {type(on).__name__}")
+        self._permissive = on
+        if self._state == PowerSupplyState.TRIPPED:
+            return
+        if on:
+            if self._state == PowerSupplyState.IDLE:
+                self._state = PowerSupplyState.ARMED
+        else:
+            self._setpoint_a = 0.0
+            self._setpoint_w = None
+            self._state = PowerSupplyState.IDLE
+
+    def set_current_setpoint(self, value_a: float) -> float:
+        """Apply a current setpoint (Amps).
+
+        The value is clamped to [current_setpoint_min_a, current_setpoint_max_a]
+        before being applied. Setpoint application is rejected in IDLE and
+        TRIPPED states (returns clamped value but does not change internal
+        setpoint).
+
+        Precondition: value_a is finite numeric.
+        Postcondition:
+            - If state was ARMED / RUNNING: internal setpoint_a == clamped value;
+              mode == CURRENT; setpoint_w == None
+            - If clamped > 0 and state was ARMED: state -> RUNNING
+            - Returns the clamped value that would be applied.
+
+        Raises:
+            TypeError: if value_a is not numeric.
+            ValueError: if value_a is NaN or infinite.
+        """
+        if not isinstance(value_a, int | float) or isinstance(value_a, bool):
+            raise TypeError(f"value_a must be numeric, got {type(value_a).__name__}")
+        v = float(value_a)
+        if not math.isfinite(v):
+            raise ValueError(f"value_a must be finite, got {v}")
+
+        clamped = max(
+            self._config.current_setpoint_min_a,
+            min(v, self._config.current_setpoint_max_a),
+        )
+
+        if self._state in (PowerSupplyState.ARMED, PowerSupplyState.RUNNING):
+            self._setpoint_a = clamped
+            self._setpoint_w = None
+            self._mode = PowerSupplyMode.CURRENT
+            if self._state == PowerSupplyState.ARMED and clamped > 0.0:
+                self._state = PowerSupplyState.RUNNING
+        elif self._state == PowerSupplyState.IDLE:
+            logger.warning(
+                "current setpoint %.3f A ignored — controller in IDLE; "
+                "enable permissive first",
+                clamped,
+            )
+        elif self._state == PowerSupplyState.TRIPPED:
+            logger.warning(
+                "current setpoint %.3f A ignored — controller TRIPPED; "
+                "acknowledge first",
+                clamped,
+            )
+        return clamped
+
+    def set_power_setpoint(self, value_w: float) -> float:
+        """Apply a power setpoint (Watts).
+
+        In POWER mode, the controller derives a target current from the
+        most recent measured voltage: I_target = P_target / V_measured. The
+        derived current is then clamped to the operator current bounds, and
+        the resulting *achievable* power is returned.
+
+        Precondition: value_w is finite numeric.
+        Postcondition:
+            - If state was ARMED / RUNNING and V_measured > 0: setpoint_w stored,
+              mode == POWER, setpoint_a derived from V_measured
+            - If state was ARMED and derived current > 0: state -> RUNNING
+            - Returns the power that will actually be achieved given clamping.
+
+        Raises:
+            TypeError: if value_w is not numeric.
+            ValueError: if value_w is NaN or infinite, or negative.
+        """
+        if not isinstance(value_w, int | float) or isinstance(value_w, bool):
+            raise TypeError(f"value_w must be numeric, got {type(value_w).__name__}")
+        w = float(value_w)
+        if not math.isfinite(w):
+            raise ValueError(f"value_w must be finite, got {w}")
+        if w < 0.0:
+            raise ValueError(f"value_w must be non-negative, got {w}")
+
+        if self._last_v < 0.1:
+            logger.warning(
+                "power setpoint %.1f W ignored — measured voltage %.3f V too "
+                "low for divide",
+                w,
+                self._last_v,
+            )
+            return 0.0
+
+        i_raw = w / self._last_v
+        clamped_i = max(
+            self._config.current_setpoint_min_a,
+            min(i_raw, self._config.current_setpoint_max_a),
+        )
+        achievable_w = clamped_i * self._last_v
+
+        if self._state in (PowerSupplyState.ARMED, PowerSupplyState.RUNNING):
+            self._setpoint_a = clamped_i
+            self._setpoint_w = w
+            self._mode = PowerSupplyMode.POWER
+            if self._state == PowerSupplyState.ARMED and clamped_i > 0.0:
+                self._state = PowerSupplyState.RUNNING
+        elif self._state == PowerSupplyState.IDLE:
+            logger.warning(
+                "power setpoint %.1f W ignored — controller IDLE; "
+                "enable permissive first",
+                w,
+            )
+        elif self._state == PowerSupplyState.TRIPPED:
+            logger.warning(
+                "power setpoint %.1f W ignored — controller TRIPPED; acknowledge first",
+                w,
+            )
+        return achievable_w
+
+    def tick(
+        self,
+        measured_current_a: float,
+        measured_voltage_v: float,
+        measured_temp_c: float,
+    ) -> float:
+        """Advance the controller one cycle and return the AO command percent.
+
+        Reads feedback inputs, evaluates trip conditions (latching them on
+        breach), recomputes current setpoint when in POWER mode, and returns
+        the AO command percent (0..100) the caller should send to the PLC.
+
+        Precondition: all three measured inputs are finite floats. Non-finite
+        inputs are treated as 0 (safe).
+        Postcondition: returned percent is in [0, 100]; trips are latched if
+        their conditions are met.
+        """
+        self._last_i = (
+            float(measured_current_a)
+            if isinstance(measured_current_a, int | float)
+            and math.isfinite(float(measured_current_a))
+            else 0.0
+        )
+        self._last_v = (
+            float(measured_voltage_v)
+            if isinstance(measured_voltage_v, int | float)
+            and math.isfinite(float(measured_voltage_v))
+            else 0.0
+        )
+        self._last_t = (
+            float(measured_temp_c)
+            if isinstance(measured_temp_c, int | float)
+            and math.isfinite(float(measured_temp_c))
+            else 0.0
+        )
+
+        measured_power_w = self._last_v * self._last_i
+
+        # Trip evaluation (latching)
+        if measured_power_w > self._config.power_alarm_max_w:
+            self._trips.add("HH_POWER")
+        if self._last_t > self._config.temp_alarm_max_c:
+            self._trips.add("HH_TEMP")
+        if self._trips and self._state != PowerSupplyState.TRIPPED:
+            logger.error(
+                "trip latched: %s (P=%.1f W, T=%.1f C)",
+                ",".join(sorted(self._trips)),
+                measured_power_w,
+                self._last_t,
+            )
+            self._state = PowerSupplyState.TRIPPED
+
+        # In POWER mode, recompute current target from latest V
+        if (
+            self._mode == PowerSupplyMode.POWER
+            and self._state == PowerSupplyState.RUNNING
+            and self._setpoint_w is not None
+            and self._last_v >= 0.1
+        ):
+            i_raw = self._setpoint_w / self._last_v
+            self._setpoint_a = max(
+                self._config.current_setpoint_min_a,
+                min(i_raw, self._config.current_setpoint_max_a),
+            )
+
+        if (
+            self._state != PowerSupplyState.RUNNING
+            or not self._permissive
+            or self._trips
+        ):
+            self._last_commanded_percent = 0.0
+            return 0.0
+
+        percent = 100.0 * self._setpoint_a / self._config.current_full_scale_a
+        clamped_percent = max(0.0, min(percent, 100.0))
+        self._last_commanded_percent = clamped_percent
+        return clamped_percent
+
+    def acknowledge_trip(self) -> bool:
+        """Clear latched trips and return controller to safe idle/armed state.
+
+        Postcondition:
+            - All trips cleared.
+            - Setpoint cleared to 0.
+            - State -> ARMED if permissive is True, else IDLE.
+
+        Returns:
+            True if a trip was cleared. False if there were no trips.
+        """
+        if self._state != PowerSupplyState.TRIPPED:
+            return False
+        self._trips.clear()
+        self._setpoint_a = 0.0
+        self._setpoint_w = None
+        self._state = (
+            PowerSupplyState.ARMED if self._permissive else PowerSupplyState.IDLE
+        )
+        return True
+
+    def status(self) -> PowerSupplyStatus:
+        """Return a snapshot of controller state for serialization."""
+        return PowerSupplyStatus(
+            state=self._state,
+            mode=self._mode,
+            permissive=self._permissive,
+            setpoint_a=self._setpoint_a,
+            setpoint_w=self._setpoint_w,
+            measured_current_a=self._last_i,
+            measured_voltage_v=self._last_v,
+            measured_power_w=self._last_v * self._last_i,
+            measured_temp_c=self._last_t,
+            commanded_output_percent=self._last_commanded_percent,
+            trips=sorted(self._trips),
+        )

--- a/src/p1am_control_system/backend/power_supply.py
+++ b/src/p1am_control_system/backend/power_supply.py
@@ -19,9 +19,14 @@ from __future__ import annotations
 
 import logging
 import math
-from enum import StrEnum
+from enum import Enum
 
 from pydantic import BaseModel, Field, model_validator
+
+
+class StrEnum(str, Enum):  # noqa: UP042
+    pass
+
 
 logger = logging.getLogger("dcs_backend.power_supply")
 

--- a/src/p1am_control_system/backend/power_supply_integration.py
+++ b/src/p1am_control_system/backend/power_supply_integration.py
@@ -1,0 +1,151 @@
+"""FastAPI and PLC integration for the P1AM power-supply controller."""
+
+from __future__ import annotations
+
+import logging
+import struct
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from power_supply import (
+    PowerSupplyConfig,
+    PowerSupplyController,
+    PowerSupplyMode,
+    PowerSupplyStatus,
+)
+from pydantic import BaseModel
+
+
+class PowerSupplyService:
+    """Owns the controller and applies its command to the PLC PID pass-through."""
+
+    def __init__(self, plc_client: Any, logger: logging.Logger) -> None:
+        self.controller = PowerSupplyController(PowerSupplyConfig())
+        self._plc_client = plc_client
+        self._logger = logger
+
+    async def poll(self, tags: dict[str, float] | None) -> PowerSupplyStatus:
+        """Feed measured tags into the controller and write the AO command."""
+        current_a, voltage_v, temp_c = self._inputs_from_tags(tags)
+        command_percent = self.controller.tick(
+            measured_current_a=current_a,
+            measured_voltage_v=voltage_v,
+            measured_temp_c=temp_c,
+        )
+        await self._write_pid_setpoint(0, command_percent)
+        return self.controller.status()
+
+    def _inputs_from_tags(
+        self,
+        tags: dict[str, float] | None,
+    ) -> tuple[float, float, float]:
+        if not tags:
+            return 0.0, 0.0, 0.0
+
+        cfg = self.controller.config
+        current_pct = float(tags.get(cfg.current_feedback_tag, 0.0))
+        voltage_pct = float(tags.get(cfg.voltage_feedback_tag, 0.0))
+        temp_c = float(tags.get(cfg.temp_tag, 0.0))
+        current_a = current_pct * cfg.current_full_scale_a / 100.0
+        voltage_v = voltage_pct * cfg.voltage_full_scale_v / 100.0
+        return current_a, voltage_v, temp_c
+
+    async def _write_pid_setpoint(self, pid_index: int, value: float) -> bool:
+        """Write a PID setpoint to the PLC register pair used for AO pass-through."""
+        if not self._plc_client.connected:
+            return False
+        if pid_index < 0 or pid_index >= 4:
+            self._logger.warning("PID index %d out of range", pid_index)
+            return False
+
+        lo, hi = struct.unpack("<HH", struct.pack("<f", float(value)))
+        base = 200 + pid_index * 10
+        try:
+            async with self._plc_client.lock:
+                resp = await self._plc_client._get_client().write_registers(
+                    address=base + 2, values=[lo, hi]
+                )
+            if resp.isError():
+                self._logger.error(
+                    "write_pid_setpoint(%d, %f) failed: %s", pid_index, value, resp
+                )
+                return False
+            return True
+        except Exception as exc:
+            self._logger.error(
+                "write_pid_setpoint(%d, %f) exception: %s", pid_index, value, exc
+            )
+            return False
+
+
+class PowerSupplySetpointRequest(BaseModel):
+    """Operator-facing setpoint command."""
+
+    mode: PowerSupplyMode
+    value_a: float | None = None
+    value_w: float | None = None
+
+
+class PowerSupplyPermissiveRequest(BaseModel):
+    enabled: bool
+
+
+def create_power_supply_router(service: PowerSupplyService) -> APIRouter:
+    router = APIRouter(prefix="/api/power_supply", tags=["power_supply"])
+    controller = service.controller
+
+    @router.get("/config", response_model=PowerSupplyConfig)
+    async def get_power_supply_config() -> PowerSupplyConfig:
+        return controller.config
+
+    @router.put("/config", response_model=PowerSupplyConfig)
+    async def update_power_supply_config(
+        new_config: PowerSupplyConfig,
+    ) -> PowerSupplyConfig:
+        controller.update_config(new_config)
+        return controller.config
+
+    @router.get("/status", response_model=PowerSupplyStatus)
+    async def get_power_supply_status() -> PowerSupplyStatus:
+        return controller.status()
+
+    @router.post("/setpoint")
+    async def apply_power_supply_setpoint(
+        req: PowerSupplySetpointRequest,
+    ) -> dict[str, Any]:
+        if req.mode == PowerSupplyMode.CURRENT:
+            if req.value_a is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="value_a is required when mode='current'",
+                )
+            try:
+                applied = controller.set_current_setpoint(req.value_a)
+            except (TypeError, ValueError) as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            return {"mode": "current", "applied_a": applied}
+
+        if req.value_w is None:
+            raise HTTPException(
+                status_code=400,
+                detail="value_w is required when mode='power'",
+            )
+        try:
+            achievable = controller.set_power_setpoint(req.value_w)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"mode": "power", "achievable_w": achievable}
+
+    @router.post("/permissive")
+    async def set_power_supply_permissive(
+        req: PowerSupplyPermissiveRequest,
+    ) -> PowerSupplyStatus:
+        controller.set_permissive(req.enabled)
+        return controller.status()
+
+    @router.post("/acknowledge_trip")
+    async def acknowledge_power_supply_trip() -> PowerSupplyStatus:
+        controller.acknowledge_trip()
+        return controller.status()
+
+    return router

--- a/src/p1am_control_system/backend/tests/_power_supply_helpers.py
+++ b/src/p1am_control_system/backend/tests/_power_supply_helpers.py
@@ -1,0 +1,40 @@
+"""Shared helpers for the split power_supply test files.
+
+Kept under an underscore so pytest doesn't try to collect this as a test
+module. Each helper returns a fresh PowerSupplyController in a known state
+so individual tests can start from idle / armed / running without repeating
+the boilerplate.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from power_supply import (  # noqa: E402  (path setup above must run first)
+    PowerSupplyConfig,
+    PowerSupplyController,
+)
+
+
+def fresh_idle_controller() -> PowerSupplyController:
+    """Return a controller in IDLE state (default config)."""
+    return PowerSupplyController(PowerSupplyConfig())
+
+
+def fresh_armed_controller() -> PowerSupplyController:
+    """Return a controller already in ARMED state (permissive on)."""
+    c = fresh_idle_controller()
+    c.set_permissive(True)
+    return c
+
+
+def fresh_running_controller(sp_a: float = 10.0) -> PowerSupplyController:
+    """Return a controller in RUNNING state with a non-zero current setpoint."""
+    c = fresh_armed_controller()
+    c.set_current_setpoint(sp_a)
+    return c

--- a/src/p1am_control_system/backend/tests/test_power_supply.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply.py
@@ -15,8 +15,13 @@ Covers here:
 from __future__ import annotations
 
 import math
+import sys
+from pathlib import Path
 
 import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
 from _power_supply_helpers import (
     fresh_armed_controller,
     fresh_idle_controller,
@@ -85,9 +90,9 @@ class TestController_Init:
 
     def test_rejects_non_config_argument(self) -> None:
         with pytest.raises(TypeError):
-            PowerSupplyController("not a config")  # type: ignore[arg-type]
+            PowerSupplyController("not a config")
         with pytest.raises(TypeError):
-            PowerSupplyController({"current_full_scale_a": 10.0})  # type: ignore[arg-type]
+            PowerSupplyController({"current_full_scale_a": 10.0})
 
 
 # --------------------------------------------------------------------------
@@ -135,9 +140,9 @@ class TestPermissive:
     def test_rejects_non_bool_permissive(self) -> None:
         c = fresh_idle_controller()
         with pytest.raises(TypeError):
-            c.set_permissive(1)  # type: ignore[arg-type]
+            c.set_permissive(1)
         with pytest.raises(TypeError):
-            c.set_permissive("on")  # type: ignore[arg-type]
+            c.set_permissive("on")
 
 
 # --------------------------------------------------------------------------
@@ -235,7 +240,7 @@ class TestUpdateConfig:
     def test_update_config_type_check(self) -> None:
         c = fresh_idle_controller()
         with pytest.raises(TypeError):
-            c.update_config({"current_full_scale_a": 50.0})  # type: ignore[arg-type]
+            c.update_config({"current_full_scale_a": 50.0})
 
     def test_invalid_config_rejected_at_construction(self) -> None:
         # update_config can't take an invalid config because invalid

--- a/src/p1am_control_system/backend/tests/test_power_supply.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply.py
@@ -1,42 +1,34 @@
-"""Unit tests for the PowerSupplyController and its config model.
+"""Config-level + state-machine unit tests for PowerSupplyController.
 
-Covers:
+Split companion (`test_power_supply_runtime.py`) covers setpoint clamping,
+trip latching, and tick-output behavior under runtime feedback.
+
+Covers here:
     - Pydantic config validation (field constraints, cross-field invariants)
-    - State machine transitions across all four states
-    - Current setpoint clamping (fat-finger protection)
-    - Power setpoint derivation from measured voltage
-    - HH_POWER and HH_TEMP trip latching
-    - Trip acknowledge / reset
-    - Permissive on/off semantics
+    - Controller construction and initial state
+    - Permissive transitions (IDLE <-> ARMED, RUNNING -> IDLE, trip-latch survives)
     - Mode switching between CURRENT and POWER
-    - Type/value validation rejecting bool, NaN, infinity
-
-Designed to run with no PLC connection. Every behavior the operator might
-encounter (out-of-range setpoint, trip during runtime, trip with permissive
-off, etc.) is asserted explicitly.
+    - Status snapshot fields and the P = V * I invariant
+    - update_config() re-clamps existing setpoint without changing state
 """
 
 from __future__ import annotations
 
 import math
-import os
-import sys
 
 import pytest
-from pydantic import ValidationError
-
-# Allow running from this file's directory (backend/tests/) by adding the
-# backend dir to sys.path so `import power_supply` resolves.
-_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-if _BACKEND_DIR not in sys.path:
-    sys.path.insert(0, _BACKEND_DIR)
-
-from power_supply import (  # noqa: E402  (path setup above must run first)
+from _power_supply_helpers import (
+    fresh_armed_controller,
+    fresh_idle_controller,
+    fresh_running_controller,
+)
+from power_supply import (
     PowerSupplyConfig,
     PowerSupplyController,
     PowerSupplyMode,
     PowerSupplyState,
 )
+from pydantic import ValidationError
 
 # --------------------------------------------------------------------------
 # PowerSupplyConfig validation
@@ -84,25 +76,9 @@ class TestPowerSupplyConfigValidation:
 # --------------------------------------------------------------------------
 
 
-def _ctrl() -> PowerSupplyController:
-    return PowerSupplyController(PowerSupplyConfig())
-
-
-def _armed_ctrl() -> PowerSupplyController:
-    c = _ctrl()
-    c.set_permissive(True)
-    return c
-
-
-def _running_ctrl(sp_a: float = 10.0) -> PowerSupplyController:
-    c = _armed_ctrl()
-    c.set_current_setpoint(sp_a)
-    return c
-
-
 class TestController_Init:
     def test_initial_state_is_idle(self) -> None:
-        c = _ctrl()
+        c = fresh_idle_controller()
         assert c.state == PowerSupplyState.IDLE
         assert c.permissive is False
         assert c.trips == []
@@ -121,24 +97,24 @@ class TestController_Init:
 
 class TestPermissive:
     def test_idle_to_armed_when_permissive_on(self) -> None:
-        c = _ctrl()
+        c = fresh_idle_controller()
         c.set_permissive(True)
         assert c.state == PowerSupplyState.ARMED
         assert c.permissive is True
 
     def test_armed_to_idle_when_permissive_off(self) -> None:
-        c = _armed_ctrl()
+        c = fresh_armed_controller()
         c.set_permissive(False)
         assert c.state == PowerSupplyState.IDLE
 
     def test_running_to_idle_when_permissive_off(self) -> None:
-        c = _running_ctrl(10.0)
+        c = fresh_running_controller(10.0)
         assert c.state == PowerSupplyState.RUNNING
         c.set_permissive(False)
         assert c.state == PowerSupplyState.IDLE
 
     def test_permissive_off_clears_setpoint(self) -> None:
-        c = _running_ctrl(15.0)
+        c = fresh_running_controller(15.0)
         c.set_permissive(False)
         # Re-arming gives a clean state at 0 setpoint
         c.set_permissive(True)
@@ -147,7 +123,7 @@ class TestPermissive:
         assert cmd == 0.0
 
     def test_permissive_change_does_not_clear_trip(self) -> None:
-        c = _running_ctrl(10.0)
+        c = fresh_running_controller(10.0)
         # Drive a trip via measured power
         c.tick(measured_current_a=200.0, measured_voltage_v=20.0, measured_temp_c=25.0)
         assert c.state == PowerSupplyState.TRIPPED
@@ -157,315 +133,11 @@ class TestPermissive:
         assert c.state == PowerSupplyState.TRIPPED
 
     def test_rejects_non_bool_permissive(self) -> None:
-        c = _ctrl()
+        c = fresh_idle_controller()
         with pytest.raises(TypeError):
             c.set_permissive(1)  # type: ignore[arg-type]
         with pytest.raises(TypeError):
             c.set_permissive("on")  # type: ignore[arg-type]
-
-
-# --------------------------------------------------------------------------
-# Current setpoint — fat-finger protection
-# --------------------------------------------------------------------------
-
-
-class TestCurrentSetpoint:
-    def test_in_band_setpoint_applied(self) -> None:
-        c = _armed_ctrl()
-        applied = c.set_current_setpoint(25.0)
-        assert applied == 25.0
-        assert c.state == PowerSupplyState.RUNNING
-
-    def test_setpoint_above_max_is_clamped(self) -> None:
-        c = _armed_ctrl()
-        applied = c.set_current_setpoint(9999.0)
-        assert applied == c.config.current_setpoint_max_a
-        cmd = c.tick(0.0, 0.0, 25.0)
-        assert cmd == pytest.approx(
-            100.0 * c.config.current_setpoint_max_a / c.config.current_full_scale_a
-        )
-
-    def test_setpoint_below_min_is_clamped(self) -> None:
-        c = _armed_ctrl()
-        applied = c.set_current_setpoint(-5.0)
-        assert applied == c.config.current_setpoint_min_a
-
-    def test_setpoint_zero_keeps_state_armed(self) -> None:
-        c = _armed_ctrl()
-        c.set_current_setpoint(0.0)
-        assert c.state == PowerSupplyState.ARMED
-
-    def test_setpoint_ignored_in_idle_state(self) -> None:
-        c = _ctrl()
-        applied = c.set_current_setpoint(25.0)
-        assert applied == 25.0  # value clamped + returned
-        assert c.state == PowerSupplyState.IDLE  # but not applied
-        cmd = c.tick(0.0, 0.0, 25.0)
-        assert cmd == 0.0
-
-    def test_setpoint_ignored_in_tripped_state(self) -> None:
-        c = _running_ctrl(10.0)
-        c.tick(200.0, 20.0, 25.0)  # trip on power
-        assert c.state == PowerSupplyState.TRIPPED
-        c.set_current_setpoint(5.0)
-        cmd = c.tick(0.0, 0.0, 25.0)
-        assert cmd == 0.0
-
-    def test_rejects_nan(self) -> None:
-        c = _armed_ctrl()
-        with pytest.raises(ValueError):
-            c.set_current_setpoint(float("nan"))
-
-    def test_rejects_infinity(self) -> None:
-        c = _armed_ctrl()
-        with pytest.raises(ValueError):
-            c.set_current_setpoint(float("inf"))
-        with pytest.raises(ValueError):
-            c.set_current_setpoint(float("-inf"))
-
-    def test_rejects_non_numeric(self) -> None:
-        c = _armed_ctrl()
-        with pytest.raises(TypeError):
-            c.set_current_setpoint("10")  # type: ignore[arg-type]
-        with pytest.raises(TypeError):
-            c.set_current_setpoint(None)  # type: ignore[arg-type]
-
-    def test_rejects_bool(self) -> None:
-        # Bool is technically a subclass of int. Explicit catch keeps the
-        # caller honest.
-        c = _armed_ctrl()
-        with pytest.raises(TypeError):
-            c.set_current_setpoint(True)  # type: ignore[arg-type]
-
-
-# --------------------------------------------------------------------------
-# Power setpoint — derives current from measured voltage
-# --------------------------------------------------------------------------
-
-
-class TestPowerSetpoint:
-    def test_power_setpoint_derives_current_from_voltage(self) -> None:
-        c = _armed_ctrl()
-        # Establish a measured voltage via tick before setting power.
-        c.tick(measured_current_a=0.0, measured_voltage_v=20.0, measured_temp_c=25.0)
-        achievable = c.set_power_setpoint(200.0)
-        # 200 W / 20 V = 10 A target. Within bounds.
-        assert achievable == pytest.approx(200.0)
-        # In POWER mode now
-        assert c.mode == PowerSupplyMode.POWER
-
-    def test_power_setpoint_clamped_by_current_max(self) -> None:
-        c = _armed_ctrl()
-        c.tick(0.0, 10.0, 25.0)  # V = 10 V
-        # 1000 W / 10 V = 100 A target, clamped to current_setpoint_max_a (50)
-        achievable = c.set_power_setpoint(1000.0)
-        # achievable = 50 A * 10 V = 500 W
-        assert achievable == pytest.approx(500.0)
-
-    def test_power_setpoint_rejected_when_voltage_too_low(self) -> None:
-        c = _armed_ctrl()
-        c.tick(0.0, 0.0, 25.0)  # V = 0
-        achievable = c.set_power_setpoint(100.0)
-        assert achievable == 0.0
-        # Mode unchanged
-        assert c.state == PowerSupplyState.ARMED
-
-    def test_power_setpoint_recomputed_each_tick(self) -> None:
-        c = _armed_ctrl()
-        c.tick(0.0, 20.0, 25.0)
-        c.set_power_setpoint(200.0)  # → 10 A at 20 V
-        # Now voltage drops
-        cmd1 = c.tick(
-            measured_current_a=10.0, measured_voltage_v=10.0, measured_temp_c=25.0
-        )
-        # Should re-target: 200 / 10 = 20 A. cmd1 should be 20 % of full-scale (100 A)
-        assert cmd1 == pytest.approx(20.0)
-
-    def test_rejects_negative_power(self) -> None:
-        c = _armed_ctrl()
-        c.tick(0.0, 20.0, 25.0)
-        with pytest.raises(ValueError):
-            c.set_power_setpoint(-100.0)
-
-    def test_rejects_nan_inf_power(self) -> None:
-        c = _armed_ctrl()
-        c.tick(0.0, 20.0, 25.0)
-        with pytest.raises(ValueError):
-            c.set_power_setpoint(float("nan"))
-        with pytest.raises(ValueError):
-            c.set_power_setpoint(float("inf"))
-
-    def test_rejects_non_numeric_power(self) -> None:
-        c = _armed_ctrl()
-        c.tick(0.0, 20.0, 25.0)
-        with pytest.raises(TypeError):
-            c.set_power_setpoint("100")  # type: ignore[arg-type]
-
-
-# --------------------------------------------------------------------------
-# Trip logic — HH_POWER and HH_TEMP
-# --------------------------------------------------------------------------
-
-
-class TestTrips:
-    def test_hh_power_trips_when_measured_exceeds_threshold(self) -> None:
-        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
-        c.set_permissive(True)
-        c.set_current_setpoint(10.0)
-        # P = V * I = 30 * 20 = 600 W, exceeds 500
-        cmd = c.tick(
-            measured_current_a=20.0, measured_voltage_v=30.0, measured_temp_c=25.0
-        )
-        assert cmd == 0.0  # output zeroed
-        assert c.state == PowerSupplyState.TRIPPED
-        assert "HH_POWER" in c.trips
-
-    def test_hh_power_does_not_trip_at_threshold_minus_epsilon(self) -> None:
-        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
-        c.set_permissive(True)
-        c.set_current_setpoint(10.0)
-        c.tick(measured_current_a=10.0, measured_voltage_v=49.0, measured_temp_c=25.0)
-        # P = 490 W < 500 → no trip
-        assert c.state == PowerSupplyState.RUNNING
-        assert c.trips == []
-
-    def test_hh_temp_trips_above_threshold(self) -> None:
-        c = PowerSupplyController(PowerSupplyConfig(temp_alarm_max_c=1200.0))
-        c.set_permissive(True)
-        c.set_current_setpoint(10.0)
-        cmd = c.tick(
-            measured_current_a=10.0, measured_voltage_v=5.0, measured_temp_c=1500.0
-        )
-        assert cmd == 0.0
-        assert c.state == PowerSupplyState.TRIPPED
-        assert "HH_TEMP" in c.trips
-
-    def test_both_trips_can_latch_simultaneously(self) -> None:
-        c = PowerSupplyController(
-            PowerSupplyConfig(power_alarm_max_w=100.0, temp_alarm_max_c=100.0)
-        )
-        c.set_permissive(True)
-        c.set_current_setpoint(10.0)
-        c.tick(measured_current_a=50.0, measured_voltage_v=10.0, measured_temp_c=200.0)
-        assert c.state == PowerSupplyState.TRIPPED
-        assert "HH_POWER" in c.trips
-        assert "HH_TEMP" in c.trips
-
-    def test_trip_latches_through_safe_subsequent_tick(self) -> None:
-        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
-        c.set_permissive(True)
-        c.set_current_setpoint(10.0)
-        c.tick(measured_current_a=20.0, measured_voltage_v=30.0, measured_temp_c=25.0)
-        assert c.state == PowerSupplyState.TRIPPED
-        # Now signal returns to safe band — trip MUST stay latched
-        c.tick(measured_current_a=1.0, measured_voltage_v=1.0, measured_temp_c=25.0)
-        assert c.state == PowerSupplyState.TRIPPED
-        assert "HH_POWER" in c.trips
-
-    def test_acknowledge_trip_clears_trips_and_state(self) -> None:
-        c = _running_ctrl(10.0)
-        c.tick(measured_current_a=200.0, measured_voltage_v=20.0, measured_temp_c=25.0)
-        assert c.state == PowerSupplyState.TRIPPED
-        cleared = c.acknowledge_trip()
-        assert cleared is True
-        assert c.trips == []
-        # Permissive was on; ack returns to ARMED, not IDLE
-        assert c.state == PowerSupplyState.ARMED
-
-    def test_acknowledge_with_permissive_off_returns_to_idle(self) -> None:
-        c = _running_ctrl(10.0)
-        c.tick(200.0, 20.0, 25.0)
-        c.set_permissive(False)
-        c.acknowledge_trip()
-        assert c.state == PowerSupplyState.IDLE
-
-    def test_acknowledge_with_no_trip_returns_false(self) -> None:
-        c = _armed_ctrl()
-        assert c.acknowledge_trip() is False
-
-
-# --------------------------------------------------------------------------
-# tick() output command behavior
-# --------------------------------------------------------------------------
-
-
-class TestTickOutput:
-    def test_tick_returns_zero_in_idle(self) -> None:
-        c = _ctrl()
-        assert c.tick(0.0, 0.0, 25.0) == 0.0
-
-    def test_tick_returns_zero_in_armed(self) -> None:
-        c = _armed_ctrl()
-        assert c.tick(0.0, 0.0, 25.0) == 0.0
-
-    def test_tick_returns_zero_when_permissive_off_after_running(self) -> None:
-        c = _running_ctrl(10.0)
-        c.set_permissive(False)
-        assert c.tick(0.0, 0.0, 25.0) == 0.0
-
-    def test_tick_returns_scaled_percent_when_running(self) -> None:
-        # Default current_full_scale_a = 100 A; setpoint 25 A → 25 %
-        c = _armed_ctrl()
-        c.set_current_setpoint(25.0)
-        cmd = c.tick(0.0, 0.0, 25.0)
-        assert cmd == pytest.approx(25.0)
-
-    def test_tick_clamps_percent_to_100(self) -> None:
-        # Construct so setpoint can equal full scale.
-        cfg = PowerSupplyConfig(
-            current_full_scale_a=100.0,
-            current_setpoint_max_a=100.0,
-        )
-        c = PowerSupplyController(cfg)
-        c.set_permissive(True)
-        c.set_current_setpoint(100.0)
-        cmd = c.tick(0.0, 0.0, 25.0)
-        assert cmd == 100.0
-
-    def test_tick_handles_nan_inputs_safely(self) -> None:
-        c = _running_ctrl(10.0)
-        cmd = c.tick(
-            measured_current_a=float("nan"),
-            measured_voltage_v=float("inf"),
-            measured_temp_c=float("nan"),
-        )
-        # Bad inputs → treated as 0 → no trip, command tracks setpoint
-        assert cmd > 0.0
-        assert c.state == PowerSupplyState.RUNNING
-
-
-# --------------------------------------------------------------------------
-# Config update at runtime
-# --------------------------------------------------------------------------
-
-
-class TestUpdateConfig:
-    def test_update_config_re_clamps_existing_setpoint(self) -> None:
-        c = _armed_ctrl()
-        c.set_current_setpoint(40.0)
-        # New config with stricter max → setpoint should re-clamp.
-        new_cfg = PowerSupplyConfig(
-            current_full_scale_a=100.0,
-            current_setpoint_max_a=20.0,
-        )
-        c.update_config(new_cfg)
-        cmd = c.tick(0.0, 0.0, 25.0)
-        # Setpoint should now be 20 A → 20 % of full scale (100 A)
-        assert cmd == pytest.approx(20.0)
-
-    def test_update_config_type_check(self) -> None:
-        c = _ctrl()
-        with pytest.raises(TypeError):
-            c.update_config({"current_full_scale_a": 50.0})  # type: ignore[arg-type]
-
-    def test_invalid_config_rejected_at_construction(self) -> None:
-        # update_config can't take an invalid config because invalid
-        # configs cannot be constructed in the first place.
-        with pytest.raises(ValidationError):
-            PowerSupplyConfig(
-                current_full_scale_a=10.0,
-                current_setpoint_max_a=50.0,
-            )
 
 
 # --------------------------------------------------------------------------
@@ -475,7 +147,7 @@ class TestUpdateConfig:
 
 class TestModeSwitching:
     def test_current_setpoint_switches_mode_to_current(self) -> None:
-        c = _armed_ctrl()
+        c = fresh_armed_controller()
         c.tick(0.0, 20.0, 25.0)
         c.set_power_setpoint(200.0)
         assert c.mode == PowerSupplyMode.POWER
@@ -483,7 +155,7 @@ class TestModeSwitching:
         assert c.mode == PowerSupplyMode.CURRENT
 
     def test_power_setpoint_switches_mode_to_power(self) -> None:
-        c = _armed_ctrl()
+        c = fresh_armed_controller()
         c.set_current_setpoint(15.0)
         assert c.mode == PowerSupplyMode.CURRENT
         c.tick(0.0, 20.0, 25.0)
@@ -498,7 +170,7 @@ class TestModeSwitching:
 
 class TestStatus:
     def test_status_reports_current_state(self) -> None:
-        c = _running_ctrl(10.0)
+        c = fresh_running_controller(10.0)
         c.tick(measured_current_a=5.0, measured_voltage_v=10.0, measured_temp_c=30.0)
         s = c.status()
         assert s.state == PowerSupplyState.RUNNING
@@ -511,7 +183,7 @@ class TestStatus:
         assert s.commanded_output_percent == pytest.approx(10.0)
 
     def test_status_reports_trips(self) -> None:
-        c = _running_ctrl(10.0)
+        c = fresh_running_controller(10.0)
         c.tick(measured_current_a=200.0, measured_voltage_v=20.0, measured_temp_c=25.0)
         s = c.status()
         assert s.state == PowerSupplyState.TRIPPED
@@ -520,22 +192,56 @@ class TestStatus:
 
 
 # --------------------------------------------------------------------------
-# Sanity: math invariants
+# Math invariants
 # --------------------------------------------------------------------------
 
 
 class TestMathInvariants:
     @pytest.mark.parametrize("sp_a", [0.0, 10.0, 25.0, 50.0])
     def test_command_proportional_to_setpoint(self, sp_a: float) -> None:
-        c = _armed_ctrl()
+        c = fresh_armed_controller()
         c.set_current_setpoint(sp_a)
         cmd = c.tick(0.0, 0.0, 25.0)
         expected_pct = 100.0 * sp_a / c.config.current_full_scale_a
         assert cmd == pytest.approx(expected_pct)
 
     def test_status_power_equals_v_times_i(self) -> None:
-        c = _running_ctrl(10.0)
+        c = fresh_running_controller(10.0)
         c.tick(measured_current_a=7.5, measured_voltage_v=12.0, measured_temp_c=25.0)
         s = c.status()
         assert s.measured_power_w == pytest.approx(7.5 * 12.0)
         assert math.isfinite(s.measured_power_w)
+
+
+# --------------------------------------------------------------------------
+# update_config runtime behavior
+# --------------------------------------------------------------------------
+
+
+class TestUpdateConfig:
+    def test_update_config_re_clamps_existing_setpoint(self) -> None:
+        c = fresh_armed_controller()
+        c.set_current_setpoint(40.0)
+        # New config with stricter max → setpoint should re-clamp.
+        new_cfg = PowerSupplyConfig(
+            current_full_scale_a=100.0,
+            current_setpoint_max_a=20.0,
+        )
+        c.update_config(new_cfg)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        # Setpoint should now be 20 A → 20 % of full scale (100 A)
+        assert cmd == pytest.approx(20.0)
+
+    def test_update_config_type_check(self) -> None:
+        c = fresh_idle_controller()
+        with pytest.raises(TypeError):
+            c.update_config({"current_full_scale_a": 50.0})  # type: ignore[arg-type]
+
+    def test_invalid_config_rejected_at_construction(self) -> None:
+        # update_config can't take an invalid config because invalid
+        # configs cannot be constructed in the first place.
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(
+                current_full_scale_a=10.0,
+                current_setpoint_max_a=50.0,
+            )

--- a/src/p1am_control_system/backend/tests/test_power_supply.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply.py
@@ -1,0 +1,541 @@
+"""Unit tests for the PowerSupplyController and its config model.
+
+Covers:
+    - Pydantic config validation (field constraints, cross-field invariants)
+    - State machine transitions across all four states
+    - Current setpoint clamping (fat-finger protection)
+    - Power setpoint derivation from measured voltage
+    - HH_POWER and HH_TEMP trip latching
+    - Trip acknowledge / reset
+    - Permissive on/off semantics
+    - Mode switching between CURRENT and POWER
+    - Type/value validation rejecting bool, NaN, infinity
+
+Designed to run with no PLC connection. Every behavior the operator might
+encounter (out-of-range setpoint, trip during runtime, trip with permissive
+off, etc.) is asserted explicitly.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+# Allow running from this file's directory (backend/tests/) by adding the
+# backend dir to sys.path so `import power_supply` resolves.
+_BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _BACKEND_DIR not in sys.path:
+    sys.path.insert(0, _BACKEND_DIR)
+
+from power_supply import (  # noqa: E402  (path setup above must run first)
+    PowerSupplyConfig,
+    PowerSupplyController,
+    PowerSupplyMode,
+    PowerSupplyState,
+)
+
+# --------------------------------------------------------------------------
+# PowerSupplyConfig validation
+# --------------------------------------------------------------------------
+
+
+class TestPowerSupplyConfigValidation:
+    def test_defaults_construct(self) -> None:
+        config = PowerSupplyConfig()
+        assert config.current_full_scale_a == 100.0
+        assert config.voltage_full_scale_v == 50.0
+        assert config.current_setpoint_min_a == 0.0
+        assert config.current_setpoint_max_a == 50.0
+
+    def test_full_scale_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(current_full_scale_a=0.0)
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(voltage_full_scale_v=-1.0)
+
+    def test_setpoint_min_cannot_exceed_max(self) -> None:
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(current_setpoint_min_a=60.0, current_setpoint_max_a=50.0)
+
+    def test_setpoint_min_equal_to_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(current_setpoint_min_a=50.0, current_setpoint_max_a=50.0)
+
+    def test_setpoint_max_cannot_exceed_full_scale(self) -> None:
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(
+                current_full_scale_a=100.0,
+                current_setpoint_max_a=150.0,
+            )
+
+    def test_alarm_thresholds_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(power_alarm_max_w=0.0)
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(temp_alarm_max_c=-10.0)
+
+
+# --------------------------------------------------------------------------
+# Constructor + initial state
+# --------------------------------------------------------------------------
+
+
+def _ctrl() -> PowerSupplyController:
+    return PowerSupplyController(PowerSupplyConfig())
+
+
+def _armed_ctrl() -> PowerSupplyController:
+    c = _ctrl()
+    c.set_permissive(True)
+    return c
+
+
+def _running_ctrl(sp_a: float = 10.0) -> PowerSupplyController:
+    c = _armed_ctrl()
+    c.set_current_setpoint(sp_a)
+    return c
+
+
+class TestController_Init:
+    def test_initial_state_is_idle(self) -> None:
+        c = _ctrl()
+        assert c.state == PowerSupplyState.IDLE
+        assert c.permissive is False
+        assert c.trips == []
+
+    def test_rejects_non_config_argument(self) -> None:
+        with pytest.raises(TypeError):
+            PowerSupplyController("not a config")  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            PowerSupplyController({"current_full_scale_a": 10.0})  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Permissive transitions
+# --------------------------------------------------------------------------
+
+
+class TestPermissive:
+    def test_idle_to_armed_when_permissive_on(self) -> None:
+        c = _ctrl()
+        c.set_permissive(True)
+        assert c.state == PowerSupplyState.ARMED
+        assert c.permissive is True
+
+    def test_armed_to_idle_when_permissive_off(self) -> None:
+        c = _armed_ctrl()
+        c.set_permissive(False)
+        assert c.state == PowerSupplyState.IDLE
+
+    def test_running_to_idle_when_permissive_off(self) -> None:
+        c = _running_ctrl(10.0)
+        assert c.state == PowerSupplyState.RUNNING
+        c.set_permissive(False)
+        assert c.state == PowerSupplyState.IDLE
+
+    def test_permissive_off_clears_setpoint(self) -> None:
+        c = _running_ctrl(15.0)
+        c.set_permissive(False)
+        # Re-arming gives a clean state at 0 setpoint
+        c.set_permissive(True)
+        assert c.state == PowerSupplyState.ARMED
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == 0.0
+
+    def test_permissive_change_does_not_clear_trip(self) -> None:
+        c = _running_ctrl(10.0)
+        # Drive a trip via measured power
+        c.tick(measured_current_a=200.0, measured_voltage_v=20.0, measured_temp_c=25.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        c.set_permissive(False)
+        assert c.state == PowerSupplyState.TRIPPED
+        c.set_permissive(True)
+        assert c.state == PowerSupplyState.TRIPPED
+
+    def test_rejects_non_bool_permissive(self) -> None:
+        c = _ctrl()
+        with pytest.raises(TypeError):
+            c.set_permissive(1)  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            c.set_permissive("on")  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Current setpoint — fat-finger protection
+# --------------------------------------------------------------------------
+
+
+class TestCurrentSetpoint:
+    def test_in_band_setpoint_applied(self) -> None:
+        c = _armed_ctrl()
+        applied = c.set_current_setpoint(25.0)
+        assert applied == 25.0
+        assert c.state == PowerSupplyState.RUNNING
+
+    def test_setpoint_above_max_is_clamped(self) -> None:
+        c = _armed_ctrl()
+        applied = c.set_current_setpoint(9999.0)
+        assert applied == c.config.current_setpoint_max_a
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == pytest.approx(
+            100.0 * c.config.current_setpoint_max_a / c.config.current_full_scale_a
+        )
+
+    def test_setpoint_below_min_is_clamped(self) -> None:
+        c = _armed_ctrl()
+        applied = c.set_current_setpoint(-5.0)
+        assert applied == c.config.current_setpoint_min_a
+
+    def test_setpoint_zero_keeps_state_armed(self) -> None:
+        c = _armed_ctrl()
+        c.set_current_setpoint(0.0)
+        assert c.state == PowerSupplyState.ARMED
+
+    def test_setpoint_ignored_in_idle_state(self) -> None:
+        c = _ctrl()
+        applied = c.set_current_setpoint(25.0)
+        assert applied == 25.0  # value clamped + returned
+        assert c.state == PowerSupplyState.IDLE  # but not applied
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == 0.0
+
+    def test_setpoint_ignored_in_tripped_state(self) -> None:
+        c = _running_ctrl(10.0)
+        c.tick(200.0, 20.0, 25.0)  # trip on power
+        assert c.state == PowerSupplyState.TRIPPED
+        c.set_current_setpoint(5.0)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == 0.0
+
+    def test_rejects_nan(self) -> None:
+        c = _armed_ctrl()
+        with pytest.raises(ValueError):
+            c.set_current_setpoint(float("nan"))
+
+    def test_rejects_infinity(self) -> None:
+        c = _armed_ctrl()
+        with pytest.raises(ValueError):
+            c.set_current_setpoint(float("inf"))
+        with pytest.raises(ValueError):
+            c.set_current_setpoint(float("-inf"))
+
+    def test_rejects_non_numeric(self) -> None:
+        c = _armed_ctrl()
+        with pytest.raises(TypeError):
+            c.set_current_setpoint("10")  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            c.set_current_setpoint(None)  # type: ignore[arg-type]
+
+    def test_rejects_bool(self) -> None:
+        # Bool is technically a subclass of int. Explicit catch keeps the
+        # caller honest.
+        c = _armed_ctrl()
+        with pytest.raises(TypeError):
+            c.set_current_setpoint(True)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Power setpoint — derives current from measured voltage
+# --------------------------------------------------------------------------
+
+
+class TestPowerSetpoint:
+    def test_power_setpoint_derives_current_from_voltage(self) -> None:
+        c = _armed_ctrl()
+        # Establish a measured voltage via tick before setting power.
+        c.tick(measured_current_a=0.0, measured_voltage_v=20.0, measured_temp_c=25.0)
+        achievable = c.set_power_setpoint(200.0)
+        # 200 W / 20 V = 10 A target. Within bounds.
+        assert achievable == pytest.approx(200.0)
+        # In POWER mode now
+        assert c.mode == PowerSupplyMode.POWER
+
+    def test_power_setpoint_clamped_by_current_max(self) -> None:
+        c = _armed_ctrl()
+        c.tick(0.0, 10.0, 25.0)  # V = 10 V
+        # 1000 W / 10 V = 100 A target, clamped to current_setpoint_max_a (50)
+        achievable = c.set_power_setpoint(1000.0)
+        # achievable = 50 A * 10 V = 500 W
+        assert achievable == pytest.approx(500.0)
+
+    def test_power_setpoint_rejected_when_voltage_too_low(self) -> None:
+        c = _armed_ctrl()
+        c.tick(0.0, 0.0, 25.0)  # V = 0
+        achievable = c.set_power_setpoint(100.0)
+        assert achievable == 0.0
+        # Mode unchanged
+        assert c.state == PowerSupplyState.ARMED
+
+    def test_power_setpoint_recomputed_each_tick(self) -> None:
+        c = _armed_ctrl()
+        c.tick(0.0, 20.0, 25.0)
+        c.set_power_setpoint(200.0)  # → 10 A at 20 V
+        # Now voltage drops
+        cmd1 = c.tick(
+            measured_current_a=10.0, measured_voltage_v=10.0, measured_temp_c=25.0
+        )
+        # Should re-target: 200 / 10 = 20 A. cmd1 should be 20 % of full-scale (100 A)
+        assert cmd1 == pytest.approx(20.0)
+
+    def test_rejects_negative_power(self) -> None:
+        c = _armed_ctrl()
+        c.tick(0.0, 20.0, 25.0)
+        with pytest.raises(ValueError):
+            c.set_power_setpoint(-100.0)
+
+    def test_rejects_nan_inf_power(self) -> None:
+        c = _armed_ctrl()
+        c.tick(0.0, 20.0, 25.0)
+        with pytest.raises(ValueError):
+            c.set_power_setpoint(float("nan"))
+        with pytest.raises(ValueError):
+            c.set_power_setpoint(float("inf"))
+
+    def test_rejects_non_numeric_power(self) -> None:
+        c = _armed_ctrl()
+        c.tick(0.0, 20.0, 25.0)
+        with pytest.raises(TypeError):
+            c.set_power_setpoint("100")  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Trip logic — HH_POWER and HH_TEMP
+# --------------------------------------------------------------------------
+
+
+class TestTrips:
+    def test_hh_power_trips_when_measured_exceeds_threshold(self) -> None:
+        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        # P = V * I = 30 * 20 = 600 W, exceeds 500
+        cmd = c.tick(
+            measured_current_a=20.0, measured_voltage_v=30.0, measured_temp_c=25.0
+        )
+        assert cmd == 0.0  # output zeroed
+        assert c.state == PowerSupplyState.TRIPPED
+        assert "HH_POWER" in c.trips
+
+    def test_hh_power_does_not_trip_at_threshold_minus_epsilon(self) -> None:
+        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        c.tick(measured_current_a=10.0, measured_voltage_v=49.0, measured_temp_c=25.0)
+        # P = 490 W < 500 → no trip
+        assert c.state == PowerSupplyState.RUNNING
+        assert c.trips == []
+
+    def test_hh_temp_trips_above_threshold(self) -> None:
+        c = PowerSupplyController(PowerSupplyConfig(temp_alarm_max_c=1200.0))
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        cmd = c.tick(
+            measured_current_a=10.0, measured_voltage_v=5.0, measured_temp_c=1500.0
+        )
+        assert cmd == 0.0
+        assert c.state == PowerSupplyState.TRIPPED
+        assert "HH_TEMP" in c.trips
+
+    def test_both_trips_can_latch_simultaneously(self) -> None:
+        c = PowerSupplyController(
+            PowerSupplyConfig(power_alarm_max_w=100.0, temp_alarm_max_c=100.0)
+        )
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        c.tick(measured_current_a=50.0, measured_voltage_v=10.0, measured_temp_c=200.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        assert "HH_POWER" in c.trips
+        assert "HH_TEMP" in c.trips
+
+    def test_trip_latches_through_safe_subsequent_tick(self) -> None:
+        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        c.tick(measured_current_a=20.0, measured_voltage_v=30.0, measured_temp_c=25.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        # Now signal returns to safe band — trip MUST stay latched
+        c.tick(measured_current_a=1.0, measured_voltage_v=1.0, measured_temp_c=25.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        assert "HH_POWER" in c.trips
+
+    def test_acknowledge_trip_clears_trips_and_state(self) -> None:
+        c = _running_ctrl(10.0)
+        c.tick(measured_current_a=200.0, measured_voltage_v=20.0, measured_temp_c=25.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        cleared = c.acknowledge_trip()
+        assert cleared is True
+        assert c.trips == []
+        # Permissive was on; ack returns to ARMED, not IDLE
+        assert c.state == PowerSupplyState.ARMED
+
+    def test_acknowledge_with_permissive_off_returns_to_idle(self) -> None:
+        c = _running_ctrl(10.0)
+        c.tick(200.0, 20.0, 25.0)
+        c.set_permissive(False)
+        c.acknowledge_trip()
+        assert c.state == PowerSupplyState.IDLE
+
+    def test_acknowledge_with_no_trip_returns_false(self) -> None:
+        c = _armed_ctrl()
+        assert c.acknowledge_trip() is False
+
+
+# --------------------------------------------------------------------------
+# tick() output command behavior
+# --------------------------------------------------------------------------
+
+
+class TestTickOutput:
+    def test_tick_returns_zero_in_idle(self) -> None:
+        c = _ctrl()
+        assert c.tick(0.0, 0.0, 25.0) == 0.0
+
+    def test_tick_returns_zero_in_armed(self) -> None:
+        c = _armed_ctrl()
+        assert c.tick(0.0, 0.0, 25.0) == 0.0
+
+    def test_tick_returns_zero_when_permissive_off_after_running(self) -> None:
+        c = _running_ctrl(10.0)
+        c.set_permissive(False)
+        assert c.tick(0.0, 0.0, 25.0) == 0.0
+
+    def test_tick_returns_scaled_percent_when_running(self) -> None:
+        # Default current_full_scale_a = 100 A; setpoint 25 A → 25 %
+        c = _armed_ctrl()
+        c.set_current_setpoint(25.0)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == pytest.approx(25.0)
+
+    def test_tick_clamps_percent_to_100(self) -> None:
+        # Construct so setpoint can equal full scale.
+        cfg = PowerSupplyConfig(
+            current_full_scale_a=100.0,
+            current_setpoint_max_a=100.0,
+        )
+        c = PowerSupplyController(cfg)
+        c.set_permissive(True)
+        c.set_current_setpoint(100.0)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == 100.0
+
+    def test_tick_handles_nan_inputs_safely(self) -> None:
+        c = _running_ctrl(10.0)
+        cmd = c.tick(
+            measured_current_a=float("nan"),
+            measured_voltage_v=float("inf"),
+            measured_temp_c=float("nan"),
+        )
+        # Bad inputs → treated as 0 → no trip, command tracks setpoint
+        assert cmd > 0.0
+        assert c.state == PowerSupplyState.RUNNING
+
+
+# --------------------------------------------------------------------------
+# Config update at runtime
+# --------------------------------------------------------------------------
+
+
+class TestUpdateConfig:
+    def test_update_config_re_clamps_existing_setpoint(self) -> None:
+        c = _armed_ctrl()
+        c.set_current_setpoint(40.0)
+        # New config with stricter max → setpoint should re-clamp.
+        new_cfg = PowerSupplyConfig(
+            current_full_scale_a=100.0,
+            current_setpoint_max_a=20.0,
+        )
+        c.update_config(new_cfg)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        # Setpoint should now be 20 A → 20 % of full scale (100 A)
+        assert cmd == pytest.approx(20.0)
+
+    def test_update_config_type_check(self) -> None:
+        c = _ctrl()
+        with pytest.raises(TypeError):
+            c.update_config({"current_full_scale_a": 50.0})  # type: ignore[arg-type]
+
+    def test_invalid_config_rejected_at_construction(self) -> None:
+        # update_config can't take an invalid config because invalid
+        # configs cannot be constructed in the first place.
+        with pytest.raises(ValidationError):
+            PowerSupplyConfig(
+                current_full_scale_a=10.0,
+                current_setpoint_max_a=50.0,
+            )
+
+
+# --------------------------------------------------------------------------
+# Mode switching
+# --------------------------------------------------------------------------
+
+
+class TestModeSwitching:
+    def test_current_setpoint_switches_mode_to_current(self) -> None:
+        c = _armed_ctrl()
+        c.tick(0.0, 20.0, 25.0)
+        c.set_power_setpoint(200.0)
+        assert c.mode == PowerSupplyMode.POWER
+        c.set_current_setpoint(15.0)
+        assert c.mode == PowerSupplyMode.CURRENT
+
+    def test_power_setpoint_switches_mode_to_power(self) -> None:
+        c = _armed_ctrl()
+        c.set_current_setpoint(15.0)
+        assert c.mode == PowerSupplyMode.CURRENT
+        c.tick(0.0, 20.0, 25.0)
+        c.set_power_setpoint(200.0)
+        assert c.mode == PowerSupplyMode.POWER
+
+
+# --------------------------------------------------------------------------
+# Status snapshot
+# --------------------------------------------------------------------------
+
+
+class TestStatus:
+    def test_status_reports_current_state(self) -> None:
+        c = _running_ctrl(10.0)
+        c.tick(measured_current_a=5.0, measured_voltage_v=10.0, measured_temp_c=30.0)
+        s = c.status()
+        assert s.state == PowerSupplyState.RUNNING
+        assert s.permissive is True
+        assert s.setpoint_a == 10.0
+        assert s.measured_current_a == 5.0
+        assert s.measured_voltage_v == 10.0
+        assert s.measured_power_w == pytest.approx(50.0)
+        assert s.measured_temp_c == 30.0
+        assert s.commanded_output_percent == pytest.approx(10.0)
+
+    def test_status_reports_trips(self) -> None:
+        c = _running_ctrl(10.0)
+        c.tick(measured_current_a=200.0, measured_voltage_v=20.0, measured_temp_c=25.0)
+        s = c.status()
+        assert s.state == PowerSupplyState.TRIPPED
+        assert "HH_POWER" in s.trips
+        assert s.commanded_output_percent == 0.0
+
+
+# --------------------------------------------------------------------------
+# Sanity: math invariants
+# --------------------------------------------------------------------------
+
+
+class TestMathInvariants:
+    @pytest.mark.parametrize("sp_a", [0.0, 10.0, 25.0, 50.0])
+    def test_command_proportional_to_setpoint(self, sp_a: float) -> None:
+        c = _armed_ctrl()
+        c.set_current_setpoint(sp_a)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        expected_pct = 100.0 * sp_a / c.config.current_full_scale_a
+        assert cmd == pytest.approx(expected_pct)
+
+    def test_status_power_equals_v_times_i(self) -> None:
+        c = _running_ctrl(10.0)
+        c.tick(measured_current_a=7.5, measured_voltage_v=12.0, measured_temp_c=25.0)
+        s = c.status()
+        assert s.measured_power_w == pytest.approx(7.5 * 12.0)
+        assert math.isfinite(s.measured_power_w)

--- a/src/p1am_control_system/backend/tests/test_power_supply_runtime.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply_runtime.py
@@ -1,0 +1,297 @@
+"""Runtime / feedback-driven unit tests for PowerSupplyController.
+
+Split companion: `test_power_supply.py` covers config-level + state-machine
+behavior. This file covers what happens once the controller is fed measured
+values through `tick()`:
+    - Current setpoint clamping (fat-finger protection) and type/value
+      validation (NaN / inf / bool / string rejection)
+    - Power setpoint derivation from measured voltage
+    - HH_POWER and HH_TEMP trip latching across safe subsequent ticks
+    - Trip acknowledgement + state transitions
+    - tick() output guarantees in IDLE / ARMED / TRIPPED / no-permissive
+      states and the percentage-output clamp
+"""
+
+from __future__ import annotations
+
+import pytest
+from _power_supply_helpers import (
+    fresh_armed_controller,
+    fresh_idle_controller,
+    fresh_running_controller,
+)
+from power_supply import (
+    PowerSupplyConfig,
+    PowerSupplyController,
+    PowerSupplyMode,
+    PowerSupplyState,
+)
+
+# --------------------------------------------------------------------------
+# Current setpoint — fat-finger protection
+# --------------------------------------------------------------------------
+
+
+class TestCurrentSetpoint:
+    def test_in_band_setpoint_applied(self) -> None:
+        c = fresh_armed_controller()
+        applied = c.set_current_setpoint(25.0)
+        assert applied == 25.0
+        assert c.state == PowerSupplyState.RUNNING
+
+    def test_setpoint_above_max_is_clamped(self) -> None:
+        c = fresh_armed_controller()
+        applied = c.set_current_setpoint(9999.0)
+        assert applied == c.config.current_setpoint_max_a
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == pytest.approx(
+            100.0 * c.config.current_setpoint_max_a / c.config.current_full_scale_a
+        )
+
+    def test_setpoint_below_min_is_clamped(self) -> None:
+        c = fresh_armed_controller()
+        applied = c.set_current_setpoint(-5.0)
+        assert applied == c.config.current_setpoint_min_a
+
+    def test_setpoint_zero_keeps_state_armed(self) -> None:
+        c = fresh_armed_controller()
+        c.set_current_setpoint(0.0)
+        assert c.state == PowerSupplyState.ARMED
+
+    def test_setpoint_ignored_in_idle_state(self) -> None:
+        c = fresh_idle_controller()
+        applied = c.set_current_setpoint(25.0)
+        assert applied == 25.0  # value clamped + returned
+        assert c.state == PowerSupplyState.IDLE  # but not applied
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == 0.0
+
+    def test_setpoint_ignored_in_tripped_state(self) -> None:
+        c = fresh_running_controller(10.0)
+        c.tick(200.0, 20.0, 25.0)  # trip on power
+        assert c.state == PowerSupplyState.TRIPPED
+        c.set_current_setpoint(5.0)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == 0.0
+
+    def test_rejects_nan(self) -> None:
+        c = fresh_armed_controller()
+        with pytest.raises(ValueError, match="finite"):
+            c.set_current_setpoint(float("nan"))
+
+    def test_rejects_infinity(self) -> None:
+        c = fresh_armed_controller()
+        with pytest.raises(ValueError, match="finite"):
+            c.set_current_setpoint(float("inf"))
+        with pytest.raises(ValueError, match="finite"):
+            c.set_current_setpoint(float("-inf"))
+
+    def test_rejects_non_numeric(self) -> None:
+        c = fresh_armed_controller()
+        with pytest.raises(TypeError):
+            c.set_current_setpoint("10")  # type: ignore[arg-type]
+        with pytest.raises(TypeError):
+            c.set_current_setpoint(None)  # type: ignore[arg-type]
+
+    def test_rejects_bool(self) -> None:
+        # Bool is technically a subclass of int. Explicit catch keeps the
+        # caller honest.
+        c = fresh_armed_controller()
+        with pytest.raises(TypeError):
+            c.set_current_setpoint(True)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Power setpoint — derives current from measured voltage
+# --------------------------------------------------------------------------
+
+
+class TestPowerSetpoint:
+    def test_power_setpoint_derives_current_from_voltage(self) -> None:
+        c = fresh_armed_controller()
+        # Establish a measured voltage via tick before setting power.
+        c.tick(measured_current_a=0.0, measured_voltage_v=20.0, measured_temp_c=25.0)
+        achievable = c.set_power_setpoint(200.0)
+        # 200 W / 20 V = 10 A target. Within bounds.
+        assert achievable == pytest.approx(200.0)
+        # In POWER mode now
+        assert c.mode == PowerSupplyMode.POWER
+
+    def test_power_setpoint_clamped_by_current_max(self) -> None:
+        c = fresh_armed_controller()
+        c.tick(0.0, 10.0, 25.0)  # V = 10 V
+        # 1000 W / 10 V = 100 A target, clamped to current_setpoint_max_a (50)
+        achievable = c.set_power_setpoint(1000.0)
+        # achievable = 50 A * 10 V = 500 W
+        assert achievable == pytest.approx(500.0)
+
+    def test_power_setpoint_rejected_when_voltage_too_low(self) -> None:
+        c = fresh_armed_controller()
+        c.tick(0.0, 0.0, 25.0)  # V = 0
+        achievable = c.set_power_setpoint(100.0)
+        assert achievable == 0.0
+        # Mode unchanged
+        assert c.state == PowerSupplyState.ARMED
+
+    def test_power_setpoint_recomputed_each_tick(self) -> None:
+        c = fresh_armed_controller()
+        c.tick(0.0, 20.0, 25.0)
+        c.set_power_setpoint(200.0)  # → 10 A at 20 V
+        # Now voltage drops
+        cmd1 = c.tick(
+            measured_current_a=10.0, measured_voltage_v=10.0, measured_temp_c=25.0
+        )
+        # Should re-target: 200 / 10 = 20 A. cmd1 should be 20 % of full-scale (100 A)
+        assert cmd1 == pytest.approx(20.0)
+
+    def test_rejects_negative_power(self) -> None:
+        c = fresh_armed_controller()
+        c.tick(0.0, 20.0, 25.0)
+        with pytest.raises(ValueError, match="non-negative"):
+            c.set_power_setpoint(-100.0)
+
+    def test_rejects_nan_inf_power(self) -> None:
+        c = fresh_armed_controller()
+        c.tick(0.0, 20.0, 25.0)
+        with pytest.raises(ValueError, match="finite"):
+            c.set_power_setpoint(float("nan"))
+        with pytest.raises(ValueError, match="finite"):
+            c.set_power_setpoint(float("inf"))
+
+    def test_rejects_non_numeric_power(self) -> None:
+        c = fresh_armed_controller()
+        c.tick(0.0, 20.0, 25.0)
+        with pytest.raises(TypeError):
+            c.set_power_setpoint("100")  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------
+# Trip logic — HH_POWER and HH_TEMP
+# --------------------------------------------------------------------------
+
+
+class TestTrips:
+    def test_hh_power_trips_when_measured_exceeds_threshold(self) -> None:
+        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        # P = V * I = 30 * 20 = 600 W, exceeds 500
+        cmd = c.tick(
+            measured_current_a=20.0, measured_voltage_v=30.0, measured_temp_c=25.0
+        )
+        assert cmd == 0.0  # output zeroed
+        assert c.state == PowerSupplyState.TRIPPED
+        assert "HH_POWER" in c.trips
+
+    def test_hh_power_does_not_trip_at_threshold_minus_epsilon(self) -> None:
+        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        c.tick(measured_current_a=10.0, measured_voltage_v=49.0, measured_temp_c=25.0)
+        # P = 490 W < 500 → no trip
+        assert c.state == PowerSupplyState.RUNNING
+        assert c.trips == []
+
+    def test_hh_temp_trips_above_threshold(self) -> None:
+        c = PowerSupplyController(PowerSupplyConfig(temp_alarm_max_c=1200.0))
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        cmd = c.tick(
+            measured_current_a=10.0, measured_voltage_v=5.0, measured_temp_c=1500.0
+        )
+        assert cmd == 0.0
+        assert c.state == PowerSupplyState.TRIPPED
+        assert "HH_TEMP" in c.trips
+
+    def test_both_trips_can_latch_simultaneously(self) -> None:
+        c = PowerSupplyController(
+            PowerSupplyConfig(power_alarm_max_w=100.0, temp_alarm_max_c=100.0)
+        )
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        c.tick(measured_current_a=50.0, measured_voltage_v=10.0, measured_temp_c=200.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        assert "HH_POWER" in c.trips
+        assert "HH_TEMP" in c.trips
+
+    def test_trip_latches_through_safe_subsequent_tick(self) -> None:
+        c = PowerSupplyController(PowerSupplyConfig(power_alarm_max_w=500.0))
+        c.set_permissive(True)
+        c.set_current_setpoint(10.0)
+        c.tick(measured_current_a=20.0, measured_voltage_v=30.0, measured_temp_c=25.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        # Now signal returns to safe band — trip MUST stay latched
+        c.tick(measured_current_a=1.0, measured_voltage_v=1.0, measured_temp_c=25.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        assert "HH_POWER" in c.trips
+
+    def test_acknowledge_trip_clears_trips_and_state(self) -> None:
+        c = fresh_running_controller(10.0)
+        c.tick(measured_current_a=200.0, measured_voltage_v=20.0, measured_temp_c=25.0)
+        assert c.state == PowerSupplyState.TRIPPED
+        cleared = c.acknowledge_trip()
+        assert cleared is True
+        assert c.trips == []
+        # Permissive was on; ack returns to ARMED, not IDLE
+        assert c.state == PowerSupplyState.ARMED
+
+    def test_acknowledge_with_permissive_off_returns_to_idle(self) -> None:
+        c = fresh_running_controller(10.0)
+        c.tick(200.0, 20.0, 25.0)
+        c.set_permissive(False)
+        c.acknowledge_trip()
+        assert c.state == PowerSupplyState.IDLE
+
+    def test_acknowledge_with_no_trip_returns_false(self) -> None:
+        c = fresh_armed_controller()
+        assert c.acknowledge_trip() is False
+
+
+# --------------------------------------------------------------------------
+# tick() output command behavior
+# --------------------------------------------------------------------------
+
+
+class TestTickOutput:
+    def test_tick_returns_zero_in_idle(self) -> None:
+        c = fresh_idle_controller()
+        assert c.tick(0.0, 0.0, 25.0) == 0.0
+
+    def test_tick_returns_zero_in_armed(self) -> None:
+        c = fresh_armed_controller()
+        assert c.tick(0.0, 0.0, 25.0) == 0.0
+
+    def test_tick_returns_zero_when_permissive_off_after_running(self) -> None:
+        c = fresh_running_controller(10.0)
+        c.set_permissive(False)
+        assert c.tick(0.0, 0.0, 25.0) == 0.0
+
+    def test_tick_returns_scaled_percent_when_running(self) -> None:
+        # Default current_full_scale_a = 100 A; setpoint 25 A → 25 %
+        c = fresh_armed_controller()
+        c.set_current_setpoint(25.0)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == pytest.approx(25.0)
+
+    def test_tick_clamps_percent_to_100(self) -> None:
+        # Construct so setpoint can equal full scale.
+        cfg = PowerSupplyConfig(
+            current_full_scale_a=100.0,
+            current_setpoint_max_a=100.0,
+        )
+        c = PowerSupplyController(cfg)
+        c.set_permissive(True)
+        c.set_current_setpoint(100.0)
+        cmd = c.tick(0.0, 0.0, 25.0)
+        assert cmd == 100.0
+
+    def test_tick_handles_nan_inputs_safely(self) -> None:
+        c = fresh_running_controller(10.0)
+        cmd = c.tick(
+            measured_current_a=float("nan"),
+            measured_voltage_v=float("inf"),
+            measured_temp_c=float("nan"),
+        )
+        # Bad inputs → treated as 0 → no trip, command tracks setpoint
+        assert cmd > 0.0
+        assert c.state == PowerSupplyState.RUNNING

--- a/src/p1am_control_system/backend/tests/test_power_supply_runtime.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply_runtime.py
@@ -14,7 +14,13 @@ values through `tick()`:
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
 import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
 from _power_supply_helpers import (
     fresh_armed_controller,
     fresh_idle_controller,
@@ -89,16 +95,16 @@ class TestCurrentSetpoint:
     def test_rejects_non_numeric(self) -> None:
         c = fresh_armed_controller()
         with pytest.raises(TypeError):
-            c.set_current_setpoint("10")  # type: ignore[arg-type]
+            c.set_current_setpoint("10")
         with pytest.raises(TypeError):
-            c.set_current_setpoint(None)  # type: ignore[arg-type]
+            c.set_current_setpoint(None)
 
     def test_rejects_bool(self) -> None:
         # Bool is technically a subclass of int. Explicit catch keeps the
         # caller honest.
         c = fresh_armed_controller()
         with pytest.raises(TypeError):
-            c.set_current_setpoint(True)  # type: ignore[arg-type]
+            c.set_current_setpoint(True)
 
 
 # --------------------------------------------------------------------------
@@ -162,7 +168,7 @@ class TestPowerSetpoint:
         c = fresh_armed_controller()
         c.tick(0.0, 20.0, 25.0)
         with pytest.raises(TypeError):
-            c.set_power_setpoint("100")  # type: ignore[arg-type]
+            c.set_power_setpoint("100")
 
 
 # --------------------------------------------------------------------------

--- a/src/p1am_control_system/frontend/src/App.tsx
+++ b/src/p1am_control_system/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { EventLogView } from "./components/EventLogView";
 import { ProjectImporter } from "./components/ProjectImporter";
 import { LadderExplorer } from "./components/LadderExplorer";
 import { PlantHierarchy } from "./components/PlantHierarchy";
+import { PowerSupplyControl, type PowerSupplyStatus } from "./components/PowerSupplyControl";
 import {
   Activity,
   Sliders,
@@ -132,6 +133,7 @@ export const App: React.FC = () => {
     events: boolean;
     ladder: boolean;
     hierarchy: boolean;
+    powerSupply: boolean;
   }>({
     trends: true,
     controllers: true,
@@ -140,7 +142,11 @@ export const App: React.FC = () => {
     events: true,
     ladder: true,
     hierarchy: true,
+    powerSupply: true,
   });
+
+  // Power-supply controller live status (extracted from /api/stream).
+  const [powerSupplyStatus, setPowerSupplyStatus] = useState<PowerSupplyStatus | undefined>(undefined);
 
   // PID Tuning State
   const [selectedTuningLoop, setSelectedTuningLoop] = useState<number>(0);
@@ -692,6 +698,9 @@ export const App: React.FC = () => {
             if (typeof data.e_stop_active === "boolean") {
               setEStopActive(data.e_stop_active);
             }
+            if (data.power_supply && typeof data.power_supply === "object") {
+              setPowerSupplyStatus(data.power_supply as PowerSupplyStatus);
+            }
           } else {
             // Fallback for simple legacy tag arrays
             const rawValues = data;
@@ -1017,7 +1026,31 @@ export const App: React.FC = () => {
                 Plant Hierarchy
               </button>
             )}
+            {visibleTabs.powerSupply && (
+              <button
+                type="button"
+                className={`tab-btn ${activeTab === "powerSupply" ? "active" : ""}`}
+                onClick={() => setActiveTab("powerSupply")}
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: activeTab === "powerSupply" ? "var(--accent-purple, #a78bfa)" : "var(--text-secondary)",
+                  padding: "0.5rem 1rem",
+                  fontSize: "0.85rem",
+                  fontWeight: 600,
+                  cursor: "pointer",
+                  borderBottom: activeTab === "powerSupply" ? "2px solid var(--accent-purple, #a78bfa)" : "2px solid transparent",
+                  transition: "all var(--transition-fast)",
+                }}
+              >
+                Power Supply
+              </button>
+            )}
           </div>
+
+          {activeTab === "powerSupply" && visibleTabs.powerSupply && (
+            <PowerSupplyControl liveStatus={powerSupplyStatus} />
+          )}
 
           {/* Render Tab Contents */}
           {activeTab === "trends" && visibleTabs.trends && (

--- a/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
+++ b/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
@@ -1,0 +1,752 @@
+import React, { useEffect, useState, useCallback, useRef } from "react";
+
+/**
+ * Power-supply control tab.
+ *
+ * Talks to the backend's /api/power_supply/* endpoints and consumes the
+ * `power_supply` field on the /api/stream WebSocket payload (broadcast each
+ * scan tick by the polling loop in main.py).
+ *
+ * Safety patterns implemented:
+ *  - Setpoint clamping happens server-side, so the displayed value reflects
+ *    what was actually applied (not what was typed).
+ *  - "Apply" button submits the staged value — typing in the textbox alone
+ *    doesn't command anything. Fat-finger protection.
+ *  - Up/down nudges step by a configurable increment, also clamped server-side.
+ *  - Permissive must be ON before any setpoint takes effect (server enforces).
+ *  - Trip indicator + acknowledge are first-class UI.
+ *  - Power-mode and current-mode are visually distinct; switching modes is
+ *    explicit.
+ */
+
+export interface PowerSupplyConfig {
+  command_tag: string;
+  current_feedback_tag: string;
+  voltage_feedback_tag: string;
+  temp_tag: string;
+  current_full_scale_a: number;
+  voltage_full_scale_v: number;
+  current_setpoint_min_a: number;
+  current_setpoint_max_a: number;
+  power_alarm_max_w: number;
+  temp_alarm_max_c: number;
+}
+
+export interface PowerSupplyStatus {
+  state: "idle" | "armed" | "running" | "tripped";
+  mode: "current" | "power";
+  permissive: boolean;
+  setpoint_a: number;
+  setpoint_w: number | null;
+  measured_current_a: number;
+  measured_voltage_v: number;
+  measured_power_w: number;
+  measured_temp_c: number;
+  commanded_output_percent: number;
+  trips: string[];
+}
+
+interface Props {
+  /** Status object pushed each scan via the parent's WebSocket; undefined while waiting. */
+  liveStatus?: PowerSupplyStatus;
+}
+
+const STATE_COLORS: Record<PowerSupplyStatus["state"], string> = {
+  idle: "var(--text-secondary)",
+  armed: "var(--accent-cyan)",
+  running: "var(--color-success, #4ade80)",
+  tripped: "var(--color-danger, #ef4444)",
+};
+
+const STATE_LABELS: Record<PowerSupplyStatus["state"], string> = {
+  idle: "IDLE",
+  armed: "ARMED",
+  running: "RUNNING",
+  tripped: "TRIPPED",
+};
+
+export const PowerSupplyControl: React.FC<Props> = ({ liveStatus }) => {
+  const [config, setConfig] = useState<PowerSupplyConfig | null>(null);
+  const [configDraft, setConfigDraft] = useState<PowerSupplyConfig | null>(null);
+  const [mode, setMode] = useState<"current" | "power">("current");
+  const [stagedSetpointText, setStagedSetpointText] = useState<string>("0");
+  const [setpointStep, setSetpointStep] = useState<number>(1.0);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const lastAppliedRef = useRef<number>(0);
+
+  // Load config once.
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch("/api/power_supply/config");
+        if (!res.ok) throw new Error(`config GET ${res.status}`);
+        const cfg = (await res.json()) as PowerSupplyConfig;
+        setConfig(cfg);
+        setConfigDraft(cfg);
+      } catch (e) {
+        setError(`Load config failed: ${(e as Error).message}`);
+      }
+    };
+    load();
+  }, []);
+
+  // Sync mode display with whatever the server most recently applied.
+  useEffect(() => {
+    if (liveStatus) setMode(liveStatus.mode);
+  }, [liveStatus?.mode]);
+
+  const flash = useCallback((msg: string, kind: "info" | "error" = "info") => {
+    if (kind === "info") {
+      setInfo(msg);
+      setError(null);
+    } else {
+      setError(msg);
+      setInfo(null);
+    }
+    setTimeout(() => {
+      setInfo(null);
+      setError(null);
+    }, 4000);
+  }, []);
+
+  const applySetpoint = useCallback(
+    async (rawValue: number) => {
+      if (!Number.isFinite(rawValue)) {
+        flash("Setpoint must be a finite number", "error");
+        return;
+      }
+      if (!config) {
+        flash("Config not loaded", "error");
+        return;
+      }
+      setBusy(true);
+      try {
+        const body =
+          mode === "current"
+            ? { mode: "current", value_a: rawValue }
+            : { mode: "power", value_w: rawValue };
+        const res = await fetch("/api/power_supply/setpoint", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const json = await res.json();
+        if (!res.ok) {
+          flash(`Setpoint rejected: ${json.detail ?? res.statusText}`, "error");
+          return;
+        }
+        const applied = mode === "current" ? json.applied_a : json.achievable_w;
+        lastAppliedRef.current = applied;
+        flash(
+          mode === "current"
+            ? `Applied ${applied.toFixed(2)} A`
+            : `Achievable ${applied.toFixed(1)} W (clamped if needed)`,
+        );
+      } catch (e) {
+        flash(`Setpoint failed: ${(e as Error).message}`, "error");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [config, mode, flash],
+  );
+
+  const nudgeSetpoint = useCallback(
+    (delta: number) => {
+      const current = Number.parseFloat(stagedSetpointText);
+      const next = (Number.isFinite(current) ? current : 0) + delta;
+      setStagedSetpointText(next.toFixed(2));
+      applySetpoint(next);
+    },
+    [stagedSetpointText, applySetpoint],
+  );
+
+  const handleApplyClick = useCallback(() => {
+    const v = Number.parseFloat(stagedSetpointText);
+    if (!Number.isFinite(v)) {
+      flash("Enter a number first", "error");
+      return;
+    }
+    applySetpoint(v);
+  }, [stagedSetpointText, applySetpoint, flash]);
+
+  const setPermissive = useCallback(
+    async (enabled: boolean) => {
+      if (
+        !enabled &&
+        liveStatus?.state === "running" &&
+        !window.confirm(
+          "Disabling permissive will drop output to 0 immediately. Continue?",
+        )
+      )
+        return;
+      setBusy(true);
+      try {
+        const res = await fetch("/api/power_supply/permissive", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        flash(enabled ? "Permissive ON" : "Permissive OFF");
+      } catch (e) {
+        flash(`Permissive set failed: ${(e as Error).message}`, "error");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [liveStatus?.state, flash],
+  );
+
+  const acknowledgeTrip = useCallback(async () => {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/power_supply/acknowledge_trip", {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error(await res.text());
+      flash("Trip acknowledged");
+    } catch (e) {
+      flash(`Ack failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [flash]);
+
+  const saveConfig = useCallback(async () => {
+    if (!configDraft) return;
+    setBusy(true);
+    try {
+      const res = await fetch("/api/power_supply/config", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(configDraft),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        flash(
+          `Config rejected: ${json.detail ? JSON.stringify(json.detail) : res.statusText}`,
+          "error",
+        );
+        return;
+      }
+      setConfig(json);
+      setConfigDraft(json);
+      flash("Config saved");
+    } catch (e) {
+      flash(`Config save failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [configDraft, flash]);
+
+  if (!config || !configDraft) {
+    return (
+      <div style={{ padding: 16, color: "var(--text-secondary)" }}>
+        Loading power-supply config…
+      </div>
+    );
+  }
+
+  const s = liveStatus;
+  const stateColor = s ? STATE_COLORS[s.state] : "var(--text-secondary)";
+  const stateLabel = s ? STATE_LABELS[s.state] : "—";
+
+  return (
+    <div style={{ display: "grid", gap: 16, padding: 16 }}>
+      {/* State strip */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "auto 1fr auto auto",
+          gap: 16,
+          alignItems: "center",
+          padding: "12px 16px",
+          background: "rgba(255,255,255,0.03)",
+          border: `1px solid ${stateColor}`,
+          borderRadius: 8,
+        }}
+      >
+        <span
+          style={{
+            fontWeight: 700,
+            fontSize: "1.25rem",
+            color: stateColor,
+            padding: "4px 12px",
+            background: "rgba(255,255,255,0.05)",
+            borderRadius: 4,
+          }}
+        >
+          {stateLabel}
+        </span>
+        <span style={{ color: "var(--text-secondary)" }}>
+          Mode: <strong style={{ color: "var(--text-primary)" }}>{s?.mode ?? "—"}</strong>
+          &nbsp;|&nbsp; Output cmd:{" "}
+          <strong style={{ color: "var(--text-primary)" }}>
+            {s ? s.commanded_output_percent.toFixed(2) : "—"} %
+          </strong>
+        </span>
+        <button
+          onClick={() => setPermissive(!s?.permissive)}
+          disabled={busy}
+          style={{
+            background: s?.permissive
+              ? "var(--color-success, #4ade80)"
+              : "var(--text-secondary)",
+            color: "#000",
+            border: "none",
+            borderRadius: 4,
+            padding: "8px 14px",
+            cursor: "pointer",
+            fontWeight: 600,
+          }}
+        >
+          Permissive: {s?.permissive ? "ON" : "OFF"}
+        </button>
+        {s?.state === "tripped" && (
+          <button
+            onClick={acknowledgeTrip}
+            disabled={busy}
+            style={{
+              background: "var(--color-danger, #ef4444)",
+              color: "#fff",
+              border: "none",
+              borderRadius: 4,
+              padding: "8px 14px",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Acknowledge Trip
+          </button>
+        )}
+      </div>
+
+      {/* Trips banner */}
+      {s && s.trips.length > 0 && (
+        <div
+          style={{
+            padding: "10px 14px",
+            background: "rgba(239,68,68,0.12)",
+            border: "1px solid rgba(239,68,68,0.5)",
+            borderRadius: 6,
+            color: "var(--color-danger, #ef4444)",
+            fontWeight: 600,
+          }}
+        >
+          Active trips: {s.trips.join(", ")}
+        </div>
+      )}
+
+      {/* Setpoint card */}
+      <div
+        style={{
+          background: "rgba(255,255,255,0.03)",
+          border: "1px solid rgba(255,255,255,0.08)",
+          borderRadius: 8,
+          padding: 16,
+        }}
+      >
+        <div style={{ display: "flex", gap: 12, alignItems: "center", marginBottom: 12 }}>
+          <h3 style={{ margin: 0, color: "var(--text-primary)" }}>Setpoint</h3>
+          <div style={{ display: "flex", gap: 4 }}>
+            {(["current", "power"] as const).map((m) => (
+              <button
+                key={m}
+                onClick={() => setMode(m)}
+                style={{
+                  padding: "4px 12px",
+                  background:
+                    mode === m ? "var(--accent-cyan)" : "rgba(255,255,255,0.05)",
+                  color: mode === m ? "#000" : "var(--text-secondary)",
+                  border: "none",
+                  borderRadius: 4,
+                  cursor: "pointer",
+                  fontWeight: 600,
+                }}
+              >
+                {m === "current" ? "Current (A)" : "Power (W)"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "auto 1fr auto auto auto",
+            gap: 8,
+            alignItems: "center",
+          }}
+        >
+          <button
+            onClick={() => nudgeSetpoint(-setpointStep)}
+            disabled={busy}
+            style={{
+              padding: "8px 14px",
+              fontSize: "1.25rem",
+              background: "rgba(255,255,255,0.05)",
+              color: "var(--text-primary)",
+              border: "1px solid rgba(255,255,255,0.1)",
+              borderRadius: 4,
+              cursor: "pointer",
+            }}
+            title={`Decrement by ${setpointStep}`}
+          >
+            ▼
+          </button>
+          <input
+            type="text"
+            inputMode="decimal"
+            value={stagedSetpointText}
+            onChange={(e) => setStagedSetpointText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleApplyClick();
+            }}
+            style={{
+              padding: "10px 12px",
+              fontSize: "1.25rem",
+              background: "rgba(0,0,0,0.4)",
+              color: "var(--text-primary)",
+              border: "1px solid rgba(255,255,255,0.15)",
+              borderRadius: 4,
+              fontFamily: "monospace",
+              textAlign: "right",
+            }}
+          />
+          <button
+            onClick={() => nudgeSetpoint(setpointStep)}
+            disabled={busy}
+            style={{
+              padding: "8px 14px",
+              fontSize: "1.25rem",
+              background: "rgba(255,255,255,0.05)",
+              color: "var(--text-primary)",
+              border: "1px solid rgba(255,255,255,0.1)",
+              borderRadius: 4,
+              cursor: "pointer",
+            }}
+            title={`Increment by ${setpointStep}`}
+          >
+            ▲
+          </button>
+          <input
+            type="number"
+            value={setpointStep}
+            min={0.01}
+            step={0.1}
+            onChange={(e) =>
+              setSetpointStep(Math.max(0.01, Number.parseFloat(e.target.value) || 0.01))
+            }
+            style={{
+              width: 80,
+              padding: "8px",
+              background: "rgba(0,0,0,0.4)",
+              color: "var(--text-primary)",
+              border: "1px solid rgba(255,255,255,0.15)",
+              borderRadius: 4,
+              fontFamily: "monospace",
+            }}
+            title="Step size for ▲/▼"
+          />
+          <button
+            onClick={handleApplyClick}
+            disabled={busy}
+            style={{
+              padding: "10px 16px",
+              background: "var(--accent-cyan)",
+              color: "#000",
+              border: "none",
+              borderRadius: 4,
+              cursor: "pointer",
+              fontWeight: 700,
+              fontSize: "1rem",
+            }}
+          >
+            Apply
+          </button>
+        </div>
+        <p style={{ color: "var(--text-secondary)", marginTop: 8, fontSize: "0.85rem" }}>
+          {mode === "current"
+            ? `Range ${configDraft.current_setpoint_min_a} – ${configDraft.current_setpoint_max_a} A (server clamps any value outside this band).`
+            : `Power is converted to current via measured V. Server clamps resulting current to [${configDraft.current_setpoint_min_a}, ${configDraft.current_setpoint_max_a}] A.`}
+        </p>
+      </div>
+
+      {/* Live readings card */}
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(4, 1fr)",
+          gap: 12,
+          background: "rgba(255,255,255,0.03)",
+          border: "1px solid rgba(255,255,255,0.08)",
+          borderRadius: 8,
+          padding: 16,
+        }}
+      >
+        <Reading label="Setpoint" value={`${s?.setpoint_a.toFixed(2) ?? "—"} A`} />
+        <Reading
+          label="Measured I"
+          value={`${s?.measured_current_a.toFixed(2) ?? "—"} A`}
+        />
+        <Reading
+          label="Measured V"
+          value={`${s?.measured_voltage_v.toFixed(2) ?? "—"} V`}
+        />
+        <Reading
+          label="Power (V × I)"
+          value={`${s?.measured_power_w.toFixed(1) ?? "—"} W`}
+          warning={
+            s ? s.measured_power_w >= 0.9 * configDraft.power_alarm_max_w : false
+          }
+        />
+        <Reading
+          label="Temp"
+          value={`${s?.measured_temp_c.toFixed(1) ?? "—"} °C`}
+          warning={
+            s ? s.measured_temp_c >= 0.9 * configDraft.temp_alarm_max_c : false
+          }
+        />
+        <Reading
+          label="Commanded Output"
+          value={`${s?.commanded_output_percent.toFixed(2) ?? "—"} %`}
+        />
+        {s?.mode === "power" && (
+          <Reading
+            label="Power Setpoint"
+            value={s.setpoint_w != null ? `${s.setpoint_w.toFixed(1)} W` : "—"}
+          />
+        )}
+      </div>
+
+      {/* Config card */}
+      <details
+        style={{
+          background: "rgba(255,255,255,0.03)",
+          border: "1px solid rgba(255,255,255,0.08)",
+          borderRadius: 8,
+          padding: 16,
+        }}
+      >
+        <summary
+          style={{
+            cursor: "pointer",
+            fontWeight: 600,
+            color: "var(--text-primary)",
+            userSelect: "none",
+          }}
+        >
+          Configuration (scaling, bounds, alarm thresholds, tag map)
+        </summary>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 12,
+            marginTop: 14,
+          }}
+        >
+          <ConfigField
+            label="Current full scale (A at 100 %)"
+            value={configDraft.current_full_scale_a}
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, current_full_scale_a: v })
+            }
+          />
+          <ConfigField
+            label="Voltage full scale (V at 100 %)"
+            value={configDraft.voltage_full_scale_v}
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, voltage_full_scale_v: v })
+            }
+          />
+          <ConfigField
+            label="Min current setpoint (A)"
+            value={configDraft.current_setpoint_min_a}
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, current_setpoint_min_a: v })
+            }
+          />
+          <ConfigField
+            label="Max current setpoint (A)"
+            value={configDraft.current_setpoint_max_a}
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, current_setpoint_max_a: v })
+            }
+          />
+          <ConfigField
+            label="HH Power alarm (W)"
+            value={configDraft.power_alarm_max_w}
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, power_alarm_max_w: v })
+            }
+          />
+          <ConfigField
+            label="HH Temperature alarm (°C)"
+            value={configDraft.temp_alarm_max_c}
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, temp_alarm_max_c: v })
+            }
+          />
+          <ConfigField
+            label="Command tag"
+            value={configDraft.command_tag}
+            stringMode
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, command_tag: v as unknown as string })
+            }
+          />
+          <ConfigField
+            label="Current feedback tag"
+            value={configDraft.current_feedback_tag}
+            stringMode
+            onChange={(v) =>
+              setConfigDraft({
+                ...configDraft,
+                current_feedback_tag: v as unknown as string,
+              })
+            }
+          />
+          <ConfigField
+            label="Voltage feedback tag"
+            value={configDraft.voltage_feedback_tag}
+            stringMode
+            onChange={(v) =>
+              setConfigDraft({
+                ...configDraft,
+                voltage_feedback_tag: v as unknown as string,
+              })
+            }
+          />
+          <ConfigField
+            label="Temperature tag"
+            value={configDraft.temp_tag}
+            stringMode
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, temp_tag: v as unknown as string })
+            }
+          />
+        </div>
+        <div style={{ marginTop: 14 }}>
+          <button
+            onClick={saveConfig}
+            disabled={busy}
+            style={{
+              padding: "8px 16px",
+              background: "var(--accent-purple, #a78bfa)",
+              color: "#000",
+              border: "none",
+              borderRadius: 4,
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Save config
+          </button>
+        </div>
+      </details>
+
+      {info && (
+        <div
+          style={{
+            padding: "8px 12px",
+            background: "rgba(74,222,128,0.12)",
+            border: "1px solid rgba(74,222,128,0.5)",
+            color: "var(--color-success, #4ade80)",
+            borderRadius: 6,
+          }}
+        >
+          {info}
+        </div>
+      )}
+      {error && (
+        <div
+          style={{
+            padding: "8px 12px",
+            background: "rgba(239,68,68,0.12)",
+            border: "1px solid rgba(239,68,68,0.5)",
+            color: "var(--color-danger, #ef4444)",
+            borderRadius: 6,
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const Reading: React.FC<{ label: string; value: string; warning?: boolean }> = ({
+  label,
+  value,
+  warning,
+}) => (
+  <div
+    style={{
+      padding: "8px 12px",
+      borderRadius: 4,
+      background: warning ? "rgba(245,158,11,0.12)" : "rgba(0,0,0,0.25)",
+      border: warning
+        ? "1px solid rgba(245,158,11,0.5)"
+        : "1px solid rgba(255,255,255,0.05)",
+    }}
+  >
+    <div
+      style={{
+        color: "var(--text-secondary)",
+        fontSize: "0.75rem",
+        textTransform: "uppercase",
+        letterSpacing: 0.5,
+      }}
+    >
+      {label}
+    </div>
+    <div
+      style={{
+        color: warning ? "var(--color-warning, #f59e0b)" : "var(--text-primary)",
+        fontSize: "1.25rem",
+        fontFamily: "monospace",
+        fontWeight: 600,
+      }}
+    >
+      {value}
+    </div>
+  </div>
+);
+
+interface ConfigFieldProps {
+  label: string;
+  value: number | string;
+  stringMode?: boolean;
+  onChange: (v: number) => void;
+}
+const ConfigField: React.FC<ConfigFieldProps> = ({
+  label,
+  value,
+  stringMode,
+  onChange,
+}) => (
+  <label style={{ display: "grid", gap: 4 }}>
+    <span style={{ color: "var(--text-secondary)", fontSize: "0.8rem" }}>{label}</span>
+    <input
+      type={stringMode ? "text" : "number"}
+      value={value}
+      onChange={(e) =>
+        onChange(
+          (stringMode ? e.target.value : Number.parseFloat(e.target.value)) as number,
+        )
+      }
+      style={{
+        padding: "6px 8px",
+        background: "rgba(0,0,0,0.4)",
+        color: "var(--text-primary)",
+        border: "1px solid rgba(255,255,255,0.15)",
+        borderRadius: 4,
+        fontFamily: "monospace",
+      }}
+    />
+  </label>
+);


### PR DESCRIPTION
## Summary

Adds a new SCADA tab that lets an operator set a current or power setpoint for an external power supply through PLC AO1, with hard fat-finger protection and latching HH-power / HH-temp trips. Verified end-to-end against the bench PLC (192.168.1.100).

## Backend (TDD, DbC, LOD, DRY)

\`backend/power_supply.py\`:
- \`PowerSupplyConfig\` (Pydantic): field constraints + cross-field invariants enforced at construction.
- \`PowerSupplyController\`: state machine (IDLE / ARMED / RUNNING / TRIPPED) with one-way trip latching. Each public method documents preconditions/postconditions, validates inputs (TypeError / ValueError), and is side-effect-free against the PLC. \`tick(I, V, T)\` is the single feedback ingestion point.
- Power-mode setpoint derives \`I_target = P / V_measured\` and re-derives each scan so the loop tracks moving voltage.

\`backend/tests/test_power_supply.py\` — **57 unit tests** covering:
- Config validation (defaults, field constraints, cross-field invariants)
- All state transitions (IDLE↔ARMED↔RUNNING, one-way to TRIPPED)
- Fat-finger protection (out-of-range clamped; NaN/inf/bool/string rejected)
- HH_POWER + HH_TEMP trip latching across safe subsequent ticks
- Acknowledge → ARMED (or IDLE if permissive off)
- Permissive-off zeros setpoint and forces IDLE
- Mode switching
- Status snapshot P = V × I invariant

\`backend/main.py\`: instantiates the controller, calls \`tick()\` each scan with V/I/T extracted from the configured tags, writes the commanded percent to PID 0's setpoint (which drives AO1 via the existing pass-through), and adds a \`power_supply\` field to the \`/api/stream\` WebSocket payload. New REST endpoints:

| Method | Path | Purpose |
|---|---|---|
| GET | /api/power_supply/config | Read current config |
| PUT | /api/power_supply/config | Replace config (server re-validates) |
| GET | /api/power_supply/status | State + measured values + trips |
| POST | /api/power_supply/setpoint | Apply current or power setpoint |
| POST | /api/power_supply/permissive | Enable / disable permissive |
| POST | /api/power_supply/acknowledge_trip | Clear latched trips |

## Frontend

\`frontend/src/components/PowerSupplyControl.tsx\` — single-file tab:
- **State strip**: color-coded IDLE / ARMED / RUNNING / TRIPPED
- **Permissive toggle**: confirmation when disabling during RUNNING
- **Trip banner** + first-class Acknowledge Trip button when latched
- **Setpoint controls**: ▲/▼ with operator-configurable step + text input. The Apply button is the only thing that fires a POST; just typing doesn't command. Enter applies. Up/down arrows nudge and apply. Server-side clamp is the source of truth for what was actually applied.
- **Mode toggle**: Current (A) vs Power (W)
- **Live readings**: V, I, P=V·I, T, commanded output — amber when within 90 % of HH thresholds
- **Collapsible Config**: full-scale current/voltage, setpoint bounds, HH thresholds, tag map — Save triggers a server-side re-validated PUT

\`frontend/src/App.tsx\`: tab added to the bar (default visible), \`power_supply\` field threaded from the WebSocket into component state, passed as \`liveStatus\` so the UI updates at scan rate.

## Bench verification (live, 13-step integration test)

Ran end-to-end against PLC 192.168.1.100 with the AO1↔AI1 / AO2↔AI2 loopback:

\`\`\`
[1]  IDLE on startup                                                ✓
[2]  Setpoint silently rejected in IDLE                             ✓
[3]  Permissive on → ARMED                                          ✓
[4]  20 A setpoint → RUNNING, AO1 = 20 %                            ✓
[5]  Fat-finger 999 A → clamped to 50 A (max bound) → AO1 = 50 %    ✓
[6]  Fat-finger -10 A → clamped to 0 → AO1 = 0                      ✓
[7]  Power mode: 200 W at V=20 V → 10 A target, AO1 = 10 %          ✓
[8]  HH_POWER trip when measured P exceeds threshold                ✓
[9]  Trip drops AO command to 0 instantly                           ✓
[10] Trip latches across safe ticks                                 ✓
[11] Setpoint rejected in TRIPPED                                   ✓
[12] acknowledge_trip clears + returns to ARMED                     ✓
[13] Permissive off → IDLE, cleanup                                 ✓
\`\`\`

## Test plan

- [x] 57 unit tests pass
- [x] Live integration test: 13/13 checks pass
- [x] ruff format + check clean
- [x] Backend live with new endpoints (\`/api/power_supply/{config,status}\` smoke-tested)
- [ ] Frontend dev-server visual smoke (operator does this after pulling)
- [ ] CI lint + tests

## Safety patterns implemented (per the original requirements)

- **Fat-finger protection**: typing in the textbox alone doesn't command; explicit Apply button. Server-side clamping enforced. NaN / inf / negative / bool / string all rejected.
- **Setpoint bounds**: \`current_setpoint_min_a < current_setpoint_max_a <= current_full_scale_a\` enforced at config save time AND at every command.
- **HH-power alarm**: trip latches; output → 0 instantly; ACK required to reset.
- **HH-temperature alarm**: same latching behavior on configurable threshold (default 1200 °C).
- **Permissive**: required for any non-zero output. Disabling drops output and clears setpoint.
- **Power mode safe divide**: rejected when V < 0.1 (avoid div by ~0).
- **NaN/inf-safe tick**: bad measurements treated as 0, no trip generated from sensor failure.

## Architecture-rule compliance

- **TDD**: tests written alongside code; 57/57 pass with full state-machine coverage.
- **DbC**: every public method has Preconditions/Postconditions block in its docstring; inputs validated; consistent TypeError vs ValueError.
- **LOD**: controller does not reach into Modbus / FastAPI / React layers; \`tick()\` returns a number and the polling loop applies it.
- **DRY**: setpoint clamping is in one place (controller); the React UI just displays what server returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)