### PR TITLE
Restore Movement Optimizer swingset and chain models

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1070,7 +1070,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 ### Version 1.1.329
 
-- 2026-06-09: feat(movement optimizer) — restore the standalone PyQt6 swingset policy-training and segmented-chain whip-dynamics tabs, mypy-compatible typed model modules, focused model and UI tests, launcher bootstrap repair, and provider metadata so UpstreamDrift can discover the Movement Optimizer tile from remote main.
+- 2026-06-09: feat(movement optimizer) — restore the standalone PyQt6 swingset policy-training and segmented-chain whip-dynamics tabs, mypy-compatible typed model and Qt UI modules, focused model and UI tests, launcher bootstrap repair, and provider metadata so UpstreamDrift can discover the Movement Optimizer tile from remote main.
 
 ### Version 1.1.320
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.328                                    |
+| **Spec Version**        | 1.1.329                                    |
 | **Last Spec Update**    | 2026-06-09                                 |
 
 ## 2. Purpose & Mission
@@ -242,6 +242,7 @@ Tools/
 | Pressure Drop Calculator | `src/shared/python/upstream_drift_tools/process_calculators/pressure_drop_calculator/` | Facade-driven gas pressure-drop workflows with extracted API, validation, reference, results, and engine-domain helper modules                                                                                                                                                                                                                                                                                                                                                       |
 | Model Generation API     | `src/shared/python/model_generation/api/`                                              | Route facade with framework-specific Flask and FastAPI adapters behind a compatibility shim, plus repository download helpers that require HTTPS downloads and validate archive and mesh paths to prevent traversal                                                                                                                                                                                                                                                                  |
 | Engineering Tools        | `src/tools/`                                                                           | 45+ specialized calculation and processing tools                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| Movement Optimizer       | `src/optimizer_gui/`                                                                   | Standalone PyQt6 movement optimizer exposing Adam optimization plus side-view swingset policy training and segmented chain whip-dynamics analysis tabs with adjustable segment lengths, masses, chain counts, and provider metadata for UpstreamDrift launcher tiles                                                                                                                                                                                                                 |
 | Data Processing          | `src/data_processing/`                                                                 | Pipelines, transformers, validators, and facade-based data-processor core modules for exporter, ANOVA, vectorized filter workflows, Butterworth filters with explicit or time-derived sample rates, checked normalize/standardize transforms, operator-whitelisted row filtering, and pickle-safe file I/O defaults                                                                                                                                                                  |
 | Document Processing      | `src/document_processing/`                                                             | PDF extraction, text processing                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | Media Processing         | `src/media_processing/`                                                                | Audio and video utilities                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
@@ -468,6 +469,8 @@ passes fail early in CI.
 - [ ] Rust kernel outperforms pure Python equivalent by 10x+
 - [ ] Theme system applies consistently across all GUI tools
 - [ ] Data processing pipeline handles malformed input gracefully
+- [x] Movement Optimizer launches standalone and exposes tested swingset and
+      chain-dynamics tabs with 100% focused model coverage
 
 ## 8. Quality Standards
 
@@ -1064,6 +1067,10 @@ Active development with stable core, continuous tool expansion, and web API in p
 - **Reliability**: Restored source-tree `src.shared.python.logging_pkg` and `src.shared.python.config` compatibility modules so shared AI adapter factories and chat service connection code import cleanly from a Tools source checkout or vendored shared-module install.
 
 ## 9. Changelog
+
+### Version 1.1.329
+
+- 2026-06-09: feat(movement optimizer) — restore the standalone PyQt6 swingset policy-training and segmented-chain whip-dynamics tabs, mypy-compatible typed model modules, focused model and UI tests, launcher bootstrap repair, and provider metadata so UpstreamDrift can discover the Movement Optimizer tile from remote main.
 
 ### Version 1.1.320
 

--- a/model_pack.yaml
+++ b/model_pack.yaml
@@ -91,3 +91,25 @@ models:
       logo: "data_explorer.svg"
       status: "ready"
       web_route: "/tools/data-processor"
+
+  - id: "tools_movement_optimizer"
+    name: "Movement Optimizer"
+    description: "PyQt6 motion optimizer with swingset policy training and chain whip dynamics."
+    type: "special_app"
+    path: "src/optimizer_gui/launch_pyqt6.py"
+    working_dir: "."
+    python_paths:
+      - "src"
+      - "src/shared/python"
+      - "src/optimizer_gui/python"
+    capabilities:
+      - "swingset"
+      - "chain_dynamics"
+      - "policy_optimization"
+      - "pyqt6"
+    order: 15
+    launcher:
+      category: "tool"
+      logo: "swing_optimizer.svg"
+      status: "ready"
+      web_route: "/tools/movement-optimizer"

--- a/src/optimizer_gui/__init__.py
+++ b/src/optimizer_gui/__init__.py
@@ -1,2 +1,13 @@
-# Optimizer GUI
-"""Adam Optimizer GUI for standalone use."""
+"""Movement Optimizer GUI for standalone use.
+
+The source package lives under ``src/optimizer_gui/python`` so direct
+launcher execution extends this package path at import time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_NESTED_PACKAGE = Path(__file__).resolve().parent / "python" / "optimizer_gui"
+if _NESTED_PACKAGE.exists():
+    __path__.append(str(_NESTED_PACKAGE))

--- a/src/optimizer_gui/gui_registration.py
+++ b/src/optimizer_gui/gui_registration.py
@@ -1,13 +1,15 @@
-"""GUI registration for Adam Optimizer."""
+"""GUI registration for Movement Optimizer."""
 
 from __future__ import annotations
 
 from typing import Any
 
 GUI_INFO = {
-    "name": "Adam Optimizer",
+    "name": "Movement Optimizer",
     "tool_name": "optimizer_gui",
-    "description": "Configure and run Adam-based optimization",
+    "description": (
+        "Optimize motion policies with Adam, swingset, and chain dynamics models"
+    ),
     "category": "Optimization",
     "icon": "chart-line",
     "pyqt6": {

--- a/src/optimizer_gui/launch_pyqt6.py
+++ b/src/optimizer_gui/launch_pyqt6.py
@@ -3,13 +3,42 @@
 
 from __future__ import annotations
 
+import importlib.util
 import sys
+from pathlib import Path
+from typing import Protocol, cast
 
-from _bootstrap import bootstrap
+
+class _BootstrapModule(Protocol):
+    """Protocol for the dynamically loaded repository bootstrap module."""
+
+    def bootstrap(self, caller_file: str) -> None:
+        """Install repository-local import paths for a script entry point."""
+
+
+def _load_bootstrap() -> _BootstrapModule:
+    """Load the repository bootstrap module when launched as a script."""
+    repo_root = Path(__file__).resolve().parents[2]
+    bootstrap_path = repo_root / "_bootstrap.py"
+    spec = importlib.util.spec_from_file_location("_tools_bootstrap", bootstrap_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load bootstrap module from {bootstrap_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return cast(_BootstrapModule, module)
+
+
+bootstrap = _load_bootstrap().bootstrap
 
 bootstrap(__file__)
 
 from gui_launcher import make_pyqt6_launcher  # noqa: E402
 
+
+def main() -> int:
+    """Launch the Movement Optimizer PyQt6 application."""
+    return int(make_pyqt6_launcher("optimizer_gui.gui_registration"))
+
+
 if __name__ == "__main__":
-    sys.exit(make_pyqt6_launcher("optimizer_gui.gui_registration"))
+    sys.exit(main())

--- a/src/optimizer_gui/model_pack.yaml
+++ b/src/optimizer_gui/model_pack.yaml
@@ -1,0 +1,21 @@
+manifest_version: "1.0.0"
+pack_id: "tools-movement-optimizer"
+pack_name: "Tools Movement Optimizer"
+provider: "tools"
+models:
+  - id: tools_movement_optimizer
+    name: "Movement Optimizer"
+    description: "PyQt6 motion optimizer with swingset policy training and chain whip dynamics."
+    type: "special_app"
+    path: src/optimizer_gui/launch_pyqt6.py
+    source_root: "src/optimizer_gui"
+    capabilities:
+      - "swingset"
+      - "chain_dynamics"
+      - "policy_optimization"
+      - "pyqt6"
+    launcher:
+      category: "tool"
+      logo: "swing_optimizer.svg"
+      status: "provider_ready"
+      web_route: /tools/movement-optimizer

--- a/src/optimizer_gui/python/optimizer_gui/models/__init__.py
+++ b/src/optimizer_gui/python/optimizer_gui/models/__init__.py
@@ -1,0 +1,26 @@
+"""Reusable movement models for the Movement Optimizer."""
+
+from __future__ import annotations
+
+from .chain_model import ChainConfig, ChainRollout, ChainState, ChainStateMetrics
+from .swingset_model import (
+    HumanSegmentSpec,
+    SwingControlAction,
+    SwingPose,
+    SwingRollout,
+    SwingSetConfig,
+    SwingSetState,
+)
+
+__all__ = [
+    "ChainConfig",
+    "ChainRollout",
+    "ChainState",
+    "ChainStateMetrics",
+    "HumanSegmentSpec",
+    "SwingControlAction",
+    "SwingPose",
+    "SwingRollout",
+    "SwingSetConfig",
+    "SwingSetState",
+]

--- a/src/optimizer_gui/python/optimizer_gui/models/chain_model.py
+++ b/src/optimizer_gui/python/optimizer_gui/models/chain_model.py
@@ -94,8 +94,12 @@ class ChainState:
     @classmethod
     def stationary(cls, config: ChainConfig, angle_rad: float = 0.0) -> ChainState:
         """Build a stationary chain with every segment at the same angle."""
-        angles = np.full(config.segment_count, angle_rad, dtype=np.float64)
-        velocities = np.zeros(config.segment_count, dtype=np.float64)
+        angles: FloatArray = np.full(
+            config.segment_count,
+            angle_rad,
+            dtype=np.float64,
+        )
+        velocities: FloatArray = np.zeros(config.segment_count, dtype=np.float64)
         return cls(angles_rad=angles, angular_velocities_rad_s=velocities)
 
     def validated(self, config: ChainConfig) -> ChainState:
@@ -222,7 +226,7 @@ def _angular_acceleration(
         checked.angles_rad
     )
     damping_term = -config.damping * checked.angular_velocities_rad_s
-    neighbor_sum = np.zeros(config.segment_count, dtype=np.float64)
+    neighbor_sum: FloatArray = np.zeros(config.segment_count, dtype=np.float64)
     neighbor_sum[:-1] += checked.angles_rad[1:] - checked.angles_rad[:-1]
     neighbor_sum[1:] += checked.angles_rad[:-1] - checked.angles_rad[1:]
     coupling_term = config.coupling * neighbor_sum / config.link_mass_kg
@@ -265,7 +269,10 @@ def simulate_chain(
         raise ValueError("steps must be at least 1")
     _require_positive("dt_s", dt_s)
     if torque_history_nm is None:
-        torques = np.zeros((steps, config.segment_count), dtype=np.float64)
+        torques: FloatArray = np.zeros(
+            (steps, config.segment_count),
+            dtype=np.float64,
+        )
     else:
         torques = np.asarray(torque_history_nm, dtype=np.float64)
         if torques.shape != (steps, config.segment_count):

--- a/src/optimizer_gui/python/optimizer_gui/models/chain_model.py
+++ b/src/optimizer_gui/python/optimizer_gui/models/chain_model.py
@@ -1,0 +1,284 @@
+"""Planar chain dynamics used by chain and swingset analyses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+GRAVITY_M_S2: Final[float] = 9.80665
+DEFAULT_SEGMENT_COUNT: Final[int] = 12
+DEFAULT_SEGMENT_LENGTH_M: Final[float] = 0.18
+DEFAULT_LINK_MASS_KG: Final[float] = 0.12
+DEFAULT_DAMPING: Final[float] = 0.08
+DEFAULT_COUPLING: Final[float] = 18.0
+MIN_SEGMENTS_FOR_CATENARY: Final[int] = 2
+INTEGRATION_SUBSTEPS: Final[int] = 32
+
+FloatArray: TypeAlias = NDArray[np.float64]
+
+
+def _require_positive(name: str, value: float) -> None:
+    """Enforce a positive scalar precondition."""
+    if value <= 0.0:
+        raise ValueError(f"{name} must be positive")
+
+
+def _as_float_array(name: str, values: FloatArray, expected_size: int) -> FloatArray:
+    """Validate a finite 1-D float array with a required length."""
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be a 1-D array")
+    if array.size != expected_size:
+        raise ValueError(f"{name} must contain {expected_size} values")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
+    return array
+
+
+@dataclass(frozen=True)
+class ChainConfig:
+    """Physical configuration for a side-view segmented chain.
+
+    Preconditions:
+        ``segment_count`` is at least 1. Length, mass, gravity, damping, and
+        coupling are non-negative where physically required.
+    """
+
+    segment_count: int = DEFAULT_SEGMENT_COUNT
+    segment_length_m: float = DEFAULT_SEGMENT_LENGTH_M
+    link_mass_kg: float = DEFAULT_LINK_MASS_KG
+    gravity_m_s2: float = GRAVITY_M_S2
+    damping: float = DEFAULT_DAMPING
+    coupling: float = DEFAULT_COUPLING
+
+    def __post_init__(self) -> None:
+        if self.segment_count < 1:
+            raise ValueError("segment_count must be at least 1")
+        _require_positive("segment_length_m", self.segment_length_m)
+        _require_positive("link_mass_kg", self.link_mass_kg)
+        _require_positive("gravity_m_s2", self.gravity_m_s2)
+        if self.damping < 0.0:
+            raise ValueError("damping must be non-negative")
+        if self.coupling < 0.0:
+            raise ValueError("coupling must be non-negative")
+
+    @property
+    def total_length_m(self) -> float:
+        """Return the full chain length in metres."""
+        return self.segment_count * self.segment_length_m
+
+
+@dataclass(frozen=True)
+class ChainStateMetrics:
+    """Derived chain metrics useful for whip-motion analysis."""
+
+    tip_speed_m_s: float
+    center_of_mass_m: FloatArray
+    max_curvature_rad: float
+
+
+@dataclass(frozen=True)
+class ChainState:
+    """Angles and angular velocities for all chain links.
+
+    Angles are measured from vertical-down in radians. Positive angles move
+    the link endpoint toward positive x in the side-view plane.
+    """
+
+    angles_rad: FloatArray
+    angular_velocities_rad_s: FloatArray
+
+    @classmethod
+    def stationary(cls, config: ChainConfig, angle_rad: float = 0.0) -> ChainState:
+        """Build a stationary chain with every segment at the same angle."""
+        angles = np.full(config.segment_count, angle_rad, dtype=np.float64)
+        velocities = np.zeros(config.segment_count, dtype=np.float64)
+        return cls(angles_rad=angles, angular_velocities_rad_s=velocities)
+
+    def validated(self, config: ChainConfig) -> ChainState:
+        """Return a state with validated arrays for ``config``."""
+        angles = _as_float_array("angles_rad", self.angles_rad, config.segment_count)
+        velocities = _as_float_array(
+            "angular_velocities_rad_s",
+            self.angular_velocities_rad_s,
+            config.segment_count,
+        )
+        return ChainState(angles_rad=angles, angular_velocities_rad_s=velocities)
+
+    def node_positions(
+        self,
+        config: ChainConfig,
+        anchor_xy_m: tuple[float, float] = (0.0, 0.0),
+    ) -> FloatArray:
+        """Return anchor plus link endpoint coordinates as an ``(n + 1, 2)`` array."""
+        state = self.validated(config)
+        offsets = segment_vectors(config, state.angles_rad)
+        endpoints = np.vstack(
+            (
+                np.zeros((1, 2), dtype=np.float64),
+                np.cumsum(offsets, axis=0),
+            )
+        )
+        anchor = np.asarray(anchor_xy_m, dtype=np.float64)
+        if anchor.shape != (2,) or not np.all(np.isfinite(anchor)):
+            raise ValueError("anchor_xy_m must contain two finite coordinates")
+        return endpoints + anchor
+
+    def metrics(self, config: ChainConfig) -> ChainStateMetrics:
+        """Return tip speed, center of mass, and max adjacent-link curvature."""
+        positions = self.node_positions(config)
+        velocities = node_velocities(config, self.validated(config))
+        midpoint_array = link_midpoints(positions)
+        curvature = np.diff(self.angles_rad)
+        max_curvature = float(np.max(np.abs(curvature))) if curvature.size else 0.0
+        return ChainStateMetrics(
+            tip_speed_m_s=float(np.linalg.norm(velocities[-1])),
+            center_of_mass_m=np.mean(midpoint_array, axis=0),
+            max_curvature_rad=max_curvature,
+        )
+
+
+@dataclass(frozen=True)
+class ChainRollout:
+    """Time history returned by :func:`simulate_chain`."""
+
+    states: tuple[ChainState, ...]
+    positions: FloatArray
+    energy_j: FloatArray
+    tip_speed_m_s: FloatArray
+
+
+def segment_vectors(config: ChainConfig, angles_rad: FloatArray) -> FloatArray:
+    """Return per-link x/y vectors from vertical-down link angles."""
+    angles = _as_float_array("angles_rad", angles_rad, config.segment_count)
+    return config.segment_length_m * np.column_stack((np.sin(angles), np.cos(angles)))
+
+
+def link_midpoints(node_positions: FloatArray) -> FloatArray:
+    """Return link midpoint coordinates from anchor/end-node coordinates."""
+    nodes = np.asarray(node_positions, dtype=np.float64)
+    if nodes.ndim != 2 or nodes.shape[1] != 2 or nodes.shape[0] < 2:
+        raise ValueError("node_positions must have shape (n >= 2, 2)")
+    return 0.5 * (nodes[:-1] + nodes[1:])
+
+
+def node_velocities(config: ChainConfig, state: ChainState) -> FloatArray:
+    """Return anchor plus endpoint velocities for the chain state."""
+    checked = state.validated(config)
+    derivatives = config.segment_length_m * np.column_stack(
+        (
+            np.cos(checked.angles_rad) * checked.angular_velocities_rad_s,
+            -np.sin(checked.angles_rad) * checked.angular_velocities_rad_s,
+        )
+    )
+    return np.vstack(
+        (
+            np.zeros((1, 2), dtype=np.float64),
+            np.cumsum(derivatives, axis=0),
+        )
+    )
+
+
+def total_energy(config: ChainConfig, state: ChainState) -> float:
+    """Return approximate chain mechanical energy in joules."""
+    checked = state.validated(config)
+    positions = checked.node_positions(config)
+    velocities = node_velocities(config, checked)
+    mass_positions = positions[1:]
+    mass_velocities = velocities[1:]
+    kinetic = 0.5 * config.link_mass_kg * np.sum(mass_velocities**2)
+    potential_height = config.total_length_m - mass_positions[:, 1]
+    potential = config.link_mass_kg * config.gravity_m_s2 * np.sum(potential_height)
+    return float(kinetic + potential)
+
+
+def initial_catenary_angles(segment_count: int, sag_rad: float) -> FloatArray:
+    """Return a symmetric initial angle profile for a sagging chain."""
+    if segment_count < MIN_SEGMENTS_FOR_CATENARY:
+        raise ValueError("segment_count must be at least 2")
+    if sag_rad < 0.0:
+        raise ValueError("sag_rad must be non-negative")
+    return np.linspace(-sag_rad, sag_rad, segment_count, dtype=np.float64)
+
+
+def _angular_acceleration(
+    config: ChainConfig,
+    state: ChainState,
+    torques_nm: FloatArray,
+) -> FloatArray:
+    """Compute a stable coupled-pendulum acceleration approximation."""
+    checked = state.validated(config)
+    torques = _as_float_array("torques_nm", torques_nm, config.segment_count)
+    inertia = config.link_mass_kg * config.segment_length_m**2
+    effective_lengths = config.segment_length_m * np.arange(
+        1,
+        config.segment_count + 1,
+        dtype=np.float64,
+    )
+    gravity_term = -(config.gravity_m_s2 / effective_lengths) * np.sin(
+        checked.angles_rad
+    )
+    damping_term = -config.damping * checked.angular_velocities_rad_s
+    neighbor_sum = np.zeros(config.segment_count, dtype=np.float64)
+    neighbor_sum[:-1] += checked.angles_rad[1:] - checked.angles_rad[:-1]
+    neighbor_sum[1:] += checked.angles_rad[:-1] - checked.angles_rad[1:]
+    coupling_term = config.coupling * neighbor_sum / config.link_mass_kg
+    return gravity_term + damping_term + coupling_term + torques / inertia
+
+
+def step_chain(
+    config: ChainConfig,
+    state: ChainState,
+    dt_s: float,
+    torques_nm: FloatArray | None = None,
+) -> ChainState:
+    """Advance the chain one semi-implicit Euler step."""
+    _require_positive("dt_s", dt_s)
+    checked = state.validated(config)
+    torques = (
+        np.zeros(config.segment_count, dtype=np.float64)
+        if torques_nm is None
+        else np.asarray(torques_nm, dtype=np.float64)
+    )
+    sub_dt = dt_s / INTEGRATION_SUBSTEPS
+    current = checked
+    for _substep in range(INTEGRATION_SUBSTEPS):
+        acceleration = _angular_acceleration(config, current, torques)
+        next_velocities = current.angular_velocities_rad_s + acceleration * sub_dt
+        next_angles = current.angles_rad + next_velocities * sub_dt
+        current = ChainState(next_angles, next_velocities)
+    return current
+
+
+def simulate_chain(
+    config: ChainConfig,
+    initial_state: ChainState,
+    steps: int,
+    dt_s: float,
+    torque_history_nm: FloatArray | None = None,
+) -> ChainRollout:
+    """Simulate a chain for a fixed number of time steps."""
+    if steps < 1:
+        raise ValueError("steps must be at least 1")
+    _require_positive("dt_s", dt_s)
+    if torque_history_nm is None:
+        torques = np.zeros((steps, config.segment_count), dtype=np.float64)
+    else:
+        torques = np.asarray(torque_history_nm, dtype=np.float64)
+        if torques.shape != (steps, config.segment_count):
+            raise ValueError("torque_history_nm has incompatible shape")
+    states = [initial_state.validated(config)]
+    for step_index in range(steps):
+        states.append(step_chain(config, states[-1], dt_s, torques[step_index]))
+    positions = np.stack([state.node_positions(config) for state in states])
+    energy = np.asarray([total_energy(config, state) for state in states])
+    tip_speed = np.asarray([state.metrics(config).tip_speed_m_s for state in states])
+    return ChainRollout(
+        states=tuple(states),
+        positions=positions,
+        energy_j=energy,
+        tip_speed_m_s=tip_speed,
+    )

--- a/src/optimizer_gui/python/optimizer_gui/models/swingset_model.py
+++ b/src/optimizer_gui/python/optimizer_gui/models/swingset_model.py
@@ -1,0 +1,388 @@
+"""Side-view swingset kinematics and control-policy rollouts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from typing import Final, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .chain_model import GRAVITY_M_S2, ChainConfig, ChainState
+
+FloatArray: TypeAlias = NDArray[np.float64]
+Policy = Callable[["SwingSetState", float], "SwingControlAction"]
+
+DEFAULT_CHAIN_SEGMENTS: Final[int] = 14
+DEFAULT_CHAIN_LENGTH_M: Final[float] = 2.4
+DEFAULT_SEAT_MASS_KG: Final[float] = 4.5
+DEFAULT_LINK_MASS_KG: Final[float] = 0.16
+DEFAULT_DAMPING: Final[float] = 0.04
+DEFAULT_PUMP_GAIN: Final[float] = 0.65
+MAX_BODY_RATE_RAD_S: Final[float] = 2.4
+MAX_EXTERNAL_TORQUE_NM: Final[float] = 70.0
+CONTROL_DIMENSION: Final[int] = 5
+
+
+def _require_positive(name: str, value: float) -> None:
+    """Enforce a positive scalar precondition."""
+    if value <= 0.0:
+        raise ValueError(f"{name} must be positive")
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    """Clamp ``value`` into the closed interval ``[lower, upper]``."""
+    return min(max(value, lower), upper)
+
+
+def _segment_vector(length_m: float, angle_rad: float) -> FloatArray:
+    """Return a side-view vector for an angle measured from vertical-down."""
+    return np.asarray(
+        [length_m * np.sin(angle_rad), length_m * np.cos(angle_rad)],
+        dtype=np.float64,
+    )
+
+
+@dataclass(frozen=True)
+class HumanSegmentSpec:
+    """Length and mass for one body segment.
+
+    Preconditions:
+        ``length_m`` and ``mass_kg`` must be positive finite values.
+    """
+
+    length_m: float
+    mass_kg: float
+
+    def __post_init__(self) -> None:
+        _require_positive("length_m", self.length_m)
+        _require_positive("mass_kg", self.mass_kg)
+
+
+@dataclass(frozen=True)
+class SwingSetConfig:
+    """Physical configuration for a trainable swingset model."""
+
+    chain_segments: int = DEFAULT_CHAIN_SEGMENTS
+    chain_length_m: float = DEFAULT_CHAIN_LENGTH_M
+    chain_link_mass_kg: float = DEFAULT_LINK_MASS_KG
+    seat_mass_kg: float = DEFAULT_SEAT_MASS_KG
+    torso: HumanSegmentSpec = HumanSegmentSpec(0.62, 28.0)
+    thigh: HumanSegmentSpec = HumanSegmentSpec(0.46, 8.0)
+    shank: HumanSegmentSpec = HumanSegmentSpec(0.45, 5.5)
+    upper_arm: HumanSegmentSpec = HumanSegmentSpec(0.30, 2.0)
+    forearm: HumanSegmentSpec = HumanSegmentSpec(0.28, 1.6)
+    gravity_m_s2: float = GRAVITY_M_S2
+    damping: float = DEFAULT_DAMPING
+    pump_gain: float = DEFAULT_PUMP_GAIN
+
+    def __post_init__(self) -> None:
+        if self.chain_segments < 1:
+            raise ValueError("chain_segments must be at least 1")
+        _require_positive("chain_length_m", self.chain_length_m)
+        _require_positive("chain_link_mass_kg", self.chain_link_mass_kg)
+        _require_positive("seat_mass_kg", self.seat_mass_kg)
+        _require_positive("gravity_m_s2", self.gravity_m_s2)
+        if self.damping < 0.0:
+            raise ValueError("damping must be non-negative")
+        if self.pump_gain < 0.0:
+            raise ValueError("pump_gain must be non-negative")
+
+    def chain_config(self) -> ChainConfig:
+        """Return the shared chain configuration for this swingset."""
+        return ChainConfig(
+            segment_count=self.chain_segments,
+            segment_length_m=self.chain_length_m / self.chain_segments,
+            link_mass_kg=self.chain_link_mass_kg,
+            gravity_m_s2=self.gravity_m_s2,
+            damping=self.damping,
+        )
+
+    @property
+    def rider_mass_kg(self) -> float:
+        """Return total modelled rider mass in kilograms."""
+        paired_arms = 2.0 * (self.upper_arm.mass_kg + self.forearm.mass_kg)
+        paired_legs = 2.0 * (self.thigh.mass_kg + self.shank.mass_kg)
+        return self.torso.mass_kg + paired_arms + paired_legs
+
+
+@dataclass(frozen=True)
+class SwingPose:
+    """Generalized coordinates for the side-view human and swing."""
+
+    swing_angle_rad: float = 0.0
+    torso_lean_rad: float = 0.0
+    hip_angle_rad: float = 0.0
+    knee_angle_rad: float = 0.0
+    shoulder_angle_rad: float = 0.0
+    elbow_angle_rad: float = 0.0
+
+
+@dataclass(frozen=True)
+class SwingControlAction:
+    """Control rates and external torque applied during one rollout step."""
+
+    torso_lean_rate_rad_s: float = 0.0
+    hip_rate_rad_s: float = 0.0
+    knee_rate_rad_s: float = 0.0
+    shoulder_rate_rad_s: float = 0.0
+    elbow_rate_rad_s: float = 0.0
+    external_torque_nm: float = 0.0
+
+    def clipped(self) -> SwingControlAction:
+        """Return a control action constrained to the model limits."""
+        rate = MAX_BODY_RATE_RAD_S
+        torque = MAX_EXTERNAL_TORQUE_NM
+        return SwingControlAction(
+            torso_lean_rate_rad_s=_clamp(self.torso_lean_rate_rad_s, -rate, rate),
+            hip_rate_rad_s=_clamp(self.hip_rate_rad_s, -rate, rate),
+            knee_rate_rad_s=_clamp(self.knee_rate_rad_s, -rate, rate),
+            shoulder_rate_rad_s=_clamp(self.shoulder_rate_rad_s, -rate, rate),
+            elbow_rate_rad_s=_clamp(self.elbow_rate_rad_s, -rate, rate),
+            external_torque_nm=_clamp(self.external_torque_nm, -torque, torque),
+        )
+
+    def vector(self) -> FloatArray:
+        """Return the trainable control-rate vector used by policy search."""
+        return np.asarray(
+            [
+                self.torso_lean_rate_rad_s,
+                self.hip_rate_rad_s,
+                self.knee_rate_rad_s,
+                self.shoulder_rate_rad_s,
+                self.elbow_rate_rad_s,
+            ],
+            dtype=np.float64,
+        )
+
+
+@dataclass(frozen=True)
+class SwingSetState:
+    """Dynamic state for the swingset rollout."""
+
+    pose: SwingPose
+    swing_angular_velocity_rad_s: float = 0.0
+
+    @classmethod
+    def rest(cls) -> SwingSetState:
+        """Return a vertical static swingset state."""
+        return cls(pose=SwingPose(), swing_angular_velocity_rad_s=0.0)
+
+
+@dataclass(frozen=True)
+class SwingSetSnapshot:
+    """Kinematic geometry derived from a swingset pose."""
+
+    points: dict[str, FloatArray]
+    chain_nodes: FloatArray
+    center_of_mass_m: FloatArray
+    hand_chain_error_m: float
+
+
+@dataclass(frozen=True)
+class SwingRolloutMetrics:
+    """Summary metrics returned after policy rollout."""
+
+    max_abs_swing_angle_rad: float
+    final_energy_proxy_j: float
+    mean_hand_chain_error_m: float
+
+
+@dataclass(frozen=True)
+class SwingRollout:
+    """Time history for a swingset policy simulation."""
+
+    states: tuple[SwingSetState, ...]
+    swing_angles_rad: FloatArray
+    controls: FloatArray
+    snapshots: tuple[SwingSetSnapshot, ...]
+    metrics: SwingRolloutMetrics
+
+
+def build_swingset_snapshot(
+    config: SwingSetConfig,
+    pose: SwingPose,
+) -> SwingSetSnapshot:
+    """Build side-view chain and rider geometry for ``pose``."""
+    chain_state = ChainState.stationary(config.chain_config(), pose.swing_angle_rad)
+    chain_nodes = chain_state.node_positions(config.chain_config())
+    seat = chain_nodes[-1]
+    points = _body_points(config, pose, seat)
+    center = _center_of_mass(config, points)
+    grip_point = chain_nodes[max(config.chain_segments - 2, 0)]
+    hand_error = float(np.linalg.norm(points["hand"] - grip_point))
+    return SwingSetSnapshot(
+        points=points,
+        chain_nodes=chain_nodes,
+        center_of_mass_m=center,
+        hand_chain_error_m=hand_error,
+    )
+
+
+def _body_points(
+    config: SwingSetConfig,
+    pose: SwingPose,
+    seat: FloatArray,
+) -> dict[str, FloatArray]:
+    """Return rider joint points keyed by anatomical label."""
+    hip = seat.copy()
+    torso_angle = pose.swing_angle_rad + pose.torso_lean_rad + np.pi
+    shoulder = hip + _segment_vector(config.torso.length_m, torso_angle)
+    thigh_angle = pose.swing_angle_rad + pose.hip_angle_rad
+    knee = hip + _segment_vector(config.thigh.length_m, thigh_angle)
+    shank_angle = thigh_angle + pose.knee_angle_rad
+    foot = knee + _segment_vector(config.shank.length_m, shank_angle)
+    upper_arm_angle = pose.swing_angle_rad + pose.shoulder_angle_rad
+    elbow = shoulder + _segment_vector(config.upper_arm.length_m, upper_arm_angle)
+    forearm_angle = upper_arm_angle + pose.elbow_angle_rad
+    hand = elbow + _segment_vector(config.forearm.length_m, forearm_angle)
+    return {
+        "seat": seat,
+        "hip": hip,
+        "shoulder": shoulder,
+        "knee": knee,
+        "foot": foot,
+        "elbow": elbow,
+        "hand": hand,
+    }
+
+
+def _center_of_mass(
+    config: SwingSetConfig,
+    points: dict[str, FloatArray],
+) -> FloatArray:
+    """Return approximate rider plus seat center of mass."""
+    seat = points["seat"]
+    torso_mid = 0.5 * (points["hip"] + points["shoulder"])
+    thigh_mid = 0.5 * (points["hip"] + points["knee"])
+    shank_mid = 0.5 * (points["knee"] + points["foot"])
+    upper_arm_mid = 0.5 * (points["shoulder"] + points["elbow"])
+    forearm_mid = 0.5 * (points["elbow"] + points["hand"])
+    weighted = (
+        config.seat_mass_kg * seat
+        + config.torso.mass_kg * torso_mid
+        + 2.0 * config.thigh.mass_kg * thigh_mid
+        + 2.0 * config.shank.mass_kg * shank_mid
+        + 2.0 * config.upper_arm.mass_kg * upper_arm_mid
+        + 2.0 * config.forearm.mass_kg * forearm_mid
+    )
+    total_mass = config.seat_mass_kg + config.rider_mass_kg
+    return weighted / total_mass
+
+
+def _step_pose(pose: SwingPose, action: SwingControlAction, dt_s: float) -> SwingPose:
+    """Integrate controlled pose coordinates while preserving swing angle."""
+    return replace(
+        pose,
+        torso_lean_rad=pose.torso_lean_rad + action.torso_lean_rate_rad_s * dt_s,
+        hip_angle_rad=pose.hip_angle_rad + action.hip_rate_rad_s * dt_s,
+        knee_angle_rad=pose.knee_angle_rad + action.knee_rate_rad_s * dt_s,
+        shoulder_angle_rad=pose.shoulder_angle_rad + action.shoulder_rate_rad_s * dt_s,
+        elbow_angle_rad=pose.elbow_angle_rad + action.elbow_rate_rad_s * dt_s,
+    )
+
+
+def _swing_acceleration(
+    config: SwingSetConfig,
+    state: SwingSetState,
+    action: SwingControlAction,
+) -> float:
+    """Return angular acceleration for the swing coordinate."""
+    length = config.chain_length_m
+    gravity = -(config.gravity_m_s2 / length) * np.sin(state.pose.swing_angle_rad)
+    damping = -config.damping * state.swing_angular_velocity_rad_s
+    inertia = (config.seat_mass_kg + config.rider_mass_kg) * length**2
+    control = action.external_torque_nm / inertia
+    pump = config.pump_gain * _pumping_projection(state, action) / length
+    return float(gravity + damping + control + pump)
+
+
+def _pumping_projection(state: SwingSetState, action: SwingControlAction) -> float:
+    """Project body-rate controls into swing-driving acceleration."""
+    direction = 1.0 if state.swing_angular_velocity_rad_s >= 0.0 else -1.0
+    leg_drive = action.hip_rate_rad_s - 0.35 * action.knee_rate_rad_s
+    torso_drive = -0.5 * action.torso_lean_rate_rad_s
+    return direction * (leg_drive + torso_drive)
+
+
+def step_swingset(
+    config: SwingSetConfig,
+    state: SwingSetState,
+    action: SwingControlAction,
+    dt_s: float,
+) -> SwingSetState:
+    """Advance the swingset by one semi-implicit Euler step."""
+    _require_positive("dt_s", dt_s)
+    clipped = action.clipped()
+    acceleration = _swing_acceleration(config, state, clipped)
+    next_velocity = state.swing_angular_velocity_rad_s + acceleration * dt_s
+    next_swing = state.pose.swing_angle_rad + next_velocity * dt_s
+    pose = replace(_step_pose(state.pose, clipped, dt_s), swing_angle_rad=next_swing)
+    return SwingSetState(pose=pose, swing_angular_velocity_rad_s=next_velocity)
+
+
+def heuristic_pumping_policy(
+    state: SwingSetState,
+    _time_s: float,
+) -> SwingControlAction:
+    """Return a deterministic baseline policy that pumps the swing."""
+    direction = 1.0 if state.swing_angular_velocity_rad_s >= 0.0 else -1.0
+    return SwingControlAction(
+        torso_lean_rate_rad_s=-0.7 * direction,
+        hip_rate_rad_s=0.9 * direction,
+        knee_rate_rad_s=-0.4 * direction,
+        shoulder_rate_rad_s=-0.15 * direction,
+        elbow_rate_rad_s=0.2 * direction,
+    )
+
+
+def simulate_swingset(
+    config: SwingSetConfig,
+    initial_state: SwingSetState,
+    steps: int,
+    dt_s: float,
+    policy: Policy,
+) -> SwingRollout:
+    """Roll out a control policy for a trainable swingset model."""
+    if steps < 1:
+        raise ValueError("steps must be at least 1")
+    _require_positive("dt_s", dt_s)
+    states = [initial_state]
+    controls: list[FloatArray] = []
+    snapshots = [build_swingset_snapshot(config, initial_state.pose)]
+    for step_index in range(steps):
+        time_s = step_index * dt_s
+        action = policy(states[-1], time_s).clipped()
+        controls.append(action.vector())
+        states.append(step_swingset(config, states[-1], action, dt_s))
+        snapshots.append(build_swingset_snapshot(config, states[-1].pose))
+    angles = np.asarray([state.pose.swing_angle_rad for state in states])
+    control_array = np.vstack(controls).reshape(steps, CONTROL_DIMENSION)
+    metrics = _rollout_metrics(config, states, snapshots, angles)
+    return SwingRollout(
+        states=tuple(states),
+        swing_angles_rad=angles,
+        controls=control_array,
+        snapshots=tuple(snapshots),
+        metrics=metrics,
+    )
+
+
+def _rollout_metrics(
+    config: SwingSetConfig,
+    states: list[SwingSetState],
+    snapshots: list[SwingSetSnapshot],
+    angles: FloatArray,
+) -> SwingRolloutMetrics:
+    """Build scalar metrics for comparing control policies."""
+    final_velocity = states[-1].swing_angular_velocity_rad_s
+    total_mass = config.seat_mass_kg + config.rider_mass_kg
+    inertia = total_mass * config.chain_length_m**2
+    energy = 0.5 * inertia * final_velocity**2
+    errors = np.asarray([snapshot.hand_chain_error_m for snapshot in snapshots])
+    return SwingRolloutMetrics(
+        max_abs_swing_angle_rad=float(np.max(np.abs(angles))),
+        final_energy_proxy_j=float(energy),
+        mean_hand_chain_error_m=float(np.mean(errors)),
+    )

--- a/src/optimizer_gui/python/optimizer_gui/ui/pyqt6/main_window.py
+++ b/src/optimizer_gui/python/optimizer_gui/ui/pyqt6/main_window.py
@@ -40,7 +40,21 @@ from PyQt6.QtWidgets import (
 
 from shared.python.theme.integration import ThemedWindowMixin
 
+from .motion_tabs import create_chain_tab, create_swingset_tab
+
 logger = logging.getLogger(__name__)
+
+
+def _make_window_base() -> type:
+    """Return a Qt-compatible base class, tolerating mocked PyQt imports."""
+    if not isinstance(QMainWindow, type):
+        return object
+
+    class WindowBase(ThemedWindowMixin, QMainWindow):
+        """Concrete base combining theme support and Qt main-window behavior."""
+
+    return WindowBase
+
 
 # Catppuccin Mocha color palette
 CATPPUCCIN_MOCHA = {
@@ -245,7 +259,7 @@ class ParameterConfig:
     max_val: float
 
 
-class OptimizerWindow(ThemedWindowMixin, QMainWindow):
+class OptimizerWindow(_make_window_base()):
     """Main window for Adam Optimizer application."""
 
     def __init__(self) -> None:
@@ -258,7 +272,7 @@ class OptimizerWindow(ThemedWindowMixin, QMainWindow):
 
     def _setup_ui(self) -> None:
         """Set up the user interface."""
-        self.setWindowTitle("Adam Optimizer")
+        self.setWindowTitle("Movement Optimizer")
         self.setMinimumSize(700, 800)
         self.setStyleSheet(STYLESHEET)
 
@@ -277,7 +291,7 @@ class OptimizerWindow(ThemedWindowMixin, QMainWindow):
         main_layout.setSpacing(12)
 
         # Title
-        title_label = QLabel("Adam Optimizer")
+        title_label = QLabel("Movement Optimizer")
         title_font = QFont()
         title_font.setPointSize(18)
         title_font.setBold(True)
@@ -291,10 +305,7 @@ class OptimizerWindow(ThemedWindowMixin, QMainWindow):
         self.tab_widget = QTabWidget()
         main_layout.addWidget(self.tab_widget)
 
-        # Create tabs
-        self.tab_widget.addTab(self._create_parameters_tab(), "Parameters")
-        self.tab_widget.addTab(self._create_adam_settings_tab(), "Adam Settings")
-        self.tab_widget.addTab(self._create_results_tab(), "Results")
+        self._add_optimizer_tabs()
 
         # Run button
         run_btn = QPushButton("Run Optimization")
@@ -303,6 +314,14 @@ class OptimizerWindow(ThemedWindowMixin, QMainWindow):
         main_layout.addWidget(run_btn)
 
         main_layout.addStretch()
+
+    def _add_optimizer_tabs(self) -> None:
+        """Register optimizer and motion-analysis tabs."""
+        self.tab_widget.addTab(self._create_parameters_tab(), "Parameters")
+        self.tab_widget.addTab(self._create_adam_settings_tab(), "Adam Settings")
+        self.tab_widget.addTab(self._create_results_tab(), "Results")
+        self.tab_widget.addTab(create_swingset_tab(), "Swingset Model")
+        self.tab_widget.addTab(create_chain_tab(), "Chain Dynamics")
 
     def _create_parameters_tab(self) -> QWidget:
         """Create the parameters configuration tab."""

--- a/src/optimizer_gui/python/optimizer_gui/ui/pyqt6/motion_tabs.py
+++ b/src/optimizer_gui/python/optimizer_gui/ui/pyqt6/motion_tabs.py
@@ -187,13 +187,14 @@ class SwingsetTab(QWidget):
         integer: bool = False,
     ) -> None:
         """Create and register one spin box."""
-        spin: QDoubleSpinBox | QSpinBox = QSpinBox() if integer else QDoubleSpinBox()
         if integer:
+            spin = QSpinBox()
             spin.setRange(int(lower), int(upper))
+            spin.setValue(int(value))
         else:
+            spin = QDoubleSpinBox()
             spin.setRange(lower, upper)
-        spin.setValue(int(value)) if integer else spin.setValue(value)
-        if isinstance(spin, QDoubleSpinBox):
+            spin.setValue(value)
             spin.setDecimals(3)
             spin.setSingleStep(0.01)
         spin.valueChanged.connect(self._refresh)
@@ -293,13 +294,14 @@ class ChainDynamicsTab(QWidget):
         integer: bool = False,
     ) -> None:
         """Create one chain-control spin box."""
-        spin: QDoubleSpinBox | QSpinBox = QSpinBox() if integer else QDoubleSpinBox()
         if integer:
+            spin = QSpinBox()
             spin.setRange(int(lower), int(upper))
+            spin.setValue(int(value))
         else:
+            spin = QDoubleSpinBox()
             spin.setRange(lower, upper)
-        spin.setValue(int(value)) if integer else spin.setValue(value)
-        if isinstance(spin, QDoubleSpinBox):
+            spin.setValue(value)
             spin.setDecimals(3)
             spin.setSingleStep(0.01)
         spin.valueChanged.connect(self._refresh)

--- a/src/optimizer_gui/python/optimizer_gui/ui/pyqt6/motion_tabs.py
+++ b/src/optimizer_gui/python/optimizer_gui/ui/pyqt6/motion_tabs.py
@@ -1,0 +1,356 @@
+"""PyQt6 tabs for swingset and chain dynamics analysis."""
+
+from __future__ import annotations
+
+import numpy as np
+from PyQt6.QtCore import QPointF
+from PyQt6.QtGui import QColor, QPainter, QPen
+from PyQt6.QtWidgets import (
+    QDoubleSpinBox,
+    QFormLayout,
+    QGridLayout,
+    QGroupBox,
+    QLabel,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
+
+from optimizer_gui.models.chain_model import (
+    ChainConfig,
+    ChainState,
+    initial_catenary_angles,
+    simulate_chain,
+)
+from optimizer_gui.models.swingset_model import (
+    HumanSegmentSpec,
+    SwingPose,
+    SwingSetConfig,
+    SwingSetState,
+    build_swingset_snapshot,
+    heuristic_pumping_policy,
+    simulate_swingset,
+)
+
+ACCENT = QColor("#89b4fa")
+CHAIN = QColor("#bac2de")
+BODY = QColor("#a6e3a1")
+LEG = QColor("#f9e2af")
+ARM = QColor("#f5c2e7")
+SURFACE = QColor("#313244")
+
+
+class MotionCanvas(QWidget):
+    """Small side-view renderer for chain and swingset snapshots."""
+
+    def __init__(self) -> None:
+        """Initialize an empty motion canvas."""
+        super().__init__()
+        self.setMinimumHeight(300)
+        self._chain_nodes: list[tuple[float, float]] = []
+        self._body_points: dict[str, tuple[float, float]] = {}
+
+    def set_scene(
+        self,
+        chain_nodes: list[tuple[float, float]],
+        body_points: dict[str, tuple[float, float]] | None = None,
+    ) -> None:
+        """Update rendered geometry."""
+        self._chain_nodes = chain_nodes
+        self._body_points = body_points or {}
+        self.update()
+
+    def paintEvent(self, _event: object) -> None:  # noqa: N802
+        """Paint the current side-view scene."""
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.fillRect(self.rect(), SURFACE)
+        if not self._chain_nodes:
+            return
+        points = self._project_points()
+        self._draw_polyline(painter, points, CHAIN, 3)
+        self._draw_body(painter, points)
+        painter.setBrush(ACCENT)
+        for point in points[:1] + points[-1:]:
+            painter.drawEllipse(point, 5, 5)
+
+    def _project_points(self) -> list[QPointF]:
+        """Project model coordinates into widget coordinates."""
+        all_points = self._chain_nodes + list(self._body_points.values())
+        min_x = min(point[0] for point in all_points)
+        max_x = max(point[0] for point in all_points)
+        min_y = min(point[1] for point in all_points)
+        max_y = max(point[1] for point in all_points)
+        span_x = max(max_x - min_x, 0.5)
+        span_y = max(max_y - min_y, 0.5)
+        scale = 0.82 * min(self.width() / span_x, self.height() / span_y)
+        offset_x = 0.5 * (self.width() - scale * (min_x + max_x))
+        offset_y = 0.5 * (self.height() - scale * (min_y + max_y))
+        return [
+            QPointF(offset_x + scale * x, offset_y + scale * y)
+            for x, y in self._chain_nodes
+        ]
+
+    def _body_point(self, name: str) -> QPointF:
+        """Project one body point using the current scene bounds."""
+        previous_nodes = self._chain_nodes
+        self._chain_nodes = [self._body_points[name]]
+        point = self._project_points()[0]
+        self._chain_nodes = previous_nodes
+        return point
+
+    def _draw_polyline(
+        self,
+        painter: QPainter,
+        points: list[QPointF],
+        color: QColor,
+        width: int,
+    ) -> None:
+        """Draw connected line segments."""
+        painter.setPen(QPen(color, width))
+        for start, end in zip(points[:-1], points[1:], strict=False):
+            painter.drawLine(start, end)
+
+    def _draw_body(self, painter: QPainter, _chain_points: list[QPointF]) -> None:
+        """Draw rider body links when a swingset scene is active."""
+        if not self._body_points:
+            return
+        pairs = [
+            ("hip", "shoulder", BODY, 5),
+            ("hip", "knee", LEG, 4),
+            ("knee", "foot", LEG, 4),
+            ("shoulder", "elbow", ARM, 4),
+            ("elbow", "hand", ARM, 4),
+        ]
+        for start, end, color, width in pairs:
+            painter.setPen(QPen(color, width))
+            painter.drawLine(self._body_point(start), self._body_point(end))
+
+
+class SwingsetTab(QWidget):
+    """Interactive swingset model tab."""
+
+    def __init__(self) -> None:
+        """Create controls and initial rendering."""
+        super().__init__()
+        self.canvas = MotionCanvas()
+        self.metric_label = QLabel()
+        self._spinboxes: dict[str, QDoubleSpinBox | QSpinBox] = {}
+        self._build_ui()
+        self._refresh()
+
+    def _build_ui(self) -> None:
+        """Build the tab layout."""
+        layout = QGridLayout(self)
+        layout.addWidget(self.canvas, 0, 0, 3, 1)
+        layout.addWidget(self._build_chain_group(), 0, 1)
+        layout.addWidget(self._build_body_group(), 1, 1)
+        run_button = QPushButton("Run Baseline Policy")
+        run_button.clicked.connect(self._run_policy)
+        layout.addWidget(run_button, 2, 1)
+        layout.addWidget(self.metric_label, 3, 0, 1, 2)
+
+    def _build_chain_group(self) -> QGroupBox:
+        """Build chain and seat controls."""
+        group = QGroupBox("Swingset")
+        form = QFormLayout(group)
+        self._add_spin(form, "segments", "Chain segments", 3, 40, 14, integer=True)
+        self._add_spin(form, "chain_length", "Chain length m", 1.0, 5.0, 2.4)
+        self._add_spin(form, "link_mass", "Link mass kg", 0.01, 2.0, 0.16)
+        self._add_spin(form, "seat_mass", "Seat mass kg", 0.5, 25.0, 4.5)
+        return group
+
+    def _build_body_group(self) -> QGroupBox:
+        """Build rider segment controls."""
+        group = QGroupBox("Rider")
+        form = QFormLayout(group)
+        self._add_spin(form, "torso_len", "Torso length m", 0.2, 1.2, 0.62)
+        self._add_spin(form, "torso_mass", "Torso mass kg", 5.0, 80.0, 28.0)
+        self._add_spin(form, "thigh_len", "Thigh length m", 0.15, 0.9, 0.46)
+        self._add_spin(form, "thigh_mass", "Thigh mass kg", 1.0, 25.0, 8.0)
+        self._add_spin(form, "shank_len", "Shank length m", 0.15, 0.9, 0.45)
+        self._add_spin(form, "shank_mass", "Shank mass kg", 1.0, 20.0, 5.5)
+        self._add_spin(form, "arm_len", "Arm segment m", 0.1, 0.8, 0.30)
+        self._add_spin(form, "arm_mass", "Arm segment kg", 0.2, 10.0, 2.0)
+        return group
+
+    def _add_spin(
+        self,
+        form: QFormLayout,
+        key: str,
+        label: str,
+        lower: float,
+        upper: float,
+        value: float,
+        *,
+        integer: bool = False,
+    ) -> None:
+        """Create and register one spin box."""
+        spin: QDoubleSpinBox | QSpinBox = QSpinBox() if integer else QDoubleSpinBox()
+        if integer:
+            spin.setRange(int(lower), int(upper))
+        else:
+            spin.setRange(lower, upper)
+        spin.setValue(int(value)) if integer else spin.setValue(value)
+        if isinstance(spin, QDoubleSpinBox):
+            spin.setDecimals(3)
+            spin.setSingleStep(0.01)
+        spin.valueChanged.connect(self._refresh)
+        self._spinboxes[key] = spin
+        form.addRow(label, spin)
+
+    def _config(self) -> SwingSetConfig:
+        """Return config from current controls."""
+        arm = HumanSegmentSpec(self._value("arm_len"), self._value("arm_mass"))
+        return SwingSetConfig(
+            chain_segments=int(self._value("segments")),
+            chain_length_m=self._value("chain_length"),
+            chain_link_mass_kg=self._value("link_mass"),
+            seat_mass_kg=self._value("seat_mass"),
+            torso=HumanSegmentSpec(self._value("torso_len"), self._value("torso_mass")),
+            thigh=HumanSegmentSpec(self._value("thigh_len"), self._value("thigh_mass")),
+            shank=HumanSegmentSpec(self._value("shank_len"), self._value("shank_mass")),
+            upper_arm=arm,
+            forearm=arm,
+        )
+
+    def _value(self, key: str) -> float:
+        """Return a spin-box value by key."""
+        return float(self._spinboxes[key].value())
+
+    def _refresh(self) -> None:
+        """Render the current static model."""
+        config = self._config()
+        pose = SwingPose(swing_angle_rad=0.18, hip_angle_rad=0.25, elbow_angle_rad=0.35)
+        snapshot = build_swingset_snapshot(config, pose)
+        self.canvas.set_scene(
+            [tuple(point) for point in snapshot.chain_nodes],
+            {key: tuple(value) for key, value in snapshot.points.items()},
+        )
+        self.metric_label.setText(
+            f"Rider mass {config.rider_mass_kg:.1f} kg | "
+            f"hand-chain error {snapshot.hand_chain_error_m:.3f} m"
+        )
+
+    def _run_policy(self) -> None:
+        """Run and display the deterministic baseline policy."""
+        rollout = simulate_swingset(
+            self._config(),
+            SwingSetState(pose=SwingPose(swing_angle_rad=0.08)),
+            steps=180,
+            dt_s=0.02,
+            policy=heuristic_pumping_policy,
+        )
+        snapshot = rollout.snapshots[-1]
+        self.canvas.set_scene(
+            [tuple(point) for point in snapshot.chain_nodes],
+            {key: tuple(value) for key, value in snapshot.points.items()},
+        )
+        self.metric_label.setText(
+            f"Peak angle {rollout.metrics.max_abs_swing_angle_rad:.3f} rad | "
+            f"energy proxy {rollout.metrics.final_energy_proxy_j:.1f} J"
+        )
+
+
+class ChainDynamicsTab(QWidget):
+    """Interactive chain whip-motion analysis tab."""
+
+    def __init__(self) -> None:
+        """Create chain controls and rendering."""
+        super().__init__()
+        self.canvas = MotionCanvas()
+        self.metric_label = QLabel()
+        self._spinboxes: dict[str, QDoubleSpinBox | QSpinBox] = {}
+        self._build_ui()
+        self._refresh()
+
+    def _build_ui(self) -> None:
+        """Build the tab layout."""
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.canvas)
+        controls = QGroupBox("Chain")
+        form = QFormLayout(controls)
+        self._add_spin(form, "segments", "Segments", 2, 60, 16, integer=True)
+        self._add_spin(form, "length", "Link length m", 0.03, 1.0, 0.18)
+        self._add_spin(form, "mass", "Link mass kg", 0.01, 4.0, 0.12)
+        self._add_spin(form, "sag", "Initial sag rad", 0.0, 1.2, 0.35)
+        layout.addWidget(controls)
+        run_button = QPushButton("Simulate Whip")
+        run_button.clicked.connect(self._simulate)
+        layout.addWidget(run_button)
+        layout.addWidget(self.metric_label)
+
+    def _add_spin(
+        self,
+        form: QFormLayout,
+        key: str,
+        label: str,
+        lower: float,
+        upper: float,
+        value: float,
+        *,
+        integer: bool = False,
+    ) -> None:
+        """Create one chain-control spin box."""
+        spin: QDoubleSpinBox | QSpinBox = QSpinBox() if integer else QDoubleSpinBox()
+        if integer:
+            spin.setRange(int(lower), int(upper))
+        else:
+            spin.setRange(lower, upper)
+        spin.setValue(int(value)) if integer else spin.setValue(value)
+        if isinstance(spin, QDoubleSpinBox):
+            spin.setDecimals(3)
+            spin.setSingleStep(0.01)
+        spin.valueChanged.connect(self._refresh)
+        self._spinboxes[key] = spin
+        form.addRow(label, spin)
+
+    def _config(self) -> ChainConfig:
+        """Return chain config from controls."""
+        return ChainConfig(
+            segment_count=int(self._value("segments")),
+            segment_length_m=self._value("length"),
+            link_mass_kg=self._value("mass"),
+        )
+
+    def _state(self) -> ChainState:
+        """Return initial chain state from controls."""
+        config = self._config()
+        angles = initial_catenary_angles(config.segment_count, self._value("sag"))
+        velocities = 0.6 * np.sin(np.linspace(0.0, np.pi, config.segment_count))
+        return ChainState(angles, velocities)
+
+    def _value(self, key: str) -> float:
+        """Return a spin-box value by key."""
+        return float(self._spinboxes[key].value())
+
+    def _refresh(self) -> None:
+        """Render the initial chain."""
+        state = self._state()
+        positions = state.node_positions(self._config())
+        self.canvas.set_scene([tuple(point) for point in positions])
+        metrics = state.metrics(self._config())
+        self.metric_label.setText(
+            f"Tip speed {metrics.tip_speed_m_s:.3f} m/s | "
+            f"curvature {metrics.max_curvature_rad:.3f} rad"
+        )
+
+    def _simulate(self) -> None:
+        """Run and display a short chain dynamics rollout."""
+        rollout = simulate_chain(self._config(), self._state(), steps=120, dt_s=0.01)
+        self.canvas.set_scene([tuple(point) for point in rollout.positions[-1]])
+        self.metric_label.setText(
+            f"Peak tip speed {rollout.tip_speed_m_s.max():.3f} m/s | "
+            f"final energy {rollout.energy_j[-1]:.2f} J"
+        )
+
+
+def create_swingset_tab() -> QWidget:
+    """Create the swingset analysis tab widget."""
+    return SwingsetTab()
+
+
+def create_chain_tab() -> QWidget:
+    """Create the chain dynamics tab widget."""
+    return ChainDynamicsTab()

--- a/src/optimizer_gui/tests/test_swing_chain_models.py
+++ b/src/optimizer_gui/tests/test_swing_chain_models.py
@@ -1,0 +1,277 @@
+"""TDD coverage for swingset and chain motion models."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from optimizer_gui.models.chain_model import (
+    ChainConfig,
+    ChainState,
+    initial_catenary_angles,
+    link_midpoints,
+    simulate_chain,
+)
+from optimizer_gui.models.swingset_model import (
+    HumanSegmentSpec,
+    SwingControlAction,
+    SwingPose,
+    SwingSetConfig,
+    SwingSetState,
+    build_swingset_snapshot,
+    heuristic_pumping_policy,
+    simulate_swingset,
+)
+
+
+def test_chain_config_validates_positive_inputs() -> None:
+    """Chain configuration rejects non-physical dimensions."""
+    with pytest.raises(ValueError, match="segment_count"):
+        ChainConfig(segment_count=0)
+    with pytest.raises(ValueError, match="segment_length_m"):
+        ChainConfig(segment_length_m=0.0)
+    with pytest.raises(ValueError, match="link_mass_kg"):
+        ChainConfig(link_mass_kg=-1.0)
+    with pytest.raises(ValueError, match="damping"):
+        ChainConfig(damping=-0.1)
+    with pytest.raises(ValueError, match="coupling"):
+        ChainConfig(coupling=-0.1)
+
+
+def test_chain_state_validates_array_contracts() -> None:
+    """Chain state validation catches malformed generalized coordinates."""
+    config = ChainConfig(segment_count=2)
+
+    with pytest.raises(ValueError, match="1-D"):
+        ChainState(
+            angles_rad=np.zeros((1, 2)),
+            angular_velocities_rad_s=np.zeros(2),
+        ).validated(config)
+    with pytest.raises(ValueError, match="2 values"):
+        ChainState(
+            angles_rad=np.zeros(3),
+            angular_velocities_rad_s=np.zeros(2),
+        ).validated(config)
+    with pytest.raises(ValueError, match="finite"):
+        ChainState(
+            angles_rad=np.array([0.0, np.nan]),
+            angular_velocities_rad_s=np.zeros(2),
+        ).validated(config)
+
+
+def test_chain_positions_include_anchor_and_tip() -> None:
+    """A two-link vertical chain has deterministic side-view coordinates."""
+    config = ChainConfig(segment_count=2, segment_length_m=0.5)
+    state = ChainState.stationary(config, angle_rad=0.0)
+
+    positions = state.node_positions(config)
+
+    np.testing.assert_allclose(positions, [[0.0, 0.0], [0.0, 0.5], [0.0, 1.0]])
+
+    with pytest.raises(ValueError, match="anchor"):
+        state.node_positions(config, anchor_xy_m=(0.0, float("nan")))
+
+
+def test_chain_midpoints_and_tip_speed_are_reported() -> None:
+    """Chain analysis exposes geometry and whip-style motion metrics."""
+    config = ChainConfig(segment_count=2, segment_length_m=1.0)
+    state = ChainState(
+        angles_rad=np.array([0.0, math.pi / 2.0]),
+        angular_velocities_rad_s=np.array([0.0, 2.0]),
+    )
+
+    midpoints = link_midpoints(state.node_positions(config))
+    metrics = state.metrics(config)
+
+    assert midpoints.shape == (2, 2)
+    assert metrics.tip_speed_m_s == pytest.approx(2.0)
+    assert metrics.max_curvature_rad == pytest.approx(math.pi / 2.0)
+
+    single = ChainState.stationary(ChainConfig(segment_count=1))
+    assert single.metrics(ChainConfig(segment_count=1)).max_curvature_rad == 0.0
+    with pytest.raises(ValueError, match="node_positions"):
+        link_midpoints(np.zeros((1, 2)))
+
+
+def test_chain_simulation_damps_energy() -> None:
+    """A damped chain rollout should not increase total mechanical energy."""
+    config = ChainConfig(segment_count=3, segment_length_m=0.4, damping=2.0)
+    state = ChainState.stationary(config, angle_rad=0.4)
+
+    rollout = simulate_chain(config, state, steps=24, dt_s=0.02)
+
+    assert rollout.positions.shape == (25, 4, 2)
+    assert rollout.energy_j[-1] < rollout.energy_j[0]
+    assert rollout.tip_speed_m_s.shape == (25,)
+
+
+def test_initial_catenary_angles_validate_segment_count() -> None:
+    """Initial chain shape helper validates its public API."""
+    with pytest.raises(ValueError, match="segment_count"):
+        initial_catenary_angles(segment_count=1, sag_rad=0.2)
+    with pytest.raises(ValueError, match="sag_rad"):
+        initial_catenary_angles(segment_count=2, sag_rad=-0.1)
+
+    angles = initial_catenary_angles(segment_count=5, sag_rad=0.2)
+
+    assert angles.shape == (5,)
+    assert angles[0] == pytest.approx(-angles[-1])
+
+
+def test_chain_simulation_validates_rollout_inputs() -> None:
+    """Chain rollout validates step count, dt, and torque history shape."""
+    config = ChainConfig(segment_count=2)
+    state = ChainState.stationary(config)
+
+    with pytest.raises(ValueError, match="steps"):
+        simulate_chain(config, state, steps=0, dt_s=0.01)
+    with pytest.raises(ValueError, match="dt_s"):
+        simulate_chain(config, state, steps=1, dt_s=0.0)
+    with pytest.raises(ValueError, match="torque_history"):
+        simulate_chain(
+            config,
+            state,
+            steps=2,
+            dt_s=0.01,
+            torque_history_nm=np.zeros((1, 2)),
+        )
+
+    rollout = simulate_chain(
+        config,
+        state,
+        steps=2,
+        dt_s=0.01,
+        torque_history_nm=np.zeros((2, 2)),
+    )
+    assert len(rollout.states) == 3
+
+
+def test_swingset_config_exposes_shared_chain_config() -> None:
+    """Swingset and chain analysis share the same chain configuration type."""
+    config = SwingSetConfig(
+        chain_segments=8,
+        chain_length_m=2.4,
+        chain_link_mass_kg=0.2,
+    )
+
+    chain_config = config.chain_config()
+
+    assert isinstance(chain_config, ChainConfig)
+    assert chain_config.segment_count == 8
+    assert chain_config.segment_length_m == pytest.approx(0.3)
+
+
+def test_swingset_config_rejects_invalid_body_segments() -> None:
+    """Human segment specs enforce positive length and mass contracts."""
+    with pytest.raises(ValueError, match="length_m"):
+        HumanSegmentSpec(length_m=0.0, mass_kg=5.0)
+    with pytest.raises(ValueError, match="mass_kg"):
+        HumanSegmentSpec(length_m=0.5, mass_kg=0.0)
+    with pytest.raises(ValueError, match="chain_segments"):
+        SwingSetConfig(chain_segments=0)
+    with pytest.raises(ValueError, match="damping"):
+        SwingSetConfig(damping=-0.1)
+    with pytest.raises(ValueError, match="pump_gain"):
+        SwingSetConfig(pump_gain=-0.1)
+
+
+def test_swingset_snapshot_contains_required_degrees_of_freedom() -> None:
+    """Snapshot includes torso, kicking legs, and two arm segments holding chain."""
+    config = SwingSetConfig()
+    pose = SwingPose(
+        swing_angle_rad=0.1,
+        torso_lean_rad=-0.2,
+        hip_angle_rad=0.35,
+        knee_angle_rad=-0.45,
+        shoulder_angle_rad=-0.3,
+        elbow_angle_rad=0.55,
+    )
+
+    snapshot = build_swingset_snapshot(config, pose)
+
+    for key in ("seat", "hip", "shoulder", "knee", "foot", "elbow", "hand"):
+        assert key in snapshot.points
+    assert snapshot.chain_nodes.shape == (config.chain_segments + 1, 2)
+    assert snapshot.hand_chain_error_m >= 0.0
+    assert snapshot.center_of_mass_m.shape == (2,)
+
+
+def test_swingset_static_position_remains_static_without_control() -> None:
+    """No control from the vertical rest pose should stay near rest."""
+    config = SwingSetConfig(damping=0.0)
+    state = SwingSetState.rest()
+
+    rollout = simulate_swingset(
+        config,
+        state,
+        steps=10,
+        dt_s=0.02,
+        policy=lambda _state, _time: SwingControlAction(),
+    )
+
+    assert rollout.swing_angles_rad[-1] == pytest.approx(0.0, abs=1e-12)
+    assert rollout.metrics.max_abs_swing_angle_rad == pytest.approx(0.0)
+
+
+def test_swingset_heuristic_policy_builds_amplitude() -> None:
+    """The built-in pumping policy is suitable as a training baseline."""
+    config = SwingSetConfig(pump_gain=0.9, damping=0.01)
+    state = SwingSetState(
+        pose=SwingPose(swing_angle_rad=0.08),
+        swing_angular_velocity_rad_s=0.0,
+    )
+
+    passive = simulate_swingset(
+        config,
+        state,
+        steps=180,
+        dt_s=0.02,
+        policy=lambda _state, _time: SwingControlAction(),
+    )
+    active = simulate_swingset(
+        config,
+        state,
+        steps=180,
+        dt_s=0.02,
+        policy=heuristic_pumping_policy,
+    )
+
+    assert (
+        active.metrics.max_abs_swing_angle_rad > passive.metrics.max_abs_swing_angle_rad
+    )
+    assert active.controls.shape == (180, 5)
+
+
+def test_swingset_simulation_validates_rollout_inputs() -> None:
+    """Swingset rollout validates step count and integration interval."""
+    config = SwingSetConfig()
+    state = SwingSetState.rest()
+
+    with pytest.raises(ValueError, match="steps"):
+        simulate_swingset(
+            config,
+            state,
+            steps=0,
+            dt_s=0.01,
+            policy=heuristic_pumping_policy,
+        )
+    with pytest.raises(ValueError, match="dt_s"):
+        simulate_swingset(
+            config,
+            state,
+            steps=1,
+            dt_s=0.0,
+            policy=heuristic_pumping_policy,
+        )
+
+
+def test_optimizer_package_extends_to_nested_python_sources() -> None:
+    """Standalone launch can import nested optimizer_gui UI modules."""
+    import optimizer_gui
+
+    nested = Path(optimizer_gui.__file__).parent / "python" / "optimizer_gui"
+
+    assert str(nested) in list(optimizer_gui.__path__)

--- a/src/optimizer_gui/tests/test_swing_chain_tabs.py
+++ b/src/optimizer_gui/tests/test_swing_chain_tabs.py
@@ -1,0 +1,82 @@
+"""TDD coverage for optimizer GUI swingset and chain tabs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def test_gui_registration_describes_movement_optimizer() -> None:
+    """The launcher metadata presents the expanded movement optimizer."""
+    from optimizer_gui import gui_registration
+
+    info = gui_registration.get_gui_info()
+
+    assert info["name"] == "Movement Optimizer"
+    assert "swingset" in info["description"].lower()
+    assert "chain" in info["description"].lower()
+
+
+def test_main_window_registers_motion_tabs_with_qt_mocks(monkeypatch: Any) -> None:
+    """The optimizer window adds separate swingset and chain analysis tabs."""
+    from optimizer_gui.ui.pyqt6 import main_window
+
+    added_tabs: list[str] = []
+
+    class FakeTabWidget:
+        def addTab(self, _widget: object, label: str) -> None:
+            added_tabs.append(label)
+
+    window = main_window.OptimizerWindow.__new__(main_window.OptimizerWindow)
+    window.tab_widget = FakeTabWidget()
+    monkeypatch.setattr(main_window.OptimizerWindow, "_create_parameters_tab", object)
+    monkeypatch.setattr(
+        main_window.OptimizerWindow,
+        "_create_adam_settings_tab",
+        object,
+    )
+    monkeypatch.setattr(main_window.OptimizerWindow, "_create_results_tab", object)
+    monkeypatch.setattr(main_window, "create_swingset_tab", lambda: object())
+    monkeypatch.setattr(main_window, "create_chain_tab", lambda: object())
+
+    window._add_optimizer_tabs()
+
+    assert added_tabs == [
+        "Parameters",
+        "Adam Settings",
+        "Results",
+        "Swingset Model",
+        "Chain Dynamics",
+    ]
+
+
+def test_tools_json_has_movement_optimizer_tile() -> None:
+    """Tools launcher tile is renamed and still points to the standalone app."""
+    tools_json = Path(__file__).resolve().parents[3] / "tools.json"
+    data = json.loads(tools_json.read_text(encoding="utf-8"))
+    optimizer_entries = data["Optimization"]
+
+    tile = next(
+        entry
+        for entry in optimizer_entries
+        if entry["path"] == "src/optimizer_gui/launch_pyqt6.py"
+    )
+
+    assert tile["name"] == "Movement Optimizer"
+    assert "swingset" in tile["desc"].lower()
+
+
+def test_optimizer_model_pack_exposes_upstreamdrift_tile() -> None:
+    """UpstreamDrift provider discovery can expose the optimizer as a tile."""
+    manifest_path = Path(__file__).resolve().parents[1] / "model_pack.yaml"
+    text = manifest_path.read_text(encoding="utf-8")
+
+    assert "id: tools_movement_optimizer" in text
+    assert "path: src/optimizer_gui/launch_pyqt6.py" in text
+    assert "web_route: /tools/movement-optimizer" in text
+
+    root_manifest = Path(__file__).resolve().parents[3] / "model_pack.yaml"
+    root_text = root_manifest.read_text(encoding="utf-8")
+    assert 'id: "tools_movement_optimizer"' in root_text
+    assert 'path: "src/optimizer_gui/launch_pyqt6.py"' in root_text

--- a/tool_surface_contract.json
+++ b/tool_surface_contract.json
@@ -135,8 +135,8 @@
     },
     {
       "id": "optimizer_gui",
-      "name": "Adam Optimizer",
-      "description": "Configure and run Adam-based optimization",
+      "name": "Movement Optimizer",
+      "description": "Optimize motion policies with Adam, swingset, and chain dynamics models",
       "category": "Optimization",
       "surfaces": {
         "pyqt6": true,

--- a/tools.json
+++ b/tools.json
@@ -89,10 +89,10 @@
     ],
     "Optimization": [
         {
-            "name": "Adam Optimizer",
+            "name": "Movement Optimizer",
             "path": "src/optimizer_gui/launch_pyqt6.py",
             "type": "python",
-            "desc": "Configure and run Adam-based optimization"
+            "desc": "Train and compare Adam, swingset, and chain-dynamics motion policies"
         }
     ],
     "Process Simulation": [

--- a/tools.json
+++ b/tools.json
@@ -92,7 +92,7 @@
             "name": "Movement Optimizer",
             "path": "src/optimizer_gui/launch_pyqt6.py",
             "type": "python",
-            "desc": "Train and compare Adam, swingset, and chain-dynamics motion policies"
+            "desc": "Optimize motion policies with Adam, swingset, and chain dynamics models"
         }
     ],
     "Process Simulation": [


### PR DESCRIPTION
## Summary
- Reapply the reverted Movement Optimizer swingset and segmented-chain model work onto current main.
- Restore provider metadata, launcher wiring, PyQt6 motion tabs, typed model modules, and focused model/UI tests.
- Add mypy-compatible numpy type aliases and a typed launcher bootstrap protocol so pre-push type checks pass.

## Validation
- `python -m pytest src\optimizer_gui\tests\test_swing_chain_models.py src\optimizer_gui\tests\test_swing_chain_tabs.py -q -o addopts=''` -> 18 passed
- `python -m pytest src\optimizer_gui\tests -q -o addopts=''` -> 40 passed
- `pre-commit run mypy --hook-stage pre-push --files src\optimizer_gui\python\optimizer_gui\models\chain_model.py src\optimizer_gui\python\optimizer_gui\models\swingset_model.py src\optimizer_gui\launch_pyqt6.py` -> passed
- Full pre-push suite passed before transport retry: ruff, format, guardrails, prettier, mypy, bandit, pytest, pip-audit