### PR TITLE
fix: replace hardcoded developer-specific paths with portable resolution (#3278)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.328                                    |
+| **Spec Version**        | 1.1.329                                    |
 | **Last Spec Update**    | 2026-06-09                                 |
 
 ## 2. Purpose & Mission
@@ -645,6 +645,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | Date | Version | Changes |
 | ---- | ------- | ------- |
 
+| 2026-06-09 | 1.1.329 | fix(portability): remove developer-specific hardcoded absolute paths (#3278) — AI CLI adapters (`claude_code`, `gemini_cli`, `codex_cli`) now build PATH fallbacks from the current user's environment and home directory (no literal usernames) and `expanduser` as well as `expandvars`; fleet scripts (`fleet_autofix_patcher.py`, `fleet_safety_patcher.py`) derive `REPOS_ROOT` from the `REPOS_ROOT` env var or checkout location and `enhanced_batch_fix_dry.py` derives its root from `TOOLS_REPO_PATH`, each exiting non-zero when the root is missing; added `tests/scripts/test_no_hardcoded_user_paths.py` guarding against `C:\Users\<name>` / `/home/<name>/` literals. |
 | 2026-06-09 | 1.1.328 | fix(ci): satisfy the changed-file quality gate by explicitly annotating access-policy registry results under skipped-import mypy, add Python 3.10 `tomli` support for metadata contract tests, assert calc-backend pressure-drop values through the standardized response `data` payload, and keep Sidekick standard responses importable from the repo package path without top-level path shims. |
 | 2026-06-09 | 1.1.327 | fix(compatibility-ci): route remaining Python 3.10-exercised `StrEnum` imports through compatibility shims, make those shims type-check as native `StrEnum` under mypy while retaining Python 3.10 fallbacks, keep the integrations dashboard empty-state property explicitly typed as `bool`, and pass `.secrets.baseline` explicitly to the detect-secrets audit test so the 3.10 CI matrix validates the canonical baseline instead of failing on CLI argument parsing. |
 | 2026-06-09 | 1.1.326 | ci(coverage): keep total coverage floors as a full-suite ratchet while changed-file scoped PR runs enforce only the tracked coverage-policy packages touched by the diff; added regression coverage for the scoped/full-suite split. |

--- a/scripts/enhanced_batch_fix_dry.py
+++ b/scripts/enhanced_batch_fix_dry.py
@@ -7,12 +7,39 @@ with better pattern matching and import management.
 """
 
 import logging
+import os
 import re
 import sys
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 logger = logging.getLogger(__name__)
+
+
+def _resolve_repo_root() -> Path:
+    """Locate the Tools repo root portably.
+
+    Resolution order:
+
+    1. The ``TOOLS_REPO_PATH`` environment variable, when set.
+    2. The repo this script lives in (``scripts/`` -> repo root).
+
+    Exits non-zero with a clear message when the directory cannot be found, so
+    a headless caller never mistakes a missing root for a silent no-op.
+    """
+    env_root = os.environ.get("TOOLS_REPO_PATH")
+    candidate = (
+        Path(env_root).expanduser() if env_root else Path(__file__).resolve().parents[1]
+    )
+    if not candidate.is_dir():
+        logger.error(
+            "Could not determine the Tools repo root. Set TOOLS_REPO_PATH to the "
+            "repository checkout (got: %s).",
+            candidate,
+        )
+        sys.exit(1)
+    return candidate
+
 
 # Track total fixes
 TOTAL_FIXES = 0
@@ -411,7 +438,7 @@ def find_python_files(root: Path) -> list[Path]:
 
 def main() -> int:
     """Main entry point."""
-    repo_root = Path("/home/dieterolson/Linux_Tools/Tools")
+    repo_root = _resolve_repo_root()
 
     # Find Python files
     logger.info("Finding Python files...")

--- a/scripts/fleet_autofix_patcher.py
+++ b/scripts/fleet_autofix_patcher.py
@@ -1,13 +1,41 @@
 import logging
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
-REPOS_ROOT = Path(r"C:\Users\diete\Repositories")
+
+def _resolve_repos_root() -> Path:
+    """Locate the directory that contains the sibling fleet repos.
+
+    Resolution order, portable across machines and CI runners:
+
+    1. The ``REPOS_ROOT`` environment variable, when set.
+    2. The parent of this repo's checkout (``scripts/`` -> repo -> repos root),
+       which holds the sibling repos in the standard fleet layout.
+
+    Exits non-zero with a clear message when the directory cannot be found, so
+    a headless parent process never mistakes a missing root for a silent no-op.
+    """
+    env_root = os.environ.get("REPOS_ROOT")
+    candidate = (
+        Path(env_root).expanduser() if env_root else Path(__file__).resolve().parents[2]
+    )
+    if not candidate.is_dir():
+        logger.error(
+            "Could not determine the repos root. Set the REPOS_ROOT environment "
+            "variable to the directory containing the fleet repos (got: %s).",
+            candidate,
+        )
+        sys.exit(1)
+    return candidate
+
+
+REPOS_ROOT = _resolve_repos_root()
 TARGET_REPOS = [
     "AffineDrift",
     "Games",

--- a/scripts/fleet_safety_patcher.py
+++ b/scripts/fleet_safety_patcher.py
@@ -1,13 +1,41 @@
 import logging
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 # Setup logging
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
-REPOS_ROOT = Path(r"C:\Users\diete\Repositories")
+
+def _resolve_repos_root() -> Path:
+    """Locate the directory that contains the sibling fleet repos.
+
+    Resolution order, portable across machines and CI runners:
+
+    1. The ``REPOS_ROOT`` environment variable, when set.
+    2. The parent of this repo's checkout (``scripts/`` -> repo -> repos root),
+       which holds the sibling repos in the standard fleet layout.
+
+    Exits non-zero with a clear message when the directory cannot be found, so
+    a headless parent process never mistakes a missing root for a silent no-op.
+    """
+    env_root = os.environ.get("REPOS_ROOT")
+    candidate = (
+        Path(env_root).expanduser() if env_root else Path(__file__).resolve().parents[2]
+    )
+    if not candidate.is_dir():
+        logger.error(
+            "Could not determine the repos root. Set the REPOS_ROOT environment "
+            "variable to the directory containing the fleet repos (got: %s).",
+            candidate,
+        )
+        sys.exit(1)
+    return candidate
+
+
+REPOS_ROOT = _resolve_repos_root()
 TARGET_REPOS = [
     "AffineDrift",
     "Games",

--- a/src/shared/python/ai/adapters/claude_code_adapter.py
+++ b/src/shared/python/ai/adapters/claude_code_adapter.py
@@ -58,12 +58,15 @@ logger = get_logger(__name__)
 # slow first call doesn't surface as a misleading "CLI broken" error.
 DEFAULT_CLAUDE_CODE_TIMEOUT = 120.0  # [s]
 
-# Known install locations probed when ``claude`` is not on PATH. Order matters:
-# Windows install location first because the launcher runs on Windows.
+# Known install locations probed when ``claude`` is not on PATH. Built from the
+# current user's home directory and environment so they resolve on any host —
+# no developer-specific usernames. Order matters: Windows install locations
+# first because the launcher typically runs on Windows.
 _FALLBACK_PATHS = (
-    r"C:\Users\diete\.local\bin\claude.exe",
     r"%LOCALAPPDATA%\Programs\Claude Code\claude.exe",
-    "/home/dieterolson/.local/bin/claude",
+    r"%USERPROFILE%\.local\bin\claude.exe",
+    "~/.local/bin/claude",
+    "/usr/local/bin/claude",
 )
 
 # Static model catalogue. Claude Code does not expose a `list models` command,
@@ -100,7 +103,7 @@ def _resolve_binary(explicit: str | None = None) -> str | None:
     import os
 
     for candidate in _FALLBACK_PATHS:
-        expanded = os.path.expandvars(candidate)
+        expanded = os.path.expanduser(os.path.expandvars(candidate))
         if Path(expanded).exists():
             return expanded
     return None

--- a/src/shared/python/ai/adapters/codex_cli_adapter.py
+++ b/src/shared/python/ai/adapters/codex_cli_adapter.py
@@ -61,13 +61,14 @@ logger = get_logger(__name__)
 # chat doesn't report a misleading timeout on the very first message.
 DEFAULT_CODEX_CLI_TIMEOUT = 180.0  # [s]
 
-# Known install locations probed when ``codex`` is not on PATH. Windows-npm
-# global-bin first because that's the npm install target on the host that
-# typically runs the launcher.
+# Known install locations probed when ``codex`` is not on PATH. Built from the
+# current user's environment and home directory (no developer-specific
+# usernames). Windows-npm global-bin first because that's the npm install
+# target on the host that typically runs the launcher.
 _FALLBACK_PATHS = (
     r"%APPDATA%\npm\codex.cmd",
     r"%APPDATA%\npm\codex",
-    "/home/dieterolson/.npm-global/bin/codex",
+    "~/.npm-global/bin/codex",
     "/usr/local/bin/codex",
 )
 
@@ -102,7 +103,7 @@ def _resolve_binary(explicit: str | None = None) -> str | None:
     if found:
         return found
     for candidate in _FALLBACK_PATHS:
-        expanded = os.path.expandvars(candidate)
+        expanded = os.path.expanduser(os.path.expandvars(candidate))
         if Path(expanded).exists():
             return expanded
     return None

--- a/src/shared/python/ai/adapters/gemini_cli_adapter.py
+++ b/src/shared/python/ai/adapters/gemini_cli_adapter.py
@@ -59,11 +59,13 @@ logger = get_logger(__name__)
 # but the first call after install can be slow because the runtime warms up.
 DEFAULT_GEMINI_CLI_TIMEOUT = 120.0  # [s]
 
-# Known install locations probed when ``gemini`` is not on PATH.
+# Known install locations probed when ``gemini`` is not on PATH. Built from the
+# current user's environment and home directory — no developer-specific
+# usernames, so they resolve on any host.
 _FALLBACK_PATHS = (
     r"%APPDATA%\npm\gemini.cmd",
     r"%APPDATA%\npm\gemini",
-    "/home/dieterolson/.npm-global/bin/gemini",
+    "~/.npm-global/bin/gemini",
     "/usr/local/bin/gemini",
 )
 
@@ -97,7 +99,7 @@ def _resolve_binary(explicit: str | None = None) -> str | None:
     if found:
         return found
     for candidate in _FALLBACK_PATHS:
-        expanded = os.path.expandvars(candidate)
+        expanded = os.path.expanduser(os.path.expandvars(candidate))
         if Path(expanded).exists():
             return expanded
     return None

--- a/tests/scripts/test_no_hardcoded_user_paths.py
+++ b/tests/scripts/test_no_hardcoded_user_paths.py
@@ -1,0 +1,64 @@
+"""Guard against developer-specific absolute paths in adapters and scripts.
+
+Hardcoded home directories (e.g. ``C:\\Users\\diete`` or ``/home/dieterolson``)
+resolve only on the original developer's machine. On any other user, host, or CI
+runner they are dead paths: AI CLI adapters fall through to a non-existent
+fallback ("CLI not found"), and fleet scripts fail with ``FileNotFoundError``
+before doing useful work. This test makes such literals a hard failure.
+
+See Tools issue #3278.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# Repo root: tests/scripts/<this file> -> parents[2] is the repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories scanned for developer-specific path literals.
+_SCANNED_DIRS = (
+    _REPO_ROOT / "src" / "shared" / "python" / "ai" / "adapters",
+    _REPO_ROOT / "scripts",
+)
+
+# Windows ``C:\Users\<name>`` and POSIX ``/home/<name>/`` home-directory roots.
+# A bare username token (letters, digits, dot, underscore, hyphen) follows the
+# separator; this test file itself only contains the patterns inside raw
+# strings/comments, which are excluded below.
+_HARDCODED_HOME_RE = re.compile(
+    r"[A-Za-z]:\\Users\\[A-Za-z0-9._-]+" r"|/home/[A-Za-z0-9._-]+/",
+)
+
+
+def _iter_python_files() -> list[Path]:
+    files: list[Path] = []
+    for base in _SCANNED_DIRS:
+        if not base.exists():
+            continue
+        files.extend(sorted(base.rglob("*.py")))
+    return files
+
+
+@pytest.mark.unit
+def test_no_developer_home_paths() -> None:
+    """No source file may embed a developer-specific home directory."""
+    offenders: dict[str, list[str]] = {}
+    self_path = Path(__file__).resolve()
+    for path in _iter_python_files():
+        if path.resolve() == self_path:
+            # This guard file legitimately documents the patterns it forbids.
+            continue
+        text = path.read_text(encoding="utf-8")
+        matches = _HARDCODED_HOME_RE.findall(text)
+        if matches:
+            offenders[str(path.relative_to(_REPO_ROOT))] = sorted(set(matches))
+
+    assert not offenders, (
+        "Developer-specific hardcoded home paths found (use shutil.which / "
+        "Path.home() / env vars instead):\n"
+        + "\n".join(f"  {f}: {paths}" for f, paths in offenders.items())
+    )


### PR DESCRIPTION
## Summary
Removes developer-specific absolute paths that resolve only on the original developer's machine, per #3278. On any other user/host/CI runner these were dead paths — AI CLI adapters reported "CLI not found" even when installed, and fleet scripts `FileNotFoundError`'d or silently no-op'd before doing work.

## Changes
**AI CLI adapters** (`src/shared/python/ai/adapters/`)
- `claude_code_adapter.py`, `gemini_cli_adapter.py`, `codex_cli_adapter.py`: PATH fallback sets rebuilt from the current user's environment + home directory (`%LOCALAPPDATA%`, `%USERPROFILE%`, `%APPDATA%`, `~/.local/bin`, `~/.npm-global/bin`, `/usr/local/bin`) — no literal usernames. Resolvers now `os.path.expanduser` as well as `expandvars`. `shutil.which` remains the primary lookup.

**Fleet scripts** (`scripts/`)
- `fleet_autofix_patcher.py`, `fleet_safety_patcher.py`: derive `REPOS_ROOT` from the `REPOS_ROOT` env var or the checkout location (`parents[2]`); `sys.exit(1)` with a clear message if it cannot be determined (headless-safe contract).
- `enhanced_batch_fix_dry.py`: derive `repo_root` from `TOOLS_REPO_PATH` env var or the checkout location (`parents[1]`); `sys.exit(1)` on failure.

**Test (TDD, red→green)**
- `tests/scripts/test_no_hardcoded_user_paths.py`: greps the adapters and `scripts/` for `C:\Users\<name>` and `/home/<name>/` literals and asserts none remain. Verified failing before the fix (6 offending files) and passing after.

## Acceptance criteria
- [x] Failing-test-first evidence (path-lint test red before, green after).
- [x] No literal `C:\Users\<name>` / `/home/<name>/` strings remain in adapters or `scripts/`.
- [x] Adapters discover binaries via `shutil.which` + portable, home-relative fallbacks.
- [x] Fleet scripts derive their root portably and exit non-zero when missing.
- [x] `ruff check` and `ruff format --check` green on touched files.

## CI note
The local full-repo mypy pre-push hook flags two **pre-existing** `redundant-cast` errors in `openai_adapter.py` / `anthropic_adapter.py` — files this branch does not touch (verified on `origin/main`). Tracked separately in #3284; CI's delta-scoped quality-gate is unaffected by them.

Closes #3278

🤖 Generated with [Claude Code](https://claude.com/claude-code)