### PR TITLE
🎨 Palette: Add explicit label associations and focus states to inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -19,3 +19,6 @@
 ## 2024-06-05 - Preserving existing aria-describedby for dynamic validation
 **Learning:** When dynamically associating a validation error message with an input field using `aria-describedby`, setting the attribute blindly will overwrite any existing helpful associations (like an input hint ID).
 **Action:** Always concatenate the error message ID with any existing hint IDs (e.g., `aria-describedby="errorId hintId"`) to ensure screen readers announce both the validation error and the original helper text. When clearing the error, restore the `aria-describedby` to just the hint ID.
+## 2024-06-11 - Dynamic Input ID Generation for Screen Readers
+**Learning:** Hardcoded IDs in reusable React components (like `InputField` in `FinancialCalculator.tsx`) lead to ID collisions when rendered multiple times. This breaks `<label htmlFor="...">` associations, severely impacting screen reader accessibility as the label will only associate with the first instance of the ID on the page.
+**Action:** Always use React's `useId()` hook within reusable components to dynamically generate unique, accessible, and SSR-safe IDs for `htmlFor` and `id` bindings.

--- a/src/financial_calculator/web/src/components/FinancialCalculator.tsx
+++ b/src/financial_calculator/web/src/components/FinancialCalculator.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useId } from 'react'
 
 // Catppuccin Mocha colors
 const colors = {
@@ -192,7 +192,7 @@ function FinancialCalculator() {
 
           <button
             onClick={calculate}
-            className="w-full py-3 rounded-lg font-bold text-lg transition-colors"
+            className="w-full py-3 rounded-lg font-bold text-lg transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#89b4fa] focus-visible:ring-offset-[#1e1e2e]"
             style={{ backgroundColor: colors.blue, color: colors.base }}
           >
             Calculate Financial Model
@@ -240,17 +240,19 @@ interface InputFieldProps {
 }
 
 function InputField({ label, value, onChange, min = 0, max = 100, step = 1 }: InputFieldProps) {
+  const inputId = useId()
   return (
     <div className="flex items-center justify-between gap-4">
-      <label className="text-sm" style={{ color: colors.text }}>{label}</label>
+      <label htmlFor={inputId} className="text-sm" style={{ color: colors.text }}>{label}</label>
       <input
+        id={inputId}
         type="number"
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
         min={min}
         max={max}
         step={step}
-        className="w-32 px-3 py-2 rounded text-right"
+        className="w-32 px-3 py-2 rounded text-right focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#89b4fa]"
         style={{
           backgroundColor: colors.surface0,
           color: colors.text,


### PR DESCRIPTION
💡 **What:**
Added explicit label-to-input associations using React's `useId()` and introduced clear keyboard focus rings using Tailwind's `focus-visible` classes to the `FinancialCalculator` inputs and button.

🎯 **Why:**
The previous reusable `InputField` component lacked `id` and `htmlFor` attributes entirely. Since it's rendered multiple times, a hardcoded ID wouldn't work. Without this connection, screen readers cannot properly associate the text label with the corresponding numeric input field. Additionally, navigating via keyboard (Tab) provided no visual indication of which field was currently active.

📸 **Before/After:**
*(Screenshots verified locally using Playwright: The inputs and the bottom "Calculate Financial Model" button now correctly display a soft blue focus ring when navigated via keyboard).*

♿ **Accessibility:**
- **Screen Readers:** Inputs are now programmatically tied to their text labels via `useId()`, ensuring they are announced correctly.
- **Keyboard Navigation:** Users navigating via the "Tab" key now receive a clear, visible focus indicator (`focus-visible:ring-2 focus-visible:ring-[#89b4fa]`), adhering to WCAG focus visibility standards without penalizing mouse users.

---
*PR created automatically by Jules for task [16805686324417062012](https://jules.google.com/task/16805686324417062012) started by @dieterolson*