### PR TITLE
fix: HMI crash, dead GUI/handlers, fabricated scores (#3319, #3320, #3327, #3328)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,8 +27,8 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.382                                    |
-| **Last Spec Update**    | 2026-06-11                                 |
+| **Spec Version**        | 1.1.384                                    |
+| **Last Spec Update**    | 2026-06-12                                 |
 
 ## 2. Purpose & Mission
 

--- a/src/document_processing/pdf_renamer/src/pdf_renamer/gui.py
+++ b/src/document_processing/pdf_renamer/src/pdf_renamer/gui.py
@@ -5,13 +5,11 @@
 
 from __future__ import annotations
 
-from shared.python.theme.integration import ThemedWindowMixin
 import logging
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from numba import jit
 from PyQt6.QtCore import Qt, QThread, pyqtSignal
 from PyQt6.QtGui import QFont, QTextCursor
 from PyQt6.QtWidgets import (
@@ -37,6 +35,8 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+from shared.python.theme.integration import ThemedWindowMixin
 
 from .api_mode import APIRenameManager, RenameProposal
 from .cache import ResultCache
@@ -187,9 +187,18 @@ class ProcessingThread(QThread):
         )
         return pdf_files
 
-    @jit(nopython=True, fastmath=True)
     def _process_pdf_files(self, pdf_files: list[Path]) -> None:
-        """Process PDF files in parallel using ThreadPoolExecutor."""
+        """Process PDF files in parallel using ThreadPoolExecutor.
+
+        This method performs file I/O, constructs ``ResultCache`` /
+        ``TransactionLog`` / ``GeminiTitleLLM`` / ``ThreadPoolExecutor`` objects
+        and emits Qt signals — none of which numba ``nopython`` mode can
+        compile. The previous ``@jit(nopython=True)`` decorator raised a numba
+        ``TypingError`` on first call; since that derives from ``NumbaError``
+        (not ``TypeError``) it escaped ``run()``'s ``except`` clause, killed the
+        QThread without emitting ``finished``, and left the UI permanently stuck
+        with Start disabled and Cancel enabled (issue #3319).
+        """
         if pdf_files is None:
             raise ValueError("pdf_files must be provided")
         cache = ResultCache(self.db_path)

--- a/src/p1am_control_system/desktop/sidebar.py
+++ b/src/p1am_control_system/desktop/sidebar.py
@@ -46,6 +46,12 @@ class InspectorSidebar(QWidget):
         # User role
         self.user_role = "Operator"
 
+        # Baseline values of the safety-limit / PID spin boxes as last loaded
+        # from the routing config. Used to detect whether the user edited a
+        # read-only control (QDoubleSpinBox has no isModified(); issue #3320).
+        self._baseline_low_limit: float = 0.0
+        self._baseline_pid_setpoint: float = 0.0
+
         # Current system configuration reference
         self.routing_config = None
 
@@ -216,6 +222,7 @@ class InspectorSidebar(QWidget):
             interlock = self.routing_config.interlocks[tag_id]
             self.spin_low_limit.setValue(interlock.low_limit)
             self.spin_high_limit.setValue(interlock.high_limit)
+            self._baseline_low_limit = self.spin_low_limit.value()
 
         # 2. Check associated PID loop (either PV or CV tag matches)
         pid_found = None
@@ -233,6 +240,7 @@ class InspectorSidebar(QWidget):
             self.spin_pid_kp.setValue(pid_found.kp)
             self.spin_pid_ki.setValue(pid_found.ki)
             self.spin_pid_kd.setValue(pid_found.kd)
+            self._baseline_pid_setpoint = self.spin_pid_sp.value()
         else:
             self.pid_group.setVisible(False)
 
@@ -294,8 +302,14 @@ class InspectorSidebar(QWidget):
             self.routing_worker.start()
 
         elif self.user_role != "Admin" and (
-            self.spin_low_limit.isModified() or self.spin_pid_sp.isModified()
+            self.spin_low_limit.value() != self._baseline_low_limit
+            or self.spin_pid_sp.value() != self._baseline_pid_setpoint
         ):
+            # QDoubleSpinBox has no isModified() (that is a QLineEdit method);
+            # calling it raised AttributeError inside this slot and, since
+            # PyQt 5.5, an unhandled exception in a slot aborts the whole HMI
+            # via qFatal. Compare against the last-loaded baseline instead
+            # (issue #3320).
             QMessageBox.critical(
                 self,
                 "Access Denied",

--- a/src/shared/python/model_generation/api/rest_api_assets.py
+++ b/src/shared/python/model_generation/api/rest_api_assets.py
@@ -186,11 +186,28 @@ class AssetLibraryEditorRoutesMixin:
         )
 
     def library_remove_model(self, request: APIRequest) -> APIResponse:
-        """Return the current placeholder response for model deletion."""
-        ensure_request(request)
-        if not request.query_params.get("model_id"):
+        """Remove a model from the library (issue #3327).
+
+        ModelLibrary.remove_model is fully implemented; this handler previously
+        returned a 501 stub. ``delete_files`` (default False) optionally removes
+        the cached files as well.
+        """
+        from model_generation.library import ModelLibrary
+
+        model_id = ensure_request(request).query_params.get("model_id")
+        if not model_id:
             return APIResponse.error("Missing model_id")
-        return APIResponse.error("Remove not implemented", 501)
+
+        delete_files = str(request.query_params.get("delete_files", "")).lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+        removed = ModelLibrary().remove_model(model_id, delete_files=delete_files)
+        if not removed:
+            return APIResponse.not_found(f"Model not found: {model_id}")
+        return APIResponse.ok({"removed": True, "id": model_id})
 
     def library_download_model(self, request: APIRequest) -> APIResponse:
         """Download the URDF content for a stored model."""

--- a/src/shared/python/model_generation/api/rest_api_routes.py
+++ b/src/shared/python/model_generation/api/rest_api_routes.py
@@ -897,11 +897,20 @@ class ModelGenerationAPI:
         if not model_id:
             return APIResponse.error("Missing model_id")
 
-        ModelLibrary()
+        # ``delete_files`` is an opt-in flag (default False) mirroring
+        # ModelLibrary.remove_model; accept the usual truthy query spellings.
+        delete_files = str(request.query_params.get("delete_files", "")).lower() in (
+            "1",
+            "true",
+            "yes",
+        )
 
-        # Note: This would need implementation in ModelLibrary
-        # For now, return not implemented
-        return APIResponse.error("Remove not implemented", 501)
+        library = ModelLibrary()
+        removed = library.remove_model(model_id, delete_files=delete_files)
+        if not removed:
+            return APIResponse.not_found(f"Model not found: {model_id}")
+
+        return APIResponse.ok({"removed": True, "id": model_id})
 
     def library_download_model(self, request: APIRequest) -> APIResponse:
         """Download model URDF."""

--- a/src/video_analyzer/analyzer.py
+++ b/src/video_analyzer/analyzer.py
@@ -221,7 +221,9 @@ class SwingAnalyzer:
         recommendations = self._generate_recommendations(issues)
 
         # Calculate scores
-        scores = self._calculate_scores(tempo, balance, plane, posture, issues)
+        scores = self._calculate_scores(
+            tempo, balance, plane, posture, issues, key_positions, poses
+        )
 
         return SwingAnalysis(
             session_id=str(uuid.uuid4()),
@@ -723,11 +725,20 @@ class SwingAnalyzer:
         plane: PlaneMetrics,
         posture: PostureMetrics,
         issues: list[SwingIssue],
+        key_positions: dict[str, SwingPositionMetrics],
+        poses: list[PoseFrame],
     ) -> SwingScores:
-        """Calculate swing scores (0-100)."""
+        """Calculate swing scores (0-100).
+
+        ``rotation`` is derived from the measured X-factor (shoulder-minus-hip
+        rotation) at the top of the backswing — data the analyzer already
+        computes — instead of a hardcoded placeholder (issue #3328).
+        ``consistency`` is reported from the pose-detection confidence stability
+        across the captured frames; a single swing cannot measure swing-to-swing
+        repeatability, so this is an explicit measurement-reliability proxy
+        rather than a fabricated constant.
+        """
         # Tempo score
-        if tempo is None:
-            raise ValueError("tempo must be provided")
         if tempo is None:
             raise ValueError("tempo must be provided")
         tempo_dev = abs(tempo.tempo_ratio - 3)
@@ -749,6 +760,32 @@ class SwingAnalyzer:
             + len([i for i in issues if i.severity == "moderate"]) * 5
         )
 
+        # Rotation score — derived from the measured X-factor at the top of the
+        # backswing. A tour-quality X-factor is ~45 deg; score peaks there and
+        # falls off for under- or over-rotation. Uses the maximum X-factor seen
+        # across the key positions (top-of-backswing has the largest).
+        ideal_x_factor = 45.0
+        max_x_factor = max(
+            (m.angles.x_factor for m in key_positions.values()),
+            default=0.0,
+        )
+        rotation_score = max(
+            0.0, 100.0 - abs(max_x_factor - ideal_x_factor) * (100.0 / ideal_x_factor)
+        )
+        rotation_score = min(100.0, rotation_score)
+
+        # Consistency score — a single swing cannot measure swing-to-swing
+        # repeatability, so report the pose-detection confidence stability as an
+        # explicit measurement-reliability proxy (mean confidence penalised by
+        # its spread) instead of a fabricated constant.
+        confidences = [p.confidence for p in poses] if poses else []
+        if confidences:
+            mean_conf = sum(confidences) / len(confidences)
+            spread = max(confidences) - min(confidences)
+            consistency_score = max(0.0, min(100.0, (mean_conf - spread) * 100.0))
+        else:
+            consistency_score = 0.0
+
         # Overall
         components = [tempo_score, balance_score, plane_score, posture_score]
         overall = sum(components) / len(components) - issue_penalty / 2
@@ -760,7 +797,7 @@ class SwingAnalyzer:
             balance=balance_score,
             plane=plane_score,
             posture=posture_score,
-            rotation=75,  # Placeholder
+            rotation=rotation_score,
             timing=tempo_score,
-            consistency=80,  # Would need multiple swings
+            consistency=consistency_score,
         )

--- a/tests/p1am_control_system/test_inspector_sidebar_apply.py
+++ b/tests/p1am_control_system/test_inspector_sidebar_apply.py
@@ -1,0 +1,78 @@
+"""Regression tests for InspectorSidebar._apply_changes (#3320).
+
+An Operator clicking 'Apply' after touching a (read-only) safety/PID spin box
+previously hit ``QDoubleSpinBox.isModified()`` — a QLineEdit-only method — which
+raised ``AttributeError`` inside a Qt slot and, since PyQt 5.5, aborts the whole
+HMI via qFatal. The fix compares the spin box value against the last-loaded
+baseline instead. These tests assert the slot runs to completion and surfaces a
+normal 'Access Denied' dialog rather than crashing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt6")
+pytest.importorskip("requests")  # InspectorSidebar -> workers -> requests
+
+from PyQt6.QtWidgets import QDoubleSpinBox  # noqa: E402
+
+from p1am_control_system.desktop import sidebar as sidebar_module  # noqa: E402
+from p1am_control_system.desktop.sidebar import InspectorSidebar  # noqa: E402
+
+
+def test_qdoublespinbox_has_no_is_modified() -> None:
+    """Guard: the bug was calling a method that does not exist on the widget."""
+    assert not hasattr(QDoubleSpinBox, "isModified")
+
+
+@pytest.mark.gui
+def test_operator_apply_after_edit_shows_dialog_without_crash(
+    qapp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_critical(_parent, title, text, *args, **kwargs):  # noqa: ANN001
+        calls.append((title, text))
+        return None
+
+    monkeypatch.setattr(sidebar_module.QMessageBox, "critical", _fake_critical)
+
+    widget = InspectorSidebar()
+    widget.set_role("Operator")
+    widget.selected_tag_id = 0
+    # Establish a baseline, then simulate the operator nudging the read-only
+    # low-limit spin box above it.
+    widget._baseline_low_limit = 10.0
+    widget.spin_low_limit.setValue(25.0)
+
+    # Must not raise AttributeError (the pre-fix crash) ...
+    widget._apply_changes()
+
+    # ... and must surface the access-denied dialog exactly once.
+    assert len(calls) == 1
+    assert "Access Denied" in calls[0][0]
+
+
+@pytest.mark.gui
+def test_operator_apply_without_edit_shows_no_dialog(
+    qapp, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        sidebar_module.QMessageBox,
+        "critical",
+        lambda *a, **k: calls.append(("critical", "")),
+    )
+
+    widget = InspectorSidebar()
+    widget.set_role("Operator")
+    widget.selected_tag_id = 0
+    widget._baseline_low_limit = 10.0
+    widget._baseline_pid_setpoint = 5.0
+    widget.spin_low_limit.setValue(10.0)
+    widget.spin_pid_sp.setValue(5.0)
+
+    widget._apply_changes()
+
+    assert calls == []

--- a/tests/shared/python/model_generation/test_rest_api_routes.py
+++ b/tests/shared/python/model_generation/test_rest_api_routes.py
@@ -495,13 +495,54 @@ def test_library_add_model_missing_content_returns_400(api: ModelGenerationAPI) 
 
 
 @pytest.mark.unit
-def test_library_remove_model_returns_501(api: ModelGenerationAPI) -> None:
+def test_library_remove_model_missing_id_returns_400(api: ModelGenerationAPI) -> None:
+    req = APIRequest(
+        method=HTTPMethod.DELETE,
+        path="/api/v1/library/models/",
+        query_params={},
+    )
+    resp = api.library_remove_model(req)
+    assert resp.status_code == 400
+    assert "error" in resp.body
+
+
+@pytest.mark.unit
+def test_library_remove_model_nonexistent_returns_404(api: ModelGenerationAPI) -> None:
+    # ModelLibrary.remove_model returns False for an unknown id -> 404 (#3327).
     resp = _delete(
         api,
-        "/api/v1/library/models/some_id",
-        query_params={"model_id": "some_id"},
+        "/api/v1/library/models/nonexistent_xyz_999",
+        query_params={"model_id": "nonexistent_xyz_999"},
     )
-    assert resp.status_code == 501
+    assert resp.status_code == 404
+    assert "error" in resp.body
+
+
+@pytest.mark.unit
+def test_library_remove_model_success_returns_200(
+    api: ModelGenerationAPI, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful removal returns 200 and echoes the removed id (#3327)."""
+    captured: dict[str, object] = {}
+
+    class _FakeLibrary:
+        def remove_model(self, model_id: str, delete_files: bool = False) -> bool:
+            captured["model_id"] = model_id
+            captured["delete_files"] = delete_files
+            return True
+
+    monkeypatch.setattr(
+        "model_generation.library.ModelLibrary", _FakeLibrary, raising=False
+    )
+
+    resp = _delete(
+        api,
+        "/api/v1/library/models/abc123",
+        query_params={"model_id": "abc123", "delete_files": "true"},
+    )
+    assert resp.status_code == 200
+    assert resp.body == {"removed": True, "id": "abc123"}
+    assert captured == {"model_id": "abc123", "delete_files": True}
 
 
 @pytest.mark.unit

--- a/tests/test_phase2_critical_bugs.py
+++ b/tests/test_phase2_critical_bugs.py
@@ -258,6 +258,17 @@ class TestGodFunctionRefactoring:
             assert hasattr(ProcessingThread, "_delete_duplicate_set")
             assert hasattr(ProcessingThread, "_scan_pdf_files")
             assert hasattr(ProcessingThread, "_process_pdf_files")
+
+            # _process_pdf_files must be a plain Python function, NOT a numba
+            # @jit dispatcher (issue #3319). A numba-compiled method would be a
+            # CPUDispatcher; the original @jit(nopython=True) raised a
+            # TypingError that escaped run() and froze the GUI.
+            import inspect
+
+            assert inspect.isfunction(ProcessingThread._process_pdf_files), (
+                "_process_pdf_files must be a plain function, not a numba "
+                f"dispatcher; got {type(ProcessingThread._process_pdf_files)!r}"
+            )
         except ImportError:
             pytest.skip("PyQt6 not available for GUI tests")
 

--- a/tests/video_analyzer/test_swing_score_derivation.py
+++ b/tests/video_analyzer/test_swing_score_derivation.py
@@ -1,0 +1,96 @@
+"""Tests that swing rotation/consistency scores are derived from data (#3328).
+
+Previously ``SwingAnalyzer._calculate_scores`` returned hardcoded placeholders
+``rotation=75`` and ``consistency=80`` regardless of the analyzed swing. These
+tests assert the scores now respond to the measured X-factor and to the pose
+detection-confidence stability.
+
+The ``video_analyzer`` package transitively imports OpenCV (a declared project
+dependency); these tests skip cleanly where it is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("cv2")
+
+from src.video_analyzer.analyzer import SwingAnalyzer  # noqa: E402
+from src.video_analyzer.types import (  # noqa: E402
+    BalanceMetrics,
+    BodyAngles,
+    PlaneMetrics,
+    PoseFrame,
+    PostureMetrics,
+    SwingPositionMetrics,
+    TempoMetrics,
+)
+
+
+def _position(x_factor: float) -> SwingPositionMetrics:
+    return SwingPositionMetrics(
+        frame_number=0,
+        timestamp=0.0,
+        angles=BodyAngles(x_factor=x_factor),
+        confidence=1.0,
+    )
+
+
+def _poses(confidences: list[float]) -> list[PoseFrame]:
+    return [
+        PoseFrame(frame_number=i, timestamp=float(i), landmarks=[], confidence=c)
+        for i, c in enumerate(confidences)
+    ]
+
+
+def _scores(analyzer: SwingAnalyzer, key_positions, poses):
+    return analyzer._calculate_scores(
+        TempoMetrics(tempo_ratio=3.0),
+        BalanceMetrics(),
+        PlaneMetrics(),
+        PostureMetrics(),
+        [],
+        key_positions,
+        poses,
+    )
+
+
+@pytest.mark.unit
+def test_rotation_score_peaks_at_ideal_x_factor() -> None:
+    analyzer = SwingAnalyzer()
+    ideal = _scores(analyzer, {"top": _position(45.0)}, _poses([1.0]))
+    poor = _scores(analyzer, {"top": _position(10.0)}, _poses([1.0]))
+
+    # An ideal ~45 deg X-factor scores ~100; severe under-rotation scores much
+    # lower — and neither equals the old hardcoded 75.
+    assert ideal.rotation == pytest.approx(100.0, abs=1e-6)
+    assert poor.rotation < 30.0
+    assert poor.rotation != 75
+
+
+@pytest.mark.unit
+def test_rotation_score_uses_max_x_factor_across_positions() -> None:
+    analyzer = SwingAnalyzer()
+    positions = {"address": _position(5.0), "top": _position(45.0)}
+    scores = _scores(analyzer, positions, _poses([1.0]))
+    assert scores.rotation == pytest.approx(100.0, abs=1e-6)
+
+
+@pytest.mark.unit
+def test_consistency_reflects_confidence_stability() -> None:
+    analyzer = SwingAnalyzer()
+    steady = _scores(analyzer, {"top": _position(45.0)}, _poses([0.95, 0.96, 0.95]))
+    jittery = _scores(analyzer, {"top": _position(45.0)}, _poses([0.2, 0.99, 0.5]))
+
+    # Stable, high-confidence detection scores higher than jittery detection,
+    # and neither is the old fabricated constant 80.
+    assert steady.consistency > jittery.consistency
+    assert steady.consistency != 80
+    assert jittery.consistency != 80
+
+
+@pytest.mark.unit
+def test_consistency_zero_when_no_poses() -> None:
+    analyzer = SwingAnalyzer()
+    scores = _scores(analyzer, {"top": _position(45.0)}, [])
+    assert scores.consistency == 0.0


### PR DESCRIPTION
## Summary
Four self-contained fixes across the P1AM HMI, PDF Renamer, model-library API, and video swing analyzer.

- **#3320 (P1) HMI crash** — `InspectorSidebar._apply_changes` called `QDoubleSpinBox.isModified()`, a QLineEdit-only method. The resulting `AttributeError` inside a Qt slot aborts the entire plant HMI via qFatal whenever an Operator clicks **Apply**. Now records a baseline on load and compares the spin-box value against it.
- **#3319 (P1) PDF Renamer dead end** — removed `@jit(nopython=True, fastmath=True)` from `ProcessingThread._process_pdf_files`. The method does file I/O, builds `ResultCache`/`TransactionLog`/`GeminiTitleLLM`/`ThreadPoolExecutor` and emits Qt signals — uncompilable; the numba `TypingError` escaped `run()`'s `except` and permanently froze the UI (Start disabled, Cancel enabled). Also drops the now-unused `from numba import jit`.
- **#3327 (P2) DELETE /library model** — both handlers returned a 501 stub though `ModelLibrary.remove_model` is fully implemented. Now returns 200 with the removed id, 404 when absent, and honours `?delete_files`.
- **#3328 (P2) fabricated scores** — the swing analyzer hardcoded `rotation=75` / `consistency=80`. `rotation` is now derived from the measured X-factor at the top of backswing (data already computed); `consistency` is reported from pose-detection confidence stability — an explicit measurement-reliability proxy, since a single swing cannot measure swing-to-swing repeatability.

## Tests
- New DELETE-handler tests (missing id → 400, nonexistent → 404, success → 200) — run locally, all green.
- New rotation/consistency derivation tests (cv2-gated) and InspectorSidebar apply tests (PyQt6/requests-gated) — run in CI where those deps are installed.
- Extended the existing `ProcessingThread` test to assert `_process_pdf_files` is a plain function, not a numba dispatcher.
- ruff check/format clean; mypy clean on changed source files. SPEC.md bumped.

Closes #3319
Closes #3320
Closes #3327
Closes #3328

🤖 Generated with [Claude Code](https://claude.com/claude-code)