### PR TITLE
fix: ODE Solver invalid-input crash + busy feedback (#3321)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.394                                    |
+| **Spec Version**        | 1.1.395                                    |
 | **Last Spec Update**    | 2026-06-12                                 |
 
 ## 2. Purpose & Mission

--- a/src/ode_solver/python/ode_solver/ui/pyqt6/main_window.py
+++ b/src/ode_solver/python/ode_solver/ui/pyqt6/main_window.py
@@ -331,7 +331,25 @@ class ODESolverWindow(ThemedWindowMixin, QMainWindow):
         pathological or stiff systems cannot hang the GUI indefinitely.
         Raises ``SolverTimeoutError`` if the computation exceeds
         ``_SOLVER_TIMEOUT_S`` seconds.
+
+        Invalid user input (a bad parameter expression, a missing initial
+        condition, a non-monotonic time span, …) is reported in the results
+        pane instead of propagating out of this slot. An unhandled exception in
+        a Qt slot aborts the whole application under PyQt6, so a typo must never
+        crash the app (issue #3321). While the (synchronous) solve runs, the
+        Solve button is disabled and a wait cursor is shown so the user has
+        feedback during the up-to-``_SOLVER_TIMEOUT_S`` blocking call.
         """
+        self.solve_btn.setEnabled(False)
+        QApplication.setOverrideCursor(Qt.CursorShape.WaitCursor)
+        try:
+            self._run_solve()
+        finally:
+            QApplication.restoreOverrideCursor()
+            self.solve_btn.setEnabled(True)
+
+    def _run_solve(self) -> None:
+        """Execute the parse/solve/render pipeline (see :meth:`_solve`)."""
         try:
             from sidekick.process_calculators.ode_solver import (
                 ODESolver,
@@ -442,6 +460,18 @@ class ODESolverWindow(ThemedWindowMixin, QMainWindow):
                 f"Timeout: {e}\n\nTry reducing the time span or simplifying the ODE system."
             )
             self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['yellow']};")
+        except (ValueError, TypeError) as e:
+            # Input-validation failures: bad parameter/initial-condition text,
+            # a missing initial condition, or a contract precondition
+            # (ContractViolationError subclasses ValueError). Report rather than
+            # crash the application (issue #3321).
+            _log.info("Invalid ODE input: %s", e)
+            self.results_text.setPlainText(
+                f"Invalid input: {e}\n\n"
+                "Check that every parameter and initial condition is a number "
+                "and that an initial condition is provided for each variable."
+            )
+            self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['red']};")
         except ImportError as e:
             self.results_text.setPlainText(f"Error: {e}")
             self.results_text.setStyleSheet(f"color: {CATPPUCCIN_MOCHA['red']};")

--- a/tests/ode_solver/test_main_window.py
+++ b/tests/ode_solver/test_main_window.py
@@ -84,6 +84,51 @@ class TestParseDictInput:
             ODESolverWindow._parse_dict_input(mock_self, ["k: 1"])
 
 
+class TestRunSolveValidationHandling:
+    """_run_solve reports invalid input instead of raising (issue #3321).
+
+    Exercised via an unbound call with a mock ``self`` so no live QApplication
+    is required. The key guarantee is that bad user input never escapes the slot
+    (which would abort the whole app under PyQt6).
+    """
+
+    def _mock_window(self) -> MagicMock:
+        # No spec= here: _run_solve reads instance attributes (the Qt edit
+        # widgets, results_text) that are not part of the class namespace, so a
+        # spec-restricted mock would reject them. The widgets' return values are
+        # irrelevant because _parse_dict_input is stubbed below.
+        mock_self = MagicMock()
+        mock_self._SOLVER_TIMEOUT_S = 30.0
+        return mock_self
+
+    def test_bad_parameter_value_is_reported_not_raised(self) -> None:
+        mock_self = self._mock_window()
+        # derivatives valid; a parameter value is non-numeric -> float() raises
+        # ValueError inside _run_solve, which must be caught.
+        mock_self._parse_dict_input.side_effect = [
+            {"x": "-k*x"},  # derivatives
+            {"k": "abc"},  # parameters (non-numeric)
+            {"x": "1.0"},  # initial conditions
+        ]
+        ODESolverWindow._run_solve(mock_self)  # must NOT raise
+
+        mock_self.results_text.setPlainText.assert_called_once()
+        message = mock_self.results_text.setPlainText.call_args[0][0]
+        assert "Invalid input" in message
+
+    def test_missing_initial_condition_is_reported_not_raised(self) -> None:
+        mock_self = self._mock_window()
+        mock_self._parse_dict_input.side_effect = [
+            {"x": "-k*x"},  # derivatives
+            {"k": "0.5"},  # parameters
+            {},  # initial conditions — missing x
+        ]
+        ODESolverWindow._run_solve(mock_self)  # must NOT raise
+
+        message = mock_self.results_text.setPlainText.call_args[0][0]
+        assert "Invalid input" in message
+
+
 class TestOnPresetChangedPreconditions:
     """Unit tests for ODESolverWindow._on_preset_changed DbC guards.
 


### PR DESCRIPTION
## Summary
**P1 crash fix.** The ODE Solver's Solve slot caught only `SolverTimeoutError` and `ImportError`, so every input-validation failure (a non-numeric parameter/initial-condition, a missing initial condition, or a `require(...)` precondition — `ContractViolationError` subclasses `ValueError`) propagated out of the Qt slot. Under PyQt6 an unhandled exception in a slot calls `qFatal` and aborts the whole application, so a typo in the Parameters box killed the app.

- Split `_solve` (UI guard) from `_run_solve` (parse/solve/render pipeline).
- `_solve` disables the Solve button and shows a wait cursor for the duration of the synchronous, up-to-timeout solve, restoring both in a `finally` — giving the user feedback during the blocking call.
- `_run_solve` now catches `(ValueError, TypeError)` and reports the validation error in the results pane instead of crashing.

## Tests
Added unbound-call unit tests (bad parameter value; missing initial condition) that assert the error is reported via `results_text.setPlainText`, not raised. Full ODE main-window suite (15 tests) green; ruff/format clean. SPEC.md bumped.

Closes #3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)