### PR TITLE
🎨 Palette: Disable spellcheck and autocorrect on pendulum torque inputs

### DIFF
--- a/src/pendulum_simulator/pendulum-web/src/App.tsx
+++ b/src/pendulum_simulator/pendulum-web/src/App.tsx
@@ -466,6 +466,9 @@ export default function App() {
                     value={shoulderStr}
                     onChange={e => setShoulderStr(e.target.value)}
                     placeholder="-25, 10"
+                    spellCheck="false"
+                    autoCorrect="off"
+                    autoCapitalize="none"
                   />
                 </div>
                 <div className="coeff-row">
@@ -475,6 +478,9 @@ export default function App() {
                     value={wristStr}
                     onChange={e => setWristStr(e.target.value)}
                     placeholder="0"
+                    spellCheck="false"
+                    autoCorrect="off"
+                    autoCapitalize="none"
                   />
                 </div>
               </div>
@@ -552,15 +558,15 @@ export default function App() {
                 <h3 className="section-title">Torques</h3>
                 <div className="coeff-row">
                   <label className="param-label">Shoulder</label>
-                  <input className="coeff-input" value={shoulderStrT} onChange={e => setShoulderStrT(e.target.value)} />
+                  <input className="coeff-input" value={shoulderStrT} onChange={e => setShoulderStrT(e.target.value)} spellCheck="false" autoCorrect="off" autoCapitalize="none" />
                 </div>
                 <div className="coeff-row">
                   <label className="param-label">Elbow</label>
-                  <input className="coeff-input" value={elbowStrT} onChange={e => setElbowStrT(e.target.value)} />
+                  <input className="coeff-input" value={elbowStrT} onChange={e => setElbowStrT(e.target.value)} spellCheck="false" autoCorrect="off" autoCapitalize="none" />
                 </div>
                 <div className="coeff-row">
                   <label className="param-label">Wrist</label>
-                  <input className="coeff-input" value={wristStrT} onChange={e => setWristStrT(e.target.value)} />
+                  <input className="coeff-input" value={wristStrT} onChange={e => setWristStrT(e.target.value)} spellCheck="false" autoCorrect="off" autoCapitalize="none" />
                 </div>
               </div>
 


### PR DESCRIPTION
💡 What: Added `spellCheck="false"`, `autoCorrect="off"`, and `autoCapitalize="none"` to the torque polynomial input fields in the Pendulum Simulator application.

🎯 Why: These fields expect raw numbers or mathematical formulas (e.g., `-25, 10`). By disabling native mobile OS formatting features (like spellcheck and auto-capitalization), we prevent red squiggly lines from appearing under numbers and prevent mobile keyboards from erroneously auto-capitalizing the inputs, making the interaction significantly smoother.

📸 Before/After: Not a visual change (prevents native browser spellcheck lines).

♿ Accessibility: Ensures that screen readers or native accessibility tools do not incorrectly flag or attempt to correct numerical formulas as misspelled words.

---
*PR created automatically by Jules for task [9497632659552505493](https://jules.google.com/task/9497632659552505493) started by @dieterolson*