### PR TITLE
fix: decouple headless calc_backend engines from PyQt6 theme (#3317)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.395                                    |
+| **Spec Version**        | 1.1.399                                    |
 | **Last Spec Update**    | 2026-06-12                                 |
 
 ## 2. Purpose & Mission

--- a/src/shared/python/calc_backend/routers/wgs_reactor.py
+++ b/src/shared/python/calc_backend/routers/wgs_reactor.py
@@ -17,13 +17,22 @@ router = APIRouter(prefix="/api/calc/wgs-reactor", tags=["wgs-reactor"])
 @router.post("", response_model=WGSReactorResponse)
 def calculate_wgs(request: WGSReactorRequest) -> WGSReactorResponse:
     """Calculate WGS reactor equilibrium and optional sizing."""
+    import sidekick.process_calculators as _pc
     from sidekick.process_calculators import WGSReactorEngine
 
     if WGSReactorEngine is None:
-        raise HTTPException(
-            status_code=503,
-            detail="WGSReactorEngine not available (missing numpy/scipy)",
+        # Surface the ACTUAL import failure rather than a hardcoded, misleading
+        # "missing numpy/scipy" (issue #3317): the historical cause was the GUI
+        # theme layer dragging PyQt6 into this headless service.
+        reasons = [
+            err for err in getattr(_pc, "_import_errors", []) if "WGSReactor" in err
+        ]
+        detail = (
+            f"WGSReactorEngine unavailable: {reasons[0]}"
+            if reasons
+            else "WGSReactorEngine unavailable (import failed)"
         )
+        raise HTTPException(status_code=503, detail=detail)
 
     engine = WGSReactorEngine()
 

--- a/src/shared/python/sidekick/process_calculators/syngas_compression_calculator.py
+++ b/src/shared/python/sidekick/process_calculators/syngas_compression_calculator.py
@@ -26,9 +26,10 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, cast
 
-from shared.python.theme.integration import get_theme_manager
-from shared.python.theme.matplotlib_style import apply_plot_theme
-
+# The theme layer (get_theme_manager / apply_plot_theme) is imported lazily in
+# the GUI plotting method below, NOT at module top: theme.integration imports
+# PyQt6 unconditionally, and this module is consumed headlessly by the FastAPI
+# calc_backend (issue #3317).
 from .constants import (
     ATOL_ZERO,
     CELSIUS_TO_KELVIN_OFFSET,
@@ -533,6 +534,10 @@ if HAS_PYQT:
 
             # Create matplotlib figure
             from matplotlib.figure import Figure  # lazy import
+
+            # Lazy GUI-only theme imports (issue #3317).
+            from shared.python.theme.integration import get_theme_manager
+            from shared.python.theme.matplotlib_style import apply_plot_theme
 
             self.figure = Figure(figsize=(10, 8))
             _tm = get_theme_manager()

--- a/src/shared/python/sidekick/process_calculators/wgs_reactor_calculator.py
+++ b/src/shared/python/sidekick/process_calculators/wgs_reactor_calculator.py
@@ -29,9 +29,12 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from sidekick.utils.state_manager import safe_read_json
 
-from shared.python.theme.integration import get_theme_manager
-from shared.python.theme.matplotlib_style import apply_plot_theme
-
+# NOTE: the theme layer (get_theme_manager / apply_plot_theme) is imported
+# lazily inside the GUI plotting method, NOT at module top. theme.integration
+# imports PyQt6 unconditionally, and this module's WGSReactorEngine is consumed
+# headlessly by the FastAPI calc_backend; a top-level theme import would drag a
+# GUI toolkit into the server process and make the engine un-importable without
+# PyQt6 installed (issue #3317).
 from .constants import (
     CELSIUS_TO_KELVIN_OFFSET,
     KJ_HR_TO_KW,
@@ -602,6 +605,11 @@ if BASE_CALCULATOR_AVAILABLE:
             """Create plots tab"""
             self._plots_widget = QWidget()
             layout = QVBoxLayout()
+
+            # Lazy GUI-only imports (issue #3317): keep the headless engine
+            # import path free of PyQt6.
+            from shared.python.theme.integration import get_theme_manager
+            from shared.python.theme.matplotlib_style import apply_plot_theme
 
             self.figure = Figure(figsize=(10, 6))
             _tm = get_theme_manager()

--- a/tests/calc_backend/test_wgs_reactor_headless_import_3317.py
+++ b/tests/calc_backend/test_wgs_reactor_headless_import_3317.py
@@ -1,0 +1,82 @@
+"""calc_backend domain engines must import without a GUI toolkit (#3317).
+
+The FastAPI calc_backend is a headless web service. Its domain engines used to
+import the PyQt6 theme layer at module top, so importing ``WGSReactorEngine`` on
+a server without PyQt6 failed — and the router then returned a misleading
+"missing numpy/scipy" 503. These tests run a subprocess with PyQt6 import
+*blocked* and assert the engine still imports and never pulls in the theme/Qt
+layer.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Program run in a clean subprocess: block PyQt6 (and the theme layer that wraps
+# it), then import the engine and assert success + no Qt/theme leakage.
+_PROGRAM = textwrap.dedent(
+    """
+    import importlib.abc
+    import importlib.machinery
+    import sys
+
+
+    class _BlockQt(importlib.abc.MetaPathFinder):
+        _BLOCKED = ("PyQt6", "shared.python.theme.integration")
+
+        def find_spec(self, fullname, path, target=None):
+            if fullname == "PyQt6" or fullname.startswith("PyQt6."):
+                raise ImportError("PyQt6 is blocked for this headless test")
+            return None
+
+
+    sys.meta_path.insert(0, _BlockQt())
+
+    # Importing the engine must NOT require PyQt6 / the theme layer.
+    from sidekick.process_calculators.wgs_reactor_calculator import WGSReactorEngine
+
+    assert WGSReactorEngine is not None
+
+    # A pure-thermodynamics call must work with no GUI present.
+    engine = WGSReactorEngine()
+    k = engine.calculate_equilibrium_constant(1000.0)
+    assert k > 0
+
+    # The GUI theme layer must not have been dragged in by the import.
+    assert "shared.python.theme.integration" not in sys.modules, (
+        "engine import pulled in the PyQt6 theme layer"
+    )
+    assert "PyQt6" not in sys.modules
+
+    print("HEADLESS_OK")
+    """
+)
+
+
+@pytest.mark.unit
+def test_wgs_engine_imports_without_pyqt6() -> None:
+    # Reproduce the parent interpreter's import roots so the subprocess resolves
+    # ``sidekick`` / ``contracts`` / ``shared`` the same way the test run does.
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p and Path(p).is_dir())
+    result = subprocess.run(
+        [sys.executable, "-c", _PROGRAM],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    assert result.returncode == 0, (
+        "headless engine import failed:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "HEADLESS_OK" in result.stdout


### PR DESCRIPTION
## Summary
**P1 architectural-coupling fix.** The FastAPI `calc_backend` (a headless web service) imports its domain engines from the sidekick package, and those engine modules imported the PyQt6 theme layer at module top. `theme/integration.py` does `from PyQt6.QtWidgets import …` unconditionally, so importing `WGSReactorEngine` (or the syngas-compression calculator) dragged a GUI toolkit into the server process. On a server without PyQt6, `process_calculators/__init__.py` swallowed the `ImportError`, set `WGSReactorEngine = None`, and the router returned a misleading `503 "missing numpy/scipy"`.

- Moved the `get_theme_manager` / `apply_plot_theme` imports in `wgs_reactor_calculator.py` and `syngas_compression_calculator.py` out of module scope into the GUI plotting methods that actually use them (lazy import).
- The `wgs_reactor` router now surfaces the **actual** import error (from `process_calculators._import_errors`) instead of the hardcoded numpy/scipy text.

## Tests
Adds `tests/calc_backend/test_wgs_reactor_headless_import_3317.py`: a subprocess that blocks `PyQt6`, then asserts `WGSReactorEngine` imports, computes `calculate_equilibrium_constant(1000 K) > 0`, and that neither `PyQt6` nor `shared.python.theme.integration` ends up in `sys.modules`. ruff/format/mypy clean. SPEC.md bumped.

Closes #3317

🤖 Generated with [Claude Code](https://claude.com/claude-code)