### PR TITLE
fix: stop sidekick state_manager crossing the tool-tree boundary (#3333)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.395                                    |
+| **Spec Version**        | 1.1.400                                    |
 | **Last Spec Update**    | 2026-06-12                                 |
 
 ## 2. Purpose & Mission

--- a/src/shared/python/sidekick/tests/test_json_io_boundary_3333.py
+++ b/src/shared/python/sidekick/tests/test_json_io_boundary_3333.py
@@ -1,0 +1,74 @@
+"""sidekick state_manager must not reach across the tool-tree boundary (#3333).
+
+state_manager previously imported ``safe_read_json``/``safe_write_json`` from a
+foreign application tree via the bare name ``utils.file_utils`` and ``UTC`` from
+the bare ``compatibility`` module. Both resolved only by sys.path accident and
+broke in installed deployments. These tests pin the new self-contained behaviour.
+"""
+
+from __future__ import annotations
+
+import ast
+import datetime
+from pathlib import Path
+
+import pytest
+
+_STATE_MANAGER = Path(__file__).resolve().parents[1] / "utils" / "state_manager.py"
+
+
+@pytest.mark.unit
+def test_state_manager_has_no_cross_tree_imports() -> None:
+    """No ``from utils...`` or ``from compatibility...`` imports remain."""
+    tree = ast.parse(_STATE_MANAGER.read_text(encoding="utf-8"))
+    offending: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            root = node.module.split(".")[0]
+            if root in {"utils", "compatibility"}:
+                offending.append(node.module)
+    assert offending == [], (
+        f"state_manager still imports across the tool-tree boundary: {offending}"
+    )
+
+
+@pytest.mark.unit
+def test_state_manager_utc_is_stdlib_utc() -> None:
+    from sidekick.utils.state_manager import UTC
+
+    assert UTC is datetime.UTC
+
+
+@pytest.mark.unit
+def test_json_io_round_trip(tmp_path: Path) -> None:
+    from sidekick.utils.json_io import safe_read_json, safe_write_json
+
+    target = tmp_path / "nested" / "data.json"
+    payload = {"k": [1, 2, 3], "s": "v"}
+    assert safe_write_json(target, payload) is True
+    assert safe_read_json(target) == payload
+
+
+@pytest.mark.unit
+def test_json_io_missing_returns_default(tmp_path: Path) -> None:
+    from sidekick.utils.json_io import safe_read_json
+
+    assert safe_read_json(tmp_path / "absent.json", default="DEF") == "DEF"
+
+
+@pytest.mark.unit
+def test_json_io_none_path_raises() -> None:
+    from sidekick.utils.json_io import safe_read_json, safe_write_json
+
+    with pytest.raises(ValueError, match="file_path must be provided"):
+        safe_read_json(None)
+    with pytest.raises(ValueError, match="file_path must be provided"):
+        safe_write_json(None, {})
+
+
+@pytest.mark.unit
+def test_json_io_non_serializable_returns_false(tmp_path: Path) -> None:
+    from sidekick.utils.json_io import safe_write_json
+
+    # object() is not JSON-serialisable and there is no default= serialiser.
+    assert safe_write_json(tmp_path / "bad.json", {"x": object()}) is False

--- a/src/shared/python/sidekick/utils/json_io.py
+++ b/src/shared/python/sidekick/utils/json_io.py
@@ -1,0 +1,113 @@
+"""Self-contained JSON I/O helpers for the sidekick library.
+
+These were previously imported from a *foreign* application tree via the bare
+top-level name ``utils.file_utils`` (``src/python/src/utils/``), which resolved
+only by sys.path accident and collided with sidekick's own ``sidekick.utils``
+package of the same short name (issue #3333). Vendoring the small, dependency-
+free helpers here keeps the sidekick library self-contained and importable in an
+installed (non-checkout) deployment.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+__all__ = ["safe_read_json", "safe_write_json"]
+
+_logger = logging.getLogger(__name__)
+
+
+def safe_read_json(file_path: Path | str, default: Any = None) -> Any:
+    """Read a JSON file, returning ``default`` on missing/invalid/unreadable file.
+
+    Args:
+        file_path: Path to the JSON file. Must not be ``None``.
+        default: Value returned when the file is absent or cannot be parsed.
+
+    Returns:
+        The parsed JSON document, or ``default``.
+
+    Raises:
+        ValueError: If ``file_path`` is ``None``.
+    """
+    if file_path is None:
+        raise ValueError("file_path must be provided")
+    path = Path(file_path)
+
+    if not path.exists():
+        _logger.debug("JSON file not found: %s, using default", path)
+        return default
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        _logger.error("Invalid JSON in %s: %s", path, e)
+        return default
+    except (PermissionError, OSError) as e:
+        _logger.error("Error reading JSON file %s: %s", path, e)
+        return default
+
+
+def safe_write_json(
+    file_path: Path | str,
+    data: Any,
+    indent: int = 2,
+    create_parents: bool = True,
+    default: Callable[[Any], Any] | None = None,
+) -> bool:
+    """Atomically write ``data`` as JSON, returning success.
+
+    The write is atomic (temp file + ``os.replace``) so an interruption leaves
+    the previous file intact rather than a truncated, unparseable destination.
+
+    Args:
+        file_path: Destination path. Must not be ``None``.
+        data: JSON-serialisable payload.
+        indent: Indentation level passed to ``json.dump``.
+        create_parents: Create missing parent directories when ``True``.
+        default: Optional ``json.dump`` ``default=`` serialiser for
+            non-natively-serialisable objects.
+
+    Returns:
+        ``True`` on success, ``False`` otherwise.
+
+    Raises:
+        ValueError: If ``file_path`` is ``None``.
+    """
+    if file_path is None:
+        raise ValueError("file_path must be provided")
+    path = Path(file_path)
+
+    try:
+        if create_parents:
+            path.parent.mkdir(parents=True, exist_ok=True)
+
+        text = json.dumps(data, indent=indent, ensure_ascii=False, default=default)
+
+        # Write to a temp sibling then os.replace (atomic on POSIX and Windows),
+        # so an interruption leaves the previous file intact. ``open`` is used
+        # deliberately (not ``os.fdopen``) so file-permission failures surface
+        # the same way callers/tests expect.
+        tmp = path.with_name(f".{path.name}.tmp")
+        try:
+            with open(tmp, "w", encoding="utf-8") as handle:
+                handle.write(text)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+            raise
+        return True
+    except (PermissionError, OSError, TypeError, ValueError) as e:
+        _logger.error("Error writing JSON file %s: %s", path, e)
+        return False

--- a/src/shared/python/sidekick/utils/state_manager.py
+++ b/src/shared/python/sidekick/utils/state_manager.py
@@ -16,10 +16,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from compatibility import UTC
+# Use sidekick's OWN JSON I/O helpers and the stdlib UTC, instead of reaching
+# across the tool-tree boundary via the bare top-level names ``compatibility``
+# and ``utils.file_utils`` (a different application tree, reachable only by
+# sys.path accident and colliding with sidekick's own ``utils`` package).
+# See issue #3333.
+from .json_io import safe_read_json, safe_write_json
 
-# Use canonical file I/O utilities instead of reimplementing them
-from utils.file_utils import safe_read_json, safe_write_json
+UTC = timezone.utc  # noqa: UP017 - 3.10-compatible alias for datetime.UTC
 
 # Setup logging
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
**P2 import-boundary fix.** `sidekick/utils/state_manager.py` imported `safe_read_json`/`safe_write_json` from the bare top-level `utils.file_utils` — a *different* application tree (`src/python/src/utils/`), reachable only by sys.path accident and colliding with sidekick's own `sidekick.utils` package of the same short name — and `UTC` from the bare `compatibility` module, which is not in `[tool.setuptools] py-modules` and therefore breaks in an installed (non-checkout) deployment.

- Added `sidekick/utils/json_io.py`: self-contained, dependency-free `safe_read_json`/`safe_write_json` (atomic temp-file + `os.replace`, with `open` so permission failures surface as before).
- `state_manager` now imports them from `.json_io` and uses `datetime.timezone.utc` for `UTC`, removing both cross-boundary bare imports.
- `safe_read_json`/`safe_write_json` stay importable as `state_manager` attributes, preserving the re-export consumed by `wgs_reactor_calculator`.

## Tests
Adds `test_json_io_boundary_3333.py`: an AST assertion that no `utils.`/`compatibility.` imports remain in `state_manager`, a `UTC is datetime.UTC` identity check, and `json_io` round-trip / missing-default / `None`-precondition / non-serialisable-returns-False coverage. All 44 existing state_manager tests still pass; ruff/format/mypy clean. SPEC.md bumped.

Closes #3333

🤖 Generated with [Claude Code](https://claude.com/claude-code)