### PR TITLE
fix(conversion): unify Nm³ onto one DIN 1343 normal-state basis (#3389)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.408                                    |
+| **Spec Version**        | 1.1.409                                    |
 | **Last Spec Update**    | 2026-06-12                                 |
 
 ## 2. Purpose & Mission

--- a/src/shared/python/sidekick/calculators/conversion/gas_flow_mixin.py
+++ b/src/shared/python/sidekick/calculators/conversion/gas_flow_mixin.py
@@ -15,7 +15,12 @@ from .core import (
     standard_m3_per_hour_to_scfm,
     standard_to_actual_flow,
 )
-from .tables import GAS_DATABASE, GasProperties, StandardCondition
+from .tables import (
+    GAS_DATABASE,
+    NORMAL_REFERENCE_CONDITION,
+    GasProperties,
+    StandardCondition,
+)
 
 __all__ = [
     "GasFlowConversionMixin",
@@ -124,10 +129,13 @@ class GasFlowConversionMixin:
         """Convert gas flow value to STP-normalized m³/hr."""
         from .service import UnknownUnitError
 
+        # The "standard m³/hr" pivot here IS the Nm³ basis. Anchor it on the
+        # single authoritative normal state (DIN 1343: 0 °C, 101.325 kPa) so
+        # SCFM/ACFM ↔ Nm³ agrees with the tar-concentration mixin (issue #3389).
         if from_unit == "SCFM":
             return float(
                 scfm_to_standard_m3_per_hour(
-                    value, standard_condition, StandardCondition.STP
+                    value, standard_condition, NORMAL_REFERENCE_CONDITION
                 )
             )
         if from_unit == "ACFM":
@@ -141,7 +149,7 @@ class GasFlowConversionMixin:
             )
             return float(
                 scfm_to_standard_m3_per_hour(
-                    scfm, standard_condition, StandardCondition.STP
+                    scfm, standard_condition, NORMAL_REFERENCE_CONDITION
                 )
             )
         if from_unit in {"Nm3/hr", "Nm³/hr"}:
@@ -167,7 +175,7 @@ class GasFlowConversionMixin:
         if to_unit == "SCFM":
             return float(
                 standard_m3_per_hour_to_scfm(
-                    m3_hr_std, StandardCondition.STP, standard_condition
+                    m3_hr_std, NORMAL_REFERENCE_CONDITION, standard_condition
                 )
             )
         if to_unit == "ACFM":
@@ -177,7 +185,7 @@ class GasFlowConversionMixin:
                 )
                 raise RuntimeError(msg)
             scfm = standard_m3_per_hour_to_scfm(
-                m3_hr_std, StandardCondition.STP, standard_condition
+                m3_hr_std, NORMAL_REFERENCE_CONDITION, standard_condition
             )
             return float(
                 standard_to_actual_flow(scfm, temperature, pressure, standard_condition)

--- a/src/shared/python/sidekick/calculators/conversion/tables.py
+++ b/src/shared/python/sidekick/calculators/conversion/tables.py
@@ -151,6 +151,9 @@ __all__ = [
     "LENGTH_FACTORS",
     "MASS_FACTORS",
     "MASS_FLOW_FACTORS",
+    "NORMAL_REFERENCE_CONDITION",
+    "NORMAL_REFERENCE_PRESSURE_PA",
+    "NORMAL_REFERENCE_TEMPERATURE_K",
     "PERFORMANCE_UNITS",
     "POWER_FACTORS",
     "PRESSURE_FACTORS",
@@ -204,6 +207,30 @@ class StandardCondition(Enum):
 
     # SI Standard: Explicitly 0°C, 1 bar (Same as current STP)
     STP_SI = (STP_TEMPERATURE_K, 100000.0, "SI Standard (0°C, 1 bar)")
+
+
+# ---------------------------------------------------------------------------
+# Single authoritative "normal cubic meter" reference state (issue #3389).
+#
+# A "normal cubic meter" (Nm³) in process-engineering practice — DIN 1343,
+# ISO 13443 (gas industry usage), and the syngas/tar literature this service
+# targets — is the gas volume at the *normal state*: 273.15 K and 101 325 Pa
+# (0 °C, 1 atm). This is deliberately NOT IUPAC ``STP`` (0 °C, 100 kPa), which
+# would make every Nm³ value 1.325 % off and — worse — disagree with the tar
+# concentration mixin, which already anchors mg/Nm³ at 101.325 kPa.
+#
+# Both the gas-flow mixin and the tar-concentration mixin MUST resolve "Nm³"
+# through this one constant so the service can never again hold two
+# contradictory definitions of the same unit.
+# ---------------------------------------------------------------------------
+NORMAL_REFERENCE_CONDITION: StandardCondition = StandardCondition.STP_OLD
+"""Authoritative Nm³ reference state: 273.15 K, 101 325 Pa (DIN 1343)."""
+
+NORMAL_REFERENCE_TEMPERATURE_K: float = STP_TEMPERATURE_K
+"""Temperature [K] of the normal state used for every Nm³ basis (#3389)."""
+
+NORMAL_REFERENCE_PRESSURE_PA: float = STP_OLD_PRESSURE_PA
+"""Pressure [Pa] of the normal state used for every Nm³ basis (#3389)."""
 
 
 GAS_DATABASE: Mapping[str, GasProperties] = MappingProxyType(

--- a/src/shared/python/sidekick/calculators/conversion/tar_concentration_mixin.py
+++ b/src/shared/python/sidekick/calculators/conversion/tar_concentration_mixin.py
@@ -8,15 +8,33 @@ from __future__ import annotations
 
 import logging
 
+from .tables import (
+    NORMAL_REFERENCE_PRESSURE_PA,
+    NORMAL_REFERENCE_TEMPERATURE_K,
+)
+
 __all__ = [
     "TarConcentrationConversionMixin",
 ]
 
 _logger = logging.getLogger(__name__)
 
-# Ideal-gas molar volume at 0 °C / 1 atm [L/mol]. This mixin anchors mg/Nm³ at
-# the normal state (273.15 K, 101.325 kPa), so ppm-by-volume <-> mg/Nm³ must use
-# the 0 °C molar volume — NOT 24.45 L/mol, which is the 25 °C value and produced
+# Single authoritative Nm³ reference state, shared with the gas-flow mixin so
+# the service cannot hold two contradictory definitions of "Nm³" (issue #3389).
+_NORMAL_TEMPERATURE_K: float = NORMAL_REFERENCE_TEMPERATURE_K  # 273.15 K
+_NORMAL_PRESSURE_KPA: float = NORMAL_REFERENCE_PRESSURE_PA / 1000.0  # 101.325 kPa
+
+# The public ``tar_concentration`` default arguments are spelled as the literals
+# 273.15 / 101.325 to keep the API-contract signature representation stable, but
+# they MUST equal the shared normal-state constants. This guard makes any future
+# drift fail loudly at import time rather than silently re-splitting the Nm³
+# basis (issue #3389).
+assert _NORMAL_TEMPERATURE_K == 273.15  # noqa: S101 - import-time invariant
+assert _NORMAL_PRESSURE_KPA == 101.325  # noqa: S101 - import-time invariant
+
+# Ideal-gas molar volume at the normal state (0 °C / 1 atm) [L/mol]. Because
+# mg/Nm³ is anchored at the normal state, ppm-by-volume <-> mg/Nm³ MUST use the
+# 0 °C molar volume — NOT 24.45 L/mol, which is the 25 °C value and produced
 # results ~8.3% low while still being labelled mg/Nm³ (issue #3389).
 _MOLAR_VOLUME_NORMAL_L_PER_MOL = 22.414
 
@@ -33,8 +51,8 @@ class TarConcentrationConversionMixin:
         value: float,
         from_unit: str,
         to_unit: str,
-        temperature: float = 273.15,
-        pressure: float = 101.325,
+        temperature: float = 273.15,  # == _NORMAL_TEMPERATURE_K (DIN 1343, #3389)
+        pressure: float = 101.325,  # == _NORMAL_PRESSURE_KPA (DIN 1343, #3389)
         molecular_weight: float | None = None,
     ) -> float:
         """Convert tar concentration."""
@@ -98,9 +116,18 @@ class TarConcentrationConversionMixin:
         if factor is not None:
             return value * factor
         if from_key in {"mg/m³", "mg/m3"}:
-            return value * (temperature / 273.15) * (101.325 / pressure)
+            return (
+                value
+                * (temperature / _NORMAL_TEMPERATURE_K)
+                * (_NORMAL_PRESSURE_KPA / pressure)
+            )
         if from_key in {"g/m³", "g/m3"}:
-            return value * 1000.0 * (temperature / 273.15) * (101.325 / pressure)
+            return (
+                value
+                * 1000.0
+                * (temperature / _NORMAL_TEMPERATURE_K)
+                * (_NORMAL_PRESSURE_KPA / pressure)
+            )
         if from_key == "ppm_mass":
             assert molecular_weight is not None
             return value * molecular_weight / _MOLAR_VOLUME_NORMAL_L_PER_MOL
@@ -121,9 +148,18 @@ class TarConcentrationConversionMixin:
         if factor is not None:
             return mg_nm3_value / factor
         if to_key in {"mg/m³", "mg/m3"}:
-            return mg_nm3_value * (273.15 / temperature) * (pressure / 101.325)
+            return (
+                mg_nm3_value
+                * (_NORMAL_TEMPERATURE_K / temperature)
+                * (pressure / _NORMAL_PRESSURE_KPA)
+            )
         if to_key in {"g/m³", "g/m3"}:
-            return mg_nm3_value / 1000.0 * (273.15 / temperature) * (pressure / 101.325)
+            return (
+                mg_nm3_value
+                / 1000.0
+                * (_NORMAL_TEMPERATURE_K / temperature)
+                * (pressure / _NORMAL_PRESSURE_KPA)
+            )
         if to_key == "ppm_mass":
             assert molecular_weight is not None
             return mg_nm3_value * _MOLAR_VOLUME_NORMAL_L_PER_MOL / molecular_weight

--- a/src/shared/python/sidekick/tests/calculators/conversion/test_conversion_accuracy_3384_3388_3389.py
+++ b/src/shared/python/sidekick/tests/calculators/conversion/test_conversion_accuracy_3384_3388_3389.py
@@ -92,3 +92,54 @@ def test_ppmv_mg_nm3_roundtrip(service: UnitConversionService) -> None:
     mg = service.tar_concentration(1.0, "ppm_mass", "mg/Nm3", molecular_weight=78.11)
     back = service.tar_concentration(mg, "mg/Nm3", "ppm_mass", molecular_weight=78.11)
     assert back == pytest.approx(1.0, rel=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# #3389 (gas-flow part) — "Nm³" is the DIN 1343 normal state (0 °C, 101.325 kPa)
+# for SCFM/ACFM <-> Nm³/hr, matching the tar-concentration mixin's basis.
+# --------------------------------------------------------------------------- #
+@pytest.mark.unit
+@pytest.mark.scientific
+def test_scfm_to_nm3_hr_uses_din1343_normal_state(
+    service: UnitConversionService,
+) -> None:
+    # 1000 SCFM at 60 °F (288.706 K) -> Nm³/hr at 0 °C / 101.325 kPa.
+    # 1000 * 1.699011 m³/hr/cfm * (273.15 / 288.706) = 1607.46 Nm³/hr.
+    # The pre-#3389 IUPAC-STP (100 kPa) basis gave 1628.76 (+1.325 %).
+    value = service.convert(1000.0, "SCFM", "Nm3/hr").value
+    assert value == pytest.approx(1607.46, rel=1e-3)
+
+
+@pytest.mark.unit
+def test_scfm_nm3_hr_roundtrip(service: UnitConversionService) -> None:
+    nm3 = service.convert(1000.0, "SCFM", "Nm3/hr").value
+    back = service.convert(nm3, "Nm3/hr", "SCFM").value
+    assert back == pytest.approx(1000.0, rel=1e-9)
+
+
+@pytest.mark.unit
+def test_nm3_basis_is_shared_between_gas_flow_and_tar() -> None:
+    """The Nm³ reference state must be identical for both mixins (#3389).
+
+    A single authoritative constant is the structural guarantee that the
+    service can never again disagree with itself about what an Nm³ is.
+    """
+    from sidekick.calculators.conversion import tar_concentration_mixin as tar
+    from sidekick.calculators.conversion.tables import (
+        NORMAL_REFERENCE_CONDITION,
+        NORMAL_REFERENCE_PRESSURE_PA,
+        NORMAL_REFERENCE_TEMPERATURE_K,
+    )
+
+    # DIN 1343 normal state.
+    assert NORMAL_REFERENCE_TEMPERATURE_K == pytest.approx(273.15)
+    assert NORMAL_REFERENCE_PRESSURE_PA == pytest.approx(101325.0)
+    temp, pressure, _ = NORMAL_REFERENCE_CONDITION.value
+    assert temp == pytest.approx(NORMAL_REFERENCE_TEMPERATURE_K)
+    assert pressure == pytest.approx(NORMAL_REFERENCE_PRESSURE_PA)
+
+    # Tar mixin resolves its Nm³ basis through the same constant.
+    assert tar._NORMAL_TEMPERATURE_K == pytest.approx(NORMAL_REFERENCE_TEMPERATURE_K)
+    assert tar._NORMAL_PRESSURE_KPA == pytest.approx(
+        NORMAL_REFERENCE_PRESSURE_PA / 1000.0
+    )

--- a/tests/sidekick_api_baseline.json
+++ b/tests/sidekick_api_baseline.json
@@ -4926,6 +4926,9 @@
       "LENGTH_FACTORS",
       "MASS_FACTORS",
       "MASS_FLOW_FACTORS",
+      "NORMAL_REFERENCE_CONDITION",
+      "NORMAL_REFERENCE_PRESSURE_PA",
+      "NORMAL_REFERENCE_TEMPERATURE_K",
       "PERFORMANCE_UNITS",
       "POWER_FACTORS",
       "PRESSURE_FACTORS",
@@ -4941,6 +4944,15 @@
     ],
     "symbols": {
       "ANGULAR_VELOCITY_FACTORS": {
+        "type": "variable"
+      },
+      "NORMAL_REFERENCE_CONDITION": {
+        "type": "variable"
+      },
+      "NORMAL_REFERENCE_PRESSURE_PA": {
+        "type": "variable"
+      },
+      "NORMAL_REFERENCE_TEMPERATURE_K": {
         "type": "variable"
       },
       "AREA_FACTORS": {


### PR DESCRIPTION
## Summary
Closes #3389.

The conversion service held **three contradictory "normal" bases**: the gas-flow mixin mapped `Nm³/hr` to IUPAC STP (0 °C, **100 kPa**), while the tar-concentration mixin anchored mg/Nm³ at 0 °C / **101.325 kPa** — so the same service disagreed with itself about what a Nm³ is, and every SCFM/ACFM↔Nm³ conversion was 1.325 % off the DIN 1343 standard.

## Changes
- **Single source of truth:** new `NORMAL_REFERENCE_CONDITION` (= `STP_OLD` = 273.15 K, 101 325 Pa, DIN 1343) in `tables.py`, exported with its K/Pa scalar companions.
- **Gas-flow mixin:** Nm³ pivot now resolves through that constant instead of `StandardCondition.STP`.
- **Tar mixin:** mg/Nm³ and g/m³ anchors routed through the same constant; an import-time invariant guards the literal public-signature defaults (kept as literals so the API-contract representation stays stable).
- Regenerated the sidekick API baseline for the 3 added public names in `tables.py` (surgical edit — additive only).

## Verification (against the issue's TDD criteria)
- `SCFM→Nm³/hr` for 1000 SCFM = **1607.46** (was 1628.76) ✓
- Round-trip SCFM→Nm³/hr→SCFM = 1000.0 (exact) ✓
- 1 ppmv benzene → **3.485 mg/Nm³** (the molar-volume part landed earlier in #3396) ✓
- Consistency property test: gas-flow Nm³ basis == tar Nm³ basis ✓
- 251 conversion + stability tests pass; ruff clean.

## Cross-repo note
Gasification_Model and UpstreamDrift vendor identical copies of this mixin. Downstream coordination PRs should mirror the shared constant; not done here (single-repo PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)