### PR TITLE
ci: full-suite lane + non-vacuous heavy/e2e marker lanes (#3324, #3325)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -643,6 +643,32 @@ jobs:
           # addopt and report failures deterministically.
           pytest_args+=(-n 0)
 
+          # Guard: every entry in the always-on core_tests smoke set must
+          # actually collect at least one test. Six of these files were
+          # previously 0 bytes, so the "always-on" contract/architecture/
+          # rotation/constants/manifest coverage existed in name only and
+          # passed silently (issue #3324). Fail loudly if any entry is vacuous.
+          empty_core=()
+          for ct in "${core_tests[@]}"; do
+            collected=$(python -m pytest --collect-only -q "$ct" 2>/dev/null | grep -cE '::' || true)
+            if [ "$collected" -eq 0 ]; then
+              empty_core+=("$ct")
+            fi
+          done
+          if [ "${#empty_core[@]}" -gt 0 ]; then
+            echo "::error::core_tests entries collected 0 tests (issue #3324): ${empty_core[*]}"
+            exit 1
+          fi
+
+          # Source-keyed selection (issue #3324): translate changed *source*
+          # files to the test directories that exercise them, so editing
+          # production code without touching its test file still runs that
+          # code's tests. Reuses changed_python_files.txt from the collect step.
+          source_keyed_tests=()
+          if [ -s changed_python_files.txt ]; then
+            mapfile -t source_keyed_tests < <(python scripts/select_tests_for_changes.py changed_python_files.txt)
+          fi
+
           run_changed_tests=true
           if [ "$BRANCH_NAME" = "codex/consolidate-open-prs-20260611-tools" ]; then
             # This branch is a large consolidation PR, and collecting every
@@ -655,7 +681,9 @@ jobs:
 
           if [ "$run_changed_tests" = "true" ] && [ -s changed_test_files.txt ]; then
             mapfile -t changed_test_files < changed_test_files.txt
-            python -m pytest "${changed_test_files[@]}" "${core_tests[@]}" "${pytest_args[@]}"
+            python -m pytest "${changed_test_files[@]}" "${source_keyed_tests[@]}" "${core_tests[@]}" "${pytest_args[@]}"
+          elif [ "$run_changed_tests" = "true" ] && [ "${#source_keyed_tests[@]}" -gt 0 ]; then
+            python -m pytest "${source_keyed_tests[@]}" "${core_tests[@]}" "${pytest_args[@]}"
           else
             python -m pytest "${core_tests[@]}" "${pytest_args[@]}"
           fi

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -650,7 +650,14 @@ jobs:
           # passed silently (issue #3324). Fail loudly if any entry is vacuous.
           empty_core=()
           for ct in "${core_tests[@]}"; do
-            collected=$(python -m pytest --collect-only -q "$ct" 2>/dev/null | grep -cE '::' || true)
+            collect_output="$(mktemp)"
+            if ! python -m pytest --collect-only --quiet --quiet "$ct" >"$collect_output"; then
+              cat "$collect_output"
+              rm -f "$collect_output"
+              exit 1
+            fi
+            collected=$(grep -cE '::' "$collect_output" || true)
+            rm -f "$collect_output"
             if [ "$collected" -eq 0 ]; then
               empty_core+=("$ct")
             fi

--- a/.github/workflows/full-suite-nightly.yml
+++ b/.github/workflows/full-suite-nightly.yml
@@ -1,0 +1,138 @@
+name: Full Test Suite (Nightly)
+
+# Issue #3324: no automated lane ran the full pytest suite, so the overwhelming
+# majority of the ~2,760 tests under tests/ plus ~5,671 under src/ could never
+# execute — which is exactly how the P0 suite-gutting went undetected. This lane
+# runs the whole collection nightly (and on demand) and is gating-with-
+# notification: a failure fires the Slack webhook used by the heavy lanes.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: "0 5 * * *" # nightly 05:00 UTC (after the heavy lane at 04:00)
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  full-suite:
+    name: Full Test Suite
+    runs-on: d-sorg-fleet
+    timeout-minutes: 120
+    env:
+      HEAVY_TEST_SLACK_WEBHOOK: ${{ secrets.HEAVY_TEST_SLACK_WEBHOOK }}
+      AGENT_TOOLSDIRECTORY: ${{ runner.temp }}/_tool_cache
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install system display dependencies
+        run: |
+          while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 || sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || sudo fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do sleep 1; done; sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock && sudo apt-get -o DPkg::Lock::Timeout=300 update || true
+          sudo apt-get -o DPkg::Lock::Timeout=300 install -y --no-install-recommends \
+            xvfb x11-utils mesa-utils \
+            libgl1 libegl1 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 \
+            libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 \
+            libdbus-1-3 libxrandr2 libxss1 libxcursor1 libxcomposite1 \
+            libasound2-dev libxi6 libxtst6
+
+      - name: Install Python dependencies
+        timeout-minutes: 25
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f pyproject.toml ]; then pip install -e ".[dev,test]" || pip install -e .; fi
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest pytest-cov pytest-timeout pytest-xdist pytest-qt
+
+      - name: Configure Qt for headless CI
+        run: echo "QT_QPA_PLATFORM=offscreen" >> "$GITHUB_ENV"
+
+      - name: Run full suite
+        timeout-minutes: 90
+        run: |
+          # pipefail so the tee pipe cannot mask pytest's exit code (#3324/#3325).
+          set -o pipefail
+          export PYTHONPATH="src/data_processing/data_processor/python:src/media_processing/video_processor/python:src/shared/python:src/python/src:src:${PYTHONPATH:-}"
+          # Whole collection, excluding only the markers that genuinely cannot
+          # run in this lane (live_simulation belongs to the heavy lane; slow is
+          # opt-in). Override the pyproject addopts -m deselection (last -m wins).
+          xvfb-run -a python -m pytest tests/ src/ \
+            --import-mode=importlib \
+            -m "not live_simulation and not slow" \
+            --timeout=120 \
+            --timeout-method=thread \
+            -n auto \
+            --dist loadscope \
+            --junit-xml=full_suite_results.xml \
+            --tb=short \
+            | tee full_suite_output.log
+
+      - name: Summarize full-suite results
+        if: always()
+        run: |
+          echo "## Full Test Suite Report - Tools" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          # A vacuous full-suite run (junit missing or 0 collected) means the
+          # suite was gutted again — fail rather than report green (issue #3324).
+          if [ ! -f full_suite_results.xml ]; then
+            echo "::error::full_suite_results.xml missing — pytest crashed before writing junit or collected nothing (issue #3324)." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          python3 - <<'PYEOF'
+          import os
+          import sys
+          import xml.etree.ElementTree as ET
+          tree = ET.parse('full_suite_results.xml')
+          root = tree.getroot()
+          suite = root.find('.//testsuite') or root
+          total = int(suite.get('tests', 0))
+          failures = int(suite.get('failures', 0))
+          errors = int(suite.get('errors', 0))
+          skipped = int(suite.get('skipped', 0))
+          passed = total - failures - errors - skipped
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as fh:
+              fh.write("| Status | Count |\n|--------|-------|\n")
+              fh.write(f"| Passed | {passed} |\n")
+              fh.write(f"| Failed | {failures} |\n")
+              fh.write(f"| Errors | {errors} |\n")
+              fh.write(f"| Skipped | {skipped} |\n")
+              fh.write(f"| Total | {total} |\n\n")
+          # A real full run collects thousands of tests; a handful means the
+          # collection silently broke. Require a sane floor (issue #3324).
+          if total < 500:
+              print(f"Full suite collected only {total} tests (<500) — collection broken (issue #3324).", file=sys.stderr)
+              sys.exit(1)
+          PYEOF
+          echo "### Tail of test output" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          tail -40 full_suite_output.log >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload full-suite artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: full-suite-results-${{ github.run_id }}
+          path: |
+            full_suite_results.xml
+            full_suite_output.log
+          retention-days: 30
+
+      - name: Notify on failure
+        if: failure() && env.HEAVY_TEST_SLACK_WEBHOOK != ''
+        run: |
+          curl -s -X POST "$HEAVY_TEST_SLACK_WEBHOOK" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"Nightly full test suite failed for Tools on ${GITHUB_REF_NAME}. Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}"

--- a/.github/workflows/full-suite-nightly.yml
+++ b/.github/workflows/full-suite-nightly.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 120
     env:
       HEAVY_TEST_SLACK_WEBHOOK: ${{ secrets.HEAVY_TEST_SLACK_WEBHOOK }}
-      AGENT_TOOLSDIRECTORY: ${{ runner.temp }}/_tool_cache
+      AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/.tool-cache
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/heavy-integration-tests.yml
+++ b/.github/workflows/heavy-integration-tests.yml
@@ -5,6 +5,10 @@ concurrency:
 
 on:
   workflow_dispatch:
+  # The live_simulation + e2e lanes must actually run on a cadence, otherwise the
+  # heavy suite is vacuous (issue #3325). Keep workflow_dispatch for manual reruns.
+  schedule:
+    - cron: "0 4 * * *" # nightly 04:00 UTC
 
 jobs:
   run-heavy-tests:
@@ -77,10 +81,19 @@ jobs:
       - name: Run heavy integration tests
         timeout-minutes: 60
         run: |
+          # GitHub's default `bash -e {0}` lacks pipefail, so the `| tee` pipe
+          # below would mask pytest's exit code (including exit 5 = nothing
+          # collected). Enable pipefail so a vacuous or failing run fails the
+          # job instead of passing silently (issue #3325).
+          set -o pipefail
+          # Select BOTH the live_simulation and e2e markers: the restored
+          # tests/e2e/* suite uses the `e2e` marker, which `-m "live_simulation"`
+          # alone would never select. The last `-m` on the CLI overrides the
+          # pyproject addopts deselection (issue #3325).
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
             pytest \
               -v \
-              -m "live_simulation" \
+              -m "live_simulation or e2e" \
               --timeout=300 \
               --timeout-method=thread \
               --tb=short \
@@ -98,9 +111,17 @@ jobs:
         run: |
           echo "## Heavy Integration Test Report - Tools" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f heavy_test_results.xml ]; then
-            python3 - <<'PYEOF'
+          # Guard against a vacuous heavy run (issue #3325): if pytest crashed
+          # before writing junit, or collected zero tests, the lane covered
+          # nothing and MUST fail rather than report a green "0 tests" run.
+          if [ ! -f heavy_test_results.xml ]; then
+            echo "::error::heavy_test_results.xml missing — pytest crashed before writing junit or collected nothing." >> "$GITHUB_STEP_SUMMARY"
+            echo "heavy_test_results.xml missing — failing the heavy lane (issue #3325)." >&2
+            exit 1
+          fi
+          python3 - <<'PYEOF'
           import os
+          import sys
           import xml.etree.ElementTree as ET
           tree = ET.parse('heavy_test_results.xml')
           root = tree.getroot()
@@ -111,14 +132,19 @@ jobs:
           skipped = int(suite.get('skipped', 0))
           passed = total - failures - errors - skipped
           with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as fh:
-              fh.write(f"| Status | Count |\n|--------|-------|\n")
+              fh.write("| Status | Count |\n|--------|-------|\n")
               fh.write(f"| Passed | {passed} |\n")
               fh.write(f"| Failed | {failures} |\n")
               fh.write(f"| Errors | {errors} |\n")
               fh.write(f"| Skipped | {skipped} |\n")
               fh.write(f"| Total | {total} |\n\n")
+          if total == 0:
+              fh = open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8')
+              fh.write("::error::Heavy lane collected 0 tests — live_simulation/e2e coverage is vacuous (issue #3325).\n")
+              fh.close()
+              print("Heavy lane collected 0 tests — failing (issue #3325).", file=sys.stderr)
+              sys.exit(1)
           PYEOF
-          fi
           echo "### Tail of test output" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           tail -40 heavy_test_output.log >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true

--- a/.github/workflows/heavy-tests-opt-in.yml
+++ b/.github/workflows/heavy-tests-opt-in.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Run heavy integration tests
         timeout-minutes: 60
         run: |
+          # Enable pipefail so the `| tee` pipe cannot mask pytest's exit code
+          # (including exit 5 = nothing collected). See issue #3325.
+          set -o pipefail
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
             pytest \
               -v \
@@ -98,9 +101,16 @@ jobs:
         run: |
           echo "## Heavy Integration Test Report - Tools" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f heavy_test_results.xml ]; then
-            python3 - <<'PYEOF'
+          # Fail the lane if junit is missing (pytest crashed pre-write) or zero
+          # tests were collected — otherwise a vacuous run reports green (#3325).
+          if [ ! -f heavy_test_results.xml ]; then
+            echo "::error::heavy_test_results.xml missing — pytest crashed before writing junit or collected nothing." >> "$GITHUB_STEP_SUMMARY"
+            echo "heavy_test_results.xml missing — failing the heavy lane (issue #3325)." >&2
+            exit 1
+          fi
+          python3 - <<'PYEOF'
           import os
+          import sys
           import xml.etree.ElementTree as ET
           tree = ET.parse('heavy_test_results.xml')
           root = tree.getroot()
@@ -111,14 +121,16 @@ jobs:
           skipped = int(suite.get('skipped', 0))
           passed = total - failures - errors - skipped
           with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as fh:
-              fh.write(f"| Status | Count |\n|--------|-------|\n")
+              fh.write("| Status | Count |\n|--------|-------|\n")
               fh.write(f"| Passed | {passed} |\n")
               fh.write(f"| Failed | {failures} |\n")
               fh.write(f"| Errors | {errors} |\n")
               fh.write(f"| Skipped | {skipped} |\n")
               fh.write(f"| Total | {total} |\n\n")
+          if total == 0:
+              print("Heavy opt-in lane collected 0 tests — failing (issue #3325).", file=sys.stderr)
+              sys.exit(1)
           PYEOF
-          fi
           echo "### Tail of test output" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           tail -40 heavy_test_output.log >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.409                                    |
+| **Spec Version**        | 1.1.410                                    |
 | **Last Spec Update**    | 2026-06-12                                 |
 
 ## 2. Purpose & Mission
@@ -730,6 +730,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-06-12 | 1.1.410 | ci(#3324, #3325, #3357): add `full-suite-nightly.yml` (whole-collection nightly run with a vacuous-run guard) and `scripts/select_tests_for_changes.py` (source-keyed test selection wired into `ci-standard.yml`); add a core_tests zero-collection guard so always-on smoke entries can no longer pass with 0 collected; make the heavy/e2e lanes real (`heavy-integration-tests.yml` nightly schedule + `live_simulation or e2e` markers, `set -o pipefail`, and missing-junit/0-collected summary failures; same guards in `heavy-tests-opt-in.yml`); and update `COVERAGE_SETUP.md`/`COVERAGE_QUICK_START.md` to stop documenting the already-removed `hot_path_modules_phase2` block as an enforced gate. |
 | 2026-06-12 | 1.1.408 | fix(sidekick): avoid the nested Qt event loop in Python REPL worker completion by polling `QThread` progress through `QApplication.processEvents()` plus bounded waits, keeping synchronous `execute()` behavior while preventing Linux/offscreen Python 3.11/3.12 test aborts in the F6 async REPL path. |
 | 2026-06-12 | 1.1.406 | test(pendulum): add an explicit runtime contract assertion to the manual PyQt signal smoke script so the changed-test assertion gate recognizes `src/pendulum_simulator/signal_test.py` as behavior-checking test surface after the frameless-window cleanup touched the file. |
 | 2026-06-12 | 1.1.405 | fix(p1am-control, #3323): stop passing `Qt.GlobalColor` enum members into `pg.mkPen(color=...)` for the MPC PID-vs-MPC comparison plots in `control_tab.py`; under pyqtgraph 0.13.7+/0.14.0 with PyQt6 `mkColor` raised `TypeError: Not sure how to make a color from "(<GlobalColor.red: 7>,)"`, aborting `ControlTab()` construction and killing any test or launch that builds the Control tab. Use pyqtgraph-native color forms (`"r"` and the `(0, 100, 0)` darkGreen tuple) while leaving the theme-derived Highlight/WindowText pens untouched, and add a regression test that constructs `ControlTab()` and asserts the four MPC curve attributes exist. |

--- a/docs/development/COVERAGE_QUICK_START.md
+++ b/docs/development/COVERAGE_QUICK_START.md
@@ -124,7 +124,11 @@ Common failures:
 - Core test suite: 476 tests
 - Policy: minimum 6%, max drop 2%
 
-**Hot-path modules (Phase 2 targets — 80%):**
+**Hot-path modules (aspirational 80% targets — NOT a CI gate):**
+
+> The `hot_path_modules_phase2` config block these targets referred to was dead
+> config (read by no code) and has been removed (issue #3357). The list below is
+> a planning roadmap only; CI does not enforce it.
 
 - `src/pressure_drop_calculator` — Core process engineering
 - `src/rotation_converter` — Robotics kinematics

--- a/docs/development/COVERAGE_SETUP.md
+++ b/docs/development/COVERAGE_SETUP.md
@@ -65,29 +65,34 @@ See `.coveragerc` for full list of excluded patterns.
 
 ```json
 {
-  "minimum_total_percent": 25.0,
+  "minimum_total_percent": 60.0,
   "max_total_drop_percent": 2.0,
   "tracked_packages": {
-    "src/shared/python/notes": 49.0,
-    "src/shared/python/upstream_drift_tools": 15.0,
-    "src/shared/python/signal_toolkit": 10.0,
-    "src/shared/python/model_generation": 10.0
-  },
-  "hot_path_modules": {
-    "src/pressure_drop_calculator": 80.0,
-    "src/rotation_converter": 80.0,
-    "src/shared/python/model_generation": 80.0,
-    "src/shared/python/upstream_drift_tools": 80.0
+    "src/shared/python/notes": 95.0,
+    "src/shared/python/safe_eval.py": 99.0,
+    "src/shared/python/safe_pandas_eval.py": 99.0,
+    "src/shared/python/file_watcher/_fallback.py": 95.0,
+    "src/shared/python/signal_toolkit/adaptive_filter.py": 95.0,
+    "src/shared/python/codemap": 90.0,
+    "src/shared/python/sidekick/calculators/conversion/service.py": 90.0,
+    "src/shared/python/upstream_drift_tools": 100.0
   }
 }
 ```
 
 **Thresholds explained:**
 
-- **minimum_total_percent** (25%): Total repository coverage must stay above 25%
-- **max_total_drop_percent** (2%): If baseline is 6%, PR cannot drop below 4%
-- **tracked_packages**: Per-package minimums (higher confidence modules)
-- **hot_path_modules**: Critical path modules requiring 80% coverage (Phase 2+ target)
+- **minimum_total_percent** (60%): Repo-wide target. Only enforced on a genuine
+  full-suite run (the nightly lane), never on the changed-file-scoped PR run.
+- **max_total_drop_percent** (2%): Non-regression ratchet against the baseline.
+- **tracked_packages**: Per-package minimums enforced by
+  `scripts/check_coverage_policy.py` when a tracked package's sources change.
+
+> **Note (issue #3357):** an earlier `hot_path_modules_phase2` block was pure
+> dead config — no code ever read it — so it was removed from
+> `config/coverage_policy.json`. The hot-path targets below remain an
+> **aspirational roadmap**, not an enforced gate. Treat any "Phase 2 / 80%"
+> hot-path language in this document as a planning target, not CI behaviour.
 
 ### `config/coverage_baseline.json` — Current Baseline
 

--- a/scripts/select_tests_for_changes.py
+++ b/scripts/select_tests_for_changes.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Map changed source files to the test directories that exercise them.
+
+Issue #3324: the PR ``tests`` lane selected tests only by *changed test files*,
+so editing production code without touching its test file ran zero tests for
+that code. This script closes that gap: it reads the list of changed Python
+files (the ``changed_python_files.txt`` already produced by CI's "Collect
+Changed Coverage Inputs" step) and prints the set of existing test targets that
+cover the changed source packages.
+
+The mapping is deliberately conservative — it only emits targets that actually
+exist on disk, so the resulting ``pytest`` invocation never fails on a missing
+path. Output is one target per line on stdout, suitable for ``mapfile``/``$()``
+capture in a workflow step.
+
+Usage::
+
+    python scripts/select_tests_for_changes.py changed_python_files.txt
+    python scripts/select_tests_for_changes.py < changed_python_files.txt
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_changed_files(argv: list[str]) -> list[str]:
+    """Read changed-file paths from a path argument or stdin."""
+    if len(argv) > 1 and argv[1] not in {"-", ""}:
+        text = Path(argv[1]).read_text(encoding="utf-8")
+    else:
+        text = sys.stdin.read()
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def _candidate_targets(src_path: str) -> list[Path]:
+    """Return candidate test targets for a single changed source path.
+
+    Translates ``src/<package>/...`` and ``src/shared/python/<package>/...``
+    source paths to the ``tests/<package>/`` and in-tree ``src/**/tests/``
+    directories that conventionally mirror them.
+    """
+    p = Path(src_path)
+    parts = p.parts
+    targets: list[Path] = []
+
+    # Identify the changed file's *package root* so we can mirror it. For a
+    # shared-library path the package is its 4th segment; for a top-level tool
+    # it is the 2nd. We never walk above that root, so an unrelated ``tests``
+    # dir further up (e.g. src/shared/python/tests) does not match every change.
+    if parts[:3] == ("src", "shared", "python") and len(parts) >= 4:
+        package_depth = 4
+        mirror = REPO_ROOT / "tests" / "shared" / "python" / parts[3]
+    elif parts and parts[0] == "src" and len(parts) >= 2:
+        package_depth = 2
+        mirror = REPO_ROOT / "tests" / parts[1]
+    else:
+        return targets
+
+    # In-tree test package: only consider a ``tests`` dir at or below the
+    # package root (inclusive), walking up no further than the package itself.
+    for i in range(len(parts) - 1, package_depth - 1, -1):
+        maybe = REPO_ROOT.joinpath(*parts[:i], "tests")
+        if maybe.is_dir():
+            targets.append(maybe)
+            break
+
+    # Mirrored top-level tests/<package>/ directory.
+    targets.append(mirror)
+
+    return targets
+
+
+def select_targets(changed_files: list[str]) -> list[str]:
+    """Return sorted, de-duplicated, existing test targets for changed sources."""
+    selected: set[str] = set()
+    for src_path in changed_files:
+        # Only source files drive source-keyed selection; changed *test* files
+        # are already handled by the existing changed_test_files.txt path.
+        if not src_path.startswith("src/") or not src_path.endswith(".py"):
+            continue
+        for target in _candidate_targets(src_path):
+            if target.exists():
+                selected.add(target.relative_to(REPO_ROOT).as_posix())
+    return sorted(selected)
+
+
+def main(argv: list[str]) -> int:
+    changed = _read_changed_files(argv)
+    for target in select_targets(changed):
+        print(target)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/scripts/test_select_tests_for_changes.py
+++ b/tests/scripts/test_select_tests_for_changes.py
@@ -1,0 +1,66 @@
+"""Tests for scripts/select_tests_for_changes.py (issue #3324).
+
+Source-keyed test selection must map a changed *source* file to the existing
+test directory that exercises it, so editing production code without touching
+its test file no longer runs zero tests for that code.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "select_tests_for_changes.py"
+
+_spec = importlib.util.spec_from_file_location("select_tests_for_changes", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+select_tests_for_changes = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(select_tests_for_changes)
+
+
+@pytest.mark.unit
+def test_calc_backend_source_change_selects_its_test_dir() -> None:
+    # Acceptance criterion from #3324: a change under calc_backend/routers/
+    # must select calc_backend tests even with no test file changed.
+    targets = select_tests_for_changes.select_targets(
+        ["src/shared/python/calc_backend/routers/wgs_reactor.py"]
+    )
+    assert "tests/shared/python/calc_backend" in targets
+
+
+@pytest.mark.unit
+def test_only_existing_targets_are_emitted() -> None:
+    # A made-up package maps to no on-disk target, so nothing is emitted
+    # (the pytest invocation must never fail on a missing path).
+    targets = select_tests_for_changes.select_targets(
+        ["src/shared/python/this_package_does_not_exist/foo.py"]
+    )
+    assert targets == []
+
+
+@pytest.mark.unit
+def test_non_source_and_non_python_paths_are_ignored() -> None:
+    targets = select_tests_for_changes.select_targets(
+        [
+            "docs/readme.md",
+            "tests/shared/python/calc_backend/test_x.py",  # a test file, not src
+            "src/shared/python/calc_backend/routers/wgs_reactor.txt",  # not .py
+        ]
+    )
+    # The changed *test* file path is handled by the existing changed-test lane,
+    # not by this source-keyed mapper.
+    assert targets == []
+
+
+@pytest.mark.unit
+def test_output_is_sorted_and_deduplicated() -> None:
+    targets = select_tests_for_changes.select_targets(
+        [
+            "src/shared/python/sidekick/a.py",
+            "src/shared/python/sidekick/b.py",
+        ]
+    )
+    assert targets == sorted(set(targets))


### PR DESCRIPTION
## Summary
Closes #3324, #3325.

No workflow ran the full pytest suite, and the heavy/e2e lanes matched **zero** tests — precisely how the P0 suite-gutting went undetected. The required restoration of the previously-0-byte payload files (`tests/e2e/*`, `tests/heavy_integration/test_tools_contracts.py`) has already landed on main, so these lane fixes are now actionable.

## #3324 — full-suite coverage + source-keyed selection
- **`full-suite-nightly.yml` (new):** runs the whole collection (`tests/ src/`, `-m "not live_simulation and not slow"`) nightly + on demand on `d-sorg-fleet`, gating-with-notification (Slack on failure), with a **vacuous-run guard** (fail if junit missing or total < 500).
- **`scripts/select_tests_for_changes.py` (new):** maps changed *source* files to their mirrored `tests/<pkg>/` and in-tree `src/**/tests/` dirs. Wired into `ci-standard.yml` so editing production code without touching its test file still runs that code's tests. Acceptance: a change under `calc_backend/routers/` selects `tests/shared/python/calc_backend`.
- **core_tests zero-collection guard:** `ci-standard.yml` now fails if any always-on smoke entry collects 0 tests (six were previously 0-byte and passed silently).
- Unit tests for the mapping script (4 passing).

## #3325 — heavy/e2e lanes made real
- **`heavy-integration-tests.yml`:** nightly `schedule` trigger; `-m "live_simulation or e2e"` so the restored `tests/e2e/*` suite actually runs; `set -o pipefail` so the `| tee` pipe can't mask pytest's exit code; summary step fails on missing junit **or** 0 collected.
- **`heavy-tests-opt-in.yml`:** same pipefail + vacuous-run guard (stays dispatch-only by design).

## #3357 (hot_path sub-fix only)
The dead `hot_path_modules_phase2` config block was already removed from `coverage_policy.json`; this updates `COVERAGE_SETUP.md` + `COVERAGE_QUICK_START.md` so they stop documenting it as an enforced gate. The broader #3357 changed-file-gate work is **not** included here (it needs the companion test-selection changes the verifier flagged and risks tripping the naive 60% floor).

## Notes
- YAML validated; mapping-script lint/format clean.
- Tools allows workflow edits (unlike Tools_Private), so these lane changes are in-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)