### PR TITLE
fix(p1am): safety review fixes — E-stop reachability, truthful UI, kill robustness

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.547                                    |
+| **Spec Version**        | 1.1.548                                    |
 | **Last Spec Update**    | 2026-06-16                                 |
 
 ## 2. Purpose & Mission
@@ -91,6 +91,12 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
   guarded by focused import, provider-contract, bootstrap, and shim tests. The
   branch-name check is passed through the workflow environment so actionlint's
   script-injection guard remains enforced.
+- P1AM safety review follow-up keeps the E-stop reachable above drawer
+  overlays, makes E-stop clear/trigger UI state follow acknowledged controller
+  responses, preserves operator-owned power-supply mode selection after initial
+  server adoption, refuses setpoint applies without live status, reasserts a
+  latched E-stop on PLC reconnect, and makes Modbus E-stop writes best-effort
+  across all kill outputs before reporting failure.
 - Issue #3316 CI repair keeps the broad import-canonicalization PR's Python
   matrix on the always-on core tests plus targeted import identity,
   bootstrap, metadata, host integration, and shim contracts, avoiding the

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -232,6 +232,12 @@ async def modbus_connect_background() -> None:
                 connected = await plc_client.connect()
                 if connected:
                     logger.info("Connected to PLC successfully in background.")
+                    if e_stop_active:
+                        try:
+                            await plc_client.trigger_estop()
+                            logger.warning("Re-asserted hardware E-stop on reconnect.")
+                        except Exception as estop_err:
+                            logger.error(f"Failed to re-assert E-stop: {estop_err}")
                     # Adopt the device's real routing + interlock limits so the
                     # alarm set reflects the PLC, not the startup defaults.
                     try:
@@ -548,8 +554,13 @@ async def trigger_estop() -> dict[str, str]:
             "message": "Simulated E-stop triggered. All simulated tag values zeroed.",
         }
 
-    await plc_client.trigger_estop()
+    ok = await plc_client.trigger_estop()
     await backup_simulator.trigger_estop()
+    if not ok:
+        raise HTTPException(
+            status_code=502,
+            detail="E-stop command was not acknowledged by the PLC; controller remains latched and will retry.",
+        )
     return {"status": "success", "message": "Hardware E-stop triggered."}
 
 

--- a/src/p1am_control_system/backend/modbus_client.py
+++ b/src/p1am_control_system/backend/modbus_client.py
@@ -378,37 +378,48 @@ class AsyncModbusManager(BasePLCClient):
                 return False
 
     async def trigger_estop(self) -> bool:
-        """Zero PID setpoints and tag values so outputs go to zero and hold."""
+        """Zero PID setpoints and tag values so outputs go to zero and hold.
+
+        Best-effort and non-atomic by design: a partial kill is unsafe, so on a
+        sub-write failure we do NOT early-return — every register is attempted so
+        the output is driven down as far as possible, and ``False`` is returned
+        only after all writes so the caller (and the poll-loop re-assert) knows
+        to retry. Returns True only when every write was acknowledged.
+        """
         async with self.lock:
             if not self._connected:
                 return False
+            all_ok = True
             try:
+                client = self._get_client()
                 # PID setpoint is field 3 of each 10-register block.
                 for pid_index in range(4):
                     sp_addr = self.pid_config_address + pid_index * 10 + 2
-                    resp = await self._get_client().write_registers(
-                        address=sp_addr,
-                        values=float_to_registers(0.0),
+                    resp = await client.write_registers(
+                        address=sp_addr, values=float_to_registers(0.0)
                     )
                     if resp.isError():
+                        all_ok = False
                         logger.error(
                             f"E-stop: error zeroing PID {pid_index} setpoint: {resp}"
                         )
-                        return False
 
-                # 2. Zero all tag values.
-                zeros = []
+                # Zero all tag values (covers any directly-driven, non-PID tag).
+                zeros: list[int] = []
                 for _ in range(32):
                     zeros.extend(float_to_registers(0.0))
-                resp = await self._get_client().write_registers(
-                    address=self.estop_registers_address,
-                    values=zeros,
+                resp = await client.write_registers(
+                    address=self.estop_registers_address, values=zeros
                 )
                 if resp.isError():
+                    all_ok = False
                     logger.error(f"Error writing E-stop registers: {resp}")
-                    return False
-                logger.warning("E-stop: PID setpoints and tag values zeroed.")
-                return True
+
+                if all_ok:
+                    logger.warning("E-stop: PID setpoints and tag values zeroed.")
+                else:
+                    logger.error("E-stop: one or more zeroing writes FAILED — retry.")
+                return all_ok
             except (ModbusException, Exception) as e:
                 logger.error(f"Exception during E-stop Modbus execution: {e}")
                 self._connected = False

--- a/src/p1am_control_system/backend/tests/test_modbus_estop.py
+++ b/src/p1am_control_system/backend/tests/test_modbus_estop.py
@@ -1,0 +1,77 @@
+"""Tests for AsyncModbusManager.trigger_estop best-effort kill semantics.
+
+The kill must attempt EVERY zeroing write even when one fails (a partial kill is
+unsafe), and report False so the caller retries.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("sqlmodel")
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from modbus_client import AsyncModbusManager  # noqa: E402
+
+
+def _ok() -> MagicMock:
+    return MagicMock(isError=lambda: False)
+
+
+def _err() -> MagicMock:
+    return MagicMock(isError=lambda: True)
+
+
+def _manager_with(write_registers: AsyncMock) -> AsyncModbusManager:
+    m = AsyncModbusManager(host="127.0.0.1")
+    m._connected = True
+    raw = MagicMock()
+    raw.write_registers = write_registers
+    m._get_client = lambda: raw  # type: ignore[method-assign]
+    return m
+
+
+# 4 PID setpoint writes + 1 tag-block write = 5 total.
+_EXPECTED_WRITES = 5
+
+
+class TestTriggerEstop:
+    def test_all_writes_succeed_returns_true(self) -> None:
+        async def go() -> None:
+            wr = AsyncMock(return_value=_ok())
+            m = _manager_with(wr)
+            assert await m.trigger_estop() is True
+            assert wr.await_count == _EXPECTED_WRITES
+
+        asyncio.run(go())
+
+    def test_one_failure_still_attempts_all_and_returns_false(self) -> None:
+        async def go() -> None:
+            # Fail the 2nd PID setpoint (address 212); everything else succeeds.
+            def _side(*_: Any, address: int = 0, **__: Any) -> MagicMock:
+                return _err() if address == 212 else _ok()
+
+            wr = AsyncMock(side_effect=_side)
+            m = _manager_with(wr)
+            result = await m.trigger_estop()
+            assert result is False  # reported as failed...
+            assert wr.await_count == _EXPECTED_WRITES  # ...but ALL writes attempted
+
+        asyncio.run(go())
+
+    def test_disconnected_returns_false_without_writing(self) -> None:
+        async def go() -> None:
+            wr = AsyncMock(return_value=_ok())
+            m = _manager_with(wr)
+            m._connected = False
+            assert await m.trigger_estop() is False
+            assert wr.await_count == 0
+
+        asyncio.run(go())

--- a/src/p1am_control_system/frontend/src/App.tsx
+++ b/src/p1am_control_system/frontend/src/App.tsx
@@ -383,17 +383,55 @@ export const App: React.FC = () => {
     }
   };
 
-  // Trigger global emergency stop (E-stop)
+  // Trigger global emergency stop (E-stop). Fail toward the stopped state: on a
+  // successful POST we optimistically latch the button (the WebSocket frame
+  // corrects it), so the operator gets confirmation even if the stream is down.
   const handleEStop = async () => {
     try {
       const res = await fetch("/api/estop", { method: "POST" });
       if (res.ok) {
+        setEStopActive(true);
         triggerNotification("EMERGENCY SHUTDOWN COMMAND ISSUED!", "error");
       } else {
-        triggerNotification("Failed to issue E-stop command.", "error");
+        triggerNotification(
+          "E-STOP NOT CONFIRMED by server — verify the PLC output is dead!",
+          "error",
+        );
       }
-    } catch (err) {
-      triggerNotification("Error connecting to SCADA server for E-stop.", "error");
+    } catch {
+      triggerNotification(
+        "E-STOP request failed to reach the server — verify the PLC output!",
+        "error",
+      );
+    }
+  };
+
+  // Clear a latched E-stop. Never optimistically mark the system safe — only the
+  // server's e_stop_active (via the WebSocket) lowers the latch. On failure the
+  // button stays in the "latched" state so the UI never lies about safety.
+  const handleClearEStop = async () => {
+    if (
+      !window.confirm(
+        "Clear the emergency stop? The supply stays at zero until you " +
+          "re-enable permissive and re-enter a setpoint. Continue?",
+      )
+    )
+      return;
+    try {
+      const res = await fetch("/api/estop/clear", { method: "POST" });
+      if (!res.ok) {
+        triggerNotification(
+          "E-stop clear was rejected — system remains latched.",
+          "error",
+        );
+        return;
+      }
+      triggerNotification("E-stop cleared. Re-arm to resume.", "info");
+    } catch {
+      triggerNotification(
+        "E-stop clear failed to reach the server — system remains latched.",
+        "error",
+      );
     }
   };
 
@@ -784,7 +822,9 @@ export const App: React.FC = () => {
           justifyContent: "space-between",
           position: "sticky",
           top: 0,
-          zIndex: 50,
+          // Above the inspector drawer (200) and its backdrop (199) so the
+          // E-stop in this header is ALWAYS clickable, even with a drawer open.
+          zIndex: 300,
           background: "var(--bg-color)",
           marginBottom: "1rem",
           paddingTop: "0.85rem",
@@ -869,10 +909,7 @@ export const App: React.FC = () => {
           <EStopButton
             eStopActive={eStopActive}
             onTriggerEStop={handleEStop}
-            onClearEStop={async () => {
-              await fetch("/api/estop/clear", { method: "POST" });
-              setEStopActive(false);
-            }}
+            onClearEStop={handleClearEStop}
           />
         </div>
       </header>

--- a/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
+++ b/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
@@ -126,10 +126,17 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
     load();
   }, []);
 
-  // Sync mode display with whatever the server most recently applied.
+  // Adopt the server's mode ONCE, on the first status frame. After that the
+  // toggle is operator-owned: continuously syncing to liveStatus.mode would
+  // yank the toggle back mid-selection (the server only changes mode on an
+  // applied setpoint), which could lead to commanding the wrong quantity.
+  const modeInitialized = useRef(false);
   useEffect(() => {
-    if (liveStatus) setMode(liveStatus.mode);
-  }, [liveStatus?.mode]);
+    if (liveStatus && !modeInitialized.current) {
+      modeInitialized.current = true;
+      setMode(liveStatus.mode);
+    }
+  }, [liveStatus]);
 
   // Accumulate a rolling trend buffer from the live status broadcasts.
   useEffect(() => {
@@ -175,11 +182,16 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
       }
       // Guard rail: the server silently ignores setpoints unless the controller
       // is armed, so tell the operator instead of pretending it was applied.
-      if (liveStatus && liveStatus.state === "tripped") {
+      // If we have no live status, we can't verify permissive/trip — refuse.
+      if (!liveStatus) {
+        flash("Live status unavailable — cannot confirm permissive/trip.", "error");
+        return;
+      }
+      if (liveStatus.state === "tripped") {
         flash("Controller is TRIPPED — acknowledge the trip first.", "error");
         return;
       }
-      if (liveStatus && !liveStatus.permissive) {
+      if (!liveStatus.permissive) {
         flash("Permissive is OFF — enable it before commanding output.", "error");
         return;
       }


### PR DESCRIPTION
Fixes from a professional safety review of the HMI — real hazards where the UI could lie about a safety state or the E-stop could be unreachable / silently defeated.

## Frontend
- **E-stop was unclickable when any drawer was open** — the inspector/export/settings drawer backdrop (z-index 199) covered the sticky header (z-index 50). Header raised above the drawer (z 300) so the E-stop is **always** one click away.
- **E-stop CLEAR no longer lies on failure** — it checks the response, surfaces errors, requires a confirmation, and lets the server's `e_stop_active` (via WebSocket) drive the button, so the UI can't show "cleared" while the controller is still latched. E-stop TRIGGER optimistically latches on success (fail-toward-stopped) and warns loudly if unconfirmed.
- **PowerSupply mode desync** — the toggle was force-synced to the server every frame, which could yank it back mid-selection and lead to commanding the **wrong quantity (A vs W)**. Now adopts the server mode once, then is operator-owned.
- **Setpoint apply is refused (not silently skipped) when live status is unavailable**, so permissive/trip can't be bypassed by a dropped stream.

## Backend
- **E-stop re-asserted on PLC reconnect** — if `e_stop_active` is latched, `trigger_estop()` runs before anything else on reconnect, closing the window where the output could re-energize from stale PID setpoints after a comms drop.
- **`/api/estop` returns 502** (not a green "triggered") when the PLC doesn't acknowledge the kill write — a safety action must never be falsely confirmed.
- **`trigger_estop()` is best-effort** — it attempts every zeroing write even if one fails (a partial kill is unsafe) and returns `False` only after, so the poll-loop re-assert retries. New unit tests cover this.

## Verification
147 backend tests pass (3 new for best-effort kill), ruff clean, frontend `tsc` + `vite build` pass. **Live E-stop re-verified on hardware: 28 A → 0 and held.**

> Part of a multi-PR review response. A follow-up PR addresses data-capture robustness (export memory/streaming, retention, datetime normalization, durability config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)