### PR TITLE
feat(movement): animation layer toggles and a dedicated Plots subtab

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,6 +38,14 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 
 ### 2026-06-16 Update
 
+- Movement Optimizer analysis tabs (Swingset, Chain Dynamics) now give the user
+  per-element control over the animation via a "Show in animation" checklist
+  that toggles each MotionCanvas layer (grid/chain/rider/markers/forces)
+  independently, and each tab splits into Animation/Plots sub-tabs so the
+  analysis plots get a dedicated, roomy area. Plot legends and the policy-trace
+  legend are now toggleable (the trace legend reserves a top strip) so they no
+  longer obscure the plotted data. Shared via a `_MotionViewMixin`; legend
+  control is encapsulated in `MotionAnalysisPanel` (LoD).
 - Movement Optimizer analysis tabs now stop barbell playback when switching
   away from exercise tabs, avoiding stale animation timers indexing the
   swingset/chain tabs. Swingset and chain force overlays cache rollout-wide

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,14 +27,21 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.548                                    |
-| **Last Spec Update**    | 2026-06-16                                 |
+| **Spec Version**        | 1.1.549                                    |
+| **Last Spec Update**    | 2026-06-17                                 |
 
 ## 2. Purpose & Mission
 
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+
+### 2026-06-17 Update
+
+- Movement Optimizer motion-tab slider/text controls and scroll-panel
+  construction now live in `movement_optimizer.gui.motion_controls`, keeping
+  `motion_tabs.py` within the fleet module-size budget while preserving the
+  public `NumericControl` import surface used by the tab tests.
 
 ### 2026-06-16 Update
 

--- a/src/movement_optimizer/SPEC.md
+++ b/src/movement_optimizer/SPEC.md
@@ -11,7 +11,7 @@
 | License          | MIT                                                     |
 | Package Name     | `movement-optimizer`                                    |
 | Current Version  | `1.0.0`                                                 |
-| Spec Version     | `1.0.13`                                                |
+| Spec Version     | `1.0.14`                                                |
 | Last Spec Update | 2026-06-16                                              |
 
 ## 2. Purpose
@@ -30,6 +30,14 @@ Movement-Optimizer is a biomechanics trajectory optimizer for barbell exercises.
   frame.
 - Numeric sliders no longer emit continuous drag-time refreshes, and the
   Swingset optimizer action is styled as the primary command.
+- The Swingset and Chain Dynamics tabs now expose per-element animation
+  visibility: a "Show in animation" checklist toggles each MotionCanvas
+  layer (grid/chain/rider/markers/forces) independently, on top of the
+  existing force-vector filters.
+- Each tab splits into Animation and Plots sub-tabs so the analysis plots
+  get a roomy dedicated area; a "Show plot legends" control and a
+  toggleable, top-strip-reserving policy-trace legend keep legends from
+  obscuring the plotted curves.
 
 ### In Scope
 
@@ -146,6 +154,7 @@ mypy --ignore-missing-imports src/movement_optimizer/
 
 | Date       | Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                       |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-06-16 | 1.0.14  | Added per-element animation layer toggles (grid/chain/rider/markers/forces) to the Swingset and Chain Dynamics tabs via a shared `_MotionViewMixin`, split each tab into Animation/Plots sub-tabs, and made plot/policy-trace legends toggleable so they no longer obscure the plotted data. `MotionAnalysisPanel.set_legends_visible`/`has_legends` encapsulate legend control (LoD).                          |
 | 2026-06-15 | 1.0.12  | Lifted the legacy `scipy<1.16` ceiling after verifying current SciPy imports `CubicSpline` cleanly, and added a dependency-contract regression so the stale cap cannot return silently.                                                                                                                                                                                                                         |
 | 2026-05-16 | 1.0.11  | Isolated nightly workflow installs into a dedicated .nightly-venv virtual environment with PIP_NO_CACHE_DIR=1 to avoid shared runner cache corruption that caused ImportError: cannot import name '\_spropack' from scipy.sparse.linalg.\_propack (#462).                                                                                                                                                     |
 | 2026-04-22 | 1.0.10  | Added GUI sidebar/playback facade methods and routed main-window mixins through them to reduce deep object traversal in animation, comparison, cancellation, and signal binding code (#272).                                                                                                                                                                                                                  |

--- a/src/movement_optimizer/SPEC.md
+++ b/src/movement_optimizer/SPEC.md
@@ -11,14 +11,21 @@
 | License          | MIT                                                     |
 | Package Name     | `movement-optimizer`                                    |
 | Current Version  | `1.0.0`                                                 |
-| Spec Version     | `1.0.14`                                                |
-| Last Spec Update | 2026-06-16                                              |
+| Spec Version     | `1.0.15`                                                |
+| Last Spec Update | 2026-06-17                                              |
 
 ## 2. Purpose
 
 Movement-Optimizer is a biomechanics trajectory optimizer for barbell exercises. It models the body as a sagittal-plane planar chain, computes trajectories with Lagrangian inverse dynamics, and exposes both a GUI workflow and a headless CLI for batch optimisation.
 
 ## 3. Scope
+
+### 2026-06-17 Update
+
+- Motion-tab slider/text controls and scroll-panel construction now live in
+  `movement_optimizer.gui.motion_controls`, keeping the tab modules under the
+  enforced source-size budget without changing the Swingset or Chain Dynamics
+  interaction contract.
 
 ### 2026-06-16 Update
 

--- a/src/movement_optimizer/gui/motion_analysis_panel.py
+++ b/src/movement_optimizer/gui/motion_analysis_panel.py
@@ -72,6 +72,22 @@ class MotionAnalysisPanel(QWidget):
         """Reset every axis to a blank, themed state."""
         self._build_axes()
 
+    def set_legends_visible(self, visible: bool) -> None:
+        """Show or hide the legend on every axis that has one.
+
+        Encapsulates legend management so callers need not reach into the
+        figure's axes (Law of Demeter). Does not repaint; the caller draws.
+        Axes without a legend are skipped.
+        """
+        for axes in self.axes.values():
+            legend = axes.get_legend()
+            if legend is not None:
+                legend.set_visible(bool(visible))
+
+    def has_legends(self) -> bool:
+        """Return True if any axis currently carries a legend."""
+        return any(axes.get_legend() is not None for axes in self.axes.values())
+
     def draw(self) -> None:
         """Lay out and repaint the figure after the axes have been populated."""
         self.figure.tight_layout()

--- a/src/movement_optimizer/gui/motion_controls.py
+++ b/src/movement_optimizer/gui/motion_controls.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 D-Sorganization. All rights reserved.
+"""Reusable PyQt controls for movement-optimizer motion tabs."""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QHBoxLayout,
+    QLineEdit,
+    QScrollArea,
+    QSizePolicy,
+    QSlider,
+    QWidget,
+)
+
+
+class NumericControl(QWidget):
+    """Slider plus typed value field without spin-box arrows."""
+
+    valueChanged = pyqtSignal(float)  # noqa: N815 - Qt signal naming convention.
+
+    def __init__(
+        self,
+        lower: float,
+        upper: float,
+        value: float,
+        *,
+        integer: bool = False,
+        decimals: int = 3,
+        steps: int = 1000,
+    ) -> None:
+        super().__init__()
+        if upper <= lower:
+            raise ValueError("upper must be greater than lower")
+        self._lower = lower
+        self._upper = upper
+        self._integer = integer
+        self._decimals = 0 if integer else decimals
+        self._steps = max(1, int(upper - lower) if integer else steps)
+        self._value = self._coerce(value)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+        self.setMinimumHeight(32)
+        self.slider = QSlider(Qt.Orientation.Horizontal)
+        self.slider.setRange(0, self._steps)
+        self.slider.setTracking(False)
+        self.slider.setMinimumHeight(28)
+        self.slider.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.edit = QLineEdit()
+        self.edit.setFixedWidth(88)
+        self.edit.setMinimumHeight(28)
+        self.edit.setAlignment(Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(self.slider, stretch=1)
+        layout.addWidget(self.edit)
+
+        self.slider.valueChanged.connect(self._on_slider_changed)
+        self.edit.editingFinished.connect(self._on_text_changed)
+        self._sync_widgets()
+
+    def value(self) -> float:
+        return self._value
+
+    def set_value(self, value: float) -> None:
+        new_value = self._coerce(value)
+        if new_value == self._value:
+            self._sync_widgets()
+            return
+        self._value = new_value
+        self._sync_widgets()
+        self.valueChanged.emit(self._value)
+
+    def _coerce(self, value: float) -> float:
+        bounded = min(max(float(value), self._lower), self._upper)
+        return float(round(bounded)) if self._integer else bounded
+
+    def _value_to_slider(self, value: float) -> int:
+        ratio = (value - self._lower) / (self._upper - self._lower)
+        return round(ratio * self._steps)
+
+    def _slider_to_value(self, position: int) -> float:
+        ratio = position / self._steps
+        return self._coerce(self._lower + ratio * (self._upper - self._lower))
+
+    def _sync_widgets(self) -> None:
+        slider_value = self._value_to_slider(self._value)
+        if self.slider.value() != slider_value:
+            self.slider.blockSignals(True)
+            self.slider.setValue(slider_value)
+            self.slider.blockSignals(False)
+        text = f"{int(self._value)}" if self._integer else f"{self._value:.{self._decimals}f}"
+        if self.edit.text() != text:
+            self.edit.setText(text)
+
+    def _on_slider_changed(self, position: int) -> None:
+        self._value = self._slider_to_value(position)
+        self._sync_widgets()
+        self.valueChanged.emit(self._value)
+
+    def _on_text_changed(self) -> None:
+        try:
+            parsed = float(self.edit.text())
+        except ValueError:
+            self._sync_widgets()
+            return
+        self.set_value(parsed)
+
+
+def scrollable_control_panel(panel: QWidget) -> QScrollArea:
+    scroll_area = QScrollArea()
+    scroll_area.setWidget(panel)
+    scroll_area.setWidgetResizable(True)
+    scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+    scroll_area.setMinimumWidth(340)
+    scroll_area.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
+    return scroll_area

--- a/src/movement_optimizer/gui/motion_tabs.py
+++ b/src/movement_optimizer/gui/motion_tabs.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from itertools import pairwise
 
 import numpy as np
@@ -23,6 +23,7 @@ from PyQt6.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QSlider,
+    QTabWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -253,6 +254,15 @@ class NumericControl(QWidget):
 class MotionCanvas(QWidget):
     """Side-view renderer for chain and articulated rider snapshots."""
 
+    #: Drawable layers, in paint order, with their display labels.
+    LAYERS: tuple[tuple[str, str], ...] = (
+        ("grid", "Grid"),
+        ("chain", "Chain"),
+        ("rider", "Rider"),
+        ("markers", "Pivot markers"),
+        ("forces", "Force vectors"),
+    )
+
     def __init__(self) -> None:
         super().__init__()
         self.setMinimumHeight(360)
@@ -260,6 +270,24 @@ class MotionCanvas(QWidget):
         self._body_points: dict[str, tuple[float, float]] = {}
         self._overlay = OverlayScene()
         self._path_length_m = 0.5
+        self._layers: dict[str, bool] = {key: True for key, _ in self.LAYERS}
+
+    def set_layer_visible(self, name: str, visible: bool) -> None:
+        """Show or hide a single drawable layer and repaint.
+
+        Raises ValueError for an unknown layer name so wiring mistakes
+        surface immediately rather than silently doing nothing.
+        """
+        if name not in self._layers:
+            raise ValueError(f"unknown motion-canvas layer: {name!r}")
+        self._layers[name] = bool(visible)
+        self.update()
+
+    def is_layer_visible(self, name: str) -> bool:
+        """Return whether a drawable layer is currently visible."""
+        if name not in self._layers:
+            raise ValueError(f"unknown motion-canvas layer: {name!r}")
+        return self._layers[name]
 
     def set_scene(
         self,
@@ -284,14 +312,19 @@ class MotionCanvas(QWidget):
             return
         projector = self._projector()
         chain_points = [projector(point) for point in self._chain_nodes]
-        self._draw_grid(painter)
-        self._draw_polyline(painter, chain_points, CHAIN, 3)
-        self._draw_body(painter, projector)
-        painter.setBrush(ACCENT)
-        painter.setPen(QPen(ACCENT, 1))
-        for point in chain_points[:1] + chain_points[-1:]:
-            painter.drawEllipse(point, 5, 5)
-        self._draw_overlay(painter, projector)
+        if self._layers["grid"]:
+            self._draw_grid(painter)
+        if self._layers["chain"]:
+            self._draw_polyline(painter, chain_points, CHAIN, 3)
+        if self._layers["rider"]:
+            self._draw_body(painter, projector)
+        if self._layers["markers"]:
+            painter.setBrush(ACCENT)
+            painter.setPen(QPen(ACCENT, 1))
+            for point in chain_points[:1] + chain_points[-1:]:
+                painter.drawEllipse(point, 5, 5)
+        if self._layers["forces"]:
+            self._draw_overlay(painter, projector)
 
     def _draw_overlay(
         self,
@@ -393,7 +426,92 @@ def _scrollable_control_panel(panel: QWidget) -> QScrollArea:
     return scroll_area
 
 
-class SwingsetTab(QWidget):
+class _MotionViewMixin:
+    """Shared Animation/Plots subtab scaffolding for motion-analysis tabs.
+
+    Hosts the per-element animation layer toggles, the animation/plots
+    sub-tab split, and the plot-legend visibility control. Concrete tabs
+    must provide ``self.canvas`` (a :class:`MotionCanvas`),
+    ``self.analysis_panel`` (a :class:`MotionAnalysisPanel`), and the
+    ``self._layer_toggles`` / ``self._plot_legend_toggle`` attributes
+    referenced below.
+    """
+
+    canvas: MotionCanvas
+    analysis_panel: MotionAnalysisPanel
+    _layer_toggles: dict[str, QCheckBox]
+
+    def _build_animation_view(self) -> QWidget:
+        """The animation subtab: the motion canvas with full vertical room."""
+        view = QWidget()
+        view_layout = QVBoxLayout(view)
+        view_layout.setContentsMargins(0, 0, 0, 0)
+        view_layout.addWidget(self.canvas)
+        return view
+
+    def _build_plots_view(self) -> QWidget:
+        """The plots subtab: roomy analysis plots plus appearance controls."""
+        view = QWidget()
+        view_layout = QVBoxLayout(view)
+        view_layout.setContentsMargins(0, 0, 0, 0)
+        view_layout.setSpacing(6)
+        appearance = QHBoxLayout()
+        self._plot_legend_toggle = QCheckBox("Show plot legends")
+        self._plot_legend_toggle.setChecked(True)
+        self._plot_legend_toggle.setToolTip(
+            "Show or hide the legends on the analysis plots so they do not "
+            "obscure the plotted curves."
+        )
+        self._plot_legend_toggle.stateChanged.connect(self._refresh_plot_legends)
+        appearance.addWidget(self._plot_legend_toggle)
+        appearance.addStretch()
+        view_layout.addLayout(appearance)
+        view_layout.addWidget(self.analysis_panel, stretch=1)
+        return view
+
+    def _build_layers_group(self, layer_keys: Sequence[str] | None = None) -> QGroupBox:
+        """Build the "Show in animation" checklist.
+
+        ``layer_keys`` restricts the checklist to the layers a given tab
+        actually draws (e.g. the chain tab has no articulated rider), so no
+        inert toggles are shown. Defaults to every canvas layer.
+        """
+        allowed = set(layer_keys) if layer_keys is not None else None
+        group = QGroupBox("Show in animation")
+        layout = QVBoxLayout(group)
+        layout.setSpacing(4)
+        tips = {
+            "grid": "Background reference grid.",
+            "chain": "Swing chain polyline.",
+            "rider": "Articulated rider body segments.",
+            "markers": "Anchor and seat pivot markers.",
+            "forces": "All force and torque vector overlays.",
+        }
+        for key, label in MotionCanvas.LAYERS:
+            if allowed is not None and key not in allowed:
+                continue
+            checkbox = QCheckBox(label)
+            checkbox.setChecked(self.canvas.is_layer_visible(key))
+            checkbox.setToolTip(tips.get(key, ""))
+            checkbox.stateChanged.connect(
+                lambda _state, name=key, box=checkbox: self.canvas.set_layer_visible(
+                    name, box.isChecked()
+                )
+            )
+            self._layer_toggles[key] = checkbox
+            layout.addWidget(checkbox)
+        return group
+
+    def _apply_plot_legend_visibility(self) -> None:
+        """Match analysis-plot legend visibility to the appearance toggle."""
+        self.analysis_panel.set_legends_visible(self._plot_legend_toggle.isChecked())
+
+    def _refresh_plot_legends(self, _state: int | None = None) -> None:
+        self._apply_plot_legend_visibility()
+        self.analysis_panel.draw()
+
+
+class SwingsetTab(_MotionViewMixin, QWidget):
     """Interactive swingset model tab with cyclic policy optimization."""
 
     playbackStateChanged = pyqtSignal()  # noqa: N815 - Qt signal naming convention.
@@ -414,6 +532,7 @@ class SwingsetTab(QWidget):
         )
         self._controls: dict[str, NumericControl] = {}
         self._force_toggles: dict[str, QCheckBox] = {}
+        self._layer_toggles: dict[str, QCheckBox] = {}
         self._force_history: object | None = None
         self._force_fields: tuple[SwingForceField, ...] | None = None
         self._rollout: SwingRollout | None = None
@@ -430,7 +549,10 @@ class SwingsetTab(QWidget):
 
     def _build_ui(self) -> None:
         layout = QGridLayout(self)
-        layout.addWidget(self.canvas, 0, 0, 1, 1)
+        self.view_tabs = QTabWidget()
+        self.view_tabs.addTab(self._build_animation_view(), "Animation")
+        self.view_tabs.addTab(self._build_plots_view(), "Plots")
+        layout.addWidget(self.view_tabs, 0, 0, 2, 1)
         self._control_panel_widget = QWidget()
         right_layout = QVBoxLayout(self._control_panel_widget)
         right_layout.setContentsMargins(0, 0, 0, 0)
@@ -442,13 +564,13 @@ class SwingsetTab(QWidget):
         control_layout.setSpacing(10)
         control_layout.addWidget(self._build_chain_group())
         control_layout.addWidget(self._build_body_group())
+        control_layout.addWidget(self._build_layers_group())
         control_layout.addWidget(self._build_force_group())
         control_layout.addWidget(self._build_policy_group())
         control_layout.addWidget(self._build_policy_telemetry_group())
         control_layout.addStretch()
         self._control_scroll = _scrollable_control_panel(control_panel)
         right_layout.addWidget(self._control_scroll)
-        layout.addWidget(self.analysis_panel, 1, 0, 1, 1)
         layout.addWidget(self._control_panel_widget, 0, 1, 2, 1)
         layout.addWidget(self.metric_label, 2, 0, 1, 2)
         layout.setColumnStretch(0, 1)
@@ -719,7 +841,18 @@ class SwingsetTab(QWidget):
     def _build_policy_telemetry_group(self) -> QGroupBox:
         group = QGroupBox("Policy Telemetry")
         layout = QVBoxLayout(group)
+        self._trace_legend_toggle = QCheckBox("Show trace legend")
+        self._trace_legend_toggle.setChecked(self.policy_trace_canvas.legend_visible())
+        self._trace_legend_toggle.setToolTip(
+            "Show or hide the legend drawn over the policy-trace plot."
+        )
+        self._trace_legend_toggle.stateChanged.connect(
+            lambda _state: self.policy_trace_canvas.set_legend_visible(
+                self._trace_legend_toggle.isChecked()
+            )
+        )
         layout.addWidget(self.policy_trace_canvas)
+        layout.addWidget(self._trace_legend_toggle)
         layout.addWidget(self.policy_detail_label)
         return group
 
@@ -954,6 +1087,7 @@ class SwingsetTab(QWidget):
         plot_renderer.plot_swing_com_height(panel.axes["com_height"], history)
         plot_renderer.plot_swing_energy(panel.axes["energy"], history)
         plot_renderer.plot_swing_com_path(panel.axes["com_path"], history)
+        self._apply_plot_legend_visibility()
         panel.draw()
 
     def _refresh_overlays(self, _state: int | None = None) -> None:

--- a/src/movement_optimizer/gui/motion_tabs.py
+++ b/src/movement_optimizer/gui/motion_tabs.py
@@ -7,7 +7,7 @@ from collections.abc import Callable, Sequence
 from itertools import pairwise
 
 import numpy as np
-from PyQt6.QtCore import QPointF, Qt, QTimer, pyqtSignal
+from PyQt6.QtCore import QPointF, QTimer, pyqtSignal
 from PyQt6.QtGui import QColor, QPainter, QPen
 from PyQt6.QtWidgets import (
     QCheckBox,
@@ -16,13 +16,10 @@ from PyQt6.QtWidgets import (
     QGroupBox,
     QHBoxLayout,
     QLabel,
-    QLineEdit,
     QMessageBox,
     QProgressBar,
     QPushButton,
     QScrollArea,
-    QSizePolicy,
-    QSlider,
     QTabWidget,
     QVBoxLayout,
     QWidget,
@@ -53,6 +50,7 @@ from movement_optimizer.rendering import Palette, get_chart_color
 
 from . import plot_renderer
 from .motion_analysis_panel import MotionAnalysisPanel
+from .motion_controls import NumericControl, scrollable_control_panel
 from .policy_trace_canvas import PolicyTraceCanvas, refresh_policy_trace_palette
 from .policy_worker import PolicyOptimizationWorker
 from .vector_overlay import (
@@ -156,99 +154,6 @@ def _chain_overlay_scene(
             vec = (float(field.net_force_n[index][0]), float(field.net_force_n[index][1]))
             arrows.append(ForceArrow(origin, vec, VectorStyle(ARM)))
     return OverlayScene(arrows=tuple(arrows))
-
-
-class NumericControl(QWidget):
-    """Slider plus typed value field without spin-box arrows."""
-
-    valueChanged = pyqtSignal(float)  # noqa: N815 - Qt signal naming convention.
-
-    def __init__(
-        self,
-        lower: float,
-        upper: float,
-        value: float,
-        *,
-        integer: bool = False,
-        decimals: int = 3,
-        steps: int = 1000,
-    ) -> None:
-        super().__init__()
-        if upper <= lower:
-            raise ValueError("upper must be greater than lower")
-        self._lower = lower
-        self._upper = upper
-        self._integer = integer
-        self._decimals = 0 if integer else decimals
-        self._steps = max(1, int(upper - lower) if integer else steps)
-        self._value = self._coerce(value)
-
-        layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(8)
-        self.setMinimumHeight(32)
-        self.slider = QSlider(Qt.Orientation.Horizontal)
-        self.slider.setRange(0, self._steps)
-        self.slider.setTracking(False)
-        self.slider.setMinimumHeight(28)
-        self.slider.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        self.edit = QLineEdit()
-        self.edit.setFixedWidth(88)
-        self.edit.setMinimumHeight(28)
-        self.edit.setAlignment(Qt.AlignmentFlag.AlignRight)
-        layout.addWidget(self.slider, stretch=1)
-        layout.addWidget(self.edit)
-
-        self.slider.valueChanged.connect(self._on_slider_changed)
-        self.edit.editingFinished.connect(self._on_text_changed)
-        self._sync_widgets()
-
-    def value(self) -> float:
-        return self._value
-
-    def set_value(self, value: float) -> None:
-        new_value = self._coerce(value)
-        if new_value == self._value:
-            self._sync_widgets()
-            return
-        self._value = new_value
-        self._sync_widgets()
-        self.valueChanged.emit(self._value)
-
-    def _coerce(self, value: float) -> float:
-        bounded = min(max(float(value), self._lower), self._upper)
-        return float(round(bounded)) if self._integer else bounded
-
-    def _value_to_slider(self, value: float) -> int:
-        ratio = (value - self._lower) / (self._upper - self._lower)
-        return round(ratio * self._steps)
-
-    def _slider_to_value(self, position: int) -> float:
-        ratio = position / self._steps
-        return self._coerce(self._lower + ratio * (self._upper - self._lower))
-
-    def _sync_widgets(self) -> None:
-        slider_value = self._value_to_slider(self._value)
-        if self.slider.value() != slider_value:
-            self.slider.blockSignals(True)
-            self.slider.setValue(slider_value)
-            self.slider.blockSignals(False)
-        text = f"{int(self._value)}" if self._integer else f"{self._value:.{self._decimals}f}"
-        if self.edit.text() != text:
-            self.edit.setText(text)
-
-    def _on_slider_changed(self, position: int) -> None:
-        self._value = self._slider_to_value(position)
-        self._sync_widgets()
-        self.valueChanged.emit(self._value)
-
-    def _on_text_changed(self) -> None:
-        try:
-            parsed = float(self.edit.text())
-        except ValueError:
-            self._sync_widgets()
-            return
-        self.set_value(parsed)
 
 
 class MotionCanvas(QWidget):
@@ -416,16 +321,6 @@ class MotionCanvas(QWidget):
             )
 
 
-def _scrollable_control_panel(panel: QWidget) -> QScrollArea:
-    scroll_area = QScrollArea()
-    scroll_area.setWidget(panel)
-    scroll_area.setWidgetResizable(True)
-    scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-    scroll_area.setMinimumWidth(340)
-    scroll_area.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Expanding)
-    return scroll_area
-
-
 class _MotionViewMixin:
     """Shared Animation/Plots subtab scaffolding for motion-analysis tabs.
 
@@ -569,7 +464,7 @@ class SwingsetTab(_MotionViewMixin, QWidget):
         control_layout.addWidget(self._build_policy_group())
         control_layout.addWidget(self._build_policy_telemetry_group())
         control_layout.addStretch()
-        self._control_scroll = _scrollable_control_panel(control_panel)
+        self._control_scroll = scrollable_control_panel(control_panel)
         right_layout.addWidget(self._control_scroll)
         layout.addWidget(self._control_panel_widget, 0, 1, 2, 1)
         layout.addWidget(self.metric_label, 2, 0, 1, 2)

--- a/src/movement_optimizer/gui/motion_tabs_chain.py
+++ b/src/movement_optimizer/gui/motion_tabs_chain.py
@@ -44,12 +44,11 @@ from movement_optimizer.models.chain_forces import (
 
 from . import plot_renderer
 from .motion_analysis_panel import MotionAnalysisPanel
+from .motion_controls import NumericControl, scrollable_control_panel
 from .motion_tabs import (
     MotionCanvas,
-    NumericControl,
     _chain_overlay_scene,
     _MotionViewMixin,
-    _scrollable_control_panel,
 )
 from .vector_overlay import OverlayScene
 
@@ -248,7 +247,7 @@ class ChainDynamicsTab(_MotionViewMixin, QWidget):
         control_layout.addLayout(row)
         control_layout.addWidget(self.metric_label)
         control_layout.addStretch()
-        self._control_scroll = _scrollable_control_panel(control_panel)
+        self._control_scroll = scrollable_control_panel(control_panel)
         layout.addWidget(self._control_scroll, 0, 1, 2, 1)
         layout.setColumnStretch(0, 1)
         layout.setRowStretch(0, 1)

--- a/src/movement_optimizer/gui/motion_tabs_chain.py
+++ b/src/movement_optimizer/gui/motion_tabs_chain.py
@@ -22,6 +22,7 @@ from PyQt6.QtWidgets import (
     QLineEdit,
     QPushButton,
     QScrollArea,
+    QTabWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -47,12 +48,13 @@ from .motion_tabs import (
     MotionCanvas,
     NumericControl,
     _chain_overlay_scene,
+    _MotionViewMixin,
     _scrollable_control_panel,
 )
 from .vector_overlay import OverlayScene
 
 
-class ChainDynamicsTab(QWidget):
+class ChainDynamicsTab(_MotionViewMixin, QWidget):
     """Interactive chain whip-motion analysis tab."""
 
     def __init__(self) -> None:
@@ -71,6 +73,7 @@ class ChainDynamicsTab(QWidget):
         )
         self._controls: dict[str, NumericControl] = {}
         self._force_toggles: dict[str, QCheckBox] = {}
+        self._layer_toggles: dict[str, QCheckBox] = {}
         self._force_fields: tuple[ChainForceField, ...] | None = None
         self._rollout: ChainRollout | None = None
         self._frame_index = 0
@@ -84,7 +87,10 @@ class ChainDynamicsTab(QWidget):
 
     def _build_ui(self) -> None:
         layout = QGridLayout(self)
-        layout.addWidget(self.canvas, 0, 0, 1, 1)
+        self.view_tabs = QTabWidget()
+        self.view_tabs.addTab(self._build_animation_view(), "Animation")
+        self.view_tabs.addTab(self._build_plots_view(), "Plots")
+        layout.addWidget(self.view_tabs, 0, 0, 2, 1)
         control_panel = QWidget()
         control_layout = QVBoxLayout(control_panel)
         control_layout.setContentsMargins(8, 0, 8, 0)
@@ -220,6 +226,8 @@ class ChainDynamicsTab(QWidget):
         self.angle_edit.editingFinished.connect(self._refresh)
         form.addRow("Segment angles", self.angle_edit)
         control_layout.addWidget(controls)
+        # The chain tab draws no articulated rider, so omit that layer.
+        control_layout.addWidget(self._build_layers_group(["grid", "chain", "markers", "forces"]))
         control_layout.addWidget(self._build_force_group())
         row = QHBoxLayout()
         simulate_button = QPushButton("Simulate Whip")
@@ -241,7 +249,6 @@ class ChainDynamicsTab(QWidget):
         control_layout.addWidget(self.metric_label)
         control_layout.addStretch()
         self._control_scroll = _scrollable_control_panel(control_panel)
-        layout.addWidget(self.analysis_panel, 1, 0, 1, 1)
         layout.addWidget(self._control_scroll, 0, 1, 2, 1)
         layout.setColumnStretch(0, 1)
         layout.setRowStretch(0, 1)
@@ -409,6 +416,7 @@ class ChainDynamicsTab(QWidget):
         plot_renderer.plot_chain_tip_speed(
             panel.axes["tip_speed"], time_s, self._rollout.tip_speed_m_s[:count]
         )
+        self._apply_plot_legend_visibility()
         panel.draw()
 
     def _refresh_overlays(self, _state: int | None = None) -> None:

--- a/src/movement_optimizer/gui/policy_trace_canvas.py
+++ b/src/movement_optimizer/gui/policy_trace_canvas.py
@@ -59,16 +59,34 @@ def refresh_policy_trace_palette() -> None:
 class PolicyTraceCanvas(QWidget):
     """Compact plot of policy-search score and parameter traces."""
 
+    #: Height of the strip reserved at the top for the legend so it never
+    #: paints over the plotted series.
+    _LEGEND_BAND_PX = 22
+
     def __init__(self) -> None:
         super().__init__()
         self.setMinimumHeight(160)
         self._samples: tuple[CyclicPolicyTraceSample, ...] = ()
         self._series: dict[str, np.ndarray] = {}
+        self._legend_visible = True
 
     def set_trace(self, samples: tuple[CyclicPolicyTraceSample, ...]) -> None:
         self._samples = samples
         self._series = self._build_series(samples)
         self.update()
+
+    def set_legend_visible(self, visible: bool) -> None:
+        """Show or hide the inline legend and repaint."""
+        self._legend_visible = bool(visible)
+        self.update()
+
+    def legend_visible(self) -> bool:
+        """Return whether the inline legend is currently drawn."""
+        return self._legend_visible
+
+    def _top_margin(self) -> float:
+        """Top inset for the plotted series, reserving room for the legend."""
+        return float(self._LEGEND_BAND_PX if self._legend_visible else 8)
 
     def sample_count(self) -> int:
         return len(self._samples)
@@ -90,7 +108,8 @@ class PolicyTraceCanvas(QWidget):
         self._draw_normalized_series(painter, "hip_rate_amplitude_rad_s", ARM, 1)
         self._draw_normalized_series(painter, "torso_rate_amplitude_rad_s", BODY, 1)
         self._draw_normalized_series(painter, "knee_rate_ratio", LEG, 1)
-        self._draw_legend(painter)
+        if self._legend_visible:
+            self._draw_legend(painter)
 
     def _draw_normalized_series(
         self,
@@ -108,10 +127,13 @@ class PolicyTraceCanvas(QWidget):
             normalized = np.full(values.shape, 0.5, dtype=np.float64)
         else:
             normalized = (values - lower) / (upper - lower)
+        top = self._top_margin()
+        bottom = self.height() - 8.0
+        span = max(bottom - top, 1.0)
         points = [
             QPointF(
                 8.0 + index * (self.width() - 16.0) / (values.size - 1),
-                self.height() - 8.0 - value * (self.height() - 16.0),
+                bottom - value * span,
             )
             for index, value in enumerate(normalized)
         ]
@@ -146,9 +168,7 @@ class PolicyTraceCanvas(QWidget):
         return {
             "score_m": _trace_series(samples, lambda sample: sample.score_m),
             "best_score_m": _trace_series(samples, lambda sample: sample.best_score_m),
-            "frequency_hz": _trace_series(
-                samples, lambda sample: sample.parameters.frequency_hz
-            ),
+            "frequency_hz": _trace_series(samples, lambda sample: sample.parameters.frequency_hz),
             "hip_rate_amplitude_rad_s": _trace_series(
                 samples, lambda sample: sample.parameters.hip_rate_amplitude_rad_s
             ),

--- a/src/movement_optimizer/tests/test_motion_analysis_panel.py
+++ b/src/movement_optimizer/tests/test_motion_analysis_panel.py
@@ -149,3 +149,26 @@ class TestMotionAnalysisPanel:
 
         with pytest.raises(ValueError, match="positive"):
             MotionAnalysisPanel(["a"], rows=0, cols=1)
+
+    def test_has_legends_reflects_axis_state(self, qapp) -> None:
+        from movement_optimizer.gui.motion_analysis_panel import MotionAnalysisPanel
+
+        panel = MotionAnalysisPanel(["a", "b"], rows=1, cols=2)
+        assert panel.has_legends() is False
+        panel.axes["a"].plot([0, 1], [0, 1], label="series")
+        panel.axes["a"].legend()
+        assert panel.has_legends() is True
+
+    def test_set_legends_visible_toggles_only_legend_bearing_axes(self, qapp) -> None:
+        from movement_optimizer.gui.motion_analysis_panel import MotionAnalysisPanel
+
+        panel = MotionAnalysisPanel(["a", "b"], rows=1, cols=2)
+        panel.axes["a"].plot([0, 1], [0, 1], label="series")
+        legend = panel.axes["a"].legend()
+
+        panel.set_legends_visible(False)
+        assert legend.get_visible() is False
+        panel.set_legends_visible(True)
+        assert legend.get_visible() is True
+        # The legend-free axis is simply skipped (no error).
+        assert panel.axes["b"].get_legend() is None

--- a/src/movement_optimizer/tests/test_motion_tabs.py
+++ b/src/movement_optimizer/tests/test_motion_tabs.py
@@ -33,6 +33,7 @@ from movement_optimizer.gui.motion_tabs import (
     NumericControl,
     SwingsetTab,
 )
+from movement_optimizer.gui.policy_trace_canvas import PolicyTraceCanvas
 
 
 def _wait_for_policy_worker(qapp, swingset: SwingsetTab, timeout_s: float = 10.0) -> None:
@@ -712,3 +713,90 @@ def test_motion_tab_analysis_helpers_are_safe_without_rollout(qapp) -> None:
     chain._populate_analysis_panel()  # None-guard
     chain._refresh_overlays()  # None-guard clears overlays
     assert not chain.canvas._overlay.arrows
+
+
+def test_motion_canvas_layer_visibility_toggles(qapp) -> None:
+    canvas = MotionCanvas()
+    canvas.resize(320, 240)
+    canvas.set_scene([(0.0, 0.0), (0.0, 1.0)])
+
+    for key, _label in MotionCanvas.LAYERS:
+        assert canvas.is_layer_visible(key) is True
+
+    canvas.set_layer_visible("grid", False)
+    assert canvas.is_layer_visible("grid") is False
+    canvas.grab()  # repaint with a hidden layer must not raise
+
+    canvas.set_layer_visible("grid", True)
+    assert canvas.is_layer_visible("grid") is True
+
+
+def test_motion_canvas_rejects_unknown_layer(qapp) -> None:
+    canvas = MotionCanvas()
+    with pytest.raises(ValueError):
+        canvas.set_layer_visible("bogus", False)
+    with pytest.raises(ValueError):
+        canvas.is_layer_visible("bogus")
+
+
+def test_swingset_layer_toggles_drive_canvas_visibility(qapp) -> None:
+    swingset = SwingsetTab()
+    assert set(swingset._layer_toggles) == {key for key, _ in MotionCanvas.LAYERS}
+
+    toggle = swingset._layer_toggles["forces"]
+    assert toggle.isChecked() is True
+    toggle.setChecked(False)
+    assert swingset.canvas.is_layer_visible("forces") is False
+    toggle.setChecked(True)
+    assert swingset.canvas.is_layer_visible("forces") is True
+
+
+def test_swingset_splits_animation_and_plots_into_subtabs(qapp) -> None:
+    swingset = SwingsetTab()
+    titles = [swingset.view_tabs.tabText(i) for i in range(swingset.view_tabs.count())]
+    assert titles == ["Animation", "Plots"]
+
+
+def test_swingset_plot_legend_toggle_hides_axes_legends(qapp) -> None:
+    swingset = SwingsetTab()
+    axes = swingset.analysis_panel.axes["torques"]
+    axes.plot([0, 1], [0, 1], label="series")
+    legend = axes.legend()
+
+    swingset._plot_legend_toggle.setChecked(False)
+    assert legend.get_visible() is False
+    swingset._plot_legend_toggle.setChecked(True)
+    assert legend.get_visible() is True
+
+
+def test_chain_layer_toggles_drive_canvas_visibility(qapp) -> None:
+    chain = ChainDynamicsTab()
+    # The chain tab draws no rider, so that layer is omitted from its checklist.
+    assert set(chain._layer_toggles) == {"grid", "chain", "markers", "forces"}
+
+    toggle = chain._layer_toggles["forces"]
+    assert toggle.isChecked() is True
+    toggle.setChecked(False)
+    assert chain.canvas.is_layer_visible("forces") is False
+    toggle.setChecked(True)
+    assert chain.canvas.is_layer_visible("forces") is True
+
+
+def test_chain_splits_animation_and_plots_into_subtabs(qapp) -> None:
+    chain = ChainDynamicsTab()
+    titles = [chain.view_tabs.tabText(i) for i in range(chain.view_tabs.count())]
+    assert titles == ["Animation", "Plots"]
+
+
+def test_policy_trace_legend_toggle_reserves_plot_space(qapp) -> None:
+    trace = PolicyTraceCanvas()
+    assert trace.legend_visible() is True
+    top_with_legend = trace._top_margin()
+
+    trace.set_legend_visible(False)
+    assert trace.legend_visible() is False
+    # Hiding the legend reclaims the reserved top strip for the series.
+    assert trace._top_margin() < top_with_legend
+
+    trace.resize(200, 160)
+    trace.grab()  # repaint without the legend must not raise


### PR DESCRIPTION
## What & why

Gives the Movement-Optimizer **Swingset** and **Chain Dynamics** tabs full, intuitive control over what the animation shows, and fixes plot legends obscuring the data by moving the analysis plots into their own roomy sub-tab.

This also brings the Tools `movement_optimizer` package up to date with the (now-archived) standalone Movement-Optimizer repo: a detailed review confirmed Tools is already the more sophisticated base (async `PolicyOptimizationWorker`, cached force fields, modular `policy_trace_canvas`/`motion_tabs_chain` split), so the only missing piece was this feature, ported into Tools' layout.

## Changes

- **Per-element animation visibility** — `MotionCanvas` gains a `LAYERS` map and `set_layer_visible`/`is_layer_visible` (DbC: `ValueError` on an unknown layer). `paintEvent` guards each drawn element (grid / chain / rider / pivot markers / force vectors). A new **"Show in animation"** checklist drives them, alongside the existing per-force-vector toggles.
- **Dedicated Plots sub-tab** — each tab splits into **Animation** / **Plots** sub-tabs (`QTabWidget`), so the analysis plots get the full area instead of being squished under the animation.
- **Legends no longer obscure data** — a **"Show plot legends"** toggle (Plots sub-tab) and a toggleable **policy-trace legend** that reserves a top strip so it never paints over the trace.
- **Shared, reusable** — a `_MotionViewMixin` provides the checklist + sub-tab split + legend control to both `SwingsetTab` and `ChainDynamicsTab` (DRY). The checklist is tab-aware, so the chain tab omits the inert "Rider" layer.
- **LoD** — legend management lives in `MotionAnalysisPanel.set_legends_visible` / `has_legends`; tabs don't reach into figure axes.

## Principles

TDD (10 new tests), DbC (contract on layer names), LoD (panel owns legend logic), DRY (shared mixin), reusable (mixin + canvas layers + panel API), and reversible (every default preserves current behaviour — all layers/legends visible).

## Testing

- `ruff format --check` + `ruff check`: clean on touched files.
- `mypy`: no new errors introduced (identical error count vs base).
- `pytest src/movement_optimizer/tests/test_motion_tabs.py src/movement_optimizer/tests/test_motion_analysis_panel.py`: **65 passed** (10 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
