### PR TITLE
build(movement_optimizer): make Rust core buildable + add parity CI gate (#3517)

### DIFF
--- a/.github/workflows/maturin-movement-optimizer.yml
+++ b/.github/workflows/maturin-movement-optimizer.yml
@@ -1,0 +1,72 @@
+# Maturin CI — movement_optimizer_core Python extension
+#
+# Builds the `movement_optimizer_core` Rust crate (batch inverse dynamics / COM
+# hot path) and runs the Rust<->NumPy parity suite as a REAL gate. Previously the
+# crate was built by no workflow and `tests/test_rust_parity.py` was permanently
+# `importorskip`-skipped, so the optimizer always ran the slow NumPy fallback and
+# parity was never verified (issue #3517).
+#
+# This job installs the built wheel and asserts the extension imports (hard fail)
+# before running the parity tests, so a missing/broken accelerator breaks the
+# build instead of silently skipping.
+
+name: Maturin — movement_optimizer_core
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/movement_optimizer/**"
+  pull_request:
+    paths:
+      - "src/movement_optimizer/**"
+  workflow_dispatch:
+
+concurrency:
+  group: maturin-movement-optimizer-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity-gate:
+    name: Build movement_optimizer_core + parity gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install build + test deps
+        run: python -m pip install --upgrade pip maturin "numpy<2" "scipy>=1.10" pytest
+
+      - name: Build movement_optimizer_core wheel
+        run: maturin build --release -m src/movement_optimizer/rust_core/Cargo.toml
+
+      - name: Install the built wheel
+        run: python -m pip install src/movement_optimizer/rust_core/target/wheels/*.whl
+
+      - name: Assert the Rust extension imports (hard fail — no silent skip)
+        run: |
+          python - <<'PY'
+          import movement_optimizer_core as m
+          required = {"inverse_dynamics_batch_rs", "com_x_batch_rs", "inverse_dynamics_ndof_rs"}
+          missing = required - set(dir(m))
+          assert not missing, f"movement_optimizer_core missing exports: {missing}"
+          print("movement_optimizer_core OK:", sorted(required))
+          PY
+
+      - name: Run Rust<->NumPy parity suite (gate)
+        env:
+          PYTHONPATH: src:src/movement_optimizer
+        run: |
+          python -m pytest src/movement_optimizer/tests/test_rust_parity.py \
+            -o addopts="" -p no:cacheprovider -v

--- a/.github/workflows/maturin-movement-optimizer.yml
+++ b/.github/workflows/maturin-movement-optimizer.yml
@@ -27,9 +27,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pick-runner:
+    runs-on: d-sorg-fleet
+    timeout-minutes: 2
+    outputs:
+      runner: ${{ steps.check.outputs.runner }}
+    steps:
+      - name: Set runner
+        id: check
+        run: echo "runner=d-sorg-fleet" >> "$GITHUB_OUTPUT"
+
   parity-gate:
     name: Build movement_optimizer_core + parity gate
-    runs-on: ubuntu-latest
+    needs: pick-runner
+    runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 25
     env:
       CARGO_TERM_COLOR: always
@@ -43,7 +54,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install build + test deps
         run: python -m pip install --upgrade pip maturin "numpy<2" "scipy>=1.10" pytest

--- a/.github/workflows/maturin-movement-optimizer.yml
+++ b/.github/workflows/maturin-movement-optimizer.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   parity-gate:
     name: Build movement_optimizer_core + parity gate
-    runs-on: ubuntu-latest
+    runs-on: d-sorg-fleet
     timeout-minutes: 25
     env:
       CARGO_TERM_COLOR: always
@@ -43,7 +43,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install build + test deps
         run: python -m pip install --upgrade pip maturin "numpy<2" "scipy>=1.10" pytest

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.551                                    |
+| **Spec Version**        | 1.1.552                                    |
 | **Last Spec Update**    | 2026-06-17                                 |
 
 ## 2. Purpose & Mission
@@ -48,6 +48,11 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
   construction now live in `movement_optimizer.gui.motion_controls`, keeping
   `motion_tabs.py` within the fleet module-size budget while preserving the
   public `NumericControl` import surface used by the tab tests.
+- Movement Optimizer now has a fleet-routed, pinned
+  `maturin-movement-optimizer` workflow that builds the
+  `movement_optimizer_core` wheel, verifies required Rust exports, and runs the
+  Rust-to-NumPy inverse-dynamics parity gate without relying on top-level test
+  package imports.
 
 ### 2026-06-16 Update
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.551                                    |
+| **Spec Version**        | 1.1.552                                    |
 | **Last Spec Update**    | 2026-06-17                                 |
 
 ## 2. Purpose & Mission
@@ -38,6 +38,11 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 
 ### 2026-06-17 Update
 
+- Movement Optimizer's Rust parity workflow now routes through the self-hosted
+  runner dispatcher, uses the fleet-pinned Rust toolchain action, and imports
+  its squat fixture through the canonical movement optimizer model API so the
+  Rust wheel parity gate can run without hosted-runner or package-shadowing
+  failures (#3517).
 - Full-suite nightly installs now resolve a declared `test` extra for
   collection-time FastAPI/httpx/OpenCV dependencies (#3509), while scheduled
   and opt-in heavy/e2e workflows keep coverage reports but disable the
@@ -1064,6 +1069,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-06-17 | 1.1.552 | fix(ci, movement_optimizer, #3517): route the Rust parity workflow through the self-hosted runner dispatcher, pin the Rust toolchain action to the fleet-approved commit, and import the squat fixture through `movement_optimizer.models` so the Rust wheel parity gate avoids hosted-runner and package-shadowing failures. |
 | 2026-06-17 | 1.1.550 | fix(ci, #3509, #3510): declare the full-suite `test` extra for collection-time FastAPI/httpx/OpenCV dependencies and keep heavy/e2e coverage reporting while disabling the repo-wide coverage floor for that narrow lane. |
 | 2026-06-16 | 1.1.545 | fix(ci, #3316): append provider-contract coverage and refresh `coverage.xml` before the coverage policy gate so tracked-package thresholds see the tests that cover exported packages. |
 | 2026-06-16 | 1.1.544 | fix(imports, #3316): add a production `file_watcher` compatibility shim to preserve bare watcher imports after removing `src/shared/python` from CI and pytest search roots. |

--- a/src/movement_optimizer/rust_core/Cargo.toml
+++ b/src/movement_optimizer/rust_core/Cargo.toml
@@ -11,3 +11,10 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.21", features = ["extension-module"] }
 numpy = "0.21"
 rayon = "1.10"
+
+# Standalone workspace: this is a self-contained maturin sub-app crate that
+# must build independently (`maturin build -m src/movement_optimizer/rust_core`).
+# Without this it inherits the repo-root workspace and cargo refuses to build it
+# ("believes it's in a workspace when it's not") — the root cause of the crate
+# never being built in CI (issue #3517).
+[workspace]

--- a/src/movement_optimizer/tests/test_rust_parity.py
+++ b/src/movement_optimizer/tests/test_rust_parity.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from movement_optimizer.models import BodyModel
+from movement_optimizer.models import BodyModel, make_squat_config
 
 # Skip the entire module unless the compiled Rust accelerator is importable.
 # Importing the symbol here (rather than inside each test) lets a single
@@ -32,8 +32,6 @@ rust = pytest.importorskip(
 
 def _make_dynamics():
     """Build a reference squat ``LagrangianDynamics`` with cached M/a/g terms."""
-    from tests.conftest import make_squat_config
-
     body = BodyModel(75.0, 1.75)
     config = make_squat_config(body, 60.0)
     return config[0]


### PR DESCRIPTION
## Summary
`movement_optimizer_core` (the Rust batch-inverse-dynamics hot path) was **built by no workflow** and `tests/test_rust_parity.py` was permanently `pytest.importorskip`-skipped — so the optimizer always ran the slow NumPy fallback and Rust↔NumPy parity was never verified.

**Root cause:** `src/movement_optimizer/rust_core/Cargo.toml` was neither a member nor excluded from the repo-root workspace, so cargo/maturin refused to build it (`error: current package believes it's in a workspace when it's not`). This PR adds an empty `[workspace]` table so the self-contained maturin sub-app builds independently.

**CI gate:** adds `.github/workflows/maturin-movement-optimizer.yml` — on changes under `src/movement_optimizer/**` it builds the wheel, installs it, **asserts the extension imports (hard fail, no silent skip)**, then runs the parity suite as a real gate.

## Verified locally
- `maturin build --release -m src/movement_optimizer/rust_core/Cargo.toml` → succeeds (was failing with the workspace error before).
- Installed the wheel into a clean venv and ran `tests/test_rust_parity.py` → **4 passed** (previously skipped). Rust `inverse_dynamics_batch_rs` matches the NumPy reference to tight tolerance.

## Scope / follow-ups
- This makes the existing `inverse_dynamics_batch` Rust path build + verify. Shipping the wheel to standalone/installed users (so the launch *uses* Rust without a manual `maturin develop`) is the remaining packaging step tracked in #3514 (and is a fleet-wide "no wheel index" gap).
- `com_x_batch` wiring (#3518) is intentionally **not** done here: the Rust `com_x_batch_rs` omits the squat bar-offset term the NumPy path applies — see the note on #3518.

Part of #3513. Closes #3517.
