### PR TITLE
fix(data_processor_core): build importable maturin extension + CI import gate (#3516)

### DIFF
--- a/.github/workflows/maturin-data-processor-core.yml
+++ b/.github/workflows/maturin-data-processor-core.yml
@@ -1,0 +1,101 @@
+# Maturin CI — data_processor_core Python extension
+#
+# Builds the `data_processor_core` Rust crate (native streaming data-plane
+# engine — inspect / preview / convert / scan_batch / filter_export) and asserts
+# the extension imports so `import data_processor_core` in
+# src/shared/python/data_processor_io/rust_engine.py resolves to the native
+# backend instead of the permanent pandas fallback.
+#
+# Previously the crate had only a Cargo.toml (no [tool.maturin], no
+# pyproject.toml, no #[pymodule] entry point), so no wheel was ever built and
+# `import data_processor_core` always failed (issue #3516). This gate hard-fails
+# if the extension does not import, so a broken/missing accelerator breaks the
+# build instead of silently falling back to pandas.
+#
+# Runner platforms: the d-sorg-fleet self-hosted pool spans linux, windows, and
+# macos hosts (ubuntu / windows / macos). Python versions: 3.10, 3.11, 3.12,
+# 3.13.
+
+name: Maturin — data_processor_core
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rust_core/data-processor-core/**"
+      - "src/shared/python/data_processor_io/**"
+      - ".github/workflows/maturin-data-processor-core.yml"
+  pull_request:
+    paths:
+      - "rust_core/data-processor-core/**"
+      - "src/shared/python/data_processor_io/**"
+      - ".github/workflows/maturin-data-processor-core.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: maturin-data-processor-core-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  import-gate:
+    name: data_processor_core import gate (Python ${{ matrix.python-version }})
+    runs-on: d-sorg-fleet
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install build + test deps
+        run: python -m pip install --upgrade pip maturin pandas pytest
+
+      - name: Build data_processor_core wheel
+        run: maturin build --release -m rust_core/data-processor-core/Cargo.toml --out dist
+
+      - name: Install the built wheel
+        shell: bash
+        run: |
+          WHEEL=$(ls dist/*.whl | head -1)
+          python -m pip install "$WHEEL"
+
+      - name: Assert the extension imports (hard fail — no silent fallback)
+        shell: bash
+        run: |
+          python - <<'PY'
+          import data_processor_core as m
+          required = {
+              "py_inspect", "py_preview", "py_convert",
+              "py_scan_batch", "py_filter_export",
+          }
+          missing = required - set(dir(m))
+          assert not missing, f"data_processor_core missing exports: {missing}"
+          print("data_processor_core OK:", sorted(required))
+          PY
+
+      - name: Assert the consumer selects the Rust backend (gate)
+        shell: bash
+        env:
+          PYTHONPATH: src
+        run: |
+          python - <<'PY'
+          from shared.python.data_processor_io import rust_engine
+          assert rust_engine._RUST_AVAILABLE, (
+              "rust_engine did not detect the data_processor_core extension"
+          )
+          print("data_processor_core backend gate OK: rust available")
+          PY

--- a/.github/workflows/maturin-data-processor-core.yml
+++ b/.github/workflows/maturin-data-processor-core.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install build + test deps
         run: python -m pip install --upgrade pip maturin pandas pytest

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.551                                    |
+| **Spec Version**        | 1.1.553                                    |
 | **Last Spec Update**    | 2026-06-17                                 |
 
 ## 2. Purpose & Mission
@@ -1064,6 +1064,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-06-17 | 1.1.553 | fix(data_processor_core, #3516): add pyproject.toml + a `#[pymodule]` entry point so the maturin wheel exposes an importable `data_processor_core` extension, and add a maturin CI import gate; the consumer no longer falls back to pandas permanently. |
 | 2026-06-17 | 1.1.550 | fix(ci, #3509, #3510): declare the full-suite `test` extra for collection-time FastAPI/httpx/OpenCV dependencies and keep heavy/e2e coverage reporting while disabling the repo-wide coverage floor for that narrow lane. |
 | 2026-06-16 | 1.1.545 | fix(ci, #3316): append provider-contract coverage and refresh `coverage.xml` before the coverage policy gate so tracked-package thresholds see the tests that cover exported packages. |
 | 2026-06-16 | 1.1.544 | fix(imports, #3316): add a production `file_watcher` compatibility shim to preserve bare watcher imports after removing `src/shared/python` from CI and pytest search roots. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.553                                    |
+| **Spec Version**        | 1.1.552                                    |
 | **Last Spec Update**    | 2026-06-17                                 |
 
 ## 2. Purpose & Mission
@@ -38,6 +38,11 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 
 ### 2026-06-17 Update
 
+- Movement Optimizer's Rust parity workflow now routes through the self-hosted
+  runner dispatcher, uses the fleet-pinned Rust toolchain action, and imports
+  its squat fixture through the canonical movement optimizer model API so the
+  Rust wheel parity gate can run without hosted-runner or package-shadowing
+  failures (#3517).
 - Full-suite nightly installs now resolve a declared `test` extra for
   collection-time FastAPI/httpx/OpenCV dependencies (#3509), while scheduled
   and opt-in heavy/e2e workflows keep coverage reports but disable the
@@ -48,6 +53,11 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
   construction now live in `movement_optimizer.gui.motion_controls`, keeping
   `motion_tabs.py` within the fleet module-size budget while preserving the
   public `NumericControl` import surface used by the tab tests.
+- Movement Optimizer now has a fleet-routed, pinned
+  `maturin-movement-optimizer` workflow that builds the
+  `movement_optimizer_core` wheel, verifies required Rust exports, and runs the
+  Rust-to-NumPy inverse-dynamics parity gate without relying on top-level test
+  package imports.
 
 ### 2026-06-16 Update
 
@@ -1064,7 +1074,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
-| 2026-06-17 | 1.1.553 | fix(data_processor_core, #3516): add pyproject.toml + a `#[pymodule]` entry point so the maturin wheel exposes an importable `data_processor_core` extension, and add a maturin CI import gate; the consumer no longer falls back to pandas permanently. |
+| 2026-06-17 | 1.1.552 | fix(ci, movement_optimizer, #3517): route the Rust parity workflow through the self-hosted runner dispatcher, pin the Rust toolchain action to the fleet-approved commit, and import the squat fixture through `movement_optimizer.models` so the Rust wheel parity gate avoids hosted-runner and package-shadowing failures. |
 | 2026-06-17 | 1.1.550 | fix(ci, #3509, #3510): declare the full-suite `test` extra for collection-time FastAPI/httpx/OpenCV dependencies and keep heavy/e2e coverage reporting while disabling the repo-wide coverage floor for that narrow lane. |
 | 2026-06-16 | 1.1.545 | fix(ci, #3316): append provider-contract coverage and refresh `coverage.xml` before the coverage policy gate so tracked-package thresholds see the tests that cover exported packages. |
 | 2026-06-16 | 1.1.544 | fix(imports, #3316): add a production `file_watcher` compatibility shim to preserve bare watcher imports after removing `src/shared/python` from CI and pytest search roots. |

--- a/rust_core/data-processor-core/pyproject.toml
+++ b/rust_core/data-processor-core/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "data-processor-core"
+version = "0.1.0"
+description = "Native streaming data-plane engine for the Data Processor (Rust/PyO3)"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[tool.maturin]
+# Compiled module name MUST match the consumer's `import data_processor_core`
+# in src/shared/python/data_processor/rust_engine.py (issue #3516).
+module-name = "data_processor_core"
+features = ["python", "extension-module"]
+manifest-path = "Cargo.toml"

--- a/rust_core/data-processor-core/src/lib.rs
+++ b/rust_core/data-processor-core/src/lib.rs
@@ -8,6 +8,30 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+// ── PyO3 module entry point ─────────────────────────────────────────────────
+//
+// Without a `#[pymodule]` the maturin wheel exposed no importable extension, so
+// `import data_processor_core` in
+// `src/shared/python/data_processor/rust_engine.py` always failed and the
+// engine was stuck on the pandas fallback (issue #3516). This registers the
+// engine's Python bindings (`py_inspect`, `py_preview`, `py_convert`,
+// `py_scan_batch`, `py_filter_export`) under the top-level `data_processor_core`
+// module the consumer imports. Enabled only when building a maturin wheel
+// (`--features python`); `cargo test` without the feature still compiles.
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+/// PyO3 module entry point. The compiled module is named `data_processor_core`
+/// (see `[tool.maturin] module-name`), matching the consumer's
+/// `import data_processor_core`.
+#[cfg(feature = "python")]
+#[pymodule]
+fn data_processor_core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    engine::register(m)?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}
+
 #[derive(Debug, Error)]
 pub enum DataProcessorError {
     #[error("path must be provided")]


### PR DESCRIPTION
## Summary
`rust_core/data-processor-core/` had only a `Cargo.toml` — no `[tool.maturin]`,
no `pyproject.toml`, and no `#[pymodule]` entry point — so maturin produced no
importable extension and `import data_processor_core` (consumer
`src/shared/python/data_processor_io/rust_engine.py:49`) **always failed**,
pinning the engine to the permanent pandas fallback.

## Fix
- Add `rust_core/data-processor-core/pyproject.toml` (maturin build-system,
  `[tool.maturin] module-name="data_processor_core"`,
  `features=["python","extension-module"]`).
- Add a `#[pymodule] fn data_processor_core` in `lib.rs` that calls the existing
  `engine::register(...)`, exposing `py_inspect` / `py_preview` / `py_convert` /
  `py_scan_batch` / `py_filter_export` at the top level the consumer imports.
  Gated behind the `python` feature so `cargo test` / `cargo check` still
  compile without it.
- Add `.github/workflows/maturin-data-processor-core.yml` (mirrors the maturin
  exemplar) that builds the crate, installs the wheel, **hard-fails unless
  `import data_processor_core` succeeds**, and asserts the consumer detects the
  rust backend.
- The Python fallback logic is unchanged.

## Verification (local)
- `maturin build --release -m rust_core/data-processor-core/Cargo.toml` builds.
- The wheel imports with all 5 binding functions present.
- `rust_engine._RUST_AVAILABLE` is `True` with the wheel installed.
- inspect/preview round-trip on a CSV returns correct columns/rows via Rust.
- `cargo check -p data-processor-core` (no python feature) compiles.
- `pytest tests/unit/rust/test_ai_backend_workspace.py` — 9 passed.

Closes #3516
Part of #3513