### PR TITLE
fix(pendulum_core): add pyproject for importable maturin wheel + parity gate (#3519)

### DIFF
--- a/.github/workflows/Comment-to-Issue-Converter.yml
+++ b/.github/workflows/Comment-to-Issue-Converter.yml
@@ -24,7 +24,7 @@ permissions:
   pull-requests: read
   issues: write
 concurrency:
-  group: comment-to-issue-${{ github.repository }}
+  group: comment-to-issue-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: true
 env:
   MAX_ISSUES_PER_RUN: 5

--- a/.github/workflows/maturin-pendulum-core.yml
+++ b/.github/workflows/maturin-pendulum-core.yml
@@ -1,0 +1,114 @@
+# Maturin CI — pendulum_core Python extension
+#
+# Builds the `pendulum_core` Rust crate (shared double/triple/golfer pendulum
+# physics kernel) as a standalone maturin sub-app and asserts the extension
+# imports so `import pendulum_core` in
+# src/pendulum_simulator/src/double_pendulum_golf/native_backend.py resolves to
+# the native backend instead of the Python fallback.
+#
+# pendulum-core is intentionally excluded from the root Cargo workspace (it has
+# its own empty `[workspace]` table) and was built by no workflow. Worse, it had
+# no pyproject.toml, so a bare `maturin build` walked up to the parent
+# setuptools project and produced a mis-named, unimportable wheel (issue #3519).
+# Adding pendulum-core/pyproject.toml fixes the module name; this gate builds the
+# wheel, hard-fails unless `import pendulum_core` succeeds, and runs the
+# Rust<->Python parity/DbC suite non-skipped (it is `skipif HAS_NATIVE` and so
+# was previously always skipped in CI).
+#
+# Runner platforms: the d-sorg-fleet self-hosted pool spans linux, windows, and
+# macos hosts (ubuntu / windows / macos). Python versions: 3.10, 3.11, 3.12,
+# 3.13.
+
+name: Maturin — pendulum_core
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/pendulum_simulator/pendulum-core/**"
+      - "src/pendulum_simulator/tests/test_physics_native_dbc.py"
+      - "rust_core/math-primitives/**"
+      - ".github/workflows/maturin-pendulum-core.yml"
+  pull_request:
+    paths:
+      - "src/pendulum_simulator/pendulum-core/**"
+      - "src/pendulum_simulator/tests/test_physics_native_dbc.py"
+      - "rust_core/math-primitives/**"
+      - ".github/workflows/maturin-pendulum-core.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: maturin-pendulum-core-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity-gate:
+    name: pendulum_core build + parity gate (Python ${{ matrix.python-version }})
+    runs-on: d-sorg-fleet
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install build + test deps
+        run: python -m pip install --upgrade pip maturin "numpy>=1.24" pytest
+
+      - name: Build pendulum_core wheel
+        run: maturin build --release -m src/pendulum_simulator/pendulum-core/Cargo.toml --out dist
+
+      - name: Install the built wheel
+        shell: bash
+        run: |
+          WHEEL=$(ls dist/*.whl | head -1)
+          python -m pip install "$WHEEL"
+
+      - name: Assert the extension imports (hard fail — no silent fallback)
+        shell: bash
+        run: |
+          python - <<'PY'
+          import pendulum_core as m
+          required = {
+              "PyDoublePendulumParams", "PyGolferParams",
+              "py_double_mass_matrix", "py_golfer_mass_matrix",
+          }
+          missing = required - set(dir(m))
+          assert not missing, f"pendulum_core missing exports: {missing}"
+          print("pendulum_core OK:", sorted(required))
+          PY
+
+      - name: Assert native_backend selects the Rust backend (gate)
+        shell: bash
+        env:
+          PYTHONPATH: src/pendulum_simulator/src
+        run: |
+          python - <<'PY'
+          from double_pendulum_golf import native_backend as nb
+          assert nb._pendulum_core is not None, (
+              f"native_backend did not load pendulum_core: {nb._NATIVE_IMPORT_ERROR}"
+          )
+          print("pendulum_core backend gate OK: native loaded")
+          PY
+
+      - name: Run Rust<->Python parity/DbC suite (gate, non-skipped)
+        env:
+          PYTHONPATH: src/pendulum_simulator/src
+        run: |
+          python -m pytest \
+            src/pendulum_simulator/tests/test_physics_native_dbc.py \
+            -o addopts="" -p no:cacheprovider -v

--- a/.github/workflows/maturin-pendulum-core.yml
+++ b/.github/workflows/maturin-pendulum-core.yml
@@ -64,7 +64,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install build + test deps
         run: python -m pip install --upgrade pip maturin "numpy>=1.24" pytest

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.554                                    |
+| **Spec Version**        | 1.1.552                                    |
 | **Last Spec Update**    | 2026-06-17                                 |
 
 ## 2. Purpose & Mission
@@ -1074,7 +1074,6 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
-| 2026-06-17 | 1.1.554 | fix(pendulum_core, #3519): add `pendulum-core/pyproject.toml` so maturin builds a correctly-named importable `pendulum_core` wheel (was walking up to the parent setuptools project), and add a maturin CI build + Rust<->Python parity gate. |
 | 2026-06-17 | 1.1.552 | fix(ci, movement_optimizer, #3517): route the Rust parity workflow through the self-hosted runner dispatcher, pin the Rust toolchain action to the fleet-approved commit, and import the squat fixture through `movement_optimizer.models` so the Rust wheel parity gate avoids hosted-runner and package-shadowing failures. |
 | 2026-06-17 | 1.1.550 | fix(ci, #3509, #3510): declare the full-suite `test` extra for collection-time FastAPI/httpx/OpenCV dependencies and keep heavy/e2e coverage reporting while disabling the repo-wide coverage floor for that narrow lane. |
 | 2026-06-16 | 1.1.545 | fix(ci, #3316): append provider-contract coverage and refresh `coverage.xml` before the coverage policy gate so tracked-package thresholds see the tests that cover exported packages. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.552                                    |
+| **Spec Version**        | 1.1.554                                    |
 | **Last Spec Update**    | 2026-06-17                                 |
 
 ## 2. Purpose & Mission
@@ -1074,6 +1074,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-06-17 | 1.1.554 | fix(pendulum_core, #3519): add `pendulum-core/pyproject.toml` so maturin builds a correctly-named importable `pendulum_core` wheel (was walking up to the parent setuptools project), and add a maturin CI build + Rust<->Python parity gate. |
 | 2026-06-17 | 1.1.552 | fix(ci, movement_optimizer, #3517): route the Rust parity workflow through the self-hosted runner dispatcher, pin the Rust toolchain action to the fleet-approved commit, and import the squat fixture through `movement_optimizer.models` so the Rust wheel parity gate avoids hosted-runner and package-shadowing failures. |
 | 2026-06-17 | 1.1.550 | fix(ci, #3509, #3510): declare the full-suite `test` extra for collection-time FastAPI/httpx/OpenCV dependencies and keep heavy/e2e coverage reporting while disabling the repo-wide coverage floor for that narrow lane. |
 | 2026-06-16 | 1.1.545 | fix(ci, #3316): append provider-contract coverage and refresh `coverage.xml` before the coverage policy gate so tracked-package thresholds see the tests that cover exported packages. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | N/A                                        |
-| **Spec Version**        | 1.1.551                                    |
+| **Spec Version**        | 1.1.554                                    |
 | **Last Spec Update**    | 2026-06-17                                 |
 
 ## 2. Purpose & Mission
@@ -1064,6 +1064,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-06-17 | 1.1.554 | fix(pendulum_core, #3519): add `pendulum-core/pyproject.toml` so maturin builds a correctly-named importable `pendulum_core` wheel (was walking up to the parent setuptools project), and add a maturin CI build + Rust<->Python parity gate. |
 | 2026-06-17 | 1.1.550 | fix(ci, #3509, #3510): declare the full-suite `test` extra for collection-time FastAPI/httpx/OpenCV dependencies and keep heavy/e2e coverage reporting while disabling the repo-wide coverage floor for that narrow lane. |
 | 2026-06-16 | 1.1.545 | fix(ci, #3316): append provider-contract coverage and refresh `coverage.xml` before the coverage policy gate so tracked-package thresholds see the tests that cover exported packages. |
 | 2026-06-16 | 1.1.544 | fix(imports, #3316): add a production `file_watcher` compatibility shim to preserve bare watcher imports after removing `src/shared/python` from CI and pytest search roots. |

--- a/src/pendulum_simulator/pendulum-core/pyproject.toml
+++ b/src/pendulum_simulator/pendulum-core/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "pendulum-core"
+version = "0.2.0"
+description = "Shared physics kernel for the pendulum golf swing simulator (Rust/PyO3)"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+
+[project.optional-dependencies]
+dev = [
+    "numpy>=1.24",
+    "pytest>=7.0",
+]
+
+[tool.maturin]
+# Compiled module name MUST match `import pendulum_core` in
+# src/pendulum_simulator/src/double_pendulum_golf/native_backend.py (issue
+# #3519). Without this pyproject.toml maturin walked up to the parent
+# setuptools project and produced a mis-named, unimportable wheel.
+module-name = "pendulum_core"
+# The `python` feature pulls in pyo3 with extension-module linkage (see
+# Cargo.toml). `default = ["parallel"]` stays active for rayon.
+features = ["python"]
+manifest-path = "Cargo.toml"


### PR DESCRIPTION
## Summary
`src/pendulum_simulator/pendulum-core/` is excluded from the root Cargo
workspace and was built by no workflow. It also had **no `pyproject.toml`**, so a
bare `maturin build -m .../pendulum-core/Cargo.toml` walked up to the parent
setuptools project (`double-pendulum-golf`) and produced a **mis-named,
unimportable wheel** — `import pendulum_core` (consumer
`src/pendulum_simulator/src/double_pendulum_golf/native_backend.py:34`) failed
and the simulator stayed on the Python fallback.

## Fix
- Add `src/pendulum_simulator/pendulum-core/pyproject.toml` (maturin
  build-system, `[tool.maturin] module-name="pendulum_core"`,
  `features=["python"]`). The crate already carries an empty `[workspace]` table,
  so it builds standalone.
- Add `.github/workflows/maturin-pendulum-core.yml` (mirrors the maturin
  exemplar) that builds the crate, installs the wheel, **hard-fails unless
  `import pendulum_core` succeeds and native_backend loads it**, and runs the
  Rust<->Python parity/DbC suite (`test_physics_native_dbc.py`) **non-skipped**
  — it is `@skipif(not HAS_NATIVE)` and so was previously always skipped in CI.

## Verification (local)
- Before: wheel built as `double_pendulum_golf-*.whl`; `import pendulum_core`
  raised `ModuleNotFoundError`.
- After: `maturin build --release -m
  src/pendulum_simulator/pendulum-core/Cargo.toml` produces `pendulum_core-0.2.0`;
  the module imports with 42 symbols; `native_backend._pendulum_core is not None`.
- `pytest src/pendulum_simulator/tests/test_physics_native_dbc.py` — 29 passed,
  including `test_construction_succeeds_with_native` (non-skipped).
- `pytest tests/unit/rust/test_ai_backend_workspace.py` — 9 passed.

Closes #3519
Part of #3513