### PR TITLE
feat(p1am): temperature controller tab + power-supply signal-noise / arc detection

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | 1.1.0                                      |
-| **Spec Version**        | 1.1.588                                    |
+| **Spec Version**        | 1.1.589                                    |
 | **Last Spec Update**    | 2026-06-18                                 |
 
 ## 2. Purpose & Mission
@@ -85,6 +85,10 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
   tags, and PID tuning sessions; the MPC route now delegates the solver to a
   tested `backend/mpc.py` helper while preserving the API response shape
   (#3538, #3539).
+- P1AM power-supply rolling feedback-noise tracking now lives in a dedicated
+  `FeedbackNoiseTracker` collaborator, keeping `backend/power_supply.py` under
+  the changed-file size budget while preserving bounded current/voltage
+  windows, arc-threshold evaluation, and status serialization.
 - Movement Optimizer animation playback mixin now declares its own narrow
   MainWindow contract for tabs, playback controls, exercise tabs, and
   published exercise state, removing the module-level mypy suppression and
@@ -1207,6 +1211,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-06-18 | 1.1.589 | fix(p1am): extract power-supply rolling feedback-noise sample windows into `FeedbackNoiseTracker`, keeping `backend/power_supply.py` below the 500-line changed-file budget while preserving arc/noise status behavior. |
 | 2026-06-18 | 1.1.588 | fix(ci, movement): make the `movement_optimizer_core` maturin parity workflow create a per-job virtual environment before reinstalling NumPy, SciPy, `pytest`, and `maturin`, preventing stale self-hosted runner native package files from leaking into Rust accelerator validation. |
 | 2026-06-18 | 1.1.585 | chore(release): align `SPEC.md` with the v1.1.0 package metadata bump so release PRs that update `pyproject.toml`, `VERSION`, and `CHANGELOG.md` satisfy the spec freshness gate. |
 | 2026-06-18 | 1.1.584 | fix(ci): make Release Automation treat merged `chore(release): bump version to vX.Y.Z` commits as `bump=none` unless manually forced, preventing recursive release PR creation after protected-branch release bumps merge. |

--- a/src/p1am_control_system/backend/hardware.py
+++ b/src/p1am_control_system/backend/hardware.py
@@ -28,6 +28,7 @@ PID_COUNT = 4
 # ---- Coils ------------------------------------------------------------
 SAVE_TO_FLASH_COIL = 0
 ESTOP_RESET_COIL = 1
+HEATER_RELAY_COIL = 2  # 24 V DO -> relay -> 110 V resistive heater (temp ctrl)
 
 
 def tag_name(index: int) -> str:

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -63,6 +63,10 @@ from settings import get_settings
 from simulator_client import SimulatedPLCClient
 from sqlmodel import Session, col, select
 from state import SystemState
+from temperature_integration import (
+    TemperatureService,
+    create_temperature_router,
+)
 
 try:
     # Prefer the Rust-accelerated SCADA kernel when the compiled wheel is
@@ -94,6 +98,7 @@ modbus_manager = plc_client  # Compatibility alias
 backup_simulator = SimulatedPLCClient()
 
 power_supply_service = PowerSupplyService(plc_client=plc_client, logger=logger)
+temperature_service = TemperatureService(plc_client=plc_client, logger=logger)
 
 
 class ConnectionManager:
@@ -239,6 +244,7 @@ async def poll_plc_loop() -> None:
                 ws=ws_manager,
                 alicats=alicat_manager,
                 power_supply=power_supply_service,
+                temperature=temperature_service,
                 alarm_engine=control_context.alarm_engine,
                 active_alarm_map=control_context.active_alarms,
                 session_factory=get_session,
@@ -286,6 +292,7 @@ app = FastAPI(
 )
 app.state.control_context = control_context
 app.include_router(create_power_supply_router(power_supply_service))
+app.include_router(create_temperature_router(temperature_service))
 
 # Restrict CORS to a configured allowlist (no wildcard with credentials).
 # See cors_config.resolve_cors_settings for env-driven configuration.
@@ -449,9 +456,10 @@ async def update_routing(config: RoutingConfig) -> dict[str, str]:
 async def trigger_estop() -> dict[str, str]:
     """Immediate safety shutdown command, zeroing all tag variables."""
     control_context.engage_estop()
-    # Latch the controller FIRST so the next poll cycle cannot re-command a
-    # setpoint and re-energize the output after we zero it below.
+    # Latch the controllers FIRST so the next poll cycle cannot re-command a
+    # setpoint / re-close the heater relay and re-energize after we zero below.
     power_supply_service.engage_estop()
+    temperature_service.engage_estop()
     if not plc_client.connected:
         await backup_simulator.trigger_estop()
         control_context.reset_tag_values()
@@ -488,6 +496,10 @@ async def clear_estop() -> dict[str, str]:
                 detail="Backup simulator did not acknowledge the E-stop reset.",
             )
         control_context.clear_estop()
+        # Release the controller latches in sim mode too, otherwise they stay
+        # engaged and refuse to re-arm after the operator clears the E-stop.
+        power_supply_service.clear_estop()
+        temperature_service.clear_estop()
         return {
             "status": "success",
             "message": "Simulated E-stop cleared.",
@@ -502,10 +514,10 @@ async def clear_estop() -> dict[str, str]:
         )
     await backup_simulator.clear_estop()
     control_context.clear_estop()
-    # Release the power-supply controller latch too. It returns to IDLE with
-    # permissive off, so the operator must deliberately re-arm before any
-    # output can flow.
+    # Release the controller latches too. They return to IDLE with permissive
+    # off, so the operator must deliberately re-arm before any output can flow.
     power_supply_service.clear_estop()
+    temperature_service.clear_estop()
     return {"status": "success", "message": "Hardware E-stop cleared."}
 
 

--- a/src/p1am_control_system/backend/modbus_client.py
+++ b/src/p1am_control_system/backend/modbus_client.py
@@ -402,6 +402,26 @@ class AsyncModbusManager(BasePLCClient):
                 self._connected = False
                 return False
 
+    async def write_coil(self, address: int, value: bool) -> bool:
+        """Write a single discrete coil (public seam, e.g. the heater relay)."""
+        if not self._connected:
+            return False
+        if not isinstance(address, int) or isinstance(address, bool):
+            raise TypeError(f"address must be an int, got {type(address).__name__}")
+        if not isinstance(value, bool):
+            raise TypeError(f"value must be a bool, got {type(value).__name__}")
+        async with self.lock:
+            try:
+                resp = await self._get_client().write_coil(address=address, value=value)
+                if resp.isError():
+                    logger.error("write_coil(%d, %s) failed: %s", address, value, resp)
+                    return False
+                return True
+            except (ModbusException, Exception) as exc:
+                logger.error("write_coil(%d, %s) exception: %s", address, value, exc)
+                self._connected = False
+                return False
+
     async def write_tag(self, tag_name: str, value: float) -> bool:
         """Write a 32-bit float directly to a tag register.
 

--- a/src/p1am_control_system/backend/plc_interface.py
+++ b/src/p1am_control_system/backend/plc_interface.py
@@ -131,3 +131,15 @@ class BasePLCClient(abc.ABC):
             bool: True if the setpoint was written/accepted, False otherwise.
         """
         return False
+
+    async def write_coil(self, address: int, value: bool) -> bool:
+        """Write a single discrete coil (e.g. the heater relay).
+
+        Public seam for digital-output control (TemperatureService drives the
+        heater relay through this). Concrete default returns False so clients
+        that don't support coils keep working; Modbus and simulator override it.
+
+        Returns:
+            bool: True if the coil write was accepted, False otherwise.
+        """
+        return False

--- a/src/p1am_control_system/backend/poll_runtime.py
+++ b/src/p1am_control_system/backend/poll_runtime.py
@@ -70,6 +70,7 @@ async def _poll_once(
     ws: Any,
     alicats: Any,
     power_supply: Any,
+    temperature: Any = None,
     alarm_engine: Any,
     active_alarm_map: dict[str, dict[str, Any]],
     session_factory: Callable[[], Iterator[Session]],
@@ -105,6 +106,7 @@ async def _poll_once(
         [tags.get(f"TAG_{i}", 0.0) for i in range(32)] if tags is not None else []
     )
     ps_status = await power_supply.poll(tags)
+    temp_status = await temperature.poll(tags) if temperature is not None else None
     if estop_active and plc.connected:
         await plc.trigger_estop()
 
@@ -116,6 +118,8 @@ async def _poll_once(
         "e_stop_active": estop_active,
         "power_supply": ps_status.model_dump(),
     }
+    if temp_status is not None:
+        payload["temperature"] = temp_status.model_dump()
     await ws.broadcast(payload)
 
     if tags is not None:

--- a/src/p1am_control_system/backend/power_supply.py
+++ b/src/p1am_control_system/backend/power_supply.py
@@ -1,16 +1,8 @@
-"""Power-supply state machine, safety interlocks, and control law.
-
-The controller is fully testable without a PLC: feed measured values into
-``tick()`` and inspect state plus commanded output. Trips latch until
-``acknowledge_trip()``; E-stop latches until ``clear_estop()``.
-"""
-
 from __future__ import annotations
 
 import logging
 import math
 import time
-from collections import deque
 
 from power_supply_models import (
     PowerSupplyConfig,
@@ -18,7 +10,7 @@ from power_supply_models import (
     PowerSupplyState,
     PowerSupplyStatus,
 )
-from signal_stats import compute_noise
+from power_supply_noise import FeedbackNoiseTracker
 
 __all__ = [
     "PowerSupplyConfig",
@@ -69,10 +61,7 @@ class PowerSupplyController:
         # to arm, and rejects setpoints until clear_estop() is called. This is a
         # one-way kill — it must be explicitly cleared by an operator.
         self._estopped = False
-        # Rolling windows of recent feedback for arc/noise quantification. Bounded
-        # by noise_window so memory and compute stay flat over a long campaign.
-        self._current_samples: deque[float] = deque(maxlen=config.noise_window)
-        self._voltage_samples: deque[float] = deque(maxlen=config.noise_window)
+        self._noise = FeedbackNoiseTracker(config)
 
     @property
     def state(self) -> PowerSupplyState:
@@ -113,15 +102,7 @@ class PowerSupplyController:
             new_config.current_setpoint_min_a,
             min(self._setpoint_a, new_config.current_setpoint_max_a),
         )
-        # Resize the noise windows if the operator changed noise_window, keeping
-        # the most-recent samples (deque(..., maxlen=N) drops the oldest excess).
-        if new_config.noise_window != self._current_samples.maxlen:
-            self._current_samples = deque(
-                self._current_samples, maxlen=new_config.noise_window
-            )
-            self._voltage_samples = deque(
-                self._voltage_samples, maxlen=new_config.noise_window
-            )
+        self._noise.update_config(new_config)
 
     def set_permissive(self, on: bool) -> None:
         """Toggle permissive. A trip latch is not cleared by a permissive change.
@@ -432,10 +413,7 @@ class PowerSupplyController:
         self._last_v = self._safe_finite(measured_voltage_v)
         self._last_t = self._safe_finite(measured_temp_c)
 
-        # Accumulate feedback for noise/arc quantification regardless of command
-        # state — arcing is a property of the measured signal, not the setpoint.
-        self._current_samples.append(self._last_i)
-        self._voltage_samples.append(self._last_v)
+        self._noise.append(self._last_i, self._last_v)
 
         measured_power_w = self._last_v * self._last_i
         self._evaluate_trips(measured_power_w)
@@ -494,16 +472,7 @@ class PowerSupplyController:
 
     def status(self) -> PowerSupplyStatus:
         """Return a snapshot of controller state for serialization."""
-        current_noise = compute_noise(
-            list(self._current_samples),
-            metric=self._config.noise_metric,
-            threshold=self._config.current_arc_threshold,
-        )
-        voltage_noise = compute_noise(
-            list(self._voltage_samples),
-            metric=self._config.noise_metric,
-            threshold=self._config.voltage_arc_threshold,
-        )
+        noise = self._noise.snapshot(self._config)
         return PowerSupplyStatus(
             state=self._state,
             mode=self._mode,
@@ -523,7 +492,7 @@ class PowerSupplyController:
                 / 100.0
                 * self._config.current_full_scale_a
             ),
-            current_noise=current_noise,
-            voltage_noise=voltage_noise,
-            arcing=current_noise.arcing or voltage_noise.arcing,
+            current_noise=noise.current,
+            voltage_noise=noise.voltage,
+            arcing=noise.arcing,
         )

--- a/src/p1am_control_system/backend/power_supply.py
+++ b/src/p1am_control_system/backend/power_supply.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import math
 import time
+from collections import deque
 
 from power_supply_models import (
     PowerSupplyConfig,
@@ -17,6 +18,7 @@ from power_supply_models import (
     PowerSupplyState,
     PowerSupplyStatus,
 )
+from signal_stats import compute_noise
 
 __all__ = [
     "PowerSupplyConfig",
@@ -67,6 +69,10 @@ class PowerSupplyController:
         # to arm, and rejects setpoints until clear_estop() is called. This is a
         # one-way kill — it must be explicitly cleared by an operator.
         self._estopped = False
+        # Rolling windows of recent feedback for arc/noise quantification. Bounded
+        # by noise_window so memory and compute stay flat over a long campaign.
+        self._current_samples: deque[float] = deque(maxlen=config.noise_window)
+        self._voltage_samples: deque[float] = deque(maxlen=config.noise_window)
 
     @property
     def state(self) -> PowerSupplyState:
@@ -107,6 +113,15 @@ class PowerSupplyController:
             new_config.current_setpoint_min_a,
             min(self._setpoint_a, new_config.current_setpoint_max_a),
         )
+        # Resize the noise windows if the operator changed noise_window, keeping
+        # the most-recent samples (deque(..., maxlen=N) drops the oldest excess).
+        if new_config.noise_window != self._current_samples.maxlen:
+            self._current_samples = deque(
+                self._current_samples, maxlen=new_config.noise_window
+            )
+            self._voltage_samples = deque(
+                self._voltage_samples, maxlen=new_config.noise_window
+            )
 
     def set_permissive(self, on: bool) -> None:
         """Toggle permissive. A trip latch is not cleared by a permissive change.
@@ -417,6 +432,11 @@ class PowerSupplyController:
         self._last_v = self._safe_finite(measured_voltage_v)
         self._last_t = self._safe_finite(measured_temp_c)
 
+        # Accumulate feedback for noise/arc quantification regardless of command
+        # state — arcing is a property of the measured signal, not the setpoint.
+        self._current_samples.append(self._last_i)
+        self._voltage_samples.append(self._last_v)
+
         measured_power_w = self._last_v * self._last_i
         self._evaluate_trips(measured_power_w)
         self._recompute_power_mode_setpoint()
@@ -474,6 +494,16 @@ class PowerSupplyController:
 
     def status(self) -> PowerSupplyStatus:
         """Return a snapshot of controller state for serialization."""
+        current_noise = compute_noise(
+            list(self._current_samples),
+            metric=self._config.noise_metric,
+            threshold=self._config.current_arc_threshold,
+        )
+        voltage_noise = compute_noise(
+            list(self._voltage_samples),
+            metric=self._config.noise_metric,
+            threshold=self._config.voltage_arc_threshold,
+        )
         return PowerSupplyStatus(
             state=self._state,
             mode=self._mode,
@@ -493,4 +523,7 @@ class PowerSupplyController:
                 / 100.0
                 * self._config.current_full_scale_a
             ),
+            current_noise=current_noise,
+            voltage_noise=voltage_noise,
+            arcing=current_noise.arcing or voltage_noise.arcing,
         )

--- a/src/p1am_control_system/backend/power_supply_models.py
+++ b/src/p1am_control_system/backend/power_supply_models.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from enum import Enum
 
 from pydantic import BaseModel, Field, field_validator, model_validator
+from signal_stats import NoiseMetric, NoiseStats, compute_noise
 
 
 class StrEnum(str, Enum):  # noqa: UP042
@@ -163,6 +164,44 @@ class PowerSupplyConfig(BaseModel):
         ),
     )
 
+    # ---- Arc / signal-noise detection (DC arc shows as AC noise on the feedback) -
+    noise_window: int = Field(
+        default=100,
+        ge=2,
+        le=10_000,
+        description=(
+            "Number of most-recent feedback samples used to quantify signal "
+            "noise. At a 10 Hz scan, 100 samples ≈ a 10 s window. Bigger = "
+            "smoother/slower; smaller = twitchier/faster arc response."
+        ),
+    )
+    noise_metric: NoiseMetric = Field(
+        default=NoiseMetric.STD,
+        description=(
+            "Which noise metric the arc thresholds are compared against: 'std' "
+            "(sample std-dev, engineering units), 'peak_to_peak', 'rms' (AC RMS "
+            "about the mean), or 'cv' (dimensionless std/|mean| ratio)."
+        ),
+    )
+    current_arc_threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Arc-detect threshold for the CURRENT feedback noise, in the units "
+            "of the selected metric (A for std/p2p/rms, ratio for cv). Arcing is "
+            "flagged when the metric exceeds this. None disables current-arc "
+            "detection. Tune by watching the live noise readout on a steady arc."
+        ),
+    )
+    voltage_arc_threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Arc-detect threshold for the VOLTAGE feedback noise (units as per "
+            "the selected metric). None disables voltage-arc detection."
+        ),
+    )
+
     @field_validator(
         "command_label",
         "aux_command_label",
@@ -233,5 +272,21 @@ class PowerSupplyStatus(BaseModel):
             "the output limit: output_clamp_percent/100 * current_full_scale_a. "
             "The setpoint band may go higher, but the clamp caps real output "
             "here — the UI shows this so the two limits aren't confusing."
+        ),
+    )
+
+    current_noise: NoiseStats = Field(
+        default_factory=lambda: compute_noise([]),
+        description="Rolling noise/variability stats for the current feedback.",
+    )
+    voltage_noise: NoiseStats = Field(
+        default_factory=lambda: compute_noise([]),
+        description="Rolling noise/variability stats for the voltage feedback.",
+    )
+    arcing: bool = Field(
+        default=False,
+        description=(
+            "True when either feedback channel's noise metric exceeds its arc "
+            "threshold — the operator-facing 'system may be arcing' indicator."
         ),
     )

--- a/src/p1am_control_system/backend/power_supply_noise.py
+++ b/src/p1am_control_system/backend/power_supply_noise.py
@@ -1,0 +1,62 @@
+"""Rolling feedback-noise tracking for the power-supply controller."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+
+from power_supply_models import PowerSupplyConfig
+from signal_stats import NoiseStats, compute_noise
+
+
+@dataclass(frozen=True)
+class PowerSupplyNoiseSnapshot:
+    """Noise stats for both feedback channels plus the aggregate arc flag."""
+
+    current: NoiseStats
+    voltage: NoiseStats
+    arcing: bool
+
+
+class FeedbackNoiseTracker:
+    """Bounded current/voltage sample windows for arc-noise detection."""
+
+    def __init__(self, config: PowerSupplyConfig) -> None:
+        self._current_samples: deque[float] = deque(maxlen=config.noise_window)
+        self._voltage_samples: deque[float] = deque(maxlen=config.noise_window)
+
+    def update_config(self, config: PowerSupplyConfig) -> None:
+        """Resize windows when the operator changes the configured length."""
+        if config.noise_window == self._current_samples.maxlen:
+            return
+        self._current_samples = deque(
+            self._current_samples,
+            maxlen=config.noise_window,
+        )
+        self._voltage_samples = deque(
+            self._voltage_samples,
+            maxlen=config.noise_window,
+        )
+
+    def append(self, current_a: float, voltage_v: float) -> None:
+        """Record sanitized feedback samples for later noise analysis."""
+        self._current_samples.append(current_a)
+        self._voltage_samples.append(voltage_v)
+
+    def snapshot(self, config: PowerSupplyConfig) -> PowerSupplyNoiseSnapshot:
+        """Compute channel noise stats using the latest operator thresholds."""
+        current_noise = compute_noise(
+            list(self._current_samples),
+            metric=config.noise_metric,
+            threshold=config.current_arc_threshold,
+        )
+        voltage_noise = compute_noise(
+            list(self._voltage_samples),
+            metric=config.noise_metric,
+            threshold=config.voltage_arc_threshold,
+        )
+        return PowerSupplyNoiseSnapshot(
+            current=current_noise,
+            voltage=voltage_noise,
+            arcing=current_noise.arcing or voltage_noise.arcing,
+        )

--- a/src/p1am_control_system/backend/signal_stats.py
+++ b/src/p1am_control_system/backend/signal_stats.py
@@ -1,0 +1,214 @@
+"""Pure noise/variability statistics for power-supply feedback signals.
+
+DC-arc "arcing" shows up as a sudden rise in the AC noise riding on an
+otherwise steady DC current/voltage feedback signal. This module quantifies
+that noise from a short window of samples so the integration layer can raise an
+operator-facing arc warning when a chosen metric crosses a tunable threshold.
+
+Design notes:
+    - DbC: every public entry point validates its inputs (``TypeError`` for
+      wrong types, ``ValueError`` for out-of-range) and documents its
+      pre/postconditions.
+    - LOD: this module is pure. It imports nothing from the DB, PLC, or FastAPI
+      layers and pulls only from the stdlib (``statistics``/``math``) — no
+      numpy — so it stays light enough to run at 10 Hz on a Raspberry Pi and is
+      unit-testable in isolation.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Sequence
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+NOISE_DEFAULT_WINDOW = 100
+NOISE_DEFAULT_THRESHOLD = 0.0
+
+
+class StrEnum(str, Enum):  # noqa: UP042
+    """Compat shim for Python < 3.11 environments that don't ship StrEnum.
+
+    Inherits from `str` so the enum members serialize as plain strings when
+    passed through Pydantic / FastAPI / JSON.
+    """
+
+
+class NoiseMetric(StrEnum):
+    """Which scalar the arc threshold is evaluated against."""
+
+    STD = "std"
+    PEAK_TO_PEAK = "peak_to_peak"
+    RMS = "rms"
+    CV = "cv"
+
+
+class NoiseStats(BaseModel):
+    """Noise/variability summary of one window of feedback samples."""
+
+    sample_count: int = Field(
+        ge=0, description="Number of samples the stats were computed from."
+    )
+    mean: float = Field(description="Arithmetic mean (the DC level) of the window.")
+    std: float = Field(
+        ge=0.0,
+        description=(
+            "Sample standard deviation (ddof=1); 0.0 when fewer than 2 samples."
+        ),
+    )
+    peak_to_peak: float = Field(
+        ge=0.0, description="max - min of the window; 0.0 when empty."
+    )
+    rms_about_mean: float = Field(
+        ge=0.0,
+        description=(
+            "Population deviation RMS sqrt(mean((x-mean)^2)) — the AC content "
+            "of the signal; 0.0 when fewer than 2 samples."
+        ),
+    )
+    coeff_of_variation: float = Field(
+        ge=0.0,
+        description=(
+            "std / |mean|, the AC/DC noise ratio; 0.0 when mean==0 or fewer "
+            "than 2 samples."
+        ),
+    )
+    metric: NoiseMetric = Field(
+        description="Which metric the arc threshold was evaluated against."
+    )
+    metric_value: float = Field(
+        ge=0.0, description="Value of the selected metric for this window."
+    )
+    threshold: float | None = Field(
+        default=None,
+        description="Arc threshold in effect (None disables arc detection).",
+    )
+    arcing: bool = Field(
+        description="True iff threshold is not None and metric_value > threshold."
+    )
+
+
+def _is_real_number(value: object) -> bool:
+    """True for an int/float that is NOT a bool (bool is not numeric here)."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def compute_noise(
+    samples: Sequence[int | float],
+    *,
+    metric: NoiseMetric | str = NoiseMetric.STD,
+    threshold: float | None = None,
+) -> NoiseStats:
+    """Quantify the noise of a window of feedback samples for arc detection.
+
+    Args:
+        samples: A sequence (list/tuple) of int|float feedback readings.
+        metric: Which metric to evaluate the arc threshold against. Accepts a
+            ``NoiseMetric`` or its string value (e.g. ``"std"``).
+        threshold: Arc threshold for the chosen metric. ``None`` disables arc
+            detection (``arcing`` is always False). Otherwise must be a finite
+            number.
+
+    Returns:
+        NoiseStats with the full set of noise metrics, the selected metric and
+        its value, the threshold in effect, and the resulting ``arcing`` flag.
+
+    Raises:
+        TypeError: If ``samples`` is not a sequence (a str is rejected), if any
+            element is non-numeric (``bool`` counts as non-numeric), if
+            ``metric`` is not a ``NoiseMetric``/``str``, or if ``threshold`` is
+            neither ``None`` nor a real number.
+        ValueError: If ``metric`` is not a valid ``NoiseMetric`` value, or if
+            ``threshold`` is given but not finite (NaN/inf).
+
+    Preconditions:
+        - ``samples`` is a list/tuple of finite-or-not real numbers.
+        - ``metric`` resolves to a member of ``NoiseMetric``.
+        - ``threshold`` is ``None`` or a finite real number.
+
+    Postconditions:
+        - ``sample_count == len(samples)``.
+        - Empty input -> all numeric stats 0.0 and ``arcing`` False.
+        - A single sample -> ``mean`` is that value, every spread stat is 0.0.
+        - ``std`` uses ddof=1 (statistics.stdev) for n>=2, else 0.0.
+        - ``rms_about_mean`` is the population deviation RMS.
+        - ``coeff_of_variation`` is ``std / abs(mean)`` (0.0 if mean==0/n<2).
+        - ``metric_value`` equals the selected metric's value.
+        - ``arcing`` is ``threshold is not None and metric_value > threshold``.
+    """
+    # Reject str/bytes up front: they are sequences but not sample windows.
+    if not isinstance(samples, Sequence) or isinstance(samples, (str, bytes)):
+        raise TypeError(
+            f"samples must be a list/tuple sequence, got {type(samples).__name__}"
+        )
+    if not isinstance(metric, (NoiseMetric, str)):
+        raise TypeError(
+            f"metric must be a NoiseMetric or str, got {type(metric).__name__}"
+        )
+    try:
+        metric = NoiseMetric(metric)
+    except ValueError as exc:
+        valid = ", ".join(m.value for m in NoiseMetric)
+        raise ValueError(f"metric must be one of [{valid}], got {metric!r}") from exc
+
+    if threshold is not None:
+        if not _is_real_number(threshold):
+            raise TypeError(
+                "threshold must be None or a real number, got "
+                f"{type(threshold).__name__}"
+            )
+        if not math.isfinite(threshold):
+            raise ValueError(f"threshold must be finite, got {threshold!r}")
+
+    values: list[float] = []
+    for index, element in enumerate(samples):
+        if not _is_real_number(element):
+            raise TypeError(
+                f"samples[{index}] must be int|float, got {type(element).__name__}"
+            )
+        values.append(float(element))
+
+    sample_count = len(values)
+    if sample_count == 0:
+        mean = 0.0
+        std = 0.0
+        peak_to_peak = 0.0
+        rms_about_mean = 0.0
+        coeff_of_variation = 0.0
+    else:
+        mean = statistics.fmean(values)
+        peak_to_peak = max(values) - min(values)
+        if sample_count >= 2:
+            std = statistics.stdev(values)
+            rms_about_mean = math.sqrt(
+                statistics.fmean([(x - mean) ** 2 for x in values])
+            )
+            coeff_of_variation = std / abs(mean) if mean != 0.0 else 0.0
+        else:
+            std = 0.0
+            rms_about_mean = 0.0
+            coeff_of_variation = 0.0
+
+    metric_values: dict[NoiseMetric, float] = {
+        NoiseMetric.STD: std,
+        NoiseMetric.PEAK_TO_PEAK: peak_to_peak,
+        NoiseMetric.RMS: rms_about_mean,
+        NoiseMetric.CV: coeff_of_variation,
+    }
+    metric_value = metric_values[metric]
+    arcing = threshold is not None and metric_value > threshold
+
+    return NoiseStats(
+        sample_count=sample_count,
+        mean=mean,
+        std=std,
+        peak_to_peak=peak_to_peak,
+        rms_about_mean=rms_about_mean,
+        coeff_of_variation=coeff_of_variation,
+        metric=metric,
+        metric_value=metric_value,
+        threshold=threshold,
+        arcing=arcing,
+    )

--- a/src/p1am_control_system/backend/simulator_client.py
+++ b/src/p1am_control_system/backend/simulator_client.py
@@ -23,6 +23,9 @@ class SimulatedPLCClient(BasePLCClient):
         # Latched emergency-stop state for the simulated controller
         self.e_stop_active = False
 
+        # Discrete coil state (e.g. heater relay) so sim mode models DO writes
+        self.coils: dict[int, bool] = {}
+
         # Active configuration state (shared default — single source of truth)
         self.active_config = default_routing_config()
 
@@ -179,3 +182,9 @@ class SimulatedPLCClient(BasePLCClient):
                 self.active_config.pids[pid_index].setpoint = value
                 return True
             return False
+
+    async def write_coil(self, address: int, value: bool) -> bool:
+        """Record a simulated discrete-coil write (mirrors the Modbus seam)."""
+        async with self.lock:
+            self.coils[address] = bool(value)
+            return True

--- a/src/p1am_control_system/backend/temperature_controller.py
+++ b/src/p1am_control_system/backend/temperature_controller.py
@@ -1,0 +1,339 @@
+"""Temperature state machine, safety interlocks, and on/off control law.
+
+Controls a resistive heater through a single on/off relay using thermocouple
+temperature feedback. The controller is fully testable without a PLC: feed
+measured temperatures into ``tick()`` and inspect state plus the commanded
+relay. The relay is driven by an on/off hysteresis band around the setpoint.
+
+Trips latch until ``acknowledge_trip()``; E-stop latches until
+``clear_estop()``. A high-high (HH) cutoff latches the controller TRIPPED and
+forces the relay off the moment the measured temperature reaches the limit.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from temperature_models import (
+    TemperatureConfig,
+    TemperatureState,
+    TemperatureStatus,
+)
+
+__all__ = [
+    "TemperatureConfig",
+    "TemperatureController",
+    "TemperatureState",
+    "TemperatureStatus",
+]
+
+logger = logging.getLogger("dcs_backend.temperature")
+
+
+class TemperatureController:
+    """State machine + on/off control law for the resistive heater.
+
+    In non-running or unsafe states (IDLE / ARMED / TRIPPED / no-permissive /
+    E-stop / any trip), the relay is always forced off. In RUNNING, the relay
+    follows an on/off hysteresis band around the setpoint: it switches ON at
+    ``setpoint - deadband`` and OFF at ``setpoint + deadband``, holding its
+    previous state inside the band.
+    """
+
+    def __init__(self, config: TemperatureConfig) -> None:
+        if not isinstance(config, TemperatureConfig):
+            raise TypeError(
+                f"config must be TemperatureConfig, got {type(config).__name__}"
+            )
+        self._config = config
+        self._state = TemperatureState.IDLE
+        self._permissive = False
+        self._setpoint_c = 0.0
+        self._trips: set[str] = set()
+        self._last_t = 0.0
+        # Commanded relay state from the most recent tick. Held across ticks so
+        # the hysteresis band can keep the relay in its prior position while the
+        # measured temperature sits inside the deadband.
+        self._relay_on = False
+        # E-stop latch. While set, the controller forces the relay off, refuses
+        # to arm, and rejects setpoints until clear_estop() is called. This is a
+        # one-way kill — it must be explicitly cleared by an operator.
+        self._estopped = False
+
+    @property
+    def state(self) -> TemperatureState:
+        return self._state
+
+    @property
+    def permissive(self) -> bool:
+        return self._permissive
+
+    @property
+    def config(self) -> TemperatureConfig:
+        return self._config
+
+    @property
+    def trips(self) -> list[str]:
+        return sorted(self._trips)
+
+    @property
+    def estopped(self) -> bool:
+        return self._estopped
+
+    def update_config(self, new_config: TemperatureConfig) -> None:
+        """Replace operator-configurable parameters.
+
+        Precondition: new_config is a fully-validated TemperatureConfig.
+        Postcondition: subsequent commands and trip checks use new_config; the
+        current setpoint is re-clamped to the new bounds without changing state.
+
+        Raises:
+            TypeError: if new_config is not a TemperatureConfig instance.
+        """
+        if not isinstance(new_config, TemperatureConfig):
+            raise TypeError(
+                f"new_config must be TemperatureConfig, got {type(new_config).__name__}"
+            )
+        self._config = new_config
+        # Re-clamp current setpoint to new bounds without changing state.
+        self._setpoint_c = max(
+            new_config.setpoint_min_c,
+            min(self._setpoint_c, new_config.setpoint_max_c),
+        )
+
+    def set_permissive(self, on: bool) -> None:
+        """Toggle permissive. A trip latch is not cleared by a permissive change.
+
+        Precondition: on is a bool (no truthy coercion to catch caller bugs).
+        Postcondition:
+            - permissive == on
+            - If on goes False and state was RUNNING / ARMED, state -> IDLE,
+              setpoint -> 0
+            - If on goes True and state was IDLE, state -> ARMED
+            - If state was TRIPPED, state remains TRIPPED
+            - If E-stop is latched, on=True is ignored (stays disarmed).
+
+        Raises:
+            TypeError: if on is not exactly bool.
+        """
+        if not isinstance(on, bool):
+            raise TypeError(f"on must be bool, got {type(on).__name__}")
+        if self._estopped:
+            # A latched E-stop cannot be armed around. The relay stays off until
+            # the operator explicitly clears the E-stop.
+            if on:
+                logger.warning("permissive ON ignored — E-stop is latched")
+            self._permissive = False
+            return
+        self._permissive = on
+        if self._state == TemperatureState.TRIPPED:
+            return
+        if on:
+            if self._state == TemperatureState.IDLE:
+                self._state = TemperatureState.ARMED
+        else:
+            self._setpoint_c = 0.0
+            self._state = TemperatureState.IDLE
+
+    def set_setpoint_c(self, value_c: float) -> float:
+        """Apply a temperature setpoint (deg C).
+
+        The value is clamped to [setpoint_min_c, setpoint_max_c] before being
+        applied. Setpoint application is rejected in IDLE and TRIPPED states
+        (returns clamped value but does not change internal setpoint).
+
+        Precondition: value_c is finite numeric.
+        Postcondition:
+            - If state was ARMED / RUNNING: internal setpoint_c == clamped value
+            - If clamped > 0 and state was ARMED: state -> RUNNING
+            - Returns the clamped value that would be applied (0.0 if estopped).
+
+        Raises:
+            TypeError: if value_c is not numeric.
+            ValueError: if value_c is NaN or infinite.
+        """
+        if not isinstance(value_c, int | float) or isinstance(value_c, bool):
+            raise TypeError(f"value_c must be numeric, got {type(value_c).__name__}")
+        v = float(value_c)
+        if not math.isfinite(v):
+            raise ValueError(f"value_c must be finite, got {v}")
+
+        if self._estopped:
+            logger.warning("temperature setpoint ignored — E-stop is latched")
+            return 0.0
+
+        clamped = float(
+            max(
+                self._config.setpoint_min_c,
+                min(v, self._config.setpoint_max_c),
+            )
+        )
+
+        if self._state in (TemperatureState.ARMED, TemperatureState.RUNNING):
+            self._setpoint_c = clamped
+            if self._state == TemperatureState.ARMED and clamped > 0.0:
+                self._state = TemperatureState.RUNNING
+        elif self._state == TemperatureState.IDLE:
+            logger.warning(
+                "temperature setpoint %.1f C ignored — controller in IDLE; "
+                "enable permissive first",
+                clamped,
+            )
+        elif self._state == TemperatureState.TRIPPED:
+            logger.warning(
+                "temperature setpoint %.1f C ignored — controller TRIPPED; "
+                "acknowledge first",
+                clamped,
+            )
+        return clamped
+
+    def engage_estop(self) -> None:
+        """Latch the emergency stop: force the relay off and disarm.
+
+        This is the software half of the kill switch. It immediately drops the
+        commanded relay to off (via the latch checked in `tick()`), clears the
+        setpoint, turns permissive off, and returns the state machine to IDLE.
+        The latch persists — `set_permissive(True)` and setpoint commands are
+        rejected — until `clear_estop()` is called.
+
+        Postcondition: estopped; permissive False; state IDLE; setpoint 0;
+        relay off.
+        """
+        self._estopped = True
+        self._permissive = False
+        self._setpoint_c = 0.0
+        self._state = TemperatureState.IDLE
+        self._relay_on = False
+        logger.error("E-STOP engaged — heater relay latched off")
+
+    def clear_estop(self) -> None:
+        """Release the emergency-stop latch.
+
+        Leaves the controller IDLE with permissive off, so the operator must
+        deliberately re-arm (permissive on) and re-enter a setpoint before the
+        heater can fire again.
+
+        Postcondition: not estopped; permissive False; state IDLE; setpoint 0.
+        """
+        if not self._estopped:
+            return
+        self._estopped = False
+        self._permissive = False
+        self._setpoint_c = 0.0
+        self._state = TemperatureState.IDLE
+        logger.warning("E-stop cleared — controller idle, re-arm required")
+
+    def acknowledge_trip(self) -> bool:
+        """Clear latched trips and return controller to safe idle/armed state.
+
+        Postcondition:
+            - All trips cleared.
+            - Setpoint cleared to 0.
+            - State -> ARMED if permissive is True, else IDLE.
+
+        Returns:
+            True if a trip was cleared. False if there were no trips.
+        """
+        if self._state != TemperatureState.TRIPPED:
+            return False
+        self._trips.clear()
+        self._setpoint_c = 0.0
+        self._state = (
+            TemperatureState.ARMED if self._permissive else TemperatureState.IDLE
+        )
+        return True
+
+    @staticmethod
+    def _safe_finite(value: float) -> float:
+        """Coerce a feedback input to a finite float; non-finite values map
+        to 0 so a sensor failure can never accidentally hold the relay on or
+        smuggle a NaN through the comparisons."""
+        if not isinstance(value, int | float) or isinstance(value, bool):
+            return 0.0
+        v = float(value)
+        return v if math.isfinite(v) else 0.0
+
+    def _evaluate_trips(self) -> None:
+        """Latch the HH cutoff based on the latest temperature; flips state to
+        TRIPPED on first breach."""
+        if self._last_t >= self._config.hh_limit_c:
+            self._trips.add("HH_TEMP")
+        if self._trips and self._state != TemperatureState.TRIPPED:
+            logger.error(
+                "trip latched: %s (T=%.1f C)",
+                ",".join(sorted(self._trips)),
+                self._last_t,
+            )
+            self._state = TemperatureState.TRIPPED
+
+    def _should_force_relay_off(self) -> bool:
+        """All "kill the heater now" conditions in one place."""
+        return (
+            self._estopped
+            or self._state != TemperatureState.RUNNING
+            or not self._permissive
+            or bool(self._trips)
+        )
+
+    def tick(self, measured_temp_c: float, now: float | None = None) -> bool:
+        """Advance the controller one cycle and return the commanded relay state.
+
+        Reads the temperature feedback, evaluates the HH cutoff (latching it on
+        breach), and applies the on/off hysteresis band when RUNNING.
+
+        On/off behavior (per `deadband_c` in the config):
+          - Relay turns ON when measured <= setpoint - deadband.
+          - Relay turns OFF when measured >= setpoint + deadband.
+          - Inside the band the relay HOLDS its previous state, so it doesn't
+            chatter around the setpoint.
+          - Any path that forces the relay off (E-stop / IDLE / ARMED /
+            TRIPPED / permissive off / any trip) bypasses the band, so
+            shutdowns are always one tick.
+
+        Args:
+            measured_temp_c: thermocouple temperature in deg C.
+            now: Optional timestamp in seconds. Accepted for signature parity
+                with the power-supply controller and for future use; the
+                control law is deterministic and does not consult it.
+
+        Precondition: measured_temp_c is a finite float. Non-finite inputs are
+        treated as 0 (safe).
+        Postcondition: returns the commanded relay state; HH trip is latched if
+        its condition is met; the relay state is stored for the next tick.
+
+        Returns:
+            True if the heater relay should be energized, else False.
+        """
+        del now  # Accepted for signature parity / future use; deterministic.
+        self._last_t = self._safe_finite(measured_temp_c)
+
+        self._evaluate_trips()
+
+        if self._should_force_relay_off():
+            self._relay_on = False
+            return False
+
+        # RUNNING on/off hysteresis around the setpoint.
+        on_threshold = self._setpoint_c - self._config.deadband_c
+        off_threshold = self._setpoint_c + self._config.deadband_c
+        if self._last_t <= on_threshold:
+            self._relay_on = True
+        elif self._last_t >= off_threshold:
+            self._relay_on = False
+        # else: inside the band -> hold previous relay state.
+        return self._relay_on
+
+    def status(self) -> TemperatureStatus:
+        """Return a snapshot of controller state for serialization."""
+        return TemperatureStatus(
+            state=self._state,
+            permissive=self._permissive,
+            setpoint_c=self._setpoint_c,
+            measured_temp_c=self._last_t,
+            relay_on=self._relay_on,
+            trips=sorted(self._trips),
+            hh_limit_c=self._config.hh_limit_c,
+            deadband_c=self._config.deadband_c,
+            estopped=self._estopped,
+        )

--- a/src/p1am_control_system/backend/temperature_integration.py
+++ b/src/p1am_control_system/backend/temperature_integration.py
@@ -62,7 +62,7 @@ class TemperatureService:
             return 0.0
         cfg = self.controller.config
         temp_pct = float(tags.get(cfg.temp_tag, 0.0))
-        return temp_pct * cfg.temp_full_scale_c / 100.0
+        return float(temp_pct * cfg.temp_full_scale_c / 100.0)
 
     async def _write_relay(self, on: bool) -> bool:
         """Command the heater relay via the client's public coil seam."""

--- a/src/p1am_control_system/backend/temperature_integration.py
+++ b/src/p1am_control_system/backend/temperature_integration.py
@@ -1,0 +1,133 @@
+"""FastAPI and PLC integration for the P1AM temperature controller.
+
+Wires the pure :class:`TemperatureController` to the live PLC: it reads the
+thermocouple tag on every scan, ticks the on/off control law, and drives the
+heater relay through the client's public ``write_coil`` seam (24 V DO -> relay
+-> 110 V resistive heater). Mirrors ``power_supply_integration.py`` so the two
+control subsystems share one shape (LOD: this layer talks only to the
+controller and the PLC client's public seam, never their internals).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import hardware
+from auth_config import require_admin_key
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from temperature_controller import TemperatureController
+from temperature_models import TemperatureConfig, TemperatureStatus
+
+
+class TemperatureService:
+    """Owns the controller and applies its relay command to the PLC coil."""
+
+    def __init__(self, plc_client: Any, logger: logging.Logger) -> None:
+        self.controller = TemperatureController(TemperatureConfig())
+        self._plc_client = plc_client
+        self._logger = logger
+
+    async def poll(self, tags: dict[str, float] | None) -> TemperatureStatus:
+        """Feed the measured thermocouple into the controller, drive the relay.
+
+        Returns the controller status either way; the relay write is best-effort
+        so a momentary PLC hiccup never aborts the scan loop. Note the heater is
+        only ever *commanded on* — when the write fails the relay is whatever the
+        PLC last latched, and the controller's HH cutoff / E-stop still force the
+        commanded value to False, so a failed write can never *energize* it.
+        """
+        temp_c = self._temp_from_tags(tags)
+        relay_on = self.controller.tick(measured_temp_c=temp_c)
+        await self._write_relay(relay_on)
+        return self.controller.status()
+
+    def engage_estop(self) -> None:
+        """Latch the controller's E-stop (forces the heater relay off)."""
+        self.controller.engage_estop()
+
+    def clear_estop(self) -> None:
+        """Release the controller's E-stop latch (operator must re-arm)."""
+        self.controller.clear_estop()
+
+    def _temp_from_tags(self, tags: dict[str, float] | None) -> float:
+        """Scale the thermocouple tag (percent of full scale) into deg C.
+
+        The firmware publishes every analog channel as 0-100% of its range, so
+        the controlled temperature is ``tag_percent * temp_full_scale_c / 100``
+        (e.g. a 1400 deg C type-K range -> 50% reads as 700 deg C).
+        """
+        if not tags:
+            return 0.0
+        cfg = self.controller.config
+        temp_pct = float(tags.get(cfg.temp_tag, 0.0))
+        return temp_pct * cfg.temp_full_scale_c / 100.0
+
+    async def _write_relay(self, on: bool) -> bool:
+        """Command the heater relay via the client's public coil seam."""
+        try:
+            return bool(
+                await self._plc_client.write_coil(hardware.HEATER_RELAY_COIL, on)
+            )
+        except Exception as exc:  # best-effort: never abort the scan loop
+            self._logger.error("heater relay write failed: %s", exc)
+            return False
+
+
+class TemperatureSetpointRequest(BaseModel):
+    """Operator-facing temperature setpoint command (deg C)."""
+
+    value_c: float
+
+
+class TemperaturePermissiveRequest(BaseModel):
+    enabled: bool
+
+
+def create_temperature_router(service: TemperatureService) -> APIRouter:
+    router = APIRouter(prefix="/api/temperature", tags=["temperature"])
+    controller = service.controller
+
+    @router.get("/config", response_model=TemperatureConfig)
+    async def get_temperature_config() -> TemperatureConfig:
+        return controller.config
+
+    @router.put(
+        "/config",
+        response_model=TemperatureConfig,
+        dependencies=[Depends(require_admin_key)],
+    )
+    async def update_temperature_config(
+        new_config: TemperatureConfig,
+    ) -> TemperatureConfig:
+        controller.update_config(new_config)
+        return controller.config
+
+    @router.get("/status", response_model=TemperatureStatus)
+    async def get_temperature_status() -> TemperatureStatus:
+        return controller.status()
+
+    @router.post("/setpoint", dependencies=[Depends(require_admin_key)])
+    async def apply_temperature_setpoint(
+        req: TemperatureSetpointRequest,
+    ) -> dict[str, Any]:
+        try:
+            applied = controller.set_setpoint_c(req.value_c)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"applied_c": applied}
+
+    @router.post("/permissive", dependencies=[Depends(require_admin_key)])
+    async def set_temperature_permissive(
+        req: TemperaturePermissiveRequest,
+    ) -> TemperatureStatus:
+        controller.set_permissive(req.enabled)
+        return controller.status()
+
+    @router.post("/acknowledge_trip", dependencies=[Depends(require_admin_key)])
+    async def acknowledge_temperature_trip() -> TemperatureStatus:
+        controller.acknowledge_trip()
+        return controller.status()
+
+    return router

--- a/src/p1am_control_system/backend/temperature_models.py
+++ b/src/p1am_control_system/backend/temperature_models.py
@@ -1,0 +1,128 @@
+"""Pydantic data models + enums for the temperature subsystem.
+
+Split out of `temperature_controller.py` so the controller module stays clean
+and these models stay plain data: no business logic lives here, so this module
+is safely importable from anywhere (tests, FastAPI router, controller) without
+circular-import risk. Mirrors the structure of `power_supply_models.py`.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class StrEnum(str, Enum):  # noqa: UP042
+    """Compat shim for Python < 3.11 environments that don't ship StrEnum.
+
+    Inherits from `str` so the enum members serialize as plain strings when
+    passed through Pydantic / FastAPI / JSON.
+    """
+
+
+class TemperatureState(StrEnum):
+    """Controller state machine state."""
+
+    IDLE = "idle"
+    ARMED = "armed"
+    RUNNING = "running"
+    TRIPPED = "tripped"
+
+
+class TemperatureConfig(BaseModel):
+    """Operator-configurable parameters for the temperature controller.
+
+    All numeric fields are validated by Pydantic at construction (Pydantic's
+    Field constraints raise ValidationError on bad input). The
+    `_check_invariants` validator enforces the cross-field invariants:
+        setpoint_min_c < setpoint_max_c
+        setpoint_max_c <= temp_full_scale_c
+        hh_limit_c <= temp_full_scale_c
+    """
+
+    temp_tag: str = Field(
+        default="TAG_0",
+        description="Modbus tag carrying the controlled thermocouple (TC0).",
+    )
+
+    temp_full_scale_c: float = Field(
+        default=1400.0,
+        gt=0.0,
+        description="deg C at 100% of the thermocouple tag",
+    )
+
+    setpoint_min_c: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Lower clamp for operator temperature setpoint (deg C).",
+    )
+    setpoint_max_c: float = Field(
+        default=1400.0,
+        gt=0.0,
+        description="Upper clamp for operator temperature setpoint (deg C).",
+    )
+
+    deadband_c: float = Field(
+        default=5.0,
+        gt=0.0,
+        description="on/off hysteresis half-band around setpoint",
+    )
+    hh_limit_c: float = Field(
+        default=1400.0,
+        gt=0.0,
+        description="high-high cutoff; heater is latched off at/above this",
+    )
+
+    heater_label: str = Field(
+        default="Heater",
+        min_length=1,
+        max_length=40,
+        description="HMI name for the heater on/off relay output.",
+    )
+
+    @field_validator("heater_label")
+    @classmethod
+    def _strip_label(cls, value: str) -> str:
+        """Trim labels and reject whitespace-only names (DbC)."""
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("signal label must not be blank")
+        return trimmed
+
+    @model_validator(mode="after")
+    def _check_invariants(self) -> TemperatureConfig:
+        if self.setpoint_min_c >= self.setpoint_max_c:
+            raise ValueError(
+                f"setpoint_min_c ({self.setpoint_min_c}) must be less than "
+                f"setpoint_max_c ({self.setpoint_max_c})"
+            )
+        if self.setpoint_max_c > self.temp_full_scale_c:
+            raise ValueError(
+                f"setpoint_max_c ({self.setpoint_max_c}) must not exceed "
+                f"temp_full_scale_c ({self.temp_full_scale_c})"
+            )
+        if self.hh_limit_c > self.temp_full_scale_c:
+            raise ValueError(
+                f"hh_limit_c ({self.hh_limit_c}) must not exceed "
+                f"temp_full_scale_c ({self.temp_full_scale_c})"
+            )
+        return self
+
+
+class TemperatureStatus(BaseModel):
+    """Snapshot of controller state for the UI / WebSocket stream."""
+
+    state: TemperatureState
+    permissive: bool
+
+    setpoint_c: float
+    measured_temp_c: float
+
+    relay_on: bool
+    trips: list[str]
+
+    hh_limit_c: float
+    deadband_c: float
+
+    estopped: bool = False

--- a/src/p1am_control_system/backend/tests/test_estop_clear_clients.py
+++ b/src/p1am_control_system/backend/tests/test_estop_clear_clients.py
@@ -103,3 +103,16 @@ def test_simulator_clear_estop_resets_latch() -> None:
         assert sim.e_stop_active is False
 
     asyncio.run(_go())
+
+
+def test_simulator_write_coil_records_state() -> None:
+    """The simulator must record discrete-coil writes (e.g. the heater relay)."""
+
+    async def _go() -> None:
+        sim = SimulatedPLCClient()
+        assert await sim.write_coil(2, True) is True
+        assert sim.coils[2] is True
+        assert await sim.write_coil(2, False) is True
+        assert sim.coils[2] is False
+
+    asyncio.run(_go())

--- a/src/p1am_control_system/backend/tests/test_modbus_estop.py
+++ b/src/p1am_control_system/backend/tests/test_modbus_estop.py
@@ -131,3 +131,65 @@ class TestWritePidSetpoint:
             assert m._connected is False
 
         asyncio.run(go())
+
+
+def _manager_with_coil(write_coil: AsyncMock) -> AsyncModbusManager:
+    m = AsyncModbusManager(host="127.0.0.1")
+    m._connected = True
+    raw = MagicMock()
+    raw.write_coil = write_coil
+    m._get_client = lambda: raw  # type: ignore[method-assign]
+    return m
+
+
+class TestWriteCoil:
+    """Discrete-coil write path (e.g. the heater relay)."""
+
+    def test_success_passes_address_and_value(self) -> None:
+        async def go() -> None:
+            captured: dict[str, object] = {}
+
+            def _side(*_: Any, address: int = 0, value: bool = False) -> MagicMock:
+                captured["address"] = address
+                captured["value"] = value
+                return _ok()
+
+            wc = AsyncMock(side_effect=_side)
+            m = _manager_with_coil(wc)
+            assert await m.write_coil(2, True) is True
+            assert captured == {"address": 2, "value": True}
+
+        asyncio.run(go())
+
+    def test_disconnected_returns_false_without_writing(self) -> None:
+        async def go() -> None:
+            wc = AsyncMock(return_value=_ok())
+            m = _manager_with_coil(wc)
+            m._connected = False
+            assert await m.write_coil(2, True) is False
+            assert wc.await_count == 0
+
+        asyncio.run(go())
+
+    def test_non_bool_value_raises(self) -> None:
+        async def go() -> None:
+            m = _manager_with_coil(AsyncMock(return_value=_ok()))
+            with pytest.raises(TypeError):
+                await m.write_coil(2, 1)  # type: ignore[arg-type]
+
+        asyncio.run(go())
+
+    def test_error_response_returns_false(self) -> None:
+        async def go() -> None:
+            m = _manager_with_coil(AsyncMock(return_value=_err()))
+            assert await m.write_coil(2, True) is False
+
+        asyncio.run(go())
+
+    def test_exception_marks_disconnected(self) -> None:
+        async def go() -> None:
+            m = _manager_with_coil(AsyncMock(side_effect=RuntimeError("dropped")))
+            assert await m.write_coil(2, False) is False
+            assert m._connected is False
+
+        asyncio.run(go())

--- a/src/p1am_control_system/backend/tests/test_power_supply_noise.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply_noise.py
@@ -1,0 +1,128 @@
+"""Tests for the power-supply controller's signal-noise / arc integration.
+
+The controller accumulates every tick's current and voltage feedback into a
+bounded rolling window and surfaces NoiseStats (plus an `arcing` flag) in its
+status snapshot, so the HMI can quantify how noisy a DC-arc signal is.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from power_supply import PowerSupplyController
+from power_supply_models import PowerSupplyConfig
+from signal_stats import NoiseMetric
+
+
+def _running_controller(**cfg_kwargs: object) -> PowerSupplyController:
+    ctl = PowerSupplyController(PowerSupplyConfig(**cfg_kwargs))
+    ctl.set_permissive(True)
+    ctl.set_current_setpoint(10.0)
+    return ctl
+
+
+class TestNoiseAccumulation:
+    def test_status_reports_window_sample_count(self) -> None:
+        ctl = _running_controller()
+        for i in range(5):
+            ctl.tick(
+                measured_current_a=float(i),
+                measured_voltage_v=10.0,
+                measured_temp_c=20.0,
+                now=float(i),
+            )
+        status = ctl.status()
+        assert status.current_noise.sample_count == 5
+        assert status.voltage_noise.sample_count == 5
+
+    def test_steady_signal_has_zero_noise_and_not_arcing(self) -> None:
+        ctl = _running_controller()
+        for i in range(10):
+            ctl.tick(
+                measured_current_a=25.0,
+                measured_voltage_v=12.0,
+                measured_temp_c=20.0,
+                now=float(i),
+            )
+        status = ctl.status()
+        assert status.current_noise.std == 0.0
+        assert status.current_noise.peak_to_peak == 0.0
+        assert status.arcing is False
+
+    def test_window_is_bounded_by_noise_window(self) -> None:
+        ctl = _running_controller(noise_window=4)
+        for i in range(20):
+            ctl.tick(
+                measured_current_a=float(i),
+                measured_voltage_v=10.0,
+                measured_temp_c=20.0,
+                now=float(i),
+            )
+        # Only the last 4 samples are retained.
+        assert ctl.status().current_noise.sample_count == 4
+
+
+class TestArcDetection:
+    def test_noisy_current_over_threshold_flags_arcing(self) -> None:
+        # Alternating current feedback => large std; tiny threshold => arcing.
+        ctl = _running_controller(
+            noise_metric=NoiseMetric.STD, current_arc_threshold=1.0
+        )
+        for i in range(10):
+            ctl.tick(
+                measured_current_a=0.0 if i % 2 == 0 else 40.0,
+                measured_voltage_v=12.0,
+                measured_temp_c=20.0,
+                now=float(i),
+            )
+        status = ctl.status()
+        assert status.current_noise.arcing is True
+        assert status.arcing is True
+
+    def test_no_threshold_never_arcs(self) -> None:
+        ctl = _running_controller()  # thresholds default None
+        for i in range(10):
+            ctl.tick(
+                measured_current_a=0.0 if i % 2 == 0 else 40.0,
+                measured_voltage_v=0.0 if i % 2 else 30.0,
+                measured_temp_c=20.0,
+                now=float(i),
+            )
+        status = ctl.status()
+        assert status.current_noise.arcing is False
+        assert status.voltage_noise.arcing is False
+        assert status.arcing is False
+
+    def test_voltage_arc_alone_sets_overall_arcing(self) -> None:
+        ctl = _running_controller(
+            noise_metric=NoiseMetric.PEAK_TO_PEAK, voltage_arc_threshold=5.0
+        )
+        for i in range(10):
+            ctl.tick(
+                measured_current_a=25.0,  # steady current
+                measured_voltage_v=0.0 if i % 2 == 0 else 30.0,  # noisy voltage
+                measured_temp_c=20.0,
+                now=float(i),
+            )
+        status = ctl.status()
+        assert status.current_noise.arcing is False
+        assert status.voltage_noise.arcing is True
+        assert status.arcing is True
+
+
+class TestWindowResizePreservesRecent:
+    def test_update_config_resizes_and_keeps_recent(self) -> None:
+        ctl = _running_controller(noise_window=100)
+        for i in range(10):
+            ctl.tick(
+                measured_current_a=float(i),
+                measured_voltage_v=10.0,
+                measured_temp_c=20.0,
+                now=float(i),
+            )
+        # Shrinking the window keeps only the most-recent samples.
+        ctl.update_config(ctl.config.model_copy(update={"noise_window": 3}))
+        assert ctl.status().current_noise.sample_count == 3

--- a/src/p1am_control_system/backend/tests/test_signal_stats.py
+++ b/src/p1am_control_system/backend/tests/test_signal_stats.py
@@ -1,0 +1,226 @@
+"""Unit tests for the pure signal noise/variability stats module.
+
+Pure pydantic + stdlib, so no importorskip and no live PLC/DB is needed — these
+must run in CI. Covers a hand-computed known sequence, the constant-signal
+floor, arc-threshold behaviour across every metric, metric selection (incl. a
+plain string metric), the empty/single-sample edge cases, and DbC validation.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from signal_stats import (  # noqa: E402
+    NOISE_DEFAULT_THRESHOLD,
+    NOISE_DEFAULT_WINDOW,
+    NoiseMetric,
+    NoiseStats,
+    compute_noise,
+)
+
+# Hand-computed reference window:
+#   mean = 5.0, sample std (ddof=1) = sqrt(32/7) ~= 2.1380899,
+#   peak_to_peak = 7.0, population rms about mean = sqrt(4) = 2.0,
+#   coeff_of_variation = std / 5.0 ~= 0.4276180.
+KNOWN = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+KNOWN_STD = math.sqrt(32.0 / 7.0)
+
+
+def test_known_sequence_mean_and_spread() -> None:
+    stats = compute_noise(KNOWN)
+    assert stats.sample_count == 8
+    assert stats.mean == pytest.approx(5.0)
+    assert stats.std == pytest.approx(KNOWN_STD)
+    assert stats.peak_to_peak == pytest.approx(7.0)
+    assert stats.rms_about_mean == pytest.approx(2.0)
+    assert stats.coeff_of_variation == pytest.approx(KNOWN_STD / 5.0)
+
+
+def test_known_sequence_returns_noisestats() -> None:
+    stats = compute_noise(KNOWN)
+    assert isinstance(stats, NoiseStats)
+    # Default metric is STD with no threshold -> detection disabled.
+    assert stats.metric is NoiseMetric.STD
+    assert stats.metric_value == pytest.approx(KNOWN_STD)
+    assert stats.threshold is None
+    assert stats.arcing is False
+
+
+def test_constant_signal_has_zero_noise() -> None:
+    stats = compute_noise([3.3, 3.3, 3.3, 3.3])
+    assert stats.mean == pytest.approx(3.3)
+    assert stats.std == 0.0
+    assert stats.peak_to_peak == 0.0
+    assert stats.rms_about_mean == 0.0
+    assert stats.coeff_of_variation == 0.0
+
+
+def test_constant_signal_not_arcing_even_with_threshold() -> None:
+    stats = compute_noise([3.3] * 10, metric=NoiseMetric.RMS, threshold=0.0)
+    assert stats.metric_value == 0.0
+    # 0.0 is not strictly greater than the 0.0 threshold.
+    assert stats.arcing is False
+
+
+def test_noisy_signal_over_threshold_arcs() -> None:
+    stats = compute_noise(KNOWN, metric=NoiseMetric.STD, threshold=1.0)
+    assert stats.threshold == pytest.approx(1.0)
+    assert stats.metric_value == pytest.approx(KNOWN_STD)
+    assert stats.arcing is True
+
+
+def test_noisy_signal_under_threshold_does_not_arc() -> None:
+    stats = compute_noise(KNOWN, metric=NoiseMetric.STD, threshold=10.0)
+    assert stats.arcing is False
+
+
+def test_threshold_none_disables_arc_detection() -> None:
+    stats = compute_noise(KNOWN, metric=NoiseMetric.STD, threshold=None)
+    assert stats.threshold is None
+    assert stats.arcing is False
+
+
+def test_threshold_equal_to_value_is_not_arcing() -> None:
+    # arcing requires strictly greater-than, not >=.
+    stats = compute_noise(KNOWN, metric=NoiseMetric.PEAK_TO_PEAK, threshold=7.0)
+    assert stats.metric_value == pytest.approx(7.0)
+    assert stats.arcing is False
+
+
+def test_metric_std_selected() -> None:
+    stats = compute_noise(KNOWN, metric=NoiseMetric.STD)
+    assert stats.metric is NoiseMetric.STD
+    assert stats.metric_value == pytest.approx(KNOWN_STD)
+
+
+def test_metric_peak_to_peak_selected() -> None:
+    stats = compute_noise(KNOWN, metric=NoiseMetric.PEAK_TO_PEAK)
+    assert stats.metric is NoiseMetric.PEAK_TO_PEAK
+    assert stats.metric_value == pytest.approx(7.0)
+
+
+def test_metric_rms_selected() -> None:
+    stats = compute_noise(KNOWN, metric=NoiseMetric.RMS)
+    assert stats.metric is NoiseMetric.RMS
+    assert stats.metric_value == pytest.approx(2.0)
+
+
+def test_metric_cv_selected() -> None:
+    stats = compute_noise(KNOWN, metric=NoiseMetric.CV)
+    assert stats.metric is NoiseMetric.CV
+    assert stats.metric_value == pytest.approx(KNOWN_STD / 5.0)
+
+
+def test_metric_accepts_plain_string() -> None:
+    stats = compute_noise(KNOWN, metric="peak_to_peak")
+    assert stats.metric is NoiseMetric.PEAK_TO_PEAK
+    assert stats.metric_value == pytest.approx(7.0)
+
+
+def test_metric_selection_changes_metric_value() -> None:
+    std_v = compute_noise(KNOWN, metric=NoiseMetric.STD).metric_value
+    p2p_v = compute_noise(KNOWN, metric=NoiseMetric.PEAK_TO_PEAK).metric_value
+    rms_v = compute_noise(KNOWN, metric=NoiseMetric.RMS).metric_value
+    cv_v = compute_noise(KNOWN, metric=NoiseMetric.CV).metric_value
+    assert std_v == pytest.approx(KNOWN_STD)
+    assert p2p_v == pytest.approx(7.0)
+    assert rms_v == pytest.approx(2.0)
+    assert cv_v == pytest.approx(KNOWN_STD / 5.0)
+    assert len({round(v, 6) for v in (std_v, p2p_v, rms_v, cv_v)}) == 4
+
+
+def test_empty_window_is_all_zero_and_not_arcing() -> None:
+    stats = compute_noise([], threshold=0.0)
+    assert stats.sample_count == 0
+    assert stats.mean == 0.0
+    assert stats.std == 0.0
+    assert stats.peak_to_peak == 0.0
+    assert stats.rms_about_mean == 0.0
+    assert stats.coeff_of_variation == 0.0
+    assert stats.metric_value == 0.0
+    assert stats.arcing is False
+
+
+def test_single_sample_mean_only() -> None:
+    stats = compute_noise([42.0], metric=NoiseMetric.CV, threshold=0.0)
+    assert stats.sample_count == 1
+    assert stats.mean == pytest.approx(42.0)
+    assert stats.std == 0.0
+    assert stats.peak_to_peak == 0.0
+    assert stats.rms_about_mean == 0.0
+    assert stats.coeff_of_variation == 0.0
+    assert stats.arcing is False
+
+
+def test_zero_mean_signal_has_zero_cv() -> None:
+    # Symmetric about zero -> mean 0 -> CV guarded to 0.0 despite real spread.
+    stats = compute_noise([-2.0, 2.0, -2.0, 2.0], metric=NoiseMetric.CV)
+    assert stats.mean == pytest.approx(0.0)
+    assert stats.std > 0.0
+    assert stats.coeff_of_variation == 0.0
+
+
+def test_integer_samples_accepted() -> None:
+    stats = compute_noise([2, 4, 4, 4, 5, 5, 7, 9])
+    assert stats.mean == pytest.approx(5.0)
+    assert stats.std == pytest.approx(KNOWN_STD)
+
+
+def test_tuple_samples_accepted() -> None:
+    stats = compute_noise((2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0))
+    assert stats.peak_to_peak == pytest.approx(7.0)
+
+
+def test_module_constants() -> None:
+    assert NOISE_DEFAULT_WINDOW == 100
+    assert NOISE_DEFAULT_THRESHOLD == 0.0
+
+
+def test_dbc_non_sequence_raises_typeerror() -> None:
+    with pytest.raises(TypeError):
+        compute_noise(42)  # type: ignore[arg-type]
+
+
+def test_dbc_string_sequence_rejected() -> None:
+    with pytest.raises(TypeError):
+        compute_noise("1234")  # type: ignore[arg-type]
+
+
+def test_dbc_non_numeric_element_raises_typeerror() -> None:
+    with pytest.raises(TypeError):
+        compute_noise([1.0, "x", 3.0])  # type: ignore[list-item]
+
+
+def test_dbc_bool_element_rejected() -> None:
+    with pytest.raises(TypeError):
+        compute_noise([1.0, True, 3.0])
+
+
+def test_dbc_bad_metric_string_raises_valueerror() -> None:
+    with pytest.raises(ValueError):
+        compute_noise(KNOWN, metric="variance")
+
+
+def test_dbc_bad_metric_type_raises_typeerror() -> None:
+    with pytest.raises(TypeError):
+        compute_noise(KNOWN, metric=123)  # type: ignore[arg-type]
+
+
+def test_dbc_non_finite_threshold_raises_valueerror() -> None:
+    with pytest.raises(ValueError):
+        compute_noise(KNOWN, threshold=float("nan"))
+    with pytest.raises(ValueError):
+        compute_noise(KNOWN, threshold=float("inf"))
+
+
+def test_dbc_wrong_type_threshold_raises_typeerror() -> None:
+    with pytest.raises(TypeError):
+        compute_noise(KNOWN, threshold="0.5")  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        compute_noise(KNOWN, threshold=True)  # type: ignore[arg-type]

--- a/src/p1am_control_system/backend/tests/test_temperature_controller.py
+++ b/src/p1am_control_system/backend/tests/test_temperature_controller.py
@@ -1,0 +1,426 @@
+"""State-machine + runtime tests for TemperatureController.
+
+Companion (`test_temperature_models.py`) covers config-level validation.
+
+Covers here:
+    - Controller construction and initial state
+    - Permissive transitions (IDLE <-> ARMED, RUNNING -> IDLE, trip-latch
+      survives a permissive change)
+    - Setpoint clamping + rejection in IDLE / TRIPPED / E-stopped states
+    - On/off hysteresis (below band -> ON, above band -> OFF, inside band holds)
+    - HH cutoff latches the relay off and survives a subsequent safe tick
+    - acknowledge_trip() transitions
+    - E-stop forces the relay off and blocks arm / setpoint
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from temperature_controller import (  # noqa: E402  (path setup must run first)
+    TemperatureConfig,
+    TemperatureController,
+    TemperatureState,
+)
+
+# --------------------------------------------------------------------------
+# Fresh-controller helpers — known states without repeated boilerplate.
+# --------------------------------------------------------------------------
+
+
+def fresh_idle_controller() -> TemperatureController:
+    """Return a controller in IDLE state (default config)."""
+    return TemperatureController(TemperatureConfig())
+
+
+def fresh_armed_controller() -> TemperatureController:
+    """Return a controller already in ARMED state (permissive on)."""
+    c = fresh_idle_controller()
+    c.set_permissive(True)
+    return c
+
+
+def fresh_running_controller(sp_c: float = 500.0) -> TemperatureController:
+    """Return a controller in RUNNING state with a non-zero setpoint."""
+    c = fresh_armed_controller()
+    c.set_setpoint_c(sp_c)
+    return c
+
+
+# --------------------------------------------------------------------------
+# Constructor + initial state
+# --------------------------------------------------------------------------
+
+
+class TestControllerInit:
+    def test_initial_state_is_idle(self) -> None:
+        c = fresh_idle_controller()
+        assert c.state == TemperatureState.IDLE
+        assert c.permissive is False
+        assert c.trips == []
+        assert c.estopped is False
+
+    def test_rejects_non_config_argument(self) -> None:
+        with pytest.raises(TypeError):
+            TemperatureController("not a config")
+        with pytest.raises(TypeError):
+            TemperatureController({"temp_full_scale_c": 1000.0})
+
+    def test_config_property_returns_config(self) -> None:
+        cfg = TemperatureConfig()
+        c = TemperatureController(cfg)
+        assert c.config is cfg
+
+
+# --------------------------------------------------------------------------
+# Permissive transitions
+# --------------------------------------------------------------------------
+
+
+class TestPermissive:
+    def test_idle_to_armed_when_permissive_on(self) -> None:
+        c = fresh_idle_controller()
+        c.set_permissive(True)
+        assert c.state == TemperatureState.ARMED
+        assert c.permissive is True
+
+    def test_armed_to_idle_when_permissive_off(self) -> None:
+        c = fresh_armed_controller()
+        c.set_permissive(False)
+        assert c.state == TemperatureState.IDLE
+
+    def test_running_to_idle_when_permissive_off(self) -> None:
+        c = fresh_running_controller(500.0)
+        assert c.state == TemperatureState.RUNNING
+        c.set_permissive(False)
+        assert c.state == TemperatureState.IDLE
+
+    def test_permissive_off_clears_setpoint_and_forces_relay_off(self) -> None:
+        c = fresh_running_controller(500.0)
+        # Below the band -> relay would be ON in RUNNING.
+        assert c.tick(100.0) is True
+        c.set_permissive(False)
+        assert c.tick(100.0) is False
+        # Re-arming gives a clean state at 0 setpoint.
+        c.set_permissive(True)
+        assert c.state == TemperatureState.ARMED
+        assert c.tick(100.0) is False  # ARMED never fires
+
+    def test_permissive_change_does_not_clear_trip(self) -> None:
+        c = fresh_running_controller(500.0)
+        c.tick(measured_temp_c=1500.0)  # breaches HH limit (1400)
+        assert c.state == TemperatureState.TRIPPED
+        c.set_permissive(False)
+        assert c.state == TemperatureState.TRIPPED
+        c.set_permissive(True)
+        assert c.state == TemperatureState.TRIPPED
+
+    def test_rejects_non_bool_permissive(self) -> None:
+        c = fresh_idle_controller()
+        with pytest.raises(TypeError):
+            c.set_permissive(1)
+        with pytest.raises(TypeError):
+            c.set_permissive("on")
+
+
+# --------------------------------------------------------------------------
+# Setpoint clamping + rejection
+# --------------------------------------------------------------------------
+
+
+class TestSetpoint:
+    def test_in_band_setpoint_applied_and_runs(self) -> None:
+        c = fresh_armed_controller()
+        applied = c.set_setpoint_c(500.0)
+        assert applied == 500.0
+        assert c.state == TemperatureState.RUNNING
+
+    def test_setpoint_above_max_is_clamped(self) -> None:
+        c = fresh_armed_controller()
+        applied = c.set_setpoint_c(9999.0)
+        assert applied == c.config.setpoint_max_c
+
+    def test_setpoint_below_min_is_clamped(self) -> None:
+        c = TemperatureController(TemperatureConfig(setpoint_min_c=100.0))
+        c.set_permissive(True)
+        applied = c.set_setpoint_c(-50.0)
+        assert applied == 100.0
+
+    def test_setpoint_zero_keeps_state_armed(self) -> None:
+        c = fresh_armed_controller()
+        c.set_setpoint_c(0.0)
+        assert c.state == TemperatureState.ARMED
+
+    def test_setpoint_ignored_in_idle_state(self) -> None:
+        c = fresh_idle_controller()
+        applied = c.set_setpoint_c(500.0)
+        assert applied == 500.0  # value clamped + returned
+        assert c.state == TemperatureState.IDLE  # but not applied
+        assert c.tick(100.0) is False
+
+    def test_setpoint_ignored_in_tripped_state(self) -> None:
+        c = fresh_running_controller(500.0)
+        c.tick(1500.0)  # trip on HH
+        assert c.state == TemperatureState.TRIPPED
+        c.set_setpoint_c(300.0)
+        assert c.tick(100.0) is False
+        assert c.state == TemperatureState.TRIPPED
+
+    def test_setpoint_rejected_while_estopped(self) -> None:
+        c = fresh_armed_controller()
+        c.engage_estop()
+        assert c.set_setpoint_c(500.0) == 0.0
+
+    def test_rejects_nan(self) -> None:
+        c = fresh_armed_controller()
+        with pytest.raises(ValueError, match="finite"):
+            c.set_setpoint_c(float("nan"))
+
+    def test_rejects_infinity(self) -> None:
+        c = fresh_armed_controller()
+        with pytest.raises(ValueError, match="finite"):
+            c.set_setpoint_c(float("inf"))
+        with pytest.raises(ValueError, match="finite"):
+            c.set_setpoint_c(float("-inf"))
+
+    def test_rejects_non_numeric(self) -> None:
+        c = fresh_armed_controller()
+        with pytest.raises(TypeError):
+            c.set_setpoint_c("500")
+        with pytest.raises(TypeError):
+            c.set_setpoint_c(None)
+
+    def test_rejects_bool(self) -> None:
+        # Bool is technically a subclass of int. Explicit catch keeps the
+        # caller honest.
+        c = fresh_armed_controller()
+        with pytest.raises(TypeError):
+            c.set_setpoint_c(True)
+
+
+# --------------------------------------------------------------------------
+# On/off hysteresis control law
+# --------------------------------------------------------------------------
+
+
+class TestHysteresis:
+    def test_below_band_turns_relay_on(self) -> None:
+        # setpoint 500, deadband 5 -> ON at <= 495.
+        c = fresh_running_controller(500.0)
+        assert c.tick(490.0) is True
+        assert c.status().relay_on is True
+
+    def test_above_band_turns_relay_off(self) -> None:
+        # OFF at >= 505. Start with relay on, then drive it off.
+        c = fresh_running_controller(500.0)
+        assert c.tick(490.0) is True
+        assert c.tick(510.0) is False
+
+    def test_inside_band_holds_prior_on_state(self) -> None:
+        c = fresh_running_controller(500.0)
+        assert c.tick(490.0) is True  # below band -> ON
+        # 500 is inside [495, 505] -> hold ON.
+        assert c.tick(500.0) is True
+        assert c.tick(502.0) is True
+
+    def test_inside_band_holds_prior_off_state(self) -> None:
+        c = fresh_running_controller(500.0)
+        assert c.tick(510.0) is False  # above band -> OFF
+        # 500 is inside the band -> hold OFF.
+        assert c.tick(500.0) is False
+        assert c.tick(498.0) is False
+
+    def test_relay_toggles_across_full_cycle(self) -> None:
+        c = fresh_running_controller(500.0)
+        assert c.tick(490.0) is True  # ON
+        assert c.tick(500.0) is True  # hold ON
+        assert c.tick(510.0) is False  # OFF
+        assert c.tick(500.0) is False  # hold OFF
+        assert c.tick(494.0) is True  # ON again
+
+    def test_on_threshold_is_inclusive(self) -> None:
+        # measured == setpoint - deadband should turn ON.
+        c = fresh_running_controller(500.0)
+        assert c.tick(495.0) is True
+
+    def test_off_threshold_is_inclusive(self) -> None:
+        # measured == setpoint + deadband should turn OFF.
+        c = fresh_running_controller(500.0)
+        c.tick(490.0)  # ON first
+        assert c.tick(505.0) is False
+
+    def test_non_finite_measured_coerced_to_zero(self) -> None:
+        # NaN measured -> 0 C, which is well below the band -> relay ON.
+        c = fresh_running_controller(500.0)
+        assert c.tick(float("nan")) is True
+        assert c.status().measured_temp_c == 0.0
+
+
+# --------------------------------------------------------------------------
+# HH cutoff
+# --------------------------------------------------------------------------
+
+
+class TestHHCutoff:
+    def test_hh_trips_at_limit(self) -> None:
+        c = TemperatureController(TemperatureConfig(hh_limit_c=1000.0))
+        c.set_permissive(True)
+        c.set_setpoint_c(800.0)
+        # measured == hh_limit -> trips (>= is inclusive).
+        relay = c.tick(1000.0)
+        assert relay is False
+        assert c.state == TemperatureState.TRIPPED
+        assert "HH_TEMP" in c.trips
+
+    def test_hh_does_not_trip_below_limit(self) -> None:
+        c = TemperatureController(TemperatureConfig(hh_limit_c=1000.0))
+        c.set_permissive(True)
+        c.set_setpoint_c(800.0)
+        c.tick(999.0)
+        assert c.state == TemperatureState.RUNNING
+        assert c.trips == []
+
+    def test_hh_forces_relay_off_even_when_below_band(self) -> None:
+        # Without the HH trip, a temp well below the band would turn the relay
+        # ON. The HH latch must win and force it off.
+        c = TemperatureController(TemperatureConfig(hh_limit_c=1000.0))
+        c.set_permissive(True)
+        c.set_setpoint_c(800.0)
+        c.tick(1000.0)  # latch the trip
+        assert c.tick(100.0) is False  # safe/cold tick, but trip latched
+
+    def test_hh_trip_latches_through_safe_subsequent_tick(self) -> None:
+        c = TemperatureController(TemperatureConfig(hh_limit_c=1000.0))
+        c.set_permissive(True)
+        c.set_setpoint_c(800.0)
+        c.tick(1000.0)
+        assert c.state == TemperatureState.TRIPPED
+        # Temperature returns to a safe band; the trip must stay latched.
+        c.tick(500.0)
+        assert c.state == TemperatureState.TRIPPED
+        assert "HH_TEMP" in c.trips
+
+
+# --------------------------------------------------------------------------
+# acknowledge_trip transitions
+# --------------------------------------------------------------------------
+
+
+class TestAcknowledge:
+    def test_acknowledge_clears_trips_and_returns_to_armed(self) -> None:
+        c = fresh_running_controller(500.0)
+        c.tick(1500.0)
+        assert c.state == TemperatureState.TRIPPED
+        cleared = c.acknowledge_trip()
+        assert cleared is True
+        assert c.trips == []
+        # Permissive was on; ack returns to ARMED, not IDLE.
+        assert c.state == TemperatureState.ARMED
+
+    def test_acknowledge_with_permissive_off_returns_to_idle(self) -> None:
+        c = fresh_running_controller(500.0)
+        c.tick(1500.0)
+        c.set_permissive(False)
+        c.acknowledge_trip()
+        assert c.state == TemperatureState.IDLE
+
+    def test_acknowledge_with_no_trip_returns_false(self) -> None:
+        c = fresh_armed_controller()
+        assert c.acknowledge_trip() is False
+
+
+# --------------------------------------------------------------------------
+# tick() output guarantees in non-running states
+# --------------------------------------------------------------------------
+
+
+class TestTickOutput:
+    def test_tick_returns_false_in_idle(self) -> None:
+        c = fresh_idle_controller()
+        assert c.tick(100.0) is False
+
+    def test_tick_returns_false_in_armed(self) -> None:
+        c = fresh_armed_controller()
+        assert c.tick(100.0) is False
+
+    def test_now_argument_is_accepted_and_ignored(self) -> None:
+        c = fresh_running_controller(500.0)
+        assert c.tick(490.0, now=10.0) is True
+        assert c.tick(490.0, now=999.0) is True
+
+
+# --------------------------------------------------------------------------
+# E-stop — latched kill switch
+# --------------------------------------------------------------------------
+
+
+class TestEstop:
+    def test_engage_forces_relay_off_from_running(self) -> None:
+        c = fresh_running_controller(500.0)
+        assert c.tick(100.0) is True  # relay on (below band)
+        c.engage_estop()
+        assert c.tick(100.0) is False
+        assert c.estopped is True
+        assert c.state == TemperatureState.IDLE
+        assert c.permissive is False
+
+    def test_cannot_arm_while_estopped(self) -> None:
+        c = fresh_running_controller(500.0)
+        c.engage_estop()
+        c.set_permissive(True)  # ignored
+        assert c.permissive is False
+        assert c.state == TemperatureState.IDLE
+        assert c.tick(100.0) is False
+
+    def test_clear_releases_latch_and_requires_rearm(self) -> None:
+        c = fresh_running_controller(500.0)
+        c.engage_estop()
+        c.clear_estop()
+        assert c.estopped is False
+        assert c.permissive is False  # must re-arm explicitly
+        assert c.state == TemperatureState.IDLE
+        # After re-arm + setpoint, the relay fires again.
+        c.set_permissive(True)
+        c.set_setpoint_c(500.0)
+        assert c.tick(100.0) is True
+
+    def test_clear_when_not_estopped_is_noop(self) -> None:
+        c = fresh_running_controller(500.0)
+        c.clear_estop()
+        assert c.estopped is False
+        assert c.state == TemperatureState.RUNNING
+
+
+# --------------------------------------------------------------------------
+# update_config runtime behavior
+# --------------------------------------------------------------------------
+
+
+class TestUpdateConfig:
+    def test_update_config_re_clamps_existing_setpoint(self) -> None:
+        c = fresh_running_controller(900.0)
+        # New config with a stricter max -> setpoint should re-clamp to 500.
+        c.update_config(TemperatureConfig(setpoint_max_c=500.0))
+        # State unchanged by the config swap.
+        assert c.state == TemperatureState.RUNNING
+        # The re-clamped setpoint (500) drives the band: 600 is above
+        # 500 + 5 -> relay OFF.
+        assert c.tick(600.0) is False
+        # 490 is below 500 - 5 -> relay ON, proving the clamp moved the band.
+        assert c.tick(490.0) is True
+
+    def test_update_config_type_check(self) -> None:
+        c = fresh_idle_controller()
+        with pytest.raises(TypeError):
+            c.update_config({"setpoint_max_c": 500.0})
+
+    def test_update_config_does_not_change_state(self) -> None:
+        c = fresh_armed_controller()
+        c.update_config(TemperatureConfig(deadband_c=10.0))
+        assert c.state == TemperatureState.ARMED
+        assert c.config.deadband_c == 10.0

--- a/src/p1am_control_system/backend/tests/test_temperature_integration.py
+++ b/src/p1am_control_system/backend/tests/test_temperature_integration.py
@@ -1,0 +1,217 @@
+"""Tests for the TemperatureService and FastAPI router wiring.
+
+Covers:
+    - TemperatureService.poll() scales the thermocouple tag (percent of full
+      scale) into deg C, ticks the controller, and drives the heater relay
+      coil via the client's public write_coil seam.
+    - The relay is commanded OFF whenever the controller forces it off
+      (not running / permissive off / E-stop / HH trip), and a failed coil
+      write never aborts the scan.
+    - The FastAPI router exposes every documented endpoint with the right
+      shape (GET/PUT /config, GET /status, POST /setpoint, POST /permissive,
+      POST /acknowledge_trip).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import hardware  # noqa: E402
+from temperature_integration import (  # noqa: E402
+    TemperatureService,
+    create_temperature_router,
+)
+from temperature_models import TemperatureConfig, TemperatureState  # noqa: E402
+
+
+class _FakePLC:
+    """Minimal PLC double — only the coil seam TemperatureService touches."""
+
+    def __init__(self, *, connected: bool = True) -> None:
+        self.connected = connected
+        self.write_coil = AsyncMock(return_value=True)
+
+
+def _service(plc: Any | None = None) -> TemperatureService:
+    return TemperatureService(plc or _FakePLC(), logging.getLogger("test"))
+
+
+# --------------------------------------------------------------------------
+# poll + tag scaling
+# --------------------------------------------------------------------------
+
+
+class TestTemperatureServicePoll:
+    def test_poll_with_no_tags_is_zero_and_relay_off(self) -> None:
+        async def _go() -> None:
+            plc = _FakePLC()
+            svc = _service(plc)
+            status = await svc.poll(None)
+            assert status.measured_temp_c == 0.0
+            assert status.relay_on is False
+            assert status.state == TemperatureState.IDLE
+            plc.write_coil.assert_awaited_with(hardware.HEATER_RELAY_COIL, False)
+
+        asyncio.run(_go())
+
+    def test_temp_from_tags_scales_percent_to_celsius(self) -> None:
+        svc = _service()
+        cfg = TemperatureConfig(temp_full_scale_c=1400.0, temp_tag="TAG_0")
+        svc.controller.update_config(cfg)
+        # 50 % of a 1400 C range -> 700 C
+        assert svc._temp_from_tags({"TAG_0": 50.0}) == pytest.approx(700.0)
+        assert svc._temp_from_tags({}) == 0.0
+        assert svc._temp_from_tags(None) == 0.0
+
+    def test_poll_closes_relay_when_running_and_below_band(self) -> None:
+        async def _go() -> None:
+            plc = _FakePLC()
+            svc = _service(plc)
+            svc.controller.set_permissive(True)
+            svc.controller.set_setpoint_c(700.0)  # ARMED -> RUNNING
+            # Measured well below (setpoint - deadband) -> heater should close.
+            status = await svc.poll({"TAG_0": 0.0})
+            assert status.relay_on is True
+            plc.write_coil.assert_awaited_with(hardware.HEATER_RELAY_COIL, True)
+
+        asyncio.run(_go())
+
+    def test_poll_opens_relay_above_band(self) -> None:
+        async def _go() -> None:
+            plc = _FakePLC()
+            svc = _service(plc)
+            svc.controller.set_permissive(True)
+            svc.controller.set_setpoint_c(700.0)
+            # 60 % of 1400 = 840 C, above setpoint + deadband -> relay off.
+            status = await svc.poll({"TAG_0": 60.0})
+            assert status.relay_on is False
+            plc.write_coil.assert_awaited_with(hardware.HEATER_RELAY_COIL, False)
+
+        asyncio.run(_go())
+
+    def test_hh_cutoff_latches_relay_off(self) -> None:
+        async def _go() -> None:
+            plc = _FakePLC()
+            svc = _service(plc)
+            svc.controller.update_config(
+                TemperatureConfig(hh_limit_c=1000.0, temp_full_scale_c=1400.0)
+            )
+            svc.controller.set_permissive(True)
+            svc.controller.set_setpoint_c(700.0)
+            # 80 % of 1400 = 1120 C >= hh_limit -> trip + relay off.
+            status = await svc.poll({"TAG_0": 80.0})
+            assert status.relay_on is False
+            assert status.state == TemperatureState.TRIPPED
+            assert "HH_TEMP" in status.trips
+
+        asyncio.run(_go())
+
+    def test_estop_forces_relay_off(self) -> None:
+        async def _go() -> None:
+            plc = _FakePLC()
+            svc = _service(plc)
+            svc.controller.set_permissive(True)
+            svc.controller.set_setpoint_c(700.0)
+            svc.engage_estop()
+            status = await svc.poll({"TAG_0": 0.0})
+            assert status.relay_on is False
+            assert status.estopped is True
+            plc.write_coil.assert_awaited_with(hardware.HEATER_RELAY_COIL, False)
+
+        asyncio.run(_go())
+
+    def test_failed_coil_write_does_not_raise(self) -> None:
+        async def _go() -> None:
+            plc = _FakePLC()
+            plc.write_coil = AsyncMock(side_effect=RuntimeError("bus dropped"))
+            svc = _service(plc)
+            svc.controller.set_permissive(True)
+            svc.controller.set_setpoint_c(700.0)
+            # Must not propagate — poll returns a status regardless.
+            status = await svc.poll({"TAG_0": 0.0})
+            assert status.state == TemperatureState.RUNNING
+
+        asyncio.run(_go())
+
+
+# --------------------------------------------------------------------------
+# FastAPI router endpoints
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client_and_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[TestClient, TemperatureService]:
+    monkeypatch.setenv("P1AM_DEV_NO_AUTH", "1")
+    svc = _service()
+    app = FastAPI()
+    app.include_router(create_temperature_router(svc))
+    return TestClient(app), svc
+
+
+class TestRouterEndpoints:
+    def test_get_config_returns_defaults(
+        self, client_and_service: tuple[TestClient, TemperatureService]
+    ) -> None:
+        client, _ = client_and_service
+        resp = client.get("/api/temperature/config")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["temp_full_scale_c"] == 1400.0
+        assert body["hh_limit_c"] == 1400.0
+
+    def test_put_config_validates_and_replaces(
+        self, client_and_service: tuple[TestClient, TemperatureService]
+    ) -> None:
+        client, svc = client_and_service
+        new_cfg = svc.controller.config.model_dump()
+        new_cfg["deadband_c"] = 10.0
+        resp = client.put("/api/temperature/config", json=new_cfg)
+        assert resp.status_code == 200
+        assert svc.controller.config.deadband_c == 10.0
+
+    def test_put_config_invalid_invariant_returns_422(
+        self, client_and_service: tuple[TestClient, TemperatureService]
+    ) -> None:
+        client, svc = client_and_service
+        bad = svc.controller.config.model_dump()
+        bad["hh_limit_c"] = 9999.0  # exceeds temp_full_scale_c
+        resp = client.put("/api/temperature/config", json=bad)
+        assert resp.status_code == 422
+
+    def test_permissive_toggle_arms(
+        self, client_and_service: tuple[TestClient, TemperatureService]
+    ) -> None:
+        client, _ = client_and_service
+        resp = client.post("/api/temperature/permissive", json={"enabled": True})
+        assert resp.json()["state"] == TemperatureState.ARMED
+
+    def test_setpoint_applies_and_clamps(
+        self, client_and_service: tuple[TestClient, TemperatureService]
+    ) -> None:
+        client, _ = client_and_service
+        client.post("/api/temperature/permissive", json={"enabled": True})
+        resp = client.post("/api/temperature/setpoint", json={"value_c": 99999.0})
+        assert resp.status_code == 200
+        assert resp.json()["applied_c"] == 1400.0  # clamped to setpoint_max_c
+
+    def test_acknowledge_trip_no_op_returns_status(
+        self, client_and_service: tuple[TestClient, TemperatureService]
+    ) -> None:
+        client, _ = client_and_service
+        resp = client.post("/api/temperature/acknowledge_trip")
+        assert resp.status_code == 200
+        assert resp.json()["state"] == TemperatureState.IDLE

--- a/src/p1am_control_system/backend/tests/test_temperature_models.py
+++ b/src/p1am_control_system/backend/tests/test_temperature_models.py
@@ -1,0 +1,135 @@
+"""Config-level validation tests for TemperatureConfig + TemperatureStatus.
+
+Companion (`test_temperature_controller.py`) covers the state machine, setpoint
+clamping, hysteresis, HH cutoff, acknowledge, and E-stop behavior.
+
+Covers here:
+    - Pydantic config validation (field constraints, cross-field invariants)
+    - heater_label trimming / blank / overlong rejection
+    - TemperatureStatus construction + StrEnum serialization
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pydantic import ValidationError  # noqa: E402
+from temperature_models import (  # noqa: E402  (path setup above must run first)
+    TemperatureConfig,
+    TemperatureState,
+    TemperatureStatus,
+)
+
+# --------------------------------------------------------------------------
+# TemperatureConfig validation
+# --------------------------------------------------------------------------
+
+
+class TestTemperatureConfigValidation:
+    def test_defaults_construct(self) -> None:
+        config = TemperatureConfig()
+        assert config.temp_tag == "TAG_0"
+        assert config.temp_full_scale_c == 1400.0
+        assert config.setpoint_min_c == 0.0
+        assert config.setpoint_max_c == 1400.0
+        assert config.deadband_c == 5.0
+        assert config.hh_limit_c == 1400.0
+        assert config.heater_label == "Heater"
+
+    def test_full_scale_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(temp_full_scale_c=0.0)
+        with pytest.raises(ValidationError):
+            TemperatureConfig(temp_full_scale_c=-1.0)
+
+    def test_setpoint_min_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(setpoint_min_c=-1.0)
+
+    def test_setpoint_max_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(setpoint_max_c=0.0)
+
+    def test_deadband_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(deadband_c=0.0)
+        with pytest.raises(ValidationError):
+            TemperatureConfig(deadband_c=-5.0)
+
+    def test_hh_limit_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(hh_limit_c=0.0)
+
+    def test_setpoint_min_cannot_exceed_max(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(setpoint_min_c=600.0, setpoint_max_c=500.0)
+
+    def test_setpoint_min_equal_to_max_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(setpoint_min_c=500.0, setpoint_max_c=500.0)
+
+    def test_setpoint_max_cannot_exceed_full_scale(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(temp_full_scale_c=1000.0, setpoint_max_c=1200.0)
+
+    def test_hh_limit_cannot_exceed_full_scale(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(temp_full_scale_c=1000.0, hh_limit_c=1200.0)
+
+    def test_in_range_invariants_construct(self) -> None:
+        cfg = TemperatureConfig(
+            temp_full_scale_c=1400.0,
+            setpoint_min_c=50.0,
+            setpoint_max_c=900.0,
+            hh_limit_c=1000.0,
+        )
+        assert cfg.setpoint_max_c == 900.0
+        assert cfg.hh_limit_c == 1000.0
+
+    def test_heater_label_is_trimmed(self) -> None:
+        assert TemperatureConfig(heater_label="  Furnace  ").heater_label == "Furnace"
+
+    def test_blank_heater_label_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(heater_label="   ")
+        with pytest.raises(ValidationError):
+            TemperatureConfig(heater_label="")
+
+    def test_overlong_heater_label_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            TemperatureConfig(heater_label="x" * 41)
+
+
+# --------------------------------------------------------------------------
+# TemperatureStatus snapshot model
+# --------------------------------------------------------------------------
+
+
+class TestTemperatureStatus:
+    def test_status_constructs_and_serializes(self) -> None:
+        status = TemperatureStatus(
+            state=TemperatureState.RUNNING,
+            permissive=True,
+            setpoint_c=500.0,
+            measured_temp_c=480.0,
+            relay_on=True,
+            trips=[],
+            hh_limit_c=1400.0,
+            deadband_c=5.0,
+        )
+        assert status.state == TemperatureState.RUNNING
+        assert status.estopped is False  # default
+        dumped = status.model_dump()
+        # StrEnum members serialize as plain strings.
+        assert dumped["state"] == "running"
+
+    def test_state_enum_values(self) -> None:
+        assert TemperatureState.IDLE == "idle"
+        assert TemperatureState.ARMED == "armed"
+        assert TemperatureState.RUNNING == "running"
+        assert TemperatureState.TRIPPED == "tripped"

--- a/src/p1am_control_system/firmware/HardwareInterface.h
+++ b/src/p1am_control_system/firmware/HardwareInterface.h
@@ -28,6 +28,11 @@ class HardwareInterface {
   // Drive the safety Inhibit GPIO.
   // Precondition: none
   virtual void WriteInhibit(bool active) = 0;
+
+  // Drive the heater relay discrete output (24 V DO -> relay -> 110 V heater).
+  // Precondition: none. Postcondition: relay energized iff `on`. Implemented as
+  // a safe no-op until a discrete-output module slot is configured.
+  virtual void WriteHeaterRelay(bool on) = 0;
 };
 
 #endif  // P1AM_CONTROL_SYSTEM_FIRMWARE_HARDWARE_INTERFACE_H_

--- a/src/p1am_control_system/firmware/P1AMHardware.cpp
+++ b/src/p1am_control_system/firmware/P1AMHardware.cpp
@@ -72,3 +72,14 @@ void P1AMHardware::WriteAnalogOutput(int channel, float value) {
 void P1AMHardware::WriteInhibit(bool active) {
   digitalWrite(kPinInhibit, active ? HIGH : LOW);
 }
+
+void P1AMHardware::WriteHeaterRelay(bool on) {
+  // Safe no-op until a discrete-output module slot is configured (see header).
+  // This keeps the bench-verified build unchanged when no DO module is present.
+  if (kSlotRelay < 0) {
+    return;
+  }
+  // P1.writeDiscrete drives one channel of a discrete-output module.
+  // Library channels are 1-indexed (kChanRelay).
+  P1.writeDiscrete(on ? HIGH : LOW, kSlotRelay, kChanRelay);
+}

--- a/src/p1am_control_system/firmware/P1AMHardware.h
+++ b/src/p1am_control_system/firmware/P1AMHardware.h
@@ -14,6 +14,7 @@ class P1AMHardware : public HardwareInterface {
   float ReadAnalogInput(int channel) override;
   void WriteAnalogOutput(int channel, float value) override;
   void WriteInhibit(bool active) override;
+  void WriteHeaterRelay(bool on) override;
 
  private:
   // Actual bench-verified slot order via P1.printModules() on 2026-06-01:
@@ -21,6 +22,14 @@ class P1AMHardware : public HardwareInterface {
   //   Slot 2 = P1-04THM        (4-channel thermocouple)
   static const int kSlotAna = 1;
   static const int kSlotThm = 2;
+  // Heater relay discrete-output module. The bench stack currently has NO
+  // discrete-output module, so this is -1 (disabled -> WriteHeaterRelay is a
+  // no-op). When a P1-08TD*/P1-08TRS (or similar 24 V DO) module is installed,
+  // set kSlotRelay to its slot (from P1.printModules()) and kChanRelay to the
+  // wired channel (1-indexed), then reflash. The temperature controller drives
+  // this via Modbus coil 2.
+  static const int kSlotRelay = -1;
+  static const int kChanRelay = 1;
   // Inhibit GPIO. MUST NOT be pin 5 — the P1AM-ETH shield hardwires the W5500
   // chip-select to D5, so driving D5 from this firmware breaks Ethernet SPI.
   // D6 is free on the P1AM-100 / P1AM-ETH stack.

--- a/src/p1am_control_system/firmware/firmware.ino
+++ b/src/p1am_control_system/firmware/firmware.ino
@@ -27,6 +27,10 @@ StorageManager storage;
 unsigned long lastScanTime = 0;
 const unsigned long kScanIntervalMs = 100;
 
+// Modbus coil 2 = heater relay command from the temperature controller.
+// (Coil 0 = save-to-flash, coil 1 = E-stop reset.)
+const int kHeaterRelayCoil = 2;
+
 // Helper to Pack Float into 2 Modbus registers (IEEE-754)
 void WriteFloatToModbus(int regAddress, float val) {
   uint32_t raw;
@@ -245,6 +249,10 @@ void loop() {
       pids[i].Compute(broker, 0.1f);
     }
     interlock.Evaluate(broker, hw);
+    // Heater relay (Modbus coil 2): the temperature controller commands it, but
+    // the safety interlock always wins — a trip forces the relay off regardless.
+    bool relay_cmd = (modbusServer.coilRead(kHeaterRelayCoil) == 1);
+    hw.WriteHeaterRelay(relay_cmd && !interlock.IsTripped());
     for (int i = 0; i < SignalBroker::kNumTags; ++i) {
       WriteFloatToModbus(i * 2, broker.GetTag(i));
     }

--- a/src/p1am_control_system/frontend/src/App.tsx
+++ b/src/p1am_control_system/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { ProjectImporter } from "./components/ProjectImporter";
 import { LadderExplorer } from "./components/LadderExplorer";
 import { PlantHierarchy } from "./components/PlantHierarchy";
 import { PowerSupplyControl } from "./components/PowerSupplyControl";
+import { TemperatureControl } from "./components/TemperatureControl";
 import type { LadderTagInfo } from "./api/schemas";
 import { NotificationBanner } from "./components/NotificationBanner";
 import { TabBar } from "./components/TabBar";
@@ -103,6 +104,7 @@ export const App: React.FC = () => {
     activeAlarms,
     eStopActive,
     powerSupplyStatus,
+    temperatureStatus,
     isConnected,
     setAlicats,
     setActiveAlarms,
@@ -646,6 +648,10 @@ export const App: React.FC = () => {
               liveStatus={powerSupplyStatus}
               onExport={() => setInspectorView({ type: "export" })}
             />
+          )}
+
+          {activeTab === "temperature" && visibleTabs.temperature && (
+            <TemperatureControl liveStatus={temperatureStatus} />
           )}
 
           {/* Render Tab Contents */}

--- a/src/p1am_control_system/frontend/src/api/schemas.ts
+++ b/src/p1am_control_system/frontend/src/api/schemas.ts
@@ -79,6 +79,7 @@ export const telemetryFrameSchema = z.object({
   active_alarms: z.record(z.string(), activeAlarmSchema).optional(),
   e_stop_active: z.boolean().optional(),
   power_supply: z.unknown().optional(),
+  temperature: z.unknown().optional(),
 });
 export type TelemetryFrame = z.infer<typeof telemetryFrameSchema>;
 

--- a/src/p1am_control_system/frontend/src/components/PowerSupplyControl.css
+++ b/src/p1am_control_system/frontend/src/components/PowerSupplyControl.css
@@ -634,3 +634,101 @@
   fill: var(--text-muted);
   font-size: 12px;
 }
+
+/* ---- Signal noise / arc detection ---- */
+.ps-noise .ps-card-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.ps-noise.is-arcing {
+  border-color: var(--color-danger, #ef4444);
+  box-shadow: 0 0 0 1px var(--color-danger, #ef4444),
+    0 0 18px rgba(239, 68, 68, 0.25);
+  animation: ps-arc-pulse 1.1s ease-in-out infinite;
+}
+@keyframes ps-arc-pulse {
+  0%, 100% { box-shadow: 0 0 0 1px var(--color-danger, #ef4444), 0 0 8px rgba(239, 68, 68, 0.2); }
+  50% { box-shadow: 0 0 0 1px var(--color-danger, #ef4444), 0 0 22px rgba(239, 68, 68, 0.45); }
+}
+.ps-arc-badge {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  color: var(--text-muted);
+  background: var(--input-bg);
+  border: 1px solid var(--panel-border);
+}
+.ps-arc-badge.is-arcing {
+  color: #fff;
+  background: var(--color-danger, #ef4444);
+  border-color: var(--color-danger, #ef4444);
+}
+.ps-noise-hint {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0.35rem 0 0.75rem;
+}
+.ps-noise-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+.ps-noise-ch {
+  background: var(--input-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 0.7rem 0.85rem;
+}
+.ps-noise-ch.is-arcing {
+  border-color: var(--color-danger, #ef4444);
+  background: rgba(239, 68, 68, 0.06);
+}
+.ps-noise-ch-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.ps-noise-flag {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: var(--color-danger, #ef4444);
+}
+.ps-noise-metric {
+  font-family: var(--font-mono);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-top: 0.25rem;
+}
+.ps-noise-unit {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.ps-noise-sub {
+  font-size: 0.66rem;
+  color: var(--text-muted);
+  margin-top: 0.1rem;
+}
+.ps-noise-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  margin-top: 0.55rem;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--text-secondary);
+}

--- a/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
+++ b/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
@@ -53,6 +53,29 @@ export interface PowerSupplyConfig {
    * would scale higher. Operator safety limit for live-current testing.
    */
   output_clamp_percent: number;
+  /** Rolling window (sample count) used to quantify feedback noise. */
+  noise_window: number;
+  /** Which noise metric the arc thresholds are compared against. */
+  noise_metric: NoiseMetric;
+  /** Arc-detect threshold for current-feedback noise (null = disabled). */
+  current_arc_threshold: number | null;
+  /** Arc-detect threshold for voltage-feedback noise (null = disabled). */
+  voltage_arc_threshold: number | null;
+}
+
+export type NoiseMetric = "std" | "peak_to_peak" | "rms" | "cv";
+
+export interface NoiseStats {
+  sample_count: number;
+  mean: number;
+  std: number;
+  peak_to_peak: number;
+  rms_about_mean: number;
+  coeff_of_variation: number;
+  metric: NoiseMetric;
+  metric_value: number;
+  threshold: number | null;
+  arcing: boolean;
 }
 
 export interface PowerSupplyStatus {
@@ -73,6 +96,12 @@ export interface PowerSupplyStatus {
   output_clamped: boolean;
   /** Real deliverable max current given the clamp (clamp% × full-scale). */
   effective_max_current_a: number;
+  /** Rolling noise/variability stats for the current feedback. */
+  current_noise: NoiseStats;
+  /** Rolling noise/variability stats for the voltage feedback. */
+  voltage_noise: NoiseStats;
+  /** True when either channel's noise metric exceeds its arc threshold. */
+  arcing: boolean;
 }
 
 interface Props {
@@ -95,6 +124,37 @@ const STATE_HINTS: Record<PowerSupplyStatus["state"], string> = {
   running: "commanding output",
   tripped: "latched · acknowledge",
 };
+
+const NOISE_METRIC_LABELS: Record<NoiseMetric, string> = {
+  std: "Std deviation",
+  peak_to_peak: "Peak-to-peak",
+  rms: "AC RMS",
+  cv: "Coeff. of variation",
+};
+
+const NOISE_METRIC_HINTS: Record<NoiseMetric, string> = {
+  std: "sample standard deviation, in engineering units (A / V)",
+  peak_to_peak: "max − min over the window, in engineering units (A / V)",
+  rms: "RMS of the AC content about the mean, in engineering units (A / V)",
+  cv: "std ÷ |mean|, a dimensionless ratio (noise relative to DC level)",
+};
+
+/** Pull the value of the selected metric out of a NoiseStats snapshot. */
+function noiseMetricValue(stats: NoiseStats | undefined): number | null {
+  if (!stats) return null;
+  switch (stats.metric) {
+    case "std":
+      return stats.std;
+    case "peak_to_peak":
+      return stats.peak_to_peak;
+    case "rms":
+      return stats.rms_about_mean;
+    case "cv":
+      return stats.coeff_of_variation;
+    default:
+      return stats.metric_value;
+  }
+}
 
 export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) => {
   const [config, setConfig] = useState<PowerSupplyConfig | null>(null);
@@ -675,6 +735,39 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
         </div>
       </div>
 
+      {/* ---- Signal noise / arc detection ---- */}
+      <div className={`ps-card ps-noise ${s?.arcing ? "is-arcing" : ""}`}>
+        <div className="ps-card-title">
+          <span>Signal noise · arc detection</span>
+          <span className={`ps-arc-badge ${s?.arcing ? "is-arcing" : ""}`}>
+            {s?.arcing ? "⚡ POSSIBLE ARCING" : "stable"}
+          </span>
+        </div>
+        <p className="ps-noise-hint">
+          A DC arc rides as AC noise on the feedback. Watch the{" "}
+          <strong>{NOISE_METRIC_LABELS[config.noise_metric]}</strong> — when it
+          jumps while the setpoint is steady, the arc is active. Set a threshold
+          below to flag it automatically. Window:{" "}
+          <strong>{config.noise_window}</strong> samples (~
+          {(config.noise_window / 10).toFixed(0)} s @ 10 Hz) ·{" "}
+          {NOISE_METRIC_HINTS[config.noise_metric]}.
+        </p>
+        <div className="ps-noise-grid">
+          <NoiseChannel
+            title={config.current_feedback_label}
+            unit="A"
+            stats={s?.current_noise}
+            threshold={config.current_arc_threshold}
+          />
+          <NoiseChannel
+            title={config.voltage_feedback_label}
+            unit="V"
+            stats={s?.voltage_noise}
+            threshold={config.voltage_arc_threshold}
+          />
+        </div>
+      </div>
+
       {/* ---- Advanced config ---- */}
       {/* ---- Calibration & signal names ---- */}
       <details className="ps-card ps-config">
@@ -871,6 +964,84 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
         </div>
       </details>
 
+      <details className="ps-card ps-config">
+        <summary>Arc / noise detection — window, metric, thresholds</summary>
+        <p className="ps-noise-hint">
+          Tune how the system decides it&apos;s arcing. Pick the metric that best
+          separates a quiet DC output from a noisy arc, size the averaging window,
+          then set per-channel thresholds (leave blank to disable that channel).
+        </p>
+        <div className="ps-config-grid">
+          <ConfigField
+            label="Noise window (samples)"
+            value={configDraft.noise_window}
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, noise_window: Math.round(v) })
+            }
+          />
+          <label className="ps-field">
+            <span>Noise metric</span>
+            <select
+              value={configDraft.noise_metric}
+              onChange={(e) =>
+                setConfigDraft({
+                  ...configDraft,
+                  noise_metric: e.target.value as NoiseMetric,
+                })
+              }
+            >
+              <option value="std">Std deviation (A / V)</option>
+              <option value="peak_to_peak">Peak-to-peak (A / V)</option>
+              <option value="rms">AC RMS (A / V)</option>
+              <option value="cv">Coeff. of variation (ratio)</option>
+            </select>
+          </label>
+          <label className="ps-field">
+            <span>Current arc threshold</span>
+            <input
+              type="number"
+              placeholder="disabled"
+              value={configDraft.current_arc_threshold ?? ""}
+              onChange={(e) =>
+                setConfigDraft({
+                  ...configDraft,
+                  current_arc_threshold:
+                    e.target.value === ""
+                      ? null
+                      : Number.parseFloat(e.target.value),
+                })
+              }
+            />
+          </label>
+          <label className="ps-field">
+            <span>Voltage arc threshold</span>
+            <input
+              type="number"
+              placeholder="disabled"
+              value={configDraft.voltage_arc_threshold ?? ""}
+              onChange={(e) =>
+                setConfigDraft({
+                  ...configDraft,
+                  voltage_arc_threshold:
+                    e.target.value === ""
+                      ? null
+                      : Number.parseFloat(e.target.value),
+                })
+              }
+            />
+          </label>
+        </div>
+        <div style={{ marginTop: "1rem" }}>
+          <button
+            className={`btn ${busy ? "ps-disabled" : ""}`}
+            onClick={saveConfig}
+            disabled={busy}
+          >
+            Save Detection
+          </button>
+        </div>
+      </details>
+
       {info && <div className="ps-toast is-info">{info}</div>}
       {error && <div className="ps-toast is-error">{error}</div>}
     </div>
@@ -949,6 +1120,45 @@ const Readout: React.FC<{ label: string; value: string; warning?: boolean }> = (
     <div className="ps-readout-value">{value}</div>
   </div>
 );
+
+const NoiseChannel: React.FC<{
+  title: string;
+  unit: string;
+  stats?: NoiseStats;
+  threshold: number | null;
+}> = ({ title, unit, stats, threshold }) => {
+  const metric = stats?.metric ?? "std";
+  const u = metric === "cv" ? "" : unit;
+  const value = noiseMetricValue(stats);
+  const arcing = stats?.arcing ?? false;
+  const fmt = (n: number | null | undefined, digits = 3) =>
+    n == null ? "—" : n.toFixed(digits);
+  return (
+    <div className={`ps-noise-ch ${arcing ? "is-arcing" : ""}`}>
+      <div className="ps-noise-ch-head">
+        <span>{title}</span>
+        {arcing && <span className="ps-noise-flag">arcing</span>}
+      </div>
+      <div className="ps-noise-metric">
+        {fmt(value)} <span className="ps-noise-unit">{u || "ratio"}</span>
+      </div>
+      <div className="ps-noise-sub">
+        {NOISE_METRIC_LABELS[metric]}
+        {threshold != null
+          ? ` · threshold ${threshold} ${u}`.trimEnd()
+          : " · no threshold set"}
+      </div>
+      <div className="ps-noise-stats">
+        <span>σ {fmt(stats?.std)}</span>
+        <span>p-p {fmt(stats?.peak_to_peak)}</span>
+        <span>rms {fmt(stats?.rms_about_mean)}</span>
+        <span>cv {fmt(stats?.coeff_of_variation)}</span>
+        <span>mean {fmt(stats?.mean, 2)}</span>
+        <span>n {stats?.sample_count ?? 0}</span>
+      </div>
+    </div>
+  );
+};
 
 interface ConfigFieldProps {
   label: string;

--- a/src/p1am_control_system/frontend/src/components/TemperatureControl.css
+++ b/src/p1am_control_system/frontend/src/components/TemperatureControl.css
@@ -1,0 +1,488 @@
+/* Temperature controller screen.
+ *
+ * Industrial-HMI styling built on the app theme variables (light/dark aware),
+ * mirroring the power-supply screen. Layout goals: a glanceable status header
+ * with a prominent heater relay indicator, an unambiguous setpoint entry, a
+ * high-high cutoff banner, live telemetry, and a single-trace temperature
+ * trend with setpoint / HH reference lines.
+ */
+
+.tc {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-family: var(--font-sans);
+}
+
+/* ---- Status header -------------------------------------------------- */
+.tc-status {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 1rem 1.25rem;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-left-width: 4px;
+  border-radius: 8px;
+  box-shadow: var(--card-shadow);
+  transition: border-color var(--transition-normal);
+}
+
+.tc-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  min-width: 6.5rem;
+}
+
+.tc-state-badge {
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: 1px;
+  line-height: 1.1;
+}
+
+.tc-state-sub {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+
+/* State color theming — applied to .tc-status and the badge. */
+.tc-status.is-idle {
+  border-left-color: var(--text-muted);
+}
+.tc-status.is-armed {
+  border-left-color: var(--accent-cyan);
+}
+.tc-status.is-running {
+  border-left-color: var(--color-success);
+}
+.tc-status.is-tripped {
+  border-left-color: var(--color-error);
+  background: rgba(var(--accent-magenta-rgb), 0.04);
+}
+.is-idle .tc-state-badge {
+  color: var(--text-muted);
+}
+.is-armed .tc-state-badge {
+  color: var(--accent-cyan);
+}
+.is-running .tc-state-badge {
+  color: var(--color-success);
+}
+.is-tripped .tc-state-badge {
+  color: var(--color-error);
+}
+
+.tc-status-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.tc-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+.tc-metric-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+.tc-metric-value {
+  font-family: var(--font-mono);
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.tc-metric-value.is-warning {
+  color: var(--color-warning);
+}
+
+.tc-status-actions {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+/* ---- Heater relay indicator ---------------------------------------- */
+/* Glances as a glowing, red-hot pill when the relay is closed. */
+.tc-relay {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.5rem 0.95rem;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--input-bg);
+  font-weight: 800;
+  font-size: 0.85rem;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  transition: all var(--transition-normal);
+}
+.tc-relay .tc-relay-coil {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 50%;
+  background: var(--text-muted);
+  box-shadow: 0 0 0 0 transparent;
+  transition: all var(--transition-normal);
+}
+.tc-relay.is-on {
+  border-color: var(--color-error);
+  color: var(--color-error);
+  background: linear-gradient(
+    180deg,
+    rgba(239, 68, 68, 0.18),
+    rgba(239, 68, 68, 0.05)
+  );
+  box-shadow: 0 0 14px 1px rgba(239, 68, 68, 0.45);
+}
+.tc-relay.is-on .tc-relay-coil {
+  background: var(--color-error);
+  box-shadow: 0 0 10px 2px var(--color-error);
+  animation: tc-relay-glow 1.2s ease-in-out infinite;
+}
+@keyframes tc-relay-glow {
+  0%,
+  100% {
+    box-shadow: 0 0 8px 1px var(--color-error);
+  }
+  50% {
+    box-shadow: 0 0 16px 4px var(--color-error);
+  }
+}
+
+/* ---- Permissive switch --------------------------------------------- */
+.tc-permissive {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  background: var(--input-bg);
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+}
+.tc-permissive:hover {
+  border-color: var(--text-muted);
+}
+.tc-permissive.is-on {
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+.tc-permissive .dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: var(--text-muted);
+  box-shadow: 0 0 0 0 transparent;
+  transition: all var(--transition-fast);
+}
+.tc-permissive.is-on .dot {
+  background: var(--color-success);
+  box-shadow: 0 0 8px 1px var(--color-success);
+}
+
+/* ---- Generic card --------------------------------------------------- */
+.tc-card {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 1.1rem 1.25rem;
+  box-shadow: var(--card-shadow);
+}
+
+.tc-card-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.75px;
+  color: var(--text-secondary);
+  margin-bottom: 0.9rem;
+}
+
+/* ---- Setpoint entry ------------------------------------------------- */
+.tc-setpoint-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+.tc-step-btn {
+  width: 3rem;
+  font-size: 1.4rem;
+  font-weight: 700;
+  background: var(--input-bg);
+  color: var(--text-primary);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+.tc-step-btn:hover:not(:disabled) {
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+.tc-setpoint-input {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 1.6rem;
+  font-weight: 700;
+  text-align: right;
+  padding: 0.35rem 0.7rem;
+}
+.tc-setpoint-input:focus {
+  outline: none;
+  border-color: var(--accent-cyan);
+}
+
+.tc-setpoint-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.8rem;
+  flex-wrap: wrap;
+}
+.tc-step-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+.tc-step-field input {
+  width: 4.5rem;
+  background: var(--input-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  padding: 0.3rem 0.4rem;
+}
+
+.tc-hint {
+  margin-top: 0.7rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.tc-setpoint-warn {
+  margin: 0.7rem 0 0;
+  padding: 0.45rem 0.7rem;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
+}
+
+/* ---- Telemetry ------------------------------------------------------ */
+.tc-readouts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.7rem;
+}
+.tc-readout {
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  background: var(--input-bg);
+  border: 1px solid var(--panel-border);
+}
+.tc-readout.is-warning {
+  border-color: var(--color-warning);
+  background: rgba(245, 158, 11, 0.08);
+}
+.tc-readout-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+}
+.tc-readout-value {
+  font-family: var(--font-mono);
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+.tc-readout.is-warning .tc-readout-value {
+  color: var(--color-warning);
+}
+
+/* ---- Trips + toasts ------------------------------------------------- */
+.tc-trip-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 1rem;
+  border-radius: 8px;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
+  font-weight: 700;
+}
+
+.tc-btn-danger {
+  background: var(--color-error);
+  border-color: var(--color-error);
+  color: #fff;
+}
+.tc-btn-danger:hover {
+  filter: brightness(1.08);
+}
+
+.tc-toast {
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+.tc-toast.is-info {
+  background: rgba(16, 185, 129, 0.1);
+  border: 1px solid var(--color-success);
+  color: var(--color-success);
+}
+.tc-toast.is-error {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid var(--color-error);
+  color: var(--color-error);
+}
+
+/* ---- Advanced config ------------------------------------------------ */
+.tc-config summary {
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+  user-select: none;
+}
+.tc-config-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+@media (max-width: 700px) {
+  .tc-config-grid {
+    grid-template-columns: 1fr;
+  }
+}
+.tc-field {
+  display: grid;
+  gap: 0.3rem;
+}
+.tc-field span {
+  font-size: 0.74rem;
+  color: var(--text-secondary);
+}
+.tc-field input {
+  background: var(--input-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  padding: 0.4rem 0.55rem;
+}
+.tc-field input:focus {
+  outline: none;
+  border-color: var(--accent-cyan);
+}
+
+.tc-disabled {
+  opacity: 0.5;
+  cursor: not-allowed !important;
+}
+
+/* ---- Live trend ----------------------------------------------------- */
+.tc-trend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.tc-trend-legend {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+.tc-trend-key {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.tc-trend-key .swatch {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 2px;
+}
+.tc-trend-key strong {
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+.tc-trend-window {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+.tc-trend-svg {
+  width: 100%;
+  height: 200px;
+  display: block;
+  background: var(--input-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+}
+.tc-trend-grid {
+  stroke: var(--panel-border);
+  stroke-width: 1;
+  opacity: 0.5;
+}
+.tc-trend-axis {
+  fill: var(--text-muted);
+  font-size: 9px;
+  font-family: var(--font-mono);
+}
+.tc-trend-line {
+  fill: none;
+  stroke-width: 2;
+  vector-effect: non-scaling-stroke;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+.tc-trend-ref {
+  stroke-width: 1.5;
+  stroke-dasharray: 5 4;
+  opacity: 0.85;
+  vector-effect: non-scaling-stroke;
+}
+.tc-trend-empty {
+  fill: var(--text-muted);
+  font-size: 12px;
+}

--- a/src/p1am_control_system/frontend/src/components/TemperatureControl.tsx
+++ b/src/p1am_control_system/frontend/src/components/TemperatureControl.tsx
@@ -1,0 +1,742 @@
+import React, { useEffect, useState, useCallback } from "react";
+import "./TemperatureControl.css";
+
+// Rolling trend buffer: ~300 samples at the ~10 Hz broadcast rate ≈ 30 s.
+const TREND_MAX_POINTS = 300;
+const TREND_WINDOW_SECONDS = 30;
+
+/**
+ * Temperature controller tab.
+ *
+ * Drives a resistive heater through an on/off relay using a thermocouple
+ * temperature reading (0–1400 °C). Talks to the backend's /api/temperature/*
+ * endpoints and consumes the `temperature` field on the /api/stream WebSocket
+ * payload (broadcast each scan tick by the parent), exactly like
+ * PowerSupplyControl.
+ *
+ * Safety patterns implemented:
+ *  - On/off (bang-bang) control: the relay closes below setpoint − deadband and
+ *    opens above setpoint. A prominent HEATER relay indicator shows real state.
+ *  - High-high cutoff: a hard limit that latches the heater OFF and trips the
+ *    controller; the operator must acknowledge to reset (server enforces).
+ *  - Setpoint clamping happens server-side, so the displayed value reflects what
+ *    was actually applied (not what was typed).
+ *  - "Apply Setpoint" commits the staged value — typing alone commands nothing.
+ *  - Permissive must be ON before any setpoint takes effect (server enforces).
+ */
+
+export interface TemperatureConfig {
+  temp_tag: string;
+  temp_full_scale_c: number;
+  setpoint_min_c: number;
+  setpoint_max_c: number;
+  deadband_c: number;
+  hh_limit_c: number;
+  heater_label: string;
+}
+
+export interface TemperatureStatus {
+  state: "idle" | "armed" | "running" | "tripped";
+  permissive: boolean;
+  setpoint_c: number;
+  measured_temp_c: number;
+  relay_on: boolean;
+  trips: string[];
+  hh_limit_c: number;
+  deadband_c: number;
+}
+
+interface Props {
+  /** Status pushed each scan via the parent's WebSocket; undefined while waiting. */
+  liveStatus?: TemperatureStatus;
+}
+
+const STATE_LABELS: Record<TemperatureStatus["state"], string> = {
+  idle: "IDLE",
+  armed: "ARMED",
+  running: "RUNNING",
+  tripped: "TRIPPED",
+};
+
+const STATE_HINTS: Record<TemperatureStatus["state"], string> = {
+  idle: "permissive off",
+  armed: "ready · set a target",
+  running: "regulating heater",
+  tripped: "latched · acknowledge",
+};
+
+/** True when any trip name looks like a high-high temperature cutoff. */
+function hasHighHighTrip(trips: string[]): boolean {
+  return trips.some((t) => /(hh|high.?high|over.?temp)/i.test(t));
+}
+
+export const TemperatureControl: React.FC<Props> = ({ liveStatus }) => {
+  const [config, setConfig] = useState<TemperatureConfig | null>(null);
+  const [configDraft, setConfigDraft] = useState<TemperatureConfig | null>(null);
+  const [stagedSetpointText, setStagedSetpointText] = useState<string>("0");
+  const [setpointStep, setSetpointStep] = useState<number>(10);
+  const [trend, setTrend] = useState<number[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+
+  // Load config once.
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch("/api/temperature/config");
+        if (!res.ok) throw new Error(`config GET ${res.status}`);
+        const cfg = (await res.json()) as TemperatureConfig;
+        setConfig(cfg);
+        setConfigDraft(cfg);
+      } catch (e) {
+        setError(`Load config failed: ${(e as Error).message}`);
+      }
+    };
+    load();
+  }, []);
+
+  // Accumulate a rolling trend buffer from the live status broadcasts.
+  useEffect(() => {
+    if (!liveStatus) return;
+    setTrend((prev) => {
+      const next = [...prev, liveStatus.measured_temp_c];
+      return next.length > TREND_MAX_POINTS
+        ? next.slice(next.length - TREND_MAX_POINTS)
+        : next;
+    });
+  }, [liveStatus]);
+
+  const flash = useCallback((msg: string, kind: "info" | "error" = "info") => {
+    if (kind === "info") {
+      setInfo(msg);
+      setError(null);
+    } else {
+      setError(msg);
+      setInfo(null);
+    }
+    setTimeout(() => {
+      setInfo(null);
+      setError(null);
+    }, 4000);
+  }, []);
+
+  const applySetpoint = useCallback(
+    async (rawValue: number) => {
+      if (!Number.isFinite(rawValue)) {
+        flash("Setpoint must be a finite number", "error");
+        return;
+      }
+      if (!config) {
+        flash("Config not loaded", "error");
+        return;
+      }
+      // Guard rail: the server silently ignores setpoints unless the controller
+      // is armed, so tell the operator instead of pretending it was applied.
+      // Without live status we can't verify permissive/trip — refuse.
+      if (!liveStatus) {
+        flash("Live status unavailable — cannot confirm permissive/trip.", "error");
+        return;
+      }
+      if (liveStatus.state === "tripped") {
+        flash("Controller is TRIPPED — acknowledge the trip first.", "error");
+        return;
+      }
+      if (!liveStatus.permissive) {
+        flash("Permissive is OFF — enable it before commanding the heater.", "error");
+        return;
+      }
+      setBusy(true);
+      try {
+        const res = await fetch("/api/temperature/setpoint", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ value_c: rawValue }),
+        });
+        const json = await res.json();
+        if (!res.ok) {
+          flash(`Setpoint rejected: ${json.detail ?? res.statusText}`, "error");
+          return;
+        }
+        const applied = json.applied_c as number;
+        setStagedSetpointText(applied.toFixed(1));
+        flash(`Applied ${applied.toFixed(1)} °C`);
+      } catch (e) {
+        flash(`Setpoint failed: ${(e as Error).message}`, "error");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [config, flash, liveStatus],
+  );
+
+  const nudgeSetpoint = useCallback(
+    (delta: number) => {
+      const current = Number.parseFloat(stagedSetpointText);
+      const next = Math.max(0, (Number.isFinite(current) ? current : 0) + delta);
+      setStagedSetpointText(next.toFixed(1));
+      applySetpoint(next);
+    },
+    [stagedSetpointText, applySetpoint],
+  );
+
+  const handleApplyClick = useCallback(() => {
+    const v = Number.parseFloat(stagedSetpointText);
+    if (!Number.isFinite(v)) {
+      flash("Enter a number first", "error");
+      return;
+    }
+    applySetpoint(v);
+  }, [stagedSetpointText, applySetpoint, flash]);
+
+  const setPermissive = useCallback(
+    async (enabled: boolean) => {
+      if (
+        !enabled &&
+        liveStatus?.relay_on &&
+        !window.confirm(
+          "Disabling permissive will open the heater relay immediately. Continue?",
+        )
+      )
+        return;
+      setBusy(true);
+      try {
+        const res = await fetch("/api/temperature/permissive", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ enabled }),
+        });
+        if (!res.ok) throw new Error(await res.text());
+        flash(enabled ? "Permissive ON" : "Permissive OFF");
+      } catch (e) {
+        flash(`Permissive set failed: ${(e as Error).message}`, "error");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [liveStatus?.relay_on, flash],
+  );
+
+  const acknowledgeTrip = useCallback(async () => {
+    setBusy(true);
+    try {
+      const res = await fetch("/api/temperature/acknowledge_trip", {
+        method: "POST",
+      });
+      if (!res.ok) throw new Error(await res.text());
+      flash("Trip acknowledged");
+    } catch (e) {
+      flash(`Ack failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [flash]);
+
+  const saveConfig = useCallback(async () => {
+    if (!configDraft) return;
+    setBusy(true);
+    try {
+      const res = await fetch("/api/temperature/config", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(configDraft),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        flash(
+          `Config rejected: ${
+            json.detail ? JSON.stringify(json.detail) : res.statusText
+          }`,
+          "error",
+        );
+        return;
+      }
+      setConfig(json);
+      setConfigDraft(json);
+      flash("Configuration saved");
+    } catch (e) {
+      flash(`Config save failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [configDraft, flash]);
+
+  if (!config || !configDraft) {
+    return (
+      <div className="tc">
+        <div className="tc-card" style={{ color: "var(--text-muted)" }}>
+          Loading temperature config…
+        </div>
+      </div>
+    );
+  }
+
+  const s = liveStatus;
+  const state = s?.state ?? "idle";
+  const relayOn = s?.relay_on ?? false;
+  const hhLimit = s?.hh_limit_c ?? config.hh_limit_c;
+  const deadband = s?.deadband_c ?? config.deadband_c;
+  const tripped = state === "tripped";
+  const hhTripped = tripped || (s ? hasHighHighTrip(s.trips) : false);
+
+  // Highlight measured temperature amber within ~90 % of the HH limit.
+  const tempWarn = s ? s.measured_temp_c >= 0.9 * hhLimit : false;
+
+  // Live setpoint warning (shown under the entry; does not block typing).
+  const stagedValue = Number.parseFloat(stagedSetpointText);
+  let setpointWarning: string | null = null;
+  if (Number.isFinite(stagedValue)) {
+    if (stagedValue > config.setpoint_max_c) {
+      setpointWarning = `Above max setpoint (${config.setpoint_max_c} °C) — will be clamped.`;
+    } else if (stagedValue < config.setpoint_min_c) {
+      setpointWarning = `Below min setpoint (${config.setpoint_min_c} °C) — will be clamped.`;
+    } else if (stagedValue >= hhLimit) {
+      setpointWarning = `At or above the high-high cutoff (${hhLimit} °C) — the heater would latch OFF.`;
+    }
+  }
+
+  return (
+    <div className="tc">
+      {/* ---- Status header ---- */}
+      <div className={`tc-status is-${state}`}>
+        <div className="tc-state">
+          <span className="tc-state-badge">{STATE_LABELS[state]}</span>
+          <span className="tc-state-sub">{STATE_HINTS[state]}</span>
+        </div>
+
+        <div className="tc-status-metrics">
+          <div className="tc-metric">
+            <span className="tc-metric-label">Measured</span>
+            <span className={`tc-metric-value ${tempWarn ? "is-warning" : ""}`}>
+              {s ? s.measured_temp_c.toFixed(1) : "—"} °C
+            </span>
+          </div>
+          <div className="tc-metric">
+            <span className="tc-metric-label">Setpoint</span>
+            <span className="tc-metric-value">
+              {s ? s.setpoint_c.toFixed(1) : "—"} °C
+            </span>
+          </div>
+          <div className="tc-metric">
+            <span className="tc-metric-label">HH limit</span>
+            <span className="tc-metric-value is-warning">{hhLimit.toFixed(0)} °C</span>
+          </div>
+        </div>
+
+        <div className="tc-status-actions">
+          {/* Prominent heater relay indicator */}
+          <div
+            className={`tc-relay ${relayOn ? "is-on" : ""}`}
+            title={`${config.heater_label} relay`}
+            aria-label={`Heater relay ${relayOn ? "on" : "off"}`}
+          >
+            <span className="tc-relay-coil" />
+            <span className="tc-relay-text">
+              HEATER {relayOn ? "ON" : "OFF"}
+            </span>
+          </div>
+
+          {tripped && (
+            <button
+              className={`btn tc-btn-danger ${busy ? "tc-disabled" : ""}`}
+              onClick={acknowledgeTrip}
+              disabled={busy}
+            >
+              Acknowledge Trip
+            </button>
+          )}
+          <button
+            className={`tc-permissive ${s?.permissive ? "is-on" : ""}`}
+            onClick={() => setPermissive(!s?.permissive)}
+            disabled={busy}
+            title="Master enable — the heater relay is forced open while OFF"
+          >
+            <span className="dot" />
+            {s?.permissive ? "PERMISSIVE ON" : "PERMISSIVE OFF"}
+          </button>
+        </div>
+      </div>
+
+      {/* ---- High-high cutoff banner ---- */}
+      {hhTripped && (
+        <div className="tc-trip-banner">
+          ⚠ High-high temperature cutoff — heater latched OFF. Acknowledge to
+          reset.
+        </div>
+      )}
+
+      {/* ---- Generic trips banner (non-HH trips still surface) ---- */}
+      {s && s.trips.length > 0 && !hhTripped && (
+        <div className="tc-trip-banner">⚠ Active trips: {s.trips.join(", ")}</div>
+      )}
+
+      {/* ---- Live trend ---- */}
+      <div className="tc-card">
+        <div className="tc-card-title">
+          <span>Live temperature — {config.heater_label}</span>
+        </div>
+        <TempTrend
+          samples={trend}
+          fullScale={config.temp_full_scale_c}
+          setpoint={s?.setpoint_c ?? config.setpoint_min_c}
+          hhLimit={hhLimit}
+          windowSeconds={TREND_WINDOW_SECONDS}
+        />
+      </div>
+
+      {/* ---- Setpoint ---- */}
+      <div className="tc-card">
+        <div className="tc-card-title">
+          <span>Setpoint</span>
+        </div>
+
+        <div className="tc-setpoint-row">
+          <button
+            className="tc-step-btn"
+            onClick={() => nudgeSetpoint(-setpointStep)}
+            disabled={busy}
+            title={`Decrease by ${setpointStep} °C`}
+          >
+            −
+          </button>
+          <input
+            className="tc-setpoint-input"
+            type="text"
+            inputMode="decimal"
+            value={stagedSetpointText}
+            onChange={(e) => setStagedSetpointText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleApplyClick();
+            }}
+          />
+          <button
+            className="tc-step-btn"
+            onClick={() => nudgeSetpoint(setpointStep)}
+            disabled={busy}
+            title={`Increase by ${setpointStep} °C`}
+          >
+            +
+          </button>
+        </div>
+
+        <div className="tc-setpoint-controls">
+          <span className="tc-step-field">
+            step&nbsp;
+            <input
+              type="number"
+              min={1}
+              step={1}
+              value={setpointStep}
+              onChange={(e) =>
+                setSetpointStep(Math.max(1, Number.parseFloat(e.target.value) || 1))
+              }
+            />
+            °C
+          </span>
+          <button
+            className={`btn btn-primary ${busy ? "tc-disabled" : ""}`}
+            onClick={handleApplyClick}
+            disabled={busy}
+          >
+            Apply Setpoint
+          </button>
+        </div>
+
+        {s && s.state === "tripped" ? (
+          <p className="tc-setpoint-warn">
+            ⚠ Controller is TRIPPED — acknowledge the trip before commanding.
+          </p>
+        ) : s && !s.permissive ? (
+          <p className="tc-setpoint-warn">
+            ⚠ Permissive is OFF — enable it (switch, top-right) before commanding
+            the heater.
+          </p>
+        ) : !s ? (
+          <p className="tc-setpoint-warn">
+            ⚠ Live status unavailable — commands are blocked until the controller
+            reports in.
+          </p>
+        ) : (
+          setpointWarning && <p className="tc-setpoint-warn">⚠ {setpointWarning}</p>
+        )}
+
+        <p className="tc-hint">
+          Allowed setpoint {config.setpoint_min_c}–{config.setpoint_max_c} °C. The
+          relay closes below <strong>setpoint − {deadband.toFixed(0)} °C</strong>{" "}
+          and opens at setpoint (bang-bang control). The high-high cutoff at{" "}
+          <strong>{hhLimit.toFixed(0)} °C</strong> latches the heater OFF
+          regardless of setpoint.
+        </p>
+      </div>
+
+      {/* ---- Live telemetry ---- */}
+      <div className="tc-card">
+        <div className="tc-card-title">Live telemetry</div>
+        <div className="tc-readouts">
+          <Readout label="Setpoint" value={`${s?.setpoint_c.toFixed(1) ?? "—"} °C`} />
+          <Readout
+            label="Measured temp"
+            value={`${s?.measured_temp_c.toFixed(1) ?? "—"} °C`}
+            warning={tempWarn}
+          />
+          <Readout
+            label="Relay state"
+            value={s ? (relayOn ? "ON" : "OFF") : "—"}
+            warning={relayOn}
+          />
+          <Readout label="HH limit" value={`${hhLimit.toFixed(0)} °C`} />
+        </div>
+      </div>
+
+      {/* ---- Advanced config ---- */}
+      <details className="tc-card tc-config">
+        <summary>Calibration &amp; limits</summary>
+
+        <p className="tc-hint" style={{ marginTop: "0.8rem" }}>
+          The thermocouple module reports temperature directly. These limits set
+          the safe operating envelope — the server clamps setpoints to the band and
+          latches the heater OFF at the high-high cutoff.
+        </p>
+
+        <div className="tc-config-grid">
+          <ConfigField
+            label="Deadband (°C)"
+            value={configDraft.deadband_c}
+            onChange={(v) => setConfigDraft({ ...configDraft, deadband_c: v })}
+          />
+          <ConfigField
+            label="High-high cutoff (°C)"
+            value={configDraft.hh_limit_c}
+            onChange={(v) => setConfigDraft({ ...configDraft, hh_limit_c: v })}
+          />
+          <ConfigField
+            label="Temperature full scale (°C)"
+            value={configDraft.temp_full_scale_c}
+            onChange={(v) => setConfigDraft({ ...configDraft, temp_full_scale_c: v })}
+          />
+          <ConfigField
+            label="Max setpoint (°C)"
+            value={configDraft.setpoint_max_c}
+            onChange={(v) => setConfigDraft({ ...configDraft, setpoint_max_c: v })}
+          />
+          <ConfigField
+            label="Temperature tag"
+            value={configDraft.temp_tag}
+            stringMode
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, temp_tag: v as unknown as string })
+            }
+          />
+          <ConfigField
+            label="Heater label"
+            value={configDraft.heater_label}
+            stringMode
+            onChange={(v) =>
+              setConfigDraft({ ...configDraft, heater_label: v as unknown as string })
+            }
+          />
+        </div>
+
+        <div style={{ marginTop: "1rem" }}>
+          <button
+            className={`btn ${busy ? "tc-disabled" : ""}`}
+            onClick={saveConfig}
+            disabled={busy}
+          >
+            Save Configuration
+          </button>
+        </div>
+      </details>
+
+      {info && <div className="tc-toast is-info">{info}</div>}
+      {error && <div className="tc-toast is-error">{error}</div>}
+    </div>
+  );
+};
+
+/**
+ * Compact single-trace temperature trend for the controller screen: measured
+ * temperature plotted against a 0–full-scale °C Y axis, with the setpoint and
+ * high-high cutoff drawn as horizontal reference lines.
+ *
+ * Self-contained SVG (no chart lib): the parent accumulates a rolling sample
+ * buffer from the live status and passes it in.
+ */
+const TREND_W = 600;
+const TREND_H = 180;
+const TREND_PAD_L = 40;
+const TREND_PAD_R = 10;
+const TREND_PAD_T = 10;
+const TREND_PAD_B = 18;
+const TREND_PLOT_W = TREND_W - TREND_PAD_L - TREND_PAD_R;
+const TREND_PLOT_H = TREND_H - TREND_PAD_T - TREND_PAD_B;
+
+const TEMP_COLOR = "var(--color-error)";
+const SETPOINT_COLOR = "var(--accent-cyan)";
+const HH_COLOR = "var(--color-warning)";
+
+function tempPath(values: number[], fullScale: number): string {
+  if (values.length < 2 || fullScale <= 0) return "";
+  const n = values.length;
+  return values
+    .map((val, idx) => {
+      const x = TREND_PAD_L + (idx / (n - 1)) * TREND_PLOT_W;
+      const frac = Math.max(0, Math.min(1, val / fullScale));
+      const y = TREND_PAD_T + (1 - frac) * TREND_PLOT_H;
+      return `${idx === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+interface TrendProps {
+  samples: number[];
+  fullScale: number;
+  setpoint: number;
+  hhLimit: number;
+  windowSeconds: number;
+}
+
+const TempTrend: React.FC<TrendProps> = ({
+  samples,
+  fullScale,
+  setpoint,
+  hhLimit,
+  windowSeconds,
+}) => {
+  const path = tempPath(samples, fullScale);
+  const last = samples[samples.length - 1];
+
+  const refY = (value: number): number => {
+    const frac = Math.max(0, Math.min(1, value / fullScale));
+    return TREND_PAD_T + (1 - frac) * TREND_PLOT_H;
+  };
+
+  return (
+    <div className="tc-trend">
+      <div className="tc-trend-legend">
+        <span className="tc-trend-key">
+          <span className="swatch" style={{ background: TEMP_COLOR }} />
+          Measured
+          <strong>{last != null ? `${last.toFixed(1)} °C` : "—"}</strong>
+        </span>
+        <span className="tc-trend-key">
+          <span className="swatch" style={{ background: SETPOINT_COLOR }} />
+          Setpoint
+          <strong>{setpoint.toFixed(1)} °C</strong>
+        </span>
+        <span className="tc-trend-key">
+          <span className="swatch" style={{ background: HH_COLOR }} />
+          HH cutoff
+          <strong>{hhLimit.toFixed(0)} °C</strong>
+        </span>
+        <span className="tc-trend-window">
+          last {windowSeconds}s · 0–{fullScale.toFixed(0)} °C
+        </span>
+      </div>
+
+      <svg
+        className="tc-trend-svg"
+        viewBox={`0 0 ${TREND_W} ${TREND_H}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Temperature trend"
+      >
+        {/* gridlines + °C axis labels at 0/25/50/75/100 % of full scale */}
+        {[0, 0.25, 0.5, 0.75, 1].map((frac) => {
+          const y = TREND_PAD_T + (1 - frac) * TREND_PLOT_H;
+          return (
+            <g key={frac}>
+              <line
+                x1={TREND_PAD_L}
+                y1={y}
+                x2={TREND_W - TREND_PAD_R}
+                y2={y}
+                className="tc-trend-grid"
+              />
+              <text
+                x={TREND_PAD_L - 6}
+                y={y + 3}
+                className="tc-trend-axis"
+                textAnchor="end"
+              >
+                {(frac * fullScale).toFixed(0)}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* setpoint + HH reference lines */}
+        {fullScale > 0 && (
+          <>
+            <line
+              x1={TREND_PAD_L}
+              y1={refY(setpoint)}
+              x2={TREND_W - TREND_PAD_R}
+              y2={refY(setpoint)}
+              className="tc-trend-ref"
+              stroke={SETPOINT_COLOR}
+            />
+            <line
+              x1={TREND_PAD_L}
+              y1={refY(hhLimit)}
+              x2={TREND_W - TREND_PAD_R}
+              y2={refY(hhLimit)}
+              className="tc-trend-ref"
+              stroke={HH_COLOR}
+            />
+          </>
+        )}
+
+        {samples.length < 2 ? (
+          <text
+            x={TREND_W / 2}
+            y={TREND_H / 2}
+            className="tc-trend-empty"
+            textAnchor="middle"
+          >
+            waiting for live data…
+          </text>
+        ) : (
+          <path d={path} className="tc-trend-line" stroke={TEMP_COLOR} />
+        )}
+      </svg>
+    </div>
+  );
+};
+
+const Readout: React.FC<{ label: string; value: string; warning?: boolean }> = ({
+  label,
+  value,
+  warning,
+}) => (
+  <div className={`tc-readout ${warning ? "is-warning" : ""}`}>
+    <div className="tc-readout-label">{label}</div>
+    <div className="tc-readout-value">{value}</div>
+  </div>
+);
+
+interface ConfigFieldProps {
+  label: string;
+  value: number | string;
+  stringMode?: boolean;
+  onChange: (v: number) => void;
+}
+const ConfigField: React.FC<ConfigFieldProps> = ({
+  label,
+  value,
+  stringMode,
+  onChange,
+}) => (
+  <label className="tc-field">
+    <span>{label}</span>
+    <input
+      type={stringMode ? "text" : "number"}
+      value={value}
+      onChange={(e) =>
+        onChange(
+          (stringMode ? e.target.value : Number.parseFloat(e.target.value)) as number,
+        )
+      }
+    />
+  </label>
+);

--- a/src/p1am_control_system/frontend/src/hooks/useTelemetryStream.ts
+++ b/src/p1am_control_system/frontend/src/hooks/useTelemetryStream.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { TAG_COUNT } from "../lib/tags";
 import { telemetryFrameSchema } from "../api/schemas";
 import type { PowerSupplyStatus } from "../components/PowerSupplyControl";
+import type { TemperatureStatus } from "../components/TemperatureControl";
 import type { AlicatMFCState, ActiveAlarm } from "../api/schemas";
 
 /**
@@ -19,6 +20,7 @@ export interface TelemetryState {
   activeAlarms: ActiveAlarm[];
   eStopActive: boolean;
   powerSupplyStatus: PowerSupplyStatus | undefined;
+  temperatureStatus: TemperatureStatus | undefined;
   isConnected: boolean;
 }
 
@@ -51,6 +53,9 @@ export function useTelemetryStream(
   const [eStopActive, setEStopActive] = useState<boolean>(false);
   const [powerSupplyStatus, setPowerSupplyStatus] = useState<
     PowerSupplyStatus | undefined
+  >(undefined);
+  const [temperatureStatus, setTemperatureStatus] = useState<
+    TemperatureStatus | undefined
   >(undefined);
   const [isConnected, setIsConnected] = useState<boolean>(false);
 
@@ -110,6 +115,9 @@ export function useTelemetryStream(
           if (frame.power_supply) {
             setPowerSupplyStatus(frame.power_supply as PowerSupplyStatus);
           }
+          if (frame.temperature) {
+            setTemperatureStatus(frame.temperature as TemperatureStatus);
+          }
           return;
         }
 
@@ -148,6 +156,7 @@ export function useTelemetryStream(
     activeAlarms,
     eStopActive,
     powerSupplyStatus,
+    temperatureStatus,
     isConnected,
     setAlicats,
     setActiveAlarms,

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -17,7 +17,8 @@ export type TabId =
   | "events"
   | "ladder"
   | "hierarchy"
-  | "powerSupply";
+  | "powerSupply"
+  | "temperature";
 
 export interface TabDef {
   /** Stable identifier used as the `activeTab` value and visibility key. */
@@ -78,6 +79,12 @@ export const TABS: readonly TabDef[] = [
     label: "Power Supply",
     settingsLabel: "Power Supply Controller",
     accentVar: "var(--accent-purple, #a78bfa)",
+  },
+  {
+    id: "temperature",
+    label: "Temperature",
+    settingsLabel: "Temperature Controller",
+    accentVar: "var(--accent-orange, #fb923c)",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary
Two operator-facing additions to the P1AM HMI, both fully TDD/DbC/LOD/DRY.

### 1. Temperature controller (new tab)
On/off relay control of a resistive heater from a type-K thermocouple, **0–1400 °C**, separate from the Power Supply tab.
- Hysteresis (deadband) on/off control around the setpoint.
- **High-high cutoff**: at/above `hh_limit_c` the heater relay is latched **OFF** (TRIPPED) until acknowledged.
- E-stop forces the relay off and blocks re-arm (same latch semantics as the power supply).
- 24 V digital out → relay → 110 V heater, driven on **Modbus coil 2**; the firmware safety interlock always wins (a trip forces the relay off).
- New HMI tab: state badge, glowing HEATER ON/OFF indicator, permissive switch, setpoint entry (°C) with steppers, HH-cutoff banner, live temperature trend, calibration/limits config.

### 2. Signal-noise / arc detection (power-supply tab)
Quantifies how noisy the DC-arc current & voltage feedback are so the operator can recognize **arcing**.
- New pure `signal_stats` module: std / peak-to-peak / AC-RMS / coefficient-of-variation over a bounded rolling window.
- **User-tunable**: window size, metric, and per-channel arc thresholds. An `arcing` flag + live noise readouts on the PS screen.

## Plumbing
- `hardware.HEATER_RELAY_COIL` (coil 2); public `write_coil` seam on the PLC interface, Modbus client (input-validated, error/exception-safe) and simulator.
- E-stop engage/clear now also drives the temperature controller; the **simulated** clear path now releases both controller latches (fixes a pre-existing re-arm gap).
- Firmware: `HardwareInterface.WriteHeaterRelay` + `P1AMHardware` impl — a **safe no-op until a discrete-output module slot is configured** (the bench stack has no DO module yet), with header docs for wiring it.

## Hardware bring-up note
The relay control + firmware path are implemented and the firmware **compiles** (P1AM-100, 21% flash), but driving a real heater needs: (a) a discrete-output module installed, (b) `kSlotRelay`/`kChanRelay` set in `P1AMHardware.h`, (c) a reflash. Software is validated in simulator mode end-to-end.

## Tests / gates (all green locally)
- Backend: **386 passed** (new: temperature controller/models/integration, signal-stats, PS-noise integration, `write_coil` for modbus + simulator).
- Frontend: `tsc` clean, **vitest 30 passed**, `vite build` clean.
- Firmware: `arduino-cli compile` clean.
- `ruff check` + `ruff format --check` clean on all changed files; mypy clean on new/changed code (pre-existing repo-wide mypy findings untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)