### PR TITLE
fix(p1am/firmware): thermocouple type-K + Celsius + full 0–1400 °C scale

### DIFF
--- a/src/p1am_control_system/firmware/P1AMHardware.cpp
+++ b/src/p1am_control_system/firmware/P1AMHardware.cpp
@@ -19,6 +19,17 @@ P1AMHardware::P1AMHardware() {}
 
 void P1AMHardware::Begin() {
   P1.init();
+  // Override the P1-04THM's power-up default (type-J, Fahrenheit) with type-K
+  // in degrees Celsius — otherwise a type-K probe reads in F (e.g. ~28 C indoor
+  // air shows as ~83 F). Config bytes per the FACTS module reference:
+  //   0x4003           enable channels 1-4
+  //   0x6001           degrees C + low-side burnout (default 0x6005 = degrees F)
+  //   0x21 11 .. 0x24 11  per-channel range; type nibble 1 = type-K
+  // Verify after flashing with P1.readModuleConfig(); room air should read ~25 C.
+  static const char kThmTypeKCelsius[20] = {
+      0x40, 0x03, 0x60, 0x01, 0x21, 0x11, 0x22, 0x11, 0x23, 0x11,
+      0x24, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  P1.configureModule(kThmTypeKCelsius, kSlotThm);
   pinMode(kPinInhibit, OUTPUT);
   digitalWrite(kPinInhibit, LOW);
 }

--- a/src/p1am_control_system/firmware/SignalBroker.cpp
+++ b/src/p1am_control_system/firmware/SignalBroker.cpp
@@ -92,14 +92,17 @@ int SignalBroker::GetOutputRouting(int channel) const {
 }
 
 void SignalBroker::ReadHardwareInputs(HardwareInterface& hw) {
-  // Read and scale 4 Thermocouples (channels 0 to 3)
-  // We assume thermocouple inputs range from 0.0 to 1000.0 Celsius.
-  // We scale 0-1000 C -> 0.0% - 100.0% Tag values.
+  // Read and scale 4 Thermocouples (channels 0 to 3).
+  // Type-K range is ~0-1372 C; we scale 0-1400 C -> 0.0%-100.0% tag values so
+  // the heater controller's full 0-1400 C span fits the 0-100% broker tag.
+  // NOTE: this full-scale (1400) MUST match the backend temperature
+  // controller's temp_full_scale_c so the reported deg C is correct.
+  static const float kThermocoupleFullScaleC = 1400.0f;
   for (int i = 0; i < 4; ++i) {
     int target_tag = input_routing_[i];
     if (target_tag != kUnmappedTag) {
       float temp = hw.ReadThermocouple(i);
-      float scaled = temp / 10.0f;  // 0 - 1000 C maps to 0 - 100 %
+      float scaled = temp * (100.0f / kThermocoupleFullScaleC);  // C -> %
       SetTag(target_tag, scaled);
     }
   }


### PR DESCRIPTION
## Problem (found while bringing up the new Temperature tab)
A type-K probe in ~25–28 °C room air showed a wrong, out-of-range temperature. Root cause, confirmed from live tags: `TAG_0` sat rock-stable at **8.33**. The P1-04THM was running the P1AM library's **power-up default (type-J, Fahrenheit)**, so it read ~**83.3 °F** (≈ 28.5 °C). The broker's `°C/10` scaling turned 83.3 → tag `8.33`, and the new backend (1400 °C full-scale) rendered that as ~116 °C. The probe/wiring were fine all along — only the module units/type and the scale were wrong.

## Fix (firmware)
- **`P1AMHardware::Begin`** now configures the P1-04THM for **type-K in degrees Celsius** after `P1.init()` (config word `0x6001` = °C + low-side burnout; per-channel type nibble `1` = type-K), overriding the library default.
- **`SignalBroker`** scales thermocouples **0–1400 °C → 0–100 %** (was 0–1000 °C), so the heater controller's full 0–1400 °C span fits the broker's 0–100 % tag and matches the backend `temp_full_scale_c` (1400).

## After merge — reflash required
This is firmware; it takes effect only after a reflash:
```
./run_pi.sh fw-flash      # needs the P1AM on USB (/dev/ttyACM0)
```
Then confirm room air reads ~25 °C on the **Temperature** tab (and optionally read the config back with `P1.readModuleConfig()`).

Compiles clean for P1AM-100 (21% flash). Config bytes are from the FACTS module reference; verify on first flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)