### PR TITLE
feat(p1am/firmware): drive heater relay from GPIO D2 (active-HIGH)

### DIFF
--- a/src/p1am_control_system/firmware/P1AMHardware.cpp
+++ b/src/p1am_control_system/firmware/P1AMHardware.cpp
@@ -32,6 +32,9 @@ void P1AMHardware::Begin() {
   P1.configureModule(kThmTypeKCelsius, kSlotThm);
   pinMode(kPinInhibit, OUTPUT);
   digitalWrite(kPinInhibit, LOW);
+  // Heater relay control output starts de-energized (LOW = heater OFF).
+  pinMode(kPinHeaterRelay, OUTPUT);
+  digitalWrite(kPinHeaterRelay, LOW);
 }
 
 void P1AMHardware::Update() {}
@@ -85,12 +88,6 @@ void P1AMHardware::WriteInhibit(bool active) {
 }
 
 void P1AMHardware::WriteHeaterRelay(bool on) {
-  // Safe no-op until a discrete-output module slot is configured (see header).
-  // This keeps the bench-verified build unchanged when no DO module is present.
-  if (kSlotRelay < 0) {
-    return;
-  }
-  // P1.writeDiscrete drives one channel of a discrete-output module.
-  // Library channels are 1-indexed (kChanRelay).
-  P1.writeDiscrete(on ? HIGH : LOW, kSlotRelay, kChanRelay);
+  // Active-HIGH GPIO drive (D2): HIGH = relay energized = heater ON.
+  digitalWrite(kPinHeaterRelay, on ? HIGH : LOW);
 }

--- a/src/p1am_control_system/firmware/P1AMHardware.h
+++ b/src/p1am_control_system/firmware/P1AMHardware.h
@@ -22,14 +22,15 @@ class P1AMHardware : public HardwareInterface {
   //   Slot 2 = P1-04THM        (4-channel thermocouple)
   static const int kSlotAna = 1;
   static const int kSlotThm = 2;
-  // Heater relay discrete-output module. The bench stack currently has NO
-  // discrete-output module, so this is -1 (disabled -> WriteHeaterRelay is a
-  // no-op). When a P1-08TD*/P1-08TRS (or similar 24 V DO) module is installed,
-  // set kSlotRelay to its slot (from P1.printModules()) and kChanRelay to the
-  // wired channel (1-indexed), then reflash. The temperature controller drives
-  // this via Modbus coil 2.
-  static const int kSlotRelay = -1;
-  static const int kChanRelay = 1;
+  // Heater relay control GPIO (Arduino-header digital pin D2). Driven
+  // active-HIGH: HIGH (3.3 V) = relay energized = heater ON; boots LOW. The
+  // temperature controller commands this via Modbus coil 2, and the safety
+  // interlock forces it LOW on any trip. NOTE: this is a 3.3 V logic output
+  // (~7 mA) — drive a logic-level relay board / SSR, or a small
+  // transistor/opto driver for a 24 V relay coil; it cannot switch 24 V itself.
+  // Reserved pins to avoid: D5 (Ethernet W5500 CS), D6 (inhibit), A3/A4/33
+  // (P1AM base controller).
+  static const int kPinHeaterRelay = 2;
   // Inhibit GPIO. MUST NOT be pin 5 — the P1AM-ETH shield hardwires the W5500
   // chip-select to D5, so driving D5 from this firmware breaks Ethernet SPI.
   // D6 is free on the P1AM-100 / P1AM-ETH stack.


### PR DESCRIPTION
## Summary
The bench P1AM stack has no discrete-output module, so drive the heater relay from a free **Arduino-header GPIO (D2)** instead of `P1.writeDiscrete`. Active-HIGH: pin HIGH (3.3 V) = relay energized = heater ON. The pin boots LOW (relay open) and the safety interlock forces it LOW on any trip. The temperature controller still commands it via Modbus coil 2.

## Wiring
- **Signal:** P1AM-100 Arduino digital header pin **D2** → relay-board / SSR control input (or a transistor/opto driver input).
- **Return:** any **GND** pin on the header → driver/relay-board GND.
- **3.3 V logic, ~7 mA** — it cannot switch a 24 V relay coil directly; use a logic-level relay board, an SSR with a 3–3.3 V control input, or a small transistor/opto driver.
- Reserved pins avoided: D5 (Ethernet W5500 CS), D6 (safety inhibit), A3/A4/33 (P1AM base controller).

## Requires reflash
Firmware change — takes effect only after `./run_pi.sh fw-flash` (P1AM on USB). Bench-test that E-stop and a HH temp trip both open the relay.

Compiles clean for P1AM-100 (21% flash). Follows the thermocouple type-K/°C/scale fix (PR #3604, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)