### PR TITLE
feat(p1am/hmi): Heater Controls tab, drag/right-click-hide tabs with persistence, permissive lock fix

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | 1.1.0                                      |
-| **Spec Version**        | 1.1.589                                    |
+| **Spec Version**        | 1.1.590                                    |
 | **Last Spec Update**    | 2026-06-18                                 |
 
 ## 2. Purpose & Mission
@@ -38,6 +38,15 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 
 ### 2026-06-18 Update
 
+- P1AM HMI tabs now persist operator-controlled order and visibility in
+  browser storage, with drag/drop and context-menu reorder/hide affordances
+  that reconcile saved layouts against newly added tab ids. The temperature
+  tab is presented as "Heater Controls", power and trend readouts display the
+  supply in kW, power/temperature commands use bounded fetches with explicit
+  busy feedback, and the telemetry hook falls back to polling `/api/snapshot`
+  when the WebSocket stream is stale so embedded HTTP-only views keep updating.
+  The tag inspector UI was split out of `App.tsx` without changing behavior so
+  the frontend stays inside the local HMI file-size guardrail (#3649).
 - Release Automation validation now mirrors the CI Standard changed-file Ruff
   contract: release validation collects changed Python files, applies the same
   legacy-path exclude list, and skips Ruff lint/format when a release-triggering

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -135,6 +135,10 @@ class ConnectionManager:
 ws_manager = ConnectionManager()
 shutdown_event = asyncio.Event()
 
+# Latest broadcast frame, cached so HTTP-only clients (e.g. embedded webviews
+# that can't hold a WebSocket) can poll /api/snapshot as a streaming fallback.
+latest_frame: dict[str, Any] = {}
+
 # Instantiate global Alicat manager and default devices
 alicat_manager = AlicatManager()
 alicat_manager.add_device(
@@ -234,10 +238,11 @@ async def poll_plc_loop() -> None:
 
     Saves data to DB and streams updates to WS.
     """
+    global latest_frame
     logger.info("Starting background PLC polling loop...")
     while not shutdown_event.is_set():
         try:
-            await _poll_once(
+            frame = await _poll_once(
                 plc=plc_client,
                 backup=backup_simulator,
                 latest_tag_values=control_context.latest_tags,
@@ -250,6 +255,10 @@ async def poll_plc_loop() -> None:
                 session_factory=get_session,
                 estop_active=control_context.e_stop_active,
             )
+            # Cache the frame for the /api/snapshot polling fallback. Reassigning
+            # the reference is atomic, so a concurrent reader sees a whole frame.
+            if frame:
+                latest_frame = frame
         except Exception as loop_err:
             logger.error(f"Unexpected error in PLC polling loop: {loop_err}")
         # Sleep to maintain 10Hz frequency (100ms cycle)
@@ -519,6 +528,17 @@ async def clear_estop() -> dict[str, str]:
     power_supply_service.clear_estop()
     temperature_service.clear_estop()
     return {"status": "success", "message": "Hardware E-stop cleared."}
+
+
+@app.get("/api/snapshot")
+async def get_snapshot() -> dict[str, Any]:
+    """Latest live frame — identical shape to the /api/stream WebSocket frames.
+
+    Returns the cached frame from the poll loop (no PLC round-trip), so HTTP-only
+    clients that can't hold a WebSocket — e.g. an embedded VS Code Simple Browser
+    webview — can poll this as a streaming fallback and still see live data.
+    """
+    return latest_frame
 
 
 @app.get("/api/alarms/active")

--- a/src/p1am_control_system/frontend/src/App.tsx
+++ b/src/p1am_control_system/frontend/src/App.tsx
@@ -11,6 +11,8 @@ import { LadderExplorer } from "./components/LadderExplorer";
 import { PlantHierarchy } from "./components/PlantHierarchy";
 import { PowerSupplyControl } from "./components/PowerSupplyControl";
 import { TemperatureControl } from "./components/TemperatureControl";
+import { AlicatInspector } from "./components/AlicatInspector";
+import { TagInspector } from "./components/TagInspector";
 import type { LadderTagInfo } from "./api/schemas";
 import { NotificationBanner } from "./components/NotificationBanner";
 import { TabBar } from "./components/TabBar";
@@ -25,6 +27,7 @@ import {
   saveTabVisibility,
 } from "./lib/tabs";
 import { TAG_INDICES, tagName, parseTagId } from "./lib/tags";
+import type { InspectorState } from "./lib/inspector";
 import { fmtNumber } from "./lib/format";
 import * as api from "./api/endpoints";
 import { ApiError } from "./api/client";
@@ -42,7 +45,6 @@ import {
   Activity,
   Sliders,
   Shuffle,
-  ShieldAlert,
   Sun,
   Moon,
   Info,
@@ -80,16 +82,6 @@ const DEFAULT_CONFIG: RoutingConfig = {
     hihi_limit: 100.0,
   })),
 };
-
-type InspectorState =
-  | { type: "none" }
-  | { type: "tag"; tagId: number }
-  | { type: "custom_tag"; tagName: string }
-  | { type: "pid"; index: number }
-  | { type: "routing" }
-  | { type: "alicat"; deviceId: string }
-  | { type: "settings" }
-  | { type: "export" };
 
 export const App: React.FC = () => {
   const [config, setConfig] = useState<RoutingConfig>(DEFAULT_CONFIG);
@@ -534,10 +526,8 @@ export const App: React.FC = () => {
 
   return (
     <div className="dashboard-container">
-      {/* Top Banner Notification */}
       <NotificationBanner notification={notification} />
 
-      {/* Sticky header — always visible so the E-stop is always one click away */}
       <header
         style={{
           display: "flex",
@@ -589,7 +579,6 @@ export const App: React.FC = () => {
         </div>
 
         <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
-          {/* Connection status indicator */}
           <div style={{ display: "flex", alignItems: "center", gap: "0.3rem" }}>
             <span
               className={`status-indicator ${
@@ -607,7 +596,6 @@ export const App: React.FC = () => {
             </span>
           </div>
 
-          {/* Theme Toggle */}
           <button
             type="button"
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
@@ -618,7 +606,6 @@ export const App: React.FC = () => {
             {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
           </button>
 
-          {/* Settings Gear */}
           <button
             type="button"
             onClick={() => setInspectorView(inspectorView.type === "settings" ? { type: "none" } : { type: "settings" })}
@@ -650,9 +637,7 @@ export const App: React.FC = () => {
 
       {/* Main content — the inspector is now a slide-in drawer (below), not a column */}
       <div className="main-layout-grid" style={{ gridTemplateColumns: "1fr" }}>
-        {/* Left Column (Master Dashboard elements) */}
         <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
-          {/* Tabbed Navigation Bar (centralized TABS array, #3546) */}
           <TabBar
             activeTab={activeTab}
             visibleTabs={visibleTabs}
@@ -1325,164 +1310,23 @@ export const App: React.FC = () => {
             )}
 
             {/* Tag register editor (Unified for both legacy tag index and custom named tags) */}
-            {(inspectorView.type === "tag" || inspectorView.type === "custom_tag") && (() => {
-              const isCustom = inspectorView.type === "custom_tag";
-              const tagLabel = isCustom
-                ? inspectorView.tagName
-                : tagName(inspectorView.tagId);
-              const tagInfo = allTags.find((t) => t.name === tagLabel);
-
-              // Get current value
-              const currentVal = isCustom
-                ? (tagsDict[tagLabel] ?? 0.0)
-                : (tagValues[inspectorView.tagId] ?? 0.0);
-              
-              // Check if writable (legacy tags are Read/Write, custom tags lookup from registry)
-              const rwMode = tagInfo ? tagInfo.rw_mode : "Read/Write";
-              const isWritable = rwMode === "Read/Write";
-
-              return (
-                <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-                  <div>
-                    <h3 style={{ fontSize: "1rem", fontWeight: 700, color: "var(--accent-cyan)", textTransform: "uppercase" }}>
-                      Tag Inspector
-                    </h3>
-                    <div style={{ fontSize: "0.8rem", color: "var(--text-primary)", fontWeight: 700, marginTop: "0.25rem" }} className="mono-text">
-                      {tagLabel}
-                    </div>
-                    {tagInfo && tagInfo.description && (
-                      <p style={{ fontSize: "0.75rem", color: "var(--text-secondary)", marginTop: "0.25rem", lineHeight: 1.4 }}>
-                        {tagInfo.description}
-                      </p>
-                    )}
-                    <div style={{ display: "flex", justifyContent: "space-between", background: "var(--input-bg)", padding: "0.5rem", borderRadius: "4px", marginTop: "0.5rem", border: "1px solid var(--panel-border)" }}>
-                      <span style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>Current Value:</span>
-                      <span className="mono-text" style={{ fontSize: "0.9rem", fontWeight: 700, color: "var(--accent-cyan)" }}>
-                        {currentVal.toFixed(2)}
-                      </span>
-                    </div>
-                  </div>
-
-                  {tagInfo && (
-                    <div style={{ fontSize: "0.75rem", display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.5rem", background: "rgba(255,255,255,0.01)", padding: "0.5rem", borderRadius: "4px", border: "1px solid var(--panel-border)" }}>
-                      <div>
-                        <span style={{ color: "var(--text-muted)" }}>Reg Type:</span>{" "}
-                        <strong style={{ color: "var(--text-secondary)" }}>{tagInfo.register_type || "None"}</strong>
-                      </div>
-                      <div>
-                        <span style={{ color: "var(--text-muted)" }}>Reg Num:</span>{" "}
-                        <strong style={{ color: "var(--text-secondary)" }}>{tagInfo.register_num ?? "None"}</strong>
-                      </div>
-                      <div>
-                        <span style={{ color: "var(--text-muted)" }}>Format:</span>{" "}
-                        <strong style={{ color: "var(--text-secondary)" }}>{tagInfo.data_format || "None"}</strong>
-                      </div>
-                      <div>
-                        <span style={{ color: "var(--text-muted)" }}>RW Mode:</span>{" "}
-                        <strong style={{ color: "var(--text-secondary)" }}>{tagInfo.rw_mode}</strong>
-                      </div>
-                    </div>
-                  )}
-
-                  {/* Section 1: Manual Value Override (Write Force) */}
-                  {isWritable && (
-                    <div style={{ borderTop: "1px solid var(--panel-border)", paddingTop: "0.75rem" }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: "0.3rem", marginBottom: "0.5rem" }}>
-                        <ShieldAlert size={14} color="var(--color-warning)" />
-                        <span style={{ fontSize: "0.8rem", fontWeight: 700, textTransform: "uppercase" }}>Manual Force Override</span>
-                      </div>
-                      <div className="input-group">
-                        <label className="input-label">Override Force Value</label>
-                        <input
-                          type="number"
-                          step="0.1"
-                          className="form-input"
-                          value={overrideVal}
-                          onChange={(e) => setOverrideVal(e.target.value)}
-                        />
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => setShowOverrideConfirm(true)}
-                        className="btn"
-                        style={{ width: "100%", color: "var(--color-warning)", borderColor: "var(--color-warning)", padding: "0.45rem", fontSize: "0.8rem" }}
-                      >
-                        Force Register Write
-                      </button>
-
-                      {showOverrideConfirm && (
-                        <div style={{ background: "rgba(239, 68, 68, 0.1)", border: "1px solid var(--color-error)", borderRadius: "4px", padding: "0.6rem", marginTop: "0.5rem" }}>
-                          <div style={{ fontSize: "0.75rem", fontWeight: 700, color: "var(--color-error)", marginBottom: "0.25rem" }}>Confirm Direct Write</div>
-                          <p style={{ fontSize: "0.7rem", color: "var(--text-secondary)", marginBottom: "0.6rem" }}>
-                            Forcing Tag {tagLabel} to {overrideVal} will overwrite normal logic. Continue?
-                          </p>
-                          <div style={{ display: "flex", gap: "0.4rem" }}>
-                            <button
-                              type="button"
-                              onClick={() => {
-                                const idToSubmit = isCustom ? tagLabel : inspectorView.tagId;
-                                executeOverride(idToSubmit);
-                              }}
-                              className="btn"
-                              style={{ background: "var(--color-error)", border: "none", color: "#ffffff", padding: "0.2rem 0.5rem", fontSize: "0.75rem" }}
-                            >
-                              Confirm
-                            </button>
-                            <button
-                              type="button"
-                              onClick={() => setShowOverrideConfirm(false)}
-                              className="btn"
-                              style={{ padding: "0.2rem 0.5rem", fontSize: "0.75rem" }}
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  )}
-
-                  {/* Section 2: Safety Interlocks Boundaries (Only for legacy tags currently, or if tag is in config.interlocks) */}
-                  {!isCustom && (
-                    <div style={{ borderTop: "1px solid var(--panel-border)", paddingTop: "0.75rem" }}>
-                      <div style={{ display: "flex", alignItems: "center", gap: "0.3rem", marginBottom: "0.5rem" }}>
-                        <Sliders size={14} color="var(--accent-purple)" />
-                        <span style={{ fontSize: "0.8rem", fontWeight: 700, textTransform: "uppercase" }}>Safety Limits Interlocks</span>
-                      </div>
-                      <div className="input-group">
-                        <label className="input-label">High Trip Limit (Alarm High)</label>
-                        <input
-                          type="number"
-                          step="0.5"
-                          className="form-input"
-                          value={config.interlocks[inspectorView.tagId]?.high_limit ?? 100.0}
-                          onChange={(e) => handleInterlockChange(inspectorView.tagId, "high_limit", Number(e.target.value))}
-                        />
-                      </div>
-                      <div className="input-group">
-                        <label className="input-label">Low Trip Limit (Alarm Low)</label>
-                        <input
-                          type="number"
-                          step="0.5"
-                          className="form-input"
-                          value={config.interlocks[inspectorView.tagId]?.low_limit ?? 0.0}
-                          onChange={(e) => handleInterlockChange(inspectorView.tagId, "low_limit", Number(e.target.value))}
-                        />
-                      </div>
-                      <button
-                        type="button"
-                        onClick={handleDeploy}
-                        disabled={deploying}
-                        className="btn btn-primary"
-                        style={{ width: "100%", padding: "0.5rem", fontSize: "0.85rem", marginTop: "0.5rem" }}
-                      >
-                        {deploying ? "Deploying Configuration..." : "Commit Safety Limits"}
-                      </button>
-                    </div>
-                  )}
-                </div>
-              );
-            })()}
+            {(inspectorView.type === "tag" || inspectorView.type === "custom_tag") && (
+              <TagInspector
+                view={inspectorView}
+                allTags={allTags}
+                tagsDict={tagsDict}
+                tagValues={tagValues}
+                config={config}
+                overrideVal={overrideVal}
+                showOverrideConfirm={showOverrideConfirm}
+                deploying={deploying}
+                onOverrideValChange={setOverrideVal}
+                onShowOverrideConfirmChange={setShowOverrideConfirm}
+                onExecuteOverride={executeOverride}
+                onInterlockChange={handleInterlockChange}
+                onDeploy={handleDeploy}
+              />
+            )}
 
             {/* PID Loop Tune editor */}
             {inspectorView.type === "pid" && (
@@ -1631,112 +1475,17 @@ export const App: React.FC = () => {
               </div>
             )}
 
-            {/* Alicat Mass Flow Controller inspector */}
-            {inspectorView.type === "alicat" && (() => {
-              const mfc = alicats.find((m) => m.device_id === inspectorView.deviceId);
-              if (!mfc) {
-                return (
-                  <div style={{ fontSize: "0.8rem", color: "var(--text-secondary)" }}>
-                    Alicat MFC {inspectorView.deviceId} not found.
-                  </div>
-                );
-              }
-              return (
-                <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-                  <div>
-                    <h3 style={{ fontSize: "1rem", fontWeight: 700, color: "var(--color-warning)", textTransform: "uppercase" }}>
-                      Inspect {mfc.name}
-                    </h3>
-                    <div style={{ fontSize: "0.75rem", color: "var(--text-secondary)", marginTop: "0.2rem" }}>
-                      Device ID: {mfc.device_id} | State: {mfc.connection_state}
-                    </div>
-                  </div>
-
-                  {/* Realtime Stats Block */}
-                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.5rem", background: "var(--input-bg)", padding: "0.75rem", borderRadius: "4px", border: "1px solid var(--panel-border)" }}>
-                    <div>
-                      <div style={{ fontSize: "0.65rem", color: "var(--text-muted)", textTransform: "uppercase" }}>Mass Flow</div>
-                      <div className="mono-text" style={{ fontSize: "1.05rem", fontWeight: 700, color: "var(--accent-cyan)" }}>
-                        {mfc.mass_flow.toFixed(2)} <span style={{ fontSize: "0.7rem", fontWeight: 500 }}>SLPM</span>
-                      </div>
-                    </div>
-                    <div>
-                      <div style={{ fontSize: "0.65rem", color: "var(--text-muted)", textTransform: "uppercase" }}>Vol. Flow</div>
-                      <div className="mono-text" style={{ fontSize: "1.05rem", fontWeight: 700, color: "var(--text-secondary)" }}>
-                        {mfc.volumetric_flow.toFixed(2)} <span style={{ fontSize: "0.7rem", fontWeight: 500 }}>LPM</span>
-                      </div>
-                    </div>
-                    <div style={{ marginTop: "0.35rem" }}>
-                      <div style={{ fontSize: "0.65rem", color: "var(--text-muted)", textTransform: "uppercase" }}>Pressure</div>
-                      <div className="mono-text" style={{ fontSize: "1.05rem", fontWeight: 700, color: "var(--text-primary)" }}>
-                        {mfc.pressure.toFixed(2)} <span style={{ fontSize: "0.7rem", fontWeight: 500 }}>PSIA</span>
-                      </div>
-                    </div>
-                    <div style={{ marginTop: "0.35rem" }}>
-                      <div style={{ fontSize: "0.65rem", color: "var(--text-muted)", textTransform: "uppercase" }}>Temperature</div>
-                      <div className="mono-text" style={{ fontSize: "1.05rem", fontWeight: 700, color: "var(--text-primary)" }}>
-                        {mfc.temperature.toFixed(1)} <span style={{ fontSize: "0.7rem", fontWeight: 500 }}>°C</span>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Form 1: Setpoint command */}
-                  <div style={{ borderTop: "1px solid var(--panel-border)", paddingTop: "0.75rem" }}>
-                    <label className="input-label" style={{ fontWeight: 700, marginBottom: "0.4rem", display: "block" }}>
-                      Flow Setpoint Command (SLPM)
-                    </label>
-                    <div style={{ display: "flex", gap: "0.5rem" }}>
-                      <input
-                        type="number"
-                        step="0.1"
-                        min="0"
-                        max={mfc.max_flow}
-                        className="form-input"
-                        style={{ flex: 1 }}
-                        value={alicatSetpointVal}
-                        onChange={(e) => setAlicatSetpointVal(e.target.value)}
-                      />
-                      <button
-                        type="button"
-                        className="btn btn-primary"
-                        style={{ padding: "0.45rem 1rem", fontSize: "0.8rem", whiteSpace: "nowrap" }}
-                        onClick={() => {
-                          const parsed = parseFloat(alicatSetpointVal);
-                          if (!isNaN(parsed) && parsed >= 0 && parsed <= mfc.max_flow) {
-                            handleAlicatSetpoint(mfc.device_id, parsed);
-                          } else {
-                            triggerNotification(`Please enter a valid setpoint between 0 and ${mfc.max_flow}.`, "error");
-                          }
-                        }}
-                      >
-                        Set
-                      </button>
-                    </div>
-                    <div style={{ fontSize: "0.65rem", color: "var(--text-muted)", marginTop: "0.25rem" }}>
-                      Maximum flow limit: {mfc.max_flow} SLPM
-                    </div>
-                  </div>
-
-                  {/* Form 2: Gas select dropdown */}
-                  <div style={{ borderTop: "1px solid var(--panel-border)", paddingTop: "0.75rem" }}>
-                    <label className="input-label" style={{ fontWeight: 700, marginBottom: "0.4rem", display: "block" }}>
-                      Active Gas Calibration
-                    </label>
-                    <select
-                      className="form-input"
-                      value={mfc.gas}
-                      onChange={(e) => handleAlicatGas(mfc.device_id, e.target.value)}
-                    >
-                      {["O2", "N2", "CO2", "He", "H2", "Air"].map((species) => (
-                        <option key={species} value={species}>
-                          {species} ({species === "O2" ? "Oxygen" : species === "N2" ? "Nitrogen" : species === "CO2" ? "Carbon Dioxide" : species === "He" ? "Helium" : species === "H2" ? "Hydrogen" : "Clean Air"})
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-              );
-            })()}
+            {inspectorView.type === "alicat" && (
+              <AlicatInspector
+                deviceId={inspectorView.deviceId}
+                alicats={alicats}
+                setpointValue={alicatSetpointVal}
+                onSetpointValueChange={setAlicatSetpointVal}
+                onSetpoint={handleAlicatSetpoint}
+                onGasChange={handleAlicatGas}
+                triggerNotification={triggerNotification}
+              />
+            )}
           </div>
         </aside>
       </div>

--- a/src/p1am_control_system/frontend/src/App.tsx
+++ b/src/p1am_control_system/frontend/src/App.tsx
@@ -16,7 +16,14 @@ import { NotificationBanner } from "./components/NotificationBanner";
 import { TabBar } from "./components/TabBar";
 import { CsvExporter } from "./components/CsvExporter";
 import { useTelemetryStream } from "./hooks/useTelemetryStream";
-import { TABS, type TabId, defaultTabVisibility } from "./lib/tabs";
+import {
+  TABS,
+  type TabId,
+  loadTabOrder,
+  saveTabOrder,
+  loadTabVisibility,
+  saveTabVisibility,
+} from "./lib/tabs";
 import { TAG_INDICES, tagName, parseTagId } from "./lib/tags";
 import { fmtNumber } from "./lib/format";
 import * as api from "./api/endpoints";
@@ -116,11 +123,20 @@ export const App: React.FC = () => {
   // Events history (polled separately from the live stream).
   const [eventsHistory, setEventsHistory] = useState<EventLogEntry[]>([]);
 
-  // Tab Navigation and Visibility State
+  // Tab Navigation, Order, and Visibility State (order + visibility persisted
+  // to localStorage so an operator's layout survives reloads).
   const [activeTab, setActiveTab] = useState<TabId>("powerSupply");
   const [visibleTabs, setVisibleTabs] = useState<Record<TabId, boolean>>(
-    defaultTabVisibility,
+    loadTabVisibility,
   );
+  const [tabOrder, setTabOrder] = useState<TabId[]>(loadTabOrder);
+
+  useEffect(() => {
+    saveTabOrder(tabOrder);
+  }, [tabOrder]);
+  useEffect(() => {
+    saveTabVisibility(visibleTabs);
+  }, [visibleTabs]);
 
   // PID Tuning State
   const [selectedTuningLoop, setSelectedTuningLoop] = useState<number>(0);
@@ -641,6 +657,9 @@ export const App: React.FC = () => {
             activeTab={activeTab}
             visibleTabs={visibleTabs}
             onSelect={setActiveTab}
+            order={tabOrder}
+            onReorder={setTabOrder}
+            onHide={handleTabVisibilityToggle}
           />
 
           {activeTab === "powerSupply" && visibleTabs.powerSupply && (

--- a/src/p1am_control_system/frontend/src/components/AlicatInspector.tsx
+++ b/src/p1am_control_system/frontend/src/components/AlicatInspector.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import type { AlicatMFCState } from "../api/schemas";
+import type { TriggerNotification } from "../types";
+
+export const AlicatInspector: React.FC<{
+  deviceId: string;
+  alicats: AlicatMFCState[];
+  setpointValue: string;
+  onSetpointValueChange: (value: string) => void;
+  onSetpoint: (deviceId: string, value: number) => void;
+  onGasChange: (deviceId: string, gas: string) => void;
+  triggerNotification: TriggerNotification;
+}> = ({
+  deviceId,
+  alicats,
+  setpointValue,
+  onSetpointValueChange,
+  onSetpoint,
+  onGasChange,
+  triggerNotification,
+}) => {
+  const mfc = alicats.find((item) => item.device_id === deviceId);
+  if (!mfc) {
+    return (
+      <div style={{ fontSize: "0.8rem", color: "var(--text-secondary)" }}>
+        Alicat MFC {deviceId} not found.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div>
+        <h3
+          style={{
+            fontSize: "1rem",
+            fontWeight: 700,
+            color: "var(--color-warning)",
+            textTransform: "uppercase",
+          }}
+        >
+          Inspect {mfc.name}
+        </h3>
+        <div
+          style={{
+            fontSize: "0.75rem",
+            color: "var(--text-secondary)",
+            marginTop: "0.2rem",
+          }}
+        >
+          Device ID: {mfc.device_id} | State: {mfc.connection_state}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: "0.5rem",
+          background: "var(--input-bg)",
+          padding: "0.75rem",
+          borderRadius: "4px",
+          border: "1px solid var(--panel-border)",
+        }}
+      >
+        <MfcReadout label="Mass Flow" value={mfc.mass_flow.toFixed(2)} unit="SLPM" />
+        <MfcReadout
+          label="Vol. Flow"
+          value={mfc.volumetric_flow.toFixed(2)}
+          unit="LPM"
+          muted
+        />
+        <MfcReadout label="Pressure" value={mfc.pressure.toFixed(2)} unit="PSIA" />
+        <MfcReadout
+          label="Temperature"
+          value={mfc.temperature.toFixed(1)}
+          unit={"\u00b0C"}
+        />
+      </div>
+
+      <div
+        style={{
+          borderTop: "1px solid var(--panel-border)",
+          paddingTop: "0.75rem",
+        }}
+      >
+        <label
+          className="input-label"
+          style={{ fontWeight: 700, marginBottom: "0.4rem", display: "block" }}
+        >
+          Flow Setpoint Command (SLPM)
+        </label>
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          <input
+            type="number"
+            step="0.1"
+            min="0"
+            max={mfc.max_flow}
+            className="form-input"
+            style={{ flex: 1 }}
+            value={setpointValue}
+            onChange={(e) => onSetpointValueChange(e.target.value)}
+          />
+          <button
+            type="button"
+            className="btn btn-primary"
+            style={{
+              padding: "0.45rem 1rem",
+              fontSize: "0.8rem",
+              whiteSpace: "nowrap",
+            }}
+            onClick={() => {
+              const parsed = parseFloat(setpointValue);
+              if (!isNaN(parsed) && parsed >= 0 && parsed <= mfc.max_flow) {
+                onSetpoint(mfc.device_id, parsed);
+              } else {
+                triggerNotification(
+                  `Please enter a valid setpoint between 0 and ${mfc.max_flow}.`,
+                  "error",
+                );
+              }
+            }}
+          >
+            Set
+          </button>
+        </div>
+        <div
+          style={{
+            fontSize: "0.65rem",
+            color: "var(--text-muted)",
+            marginTop: "0.25rem",
+          }}
+        >
+          Maximum flow limit: {mfc.max_flow} SLPM
+        </div>
+      </div>
+
+      <div
+        style={{
+          borderTop: "1px solid var(--panel-border)",
+          paddingTop: "0.75rem",
+        }}
+      >
+        <label
+          className="input-label"
+          style={{ fontWeight: 700, marginBottom: "0.4rem", display: "block" }}
+        >
+          Active Gas Calibration
+        </label>
+        <select
+          className="form-input"
+          value={mfc.gas}
+          onChange={(e) => onGasChange(mfc.device_id, e.target.value)}
+        >
+          {["O2", "N2", "CO2", "He", "H2", "Air"].map((species) => (
+            <option key={species} value={species}>
+              {species} ({gasLabel(species)})
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+const MfcReadout: React.FC<{
+  label: string;
+  value: string;
+  unit: string;
+  muted?: boolean;
+}> = ({ label, value, unit, muted }) => (
+  <div style={{ marginTop: label === "Mass Flow" || label === "Vol. Flow" ? 0 : "0.35rem" }}>
+    <div
+      style={{
+        fontSize: "0.65rem",
+        color: "var(--text-muted)",
+        textTransform: "uppercase",
+      }}
+    >
+      {label}
+    </div>
+    <div
+      className="mono-text"
+      style={{
+        fontSize: "1.05rem",
+        fontWeight: 700,
+        color: muted ? "var(--text-secondary)" : "var(--text-primary)",
+      }}
+    >
+      {value} <span style={{ fontSize: "0.7rem", fontWeight: 500 }}>{unit}</span>
+    </div>
+  </div>
+);
+
+function gasLabel(species: string): string {
+  if (species === "O2") return "Oxygen";
+  if (species === "N2") return "Nitrogen";
+  if (species === "CO2") return "Carbon Dioxide";
+  if (species === "He") return "Helium";
+  if (species === "H2") return "Hydrogen";
+  return "Clean Air";
+}

--- a/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
+++ b/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
@@ -126,6 +126,13 @@ const STATE_HINTS: Record<PowerSupplyStatus["state"], string> = {
   tripped: "latched · acknowledge",
 };
 
+/** Format a wattage as kW (the supply runs in the kW range). */
+function fmtKW(watts: number | null | undefined): string {
+  if (watts == null) return "—";
+  const kw = watts / 1000;
+  return `${kw.toFixed(kw >= 10 ? 1 : 2)} kW`;
+}
+
 const NOISE_METRIC_LABELS: Record<NoiseMetric, string> = {
   std: "Std deviation",
   peak_to_peak: "Peak-to-peak",
@@ -707,7 +714,7 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
           />
           <Readout
             label="Power (V × I)"
-            value={`${s?.measured_power_w.toFixed(1) ?? "—"} W`}
+            value={fmtKW(s?.measured_power_w)}
             warning={powerWarn}
           />
           <Readout
@@ -718,7 +725,7 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
           {s?.mode === "power" && (
             <Readout
               label="Power setpoint"
-              value={s.setpoint_w != null ? `${s.setpoint_w.toFixed(1)} W` : "—"}
+              value={s.setpoint_w != null ? fmtKW(s.setpoint_w) : "—"}
             />
           )}
         </div>

--- a/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
+++ b/src/p1am_control_system/frontend/src/components/PowerSupplyControl.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import { Download } from "lucide-react";
 import { PowerSupplyTrend, type TrendSample } from "./PowerSupplyTrend";
+import { fetchWithTimeout } from "../lib/fetchWithTimeout";
 import "./PowerSupplyControl.css";
 
 // Rolling trend buffer: ~300 samples at the ~10 Hz broadcast rate ≈ 30 s.
@@ -173,7 +174,7 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch("/api/power_supply/config");
+        const res = await fetchWithTimeout("/api/power_supply/config");
         if (!res.ok) throw new Error(`config GET ${res.status}`);
         const cfg = (await res.json()) as PowerSupplyConfig;
         setConfig(cfg);
@@ -261,7 +262,7 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
           mode === "current"
             ? { mode: "current", value_a: rawValue }
             : { mode: "power", value_w: rawValue };
-        const res = await fetch("/api/power_supply/setpoint", {
+        const res = await fetchWithTimeout("/api/power_supply/setpoint", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify(body),
@@ -318,7 +319,7 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
         return;
       setBusy(true);
       try {
-        const res = await fetch("/api/power_supply/permissive", {
+        const res = await fetchWithTimeout("/api/power_supply/permissive", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ enabled }),
@@ -337,7 +338,7 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
   const acknowledgeTrip = useCallback(async () => {
     setBusy(true);
     try {
-      const res = await fetch("/api/power_supply/acknowledge_trip", {
+      const res = await fetchWithTimeout("/api/power_supply/acknowledge_trip", {
         method: "POST",
       });
       if (!res.ok) throw new Error(await res.text());
@@ -355,7 +356,7 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
     async (next: PowerSupplyConfig, okMessage: string) => {
       setBusy(true);
       try {
-        const res = await fetch("/api/power_supply/config", {
+        const res = await fetchWithTimeout("/api/power_supply/config", {
           method: "PUT",
           headers: { "content-type": "application/json" },
           body: JSON.stringify(next),
@@ -490,10 +491,18 @@ export const PowerSupplyControl: React.FC<Props> = ({ liveStatus, onExport }) =>
             className={`ps-permissive ${s?.permissive ? "is-on" : ""}`}
             onClick={() => setPermissive(!s?.permissive)}
             disabled={busy}
-            title="Master enable — output is forced to 0 while OFF"
+            title={
+              busy
+                ? "Applying — please wait…"
+                : "Master enable — output is forced to 0 while OFF"
+            }
           >
             <span className="dot" />
-            {s?.permissive ? "PERMISSIVE ON" : "PERMISSIVE OFF"}
+            {busy
+              ? "APPLYING…"
+              : s?.permissive
+                ? "PERMISSIVE ON"
+                : "PERMISSIVE OFF"}
           </button>
         </div>
       </div>

--- a/src/p1am_control_system/frontend/src/components/PowerSupplyTrend.tsx
+++ b/src/p1am_control_system/frontend/src/components/PowerSupplyTrend.tsx
@@ -94,7 +94,9 @@ export const PowerSupplyTrend: React.FC<Props> = ({
         <span className="ps-trend-key">
           <span className="swatch" style={{ background: POWER_COLOR }} />
           Power
-          <strong>{last ? `${last.p.toFixed(1)} W` : "—"}</strong>
+          <strong>
+            {last ? `${(last.p / 1000).toFixed(last.p / 1000 >= 10 ? 1 : 2)} kW` : "—"}
+          </strong>
         </span>
         <span className="ps-trend-window">last {windowSeconds}s · % of full scale</span>
       </div>

--- a/src/p1am_control_system/frontend/src/components/TabBar.test.tsx
+++ b/src/p1am_control_system/frontend/src/components/TabBar.test.tsx
@@ -38,4 +38,69 @@ describe("TabBar", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Signal Routing" }));
     expect(onSelect).toHaveBeenCalledWith("routing");
   });
+
+  it("renders tabs in the caller-provided order", () => {
+    const order = ["temperature", "powerSupply", "trends"] as const;
+    const rest = TABS.map((t) => t.id).filter(
+      (id) => !order.includes(id as (typeof order)[number]),
+    );
+    render(
+      <TabBar
+        activeTab="trends"
+        visibleTabs={defaultTabVisibility()}
+        onSelect={() => {}}
+        order={[...order, ...rest]}
+      />,
+    );
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveTextContent("Heater Controls");
+    expect(tabs[1]).toHaveTextContent("Power Supply");
+  });
+
+  it("right-click menu hides a tab via onHide", () => {
+    const onHide = vi.fn();
+    render(
+      <TabBar
+        activeTab="trends"
+        visibleTabs={defaultTabVisibility()}
+        onSelect={() => {}}
+        onHide={onHide}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByRole("tab", { name: "Signal Routing" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Hide Tab" }));
+    expect(onHide).toHaveBeenCalledWith("routing");
+  });
+
+  it("right-click Move Right reorders via onReorder", () => {
+    const onReorder = vi.fn();
+    const order = TABS.map((t) => t.id);
+    render(
+      <TabBar
+        activeTab="trends"
+        visibleTabs={defaultTabVisibility()}
+        onSelect={() => {}}
+        order={order}
+        onReorder={onReorder}
+      />,
+    );
+    // Right-click the first tab and move it one slot to the right.
+    fireEvent.contextMenu(screen.getAllByRole("tab")[0]);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Move Right" }));
+    const expected = [order[1], order[0], ...order.slice(2)];
+    expect(onReorder).toHaveBeenCalledWith(expected);
+  });
+
+  it("renames the temperature tab to Heater Controls", () => {
+    render(
+      <TabBar
+        activeTab="temperature"
+        visibleTabs={defaultTabVisibility()}
+        onSelect={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole("tab", { name: "Heater Controls" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/p1am_control_system/frontend/src/components/TabBar.tsx
+++ b/src/p1am_control_system/frontend/src/components/TabBar.tsx
@@ -1,18 +1,85 @@
-import React from "react";
-import { TABS, type TabId } from "../lib/tabs";
+import React, { useEffect, useMemo, useState } from "react";
+import { TABS, type TabId, defaultTabOrder } from "../lib/tabs";
 
 /**
  * Dashboard tab bar (#3543 / #3546).
  *
- * Replaces the eight near-identical inline-styled `<button>` blocks in App.tsx
- * with a single map over the centralized {@link TABS} array. The accent color
- * is the only per-tab variation, applied via the active state.
+ * Renders the centralized {@link TABS} in a caller-controlled order. Tabs can be
+ * reordered by drag-and-drop (or the right-click menu's Move Left/Right, which
+ * also keeps reordering reachable without a pointer drag) and hidden via the
+ * right-click menu. Order/visibility state is owned by the host (App) so it can
+ * be persisted; this component only emits change callbacks.
  */
+
+const TAB_BY_ID: Record<TabId, (typeof TABS)[number]> = Object.fromEntries(
+  TABS.map((tab) => [tab.id, tab]),
+) as Record<TabId, (typeof TABS)[number]>;
+
+interface ContextMenuState {
+  id: TabId;
+  x: number;
+  y: number;
+}
+
 export const TabBar: React.FC<{
   activeTab: TabId;
   visibleTabs: Record<TabId, boolean>;
   onSelect: (id: TabId) => void;
-}> = ({ activeTab, visibleTabs, onSelect }) => {
+  /** Display order of tab ids. Defaults to the declared {@link TABS} order. */
+  order?: TabId[];
+  /** Emitted with the new full id order after a drag or Move Left/Right. */
+  onReorder?: (order: TabId[]) => void;
+  /** Emitted when the operator hides a tab from the right-click menu. */
+  onHide?: (id: TabId) => void;
+}> = ({ activeTab, visibleTabs, onSelect, order, onReorder, onHide }) => {
+  const [dragId, setDragId] = useState<TabId | null>(null);
+  const [menu, setMenu] = useState<ContextMenuState | null>(null);
+
+  // Effective order: caller's order (known ids only) + any tabs missing from it
+  // (a tab added in a new release must never be silently dropped).
+  const effectiveOrder = useMemo<TabId[]>(() => {
+    const base = order && order.length ? order : defaultTabOrder();
+    const kept = base.filter((id) => TAB_BY_ID[id]);
+    const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+    return [...kept, ...missing];
+  }, [order]);
+
+  const visibleOrdered = effectiveOrder.filter((id) => visibleTabs[id]);
+
+  // Dismiss the context menu on any outside click or Escape.
+  useEffect(() => {
+    if (!menu) return;
+    const close = () => setMenu(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenu(null);
+    };
+    window.addEventListener("click", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("click", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [menu]);
+
+  const dropBefore = (dragged: TabId, target: TabId) => {
+    if (dragged === target || !onReorder) return;
+    const next = effectiveOrder.filter((id) => id !== dragged);
+    next.splice(next.indexOf(target), 0, dragged);
+    onReorder(next);
+  };
+
+  const move = (id: TabId, dir: -1 | 1) => {
+    if (!onReorder) return;
+    const idx = effectiveOrder.indexOf(id);
+    const swap = idx + dir;
+    if (swap < 0 || swap >= effectiveOrder.length) return;
+    const next = [...effectiveOrder];
+    [next[idx], next[swap]] = [next[swap], next[idx]];
+    onReorder(next);
+  };
+
+  const menuTab = menu ? TAB_BY_ID[menu.id] : null;
+
   return (
     <div
       role="tablist"
@@ -24,25 +91,148 @@ export const TabBar: React.FC<{
         marginBottom: "0.5rem",
       }}
     >
-      {TABS.filter((tab) => visibleTabs[tab.id]).map((tab) => {
-        const isActive = activeTab === tab.id;
+      {visibleOrdered.map((id) => {
+        const tab = TAB_BY_ID[id];
+        const isActive = activeTab === id;
         return (
           <button
-            key={tab.id}
+            key={id}
             type="button"
             role="tab"
             aria-selected={isActive}
-            className={`tab-btn ${isActive ? "active" : ""}`}
-            onClick={() => onSelect(tab.id)}
+            draggable
+            className={`tab-btn ${isActive ? "active" : ""} ${
+              dragId === id ? "dragging" : ""
+            }`}
+            onClick={() => onSelect(id)}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              setMenu({ id, x: e.clientX, y: e.clientY });
+            }}
+            onDragStart={(e) => {
+              setDragId(id);
+              e.dataTransfer.effectAllowed = "move";
+            }}
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={(e) => {
+              e.preventDefault();
+              if (dragId) dropBefore(dragId, id);
+              setDragId(null);
+            }}
+            onDragEnd={() => setDragId(null)}
+            title="Drag to reorder · right-click for options"
             style={{
               color: isActive ? tab.accentVar : "var(--text-secondary)",
               borderBottomColor: isActive ? tab.accentVar : "transparent",
+              cursor: "grab",
+              opacity: dragId === id ? 0.4 : 1,
             }}
           >
             {tab.label}
           </button>
         );
       })}
+
+      {menu && menuTab && (
+        <div
+          role="menu"
+          aria-label={`${menuTab.label} tab options`}
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: "fixed",
+            top: menu.y,
+            left: menu.x,
+            zIndex: 1000,
+            minWidth: "9rem",
+            background: "var(--panel-bg)",
+            border: "1px solid var(--panel-border)",
+            borderRadius: "8px",
+            boxShadow: "0 8px 24px rgba(0,0,0,0.35)",
+            padding: "0.25rem",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
+          <div
+            style={{
+              fontSize: "0.65rem",
+              fontWeight: 700,
+              textTransform: "uppercase",
+              letterSpacing: "0.04em",
+              color: "var(--text-muted)",
+              padding: "0.3rem 0.5rem 0.2rem",
+            }}
+          >
+            {menuTab.label}
+          </div>
+          <MenuItem
+            disabled={effectiveOrder.indexOf(menu.id) === 0}
+            onClick={() => {
+              move(menu.id, -1);
+              setMenu(null);
+            }}
+          >
+            Move Left
+          </MenuItem>
+          <MenuItem
+            disabled={
+              effectiveOrder.indexOf(menu.id) === effectiveOrder.length - 1
+            }
+            onClick={() => {
+              move(menu.id, 1);
+              setMenu(null);
+            }}
+          >
+            Move Right
+          </MenuItem>
+          <MenuItem
+            danger
+            onClick={() => {
+              onHide?.(menu.id);
+              setMenu(null);
+            }}
+          >
+            Hide Tab
+          </MenuItem>
+        </div>
+      )}
     </div>
   );
 };
+
+const MenuItem: React.FC<{
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+  children: React.ReactNode;
+}> = ({ onClick, disabled, danger, children }) => (
+  <button
+    type="button"
+    role="menuitem"
+    disabled={disabled}
+    onClick={onClick}
+    style={{
+      textAlign: "left",
+      background: "none",
+      border: "none",
+      borderRadius: "6px",
+      padding: "0.4rem 0.5rem",
+      fontSize: "0.8rem",
+      cursor: disabled ? "not-allowed" : "pointer",
+      color: disabled
+        ? "var(--text-muted)"
+        : danger
+          ? "var(--color-danger, #ef4444)"
+          : "var(--text-primary)",
+      opacity: disabled ? 0.5 : 1,
+    }}
+    onMouseEnter={(e) => {
+      if (!disabled) e.currentTarget.style.background = "var(--input-bg)";
+    }}
+    onMouseLeave={(e) => {
+      e.currentTarget.style.background = "none";
+    }}
+  >
+    {children}
+  </button>
+);

--- a/src/p1am_control_system/frontend/src/components/TagInspector.test.tsx
+++ b/src/p1am_control_system/frontend/src/components/TagInspector.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { TagInspector } from "./TagInspector";
+import type { LadderTagInfo } from "../api/schemas";
+import type { RoutingConfig } from "../types";
+
+const routingConfig: RoutingConfig = {
+  input_routing: [0, 1, 2, 3, 4, 5],
+  output_routing: [10, 11],
+  pids: [],
+  interlocks: Array.from({ length: 32 }, () => ({
+    lolo_limit: 0,
+    low_limit: 5,
+    high_limit: 95,
+    hihi_limit: 100,
+  })),
+};
+
+const tagInfo = (
+  name: string,
+  rw_mode: LadderTagInfo["rw_mode"],
+): LadderTagInfo => ({
+  name,
+  rw_mode,
+  tag_type: "Real",
+  description: `${name} description`,
+  register_type: "HR",
+  register_num: 402,
+  data_format: "float",
+  scale_factor: 1,
+  area: "process",
+  unit: "unit",
+  equipment: "bench",
+});
+
+const renderInspector = (
+  overrides: Partial<React.ComponentProps<typeof TagInspector>> = {},
+) => {
+  const props: React.ComponentProps<typeof TagInspector> = {
+    view: { type: "tag", tagId: 2 },
+    allTags: [tagInfo("TAG_2", "Read/Write")],
+    tagsDict: {},
+    tagValues: [0, 0, 42.25],
+    config: routingConfig,
+    overrideVal: "7.5",
+    showOverrideConfirm: false,
+    deploying: false,
+    onOverrideValChange: vi.fn(),
+    onShowOverrideConfirmChange: vi.fn(),
+    onExecuteOverride: vi.fn(),
+    onInterlockChange: vi.fn(),
+    onDeploy: vi.fn(),
+    ...overrides,
+  };
+  render(<TagInspector {...props} />);
+  return props;
+};
+
+describe("TagInspector", () => {
+  it("renders tag metadata and asks for confirmation before executing an override", () => {
+    const props = renderInspector({ showOverrideConfirm: true });
+
+    expect(screen.getByText("TAG_2")).toBeInTheDocument();
+    expect(screen.getByText("42.25")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(props.onExecuteOverride).toHaveBeenCalledWith(2);
+  });
+
+  it("hides manual write controls for read-only custom tags", () => {
+    renderInspector({
+      view: { type: "custom_tag", tagName: "READ_ONLY_TEMP" },
+      allTags: [tagInfo("READ_ONLY_TEMP", "Read-only")],
+      tagsDict: { READ_ONLY_TEMP: 18.5 },
+    });
+
+    expect(screen.getByText("READ_ONLY_TEMP")).toBeInTheDocument();
+    expect(screen.queryByText("Force Register Write")).toBeNull();
+    expect(screen.queryByText("Safety Limits Interlocks")).toBeNull();
+  });
+});

--- a/src/p1am_control_system/frontend/src/components/TagInspector.tsx
+++ b/src/p1am_control_system/frontend/src/components/TagInspector.tsx
@@ -1,0 +1,347 @@
+import React from "react";
+import { ShieldAlert, Sliders } from "lucide-react";
+import type { LadderTagInfo } from "../api/schemas";
+import type { InspectorState } from "../lib/inspector";
+import { tagName } from "../lib/tags";
+import type { InterlockConfig, RoutingConfig } from "../types";
+
+type TagInspectorView = Extract<
+  InspectorState,
+  { type: "tag" } | { type: "custom_tag" }
+>;
+
+export const TagInspector: React.FC<{
+  view: TagInspectorView;
+  allTags: LadderTagInfo[];
+  tagsDict: Record<string, number>;
+  tagValues: number[];
+  config: RoutingConfig;
+  overrideVal: string;
+  showOverrideConfirm: boolean;
+  deploying: boolean;
+  onOverrideValChange: (value: string) => void;
+  onShowOverrideConfirmChange: (show: boolean) => void;
+  onExecuteOverride: (tagId: number | string) => void;
+  onInterlockChange: (
+    tagId: number,
+    field: keyof InterlockConfig,
+    value: number,
+  ) => void;
+  onDeploy: () => void;
+}> = ({
+  view,
+  allTags,
+  tagsDict,
+  tagValues,
+  config,
+  overrideVal,
+  showOverrideConfirm,
+  deploying,
+  onOverrideValChange,
+  onShowOverrideConfirmChange,
+  onExecuteOverride,
+  onInterlockChange,
+  onDeploy,
+}) => {
+  const isCustom = view.type === "custom_tag";
+  const tagLabel = isCustom ? view.tagName : tagName(view.tagId);
+  const tagInfo = allTags.find((t) => t.name === tagLabel);
+  const currentVal = isCustom
+    ? (tagsDict[tagLabel] ?? 0.0)
+    : (tagValues[view.tagId] ?? 0.0);
+  const rwMode = tagInfo ? tagInfo.rw_mode : "Read/Write";
+  const isWritable = rwMode === "Read/Write";
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+      <div>
+        <h3
+          style={{
+            fontSize: "1rem",
+            fontWeight: 700,
+            color: "var(--accent-cyan)",
+            textTransform: "uppercase",
+          }}
+        >
+          Tag Inspector
+        </h3>
+        <div
+          style={{
+            fontSize: "0.8rem",
+            color: "var(--text-primary)",
+            fontWeight: 700,
+            marginTop: "0.25rem",
+          }}
+          className="mono-text"
+        >
+          {tagLabel}
+        </div>
+        {tagInfo && tagInfo.description && (
+          <p
+            style={{
+              fontSize: "0.75rem",
+              color: "var(--text-secondary)",
+              marginTop: "0.25rem",
+              lineHeight: 1.4,
+            }}
+          >
+            {tagInfo.description}
+          </p>
+        )}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            background: "var(--input-bg)",
+            padding: "0.5rem",
+            borderRadius: "4px",
+            marginTop: "0.5rem",
+            border: "1px solid var(--panel-border)",
+          }}
+        >
+          <span style={{ fontSize: "0.8rem", color: "var(--text-muted)" }}>
+            Current Value:
+          </span>
+          <span
+            className="mono-text"
+            style={{
+              fontSize: "0.9rem",
+              fontWeight: 700,
+              color: "var(--accent-cyan)",
+            }}
+          >
+            {currentVal.toFixed(2)}
+          </span>
+        </div>
+      </div>
+
+      {tagInfo && (
+        <div
+          style={{
+            fontSize: "0.75rem",
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: "0.5rem",
+            background: "rgba(255,255,255,0.01)",
+            padding: "0.5rem",
+            borderRadius: "4px",
+            border: "1px solid var(--panel-border)",
+          }}
+        >
+          <div>
+            <span style={{ color: "var(--text-muted)" }}>Reg Type:</span>{" "}
+            <strong style={{ color: "var(--text-secondary)" }}>
+              {tagInfo.register_type || "None"}
+            </strong>
+          </div>
+          <div>
+            <span style={{ color: "var(--text-muted)" }}>Reg Num:</span>{" "}
+            <strong style={{ color: "var(--text-secondary)" }}>
+              {tagInfo.register_num ?? "None"}
+            </strong>
+          </div>
+          <div>
+            <span style={{ color: "var(--text-muted)" }}>Format:</span>{" "}
+            <strong style={{ color: "var(--text-secondary)" }}>
+              {tagInfo.data_format || "None"}
+            </strong>
+          </div>
+          <div>
+            <span style={{ color: "var(--text-muted)" }}>RW Mode:</span>{" "}
+            <strong style={{ color: "var(--text-secondary)" }}>
+              {tagInfo.rw_mode}
+            </strong>
+          </div>
+        </div>
+      )}
+
+      {isWritable && (
+        <div
+          style={{
+            borderTop: "1px solid var(--panel-border)",
+            paddingTop: "0.75rem",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.3rem",
+              marginBottom: "0.5rem",
+            }}
+          >
+            <ShieldAlert size={14} color="var(--color-warning)" />
+            <span
+              style={{
+                fontSize: "0.8rem",
+                fontWeight: 700,
+                textTransform: "uppercase",
+              }}
+            >
+              Manual Force Override
+            </span>
+          </div>
+          <div className="input-group">
+            <label className="input-label">Override Force Value</label>
+            <input
+              type="number"
+              step="0.1"
+              className="form-input"
+              value={overrideVal}
+              onChange={(e) => onOverrideValChange(e.target.value)}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => onShowOverrideConfirmChange(true)}
+            className="btn"
+            style={{
+              width: "100%",
+              color: "var(--color-warning)",
+              borderColor: "var(--color-warning)",
+              padding: "0.45rem",
+              fontSize: "0.8rem",
+            }}
+          >
+            Force Register Write
+          </button>
+
+          {showOverrideConfirm && (
+            <div
+              style={{
+                background: "rgba(239, 68, 68, 0.1)",
+                border: "1px solid var(--color-error)",
+                borderRadius: "4px",
+                padding: "0.6rem",
+                marginTop: "0.5rem",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: "0.75rem",
+                  fontWeight: 700,
+                  color: "var(--color-error)",
+                  marginBottom: "0.25rem",
+                }}
+              >
+                Confirm Direct Write
+              </div>
+              <p
+                style={{
+                  fontSize: "0.7rem",
+                  color: "var(--text-secondary)",
+                  marginBottom: "0.6rem",
+                }}
+              >
+                Forcing Tag {tagLabel} to {overrideVal} will overwrite normal
+                logic. Continue?
+              </p>
+              <div style={{ display: "flex", gap: "0.4rem" }}>
+                <button
+                  type="button"
+                  onClick={() =>
+                    onExecuteOverride(isCustom ? tagLabel : view.tagId)
+                  }
+                  className="btn"
+                  style={{
+                    background: "var(--color-error)",
+                    border: "none",
+                    color: "#ffffff",
+                    padding: "0.2rem 0.5rem",
+                    fontSize: "0.75rem",
+                  }}
+                >
+                  Confirm
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onShowOverrideConfirmChange(false)}
+                  className="btn"
+                  style={{ padding: "0.2rem 0.5rem", fontSize: "0.75rem" }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isCustom && (
+        <div
+          style={{
+            borderTop: "1px solid var(--panel-border)",
+            paddingTop: "0.75rem",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "0.3rem",
+              marginBottom: "0.5rem",
+            }}
+          >
+            <Sliders size={14} color="var(--accent-purple)" />
+            <span
+              style={{
+                fontSize: "0.8rem",
+                fontWeight: 700,
+                textTransform: "uppercase",
+              }}
+            >
+              Safety Limits Interlocks
+            </span>
+          </div>
+          <div className="input-group">
+            <label className="input-label">High Trip Limit (Alarm High)</label>
+            <input
+              type="number"
+              step="0.5"
+              className="form-input"
+              value={config.interlocks[view.tagId]?.high_limit ?? 100.0}
+              onChange={(e) =>
+                onInterlockChange(
+                  view.tagId,
+                  "high_limit",
+                  Number(e.target.value),
+                )
+              }
+            />
+          </div>
+          <div className="input-group">
+            <label className="input-label">Low Trip Limit (Alarm Low)</label>
+            <input
+              type="number"
+              step="0.5"
+              className="form-input"
+              value={config.interlocks[view.tagId]?.low_limit ?? 0.0}
+              onChange={(e) =>
+                onInterlockChange(
+                  view.tagId,
+                  "low_limit",
+                  Number(e.target.value),
+                )
+              }
+            />
+          </div>
+          <button
+            type="button"
+            onClick={onDeploy}
+            disabled={deploying}
+            className="btn btn-primary"
+            style={{
+              width: "100%",
+              padding: "0.5rem",
+              fontSize: "0.85rem",
+              marginTop: "0.5rem",
+            }}
+          >
+            {deploying ? "Deploying Configuration..." : "Commit Safety Limits"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+

--- a/src/p1am_control_system/frontend/src/components/TemperatureControl.tsx
+++ b/src/p1am_control_system/frontend/src/components/TemperatureControl.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback } from "react";
+import { fetchWithTimeout } from "../lib/fetchWithTimeout";
 import "./TemperatureControl.css";
 
 // Rolling trend buffer: ~300 samples at the ~10 Hz broadcast rate ≈ 30 s.
@@ -84,7 +85,7 @@ export const TemperatureControl: React.FC<Props> = ({ liveStatus }) => {
   useEffect(() => {
     const load = async () => {
       try {
-        const res = await fetch("/api/temperature/config");
+        const res = await fetchWithTimeout("/api/temperature/config");
         if (!res.ok) throw new Error(`config GET ${res.status}`);
         const cfg = (await res.json()) as TemperatureConfig;
         setConfig(cfg);
@@ -148,7 +149,7 @@ export const TemperatureControl: React.FC<Props> = ({ liveStatus }) => {
       }
       setBusy(true);
       try {
-        const res = await fetch("/api/temperature/setpoint", {
+        const res = await fetchWithTimeout("/api/temperature/setpoint", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ value_c: rawValue }),
@@ -201,7 +202,7 @@ export const TemperatureControl: React.FC<Props> = ({ liveStatus }) => {
         return;
       setBusy(true);
       try {
-        const res = await fetch("/api/temperature/permissive", {
+        const res = await fetchWithTimeout("/api/temperature/permissive", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ enabled }),
@@ -220,7 +221,7 @@ export const TemperatureControl: React.FC<Props> = ({ liveStatus }) => {
   const acknowledgeTrip = useCallback(async () => {
     setBusy(true);
     try {
-      const res = await fetch("/api/temperature/acknowledge_trip", {
+      const res = await fetchWithTimeout("/api/temperature/acknowledge_trip", {
         method: "POST",
       });
       if (!res.ok) throw new Error(await res.text());
@@ -236,7 +237,7 @@ export const TemperatureControl: React.FC<Props> = ({ liveStatus }) => {
     if (!configDraft) return;
     setBusy(true);
     try {
-      const res = await fetch("/api/temperature/config", {
+      const res = await fetchWithTimeout("/api/temperature/config", {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(configDraft),
@@ -349,10 +350,18 @@ export const TemperatureControl: React.FC<Props> = ({ liveStatus }) => {
             className={`tc-permissive ${s?.permissive ? "is-on" : ""}`}
             onClick={() => setPermissive(!s?.permissive)}
             disabled={busy}
-            title="Master enable — the heater relay is forced open while OFF"
+            title={
+              busy
+                ? "Applying — please wait…"
+                : "Master enable — the heater relay is forced open while OFF"
+            }
           >
             <span className="dot" />
-            {s?.permissive ? "PERMISSIVE ON" : "PERMISSIVE OFF"}
+            {busy
+              ? "APPLYING…"
+              : s?.permissive
+                ? "PERMISSIVE ON"
+                : "PERMISSIVE OFF"}
           </button>
         </div>
       </div>

--- a/src/p1am_control_system/frontend/src/hooks/useTelemetryStream.ts
+++ b/src/p1am_control_system/frontend/src/hooks/useTelemetryStream.ts
@@ -11,7 +11,19 @@ import type { AlicatMFCState, ActiveAlarm } from "../api/schemas";
  * Extracted from App.tsx, which inlined the entire WS lifecycle plus the
  * frame-parsing/duck-typing logic. The frame is now validated with the
  * `telemetryFrameSchema` zod contract (#3545) instead of `as`-casting fields.
+ *
+ * Resilience: some hosts can't hold a long-lived WebSocket (e.g. an embedded VS
+ * Code Simple Browser webview, or any client behind a proxy that drops idle
+ * sockets), and a backend restart drops every socket. So this hook also polls
+ * the `/api/snapshot` HTTP endpoint whenever no frame has arrived recently — the
+ * UI keeps updating over plain HTTP even with no usable WebSocket. A healthy
+ * WebSocket keeps the data fresh and the poll is a no-op.
  */
+
+/** Treat the stream as stale (fall back to HTTP polling) after this long. */
+const STALE_MS = 3000;
+/** How often to check staleness / poll the snapshot fallback. */
+const POLL_MS = 1500;
 export interface TelemetryState {
   tagValues: number[];
   history: number[][];
@@ -66,6 +78,7 @@ export function useTelemetryStream(
   useEffect(() => {
     let disposed = false;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let lastFrameAt = 0; // epoch ms of the last applied frame (WS or poll)
 
     const pushTags = (values: number[]) => {
       setTagValues(values);
@@ -76,6 +89,43 @@ export function useTelemetryStream(
         }
         return updated;
       });
+    };
+
+    // Apply one telemetry frame from either transport (WS message or snapshot
+    // poll). Returns true if it was a recognized frame.
+    const applyFrame = (raw: unknown): boolean => {
+      const parsed = telemetryFrameSchema.safeParse(raw);
+      if (parsed.success) {
+        const frame = parsed.data;
+        if (frame.tags && frame.tags.length === TAG_COUNT) {
+          pushTags(frame.tags);
+        }
+        if (frame.tags_dict) setTagsDict(frame.tags_dict);
+        if (frame.alicats) setAlicats(frame.alicats);
+        if (frame.active_alarms) {
+          setActiveAlarms(Object.values(frame.active_alarms));
+        }
+        if (typeof frame.e_stop_active === "boolean") {
+          setEStopActive(frame.e_stop_active);
+        }
+        if (frame.power_supply) {
+          setPowerSupplyStatus(frame.power_supply as PowerSupplyStatus);
+        }
+        if (frame.temperature) {
+          setTemperatureStatus(frame.temperature as TemperatureStatus);
+        }
+        lastFrameAt = Date.now();
+        setIsConnected(true);
+        return true;
+      }
+      // Legacy fallback: a bare array of tag values.
+      if (Array.isArray(raw) && raw.length === TAG_COUNT) {
+        pushTags(raw as number[]);
+        lastFrameAt = Date.now();
+        setIsConnected(true);
+        return true;
+      }
+      return false;
     };
 
     const connect = () => {
@@ -91,44 +141,14 @@ export function useTelemetryStream(
       };
 
       ws.onmessage = (event) => {
-        let raw: unknown;
         try {
-          raw = JSON.parse(event.data);
+          applyFrame(JSON.parse(event.data));
         } catch {
-          return;
-        }
-
-        const parsed = telemetryFrameSchema.safeParse(raw);
-        if (parsed.success) {
-          const frame = parsed.data;
-          if (frame.tags && frame.tags.length === TAG_COUNT) {
-            pushTags(frame.tags);
-          }
-          if (frame.tags_dict) setTagsDict(frame.tags_dict);
-          if (frame.alicats) setAlicats(frame.alicats);
-          if (frame.active_alarms) {
-            setActiveAlarms(Object.values(frame.active_alarms));
-          }
-          if (typeof frame.e_stop_active === "boolean") {
-            setEStopActive(frame.e_stop_active);
-          }
-          if (frame.power_supply) {
-            setPowerSupplyStatus(frame.power_supply as PowerSupplyStatus);
-          }
-          if (frame.temperature) {
-            setTemperatureStatus(frame.temperature as TemperatureStatus);
-          }
-          return;
-        }
-
-        // Legacy fallback: a bare array of tag values.
-        if (Array.isArray(raw) && raw.length === TAG_COUNT) {
-          pushTags(raw as number[]);
+          /* malformed frame — ignore */
         }
       };
 
       ws.onclose = () => {
-        setIsConnected(false);
         if (!disposed) {
           reconnectTimer = setTimeout(connect, 3000);
         }
@@ -139,11 +159,27 @@ export function useTelemetryStream(
       };
     };
 
+    // HTTP fallback: when no frame has arrived for STALE_MS (WS down/flaky, or a
+    // webview that can't hold a socket), pull the cached snapshot over plain HTTP.
+    const pollIfStale = async () => {
+      if (disposed || Date.now() - lastFrameAt < STALE_MS) return;
+      try {
+        const res = await fetch("/api/snapshot");
+        if (res.ok && applyFrame(await res.json())) return;
+        setIsConnected(false);
+      } catch {
+        setIsConnected(false);
+      }
+    };
+
     connect();
+    void pollIfStale(); // immediate snapshot so a fresh mount shows data fast
+    const pollTimer = setInterval(pollIfStale, POLL_MS);
 
     return () => {
       disposed = true;
       if (reconnectTimer) clearTimeout(reconnectTimer);
+      clearInterval(pollTimer);
       wsRef.current?.close();
     };
   }, []);

--- a/src/p1am_control_system/frontend/src/lib/fetchWithTimeout.ts
+++ b/src/p1am_control_system/frontend/src/lib/fetchWithTimeout.ts
@@ -1,0 +1,27 @@
+/**
+ * fetch() that always settles within `timeoutMs`.
+ *
+ * Control screens flip a `busy` flag around a request and clear it in `finally`.
+ * A plain fetch() against a backend that accepts the socket but never responds
+ * (e.g. mid-restart) hangs forever, so `busy` sticks true and every control
+ * silently locks with no way to recover but a page reload. Aborting on a timeout
+ * guarantees the promise rejects, the `finally` runs, and `busy` clears.
+ */
+export async function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  timeoutMs = 8000,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      throw new Error(`Request timed out after ${timeoutMs / 1000}s`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/p1am_control_system/frontend/src/lib/inspector.ts
+++ b/src/p1am_control_system/frontend/src/lib/inspector.ts
@@ -1,0 +1,10 @@
+export type InspectorState =
+  | { type: "none" }
+  | { type: "tag"; tagId: number }
+  | { type: "custom_tag"; tagName: string }
+  | { type: "pid"; index: number }
+  | { type: "routing" }
+  | { type: "alicat"; deviceId: string }
+  | { type: "settings" }
+  | { type: "export" };
+

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -82,8 +82,8 @@ export const TABS: readonly TabDef[] = [
   },
   {
     id: "temperature",
-    label: "Temperature",
-    settingsLabel: "Temperature Controller",
+    label: "Heater Controls",
+    settingsLabel: "Heater Controls",
     accentVar: "var(--accent-orange, #fb923c)",
   },
 ] as const;
@@ -97,4 +97,70 @@ export function defaultTabVisibility(): Record<TabId, boolean> {
     },
     {} as Record<TabId, boolean>,
   );
+}
+
+/** The canonical tab id order as declared in {@link TABS}. */
+export function defaultTabOrder(): TabId[] {
+  return TABS.map((tab) => tab.id);
+}
+
+const ORDER_KEY = "p1am.tabOrder.v1";
+const VISIBILITY_KEY = "p1am.tabVisibility.v1";
+
+/**
+ * Reconcile a saved id list with the current {@link TABS}: keep the saved order
+ * for ids that still exist, drop unknown ids, and append any tabs added since
+ * the order was saved (so a new release's tab is never silently hidden).
+ */
+function reconcileOrder(saved: readonly unknown[]): TabId[] {
+  const known = new Set<TabId>(defaultTabOrder());
+  const kept = saved.filter(
+    (id): id is TabId => typeof id === "string" && known.has(id as TabId),
+  );
+  const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+  return [...kept, ...missing];
+}
+
+/** Load the persisted tab order, falling back to the declared order. */
+export function loadTabOrder(): TabId[] {
+  try {
+    const raw = localStorage.getItem(ORDER_KEY);
+    if (raw) return reconcileOrder(JSON.parse(raw));
+  } catch {
+    /* corrupt/unavailable storage — use defaults */
+  }
+  return defaultTabOrder();
+}
+
+export function saveTabOrder(order: readonly TabId[]): void {
+  try {
+    localStorage.setItem(ORDER_KEY, JSON.stringify(order));
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
+}
+
+/** Load persisted visibility, defaulting any unknown/new tab to visible. */
+export function loadTabVisibility(): Record<TabId, boolean> {
+  const base = defaultTabVisibility();
+  try {
+    const raw = localStorage.getItem(VISIBILITY_KEY);
+    if (raw) {
+      const saved = JSON.parse(raw) as Partial<Record<TabId, boolean>>;
+      for (const tab of TABS) {
+        if (typeof saved[tab.id] === "boolean") base[tab.id] = saved[tab.id]!;
+      }
+    }
+  } catch {
+    /* corrupt/unavailable storage — use defaults */
+  }
+  return base;
+}
+
+export function saveTabVisibility(visibility: Record<TabId, boolean>): void {
+  try {
+    localStorage.setItem(VISIBILITY_KEY, JSON.stringify(visibility));
+  } catch {
+    /* storage unavailable — non-fatal */
+  }
 }


### PR DESCRIPTION
## Summary
Operator-facing HMI improvements requested at the bench.

- **Rename** the "Temperature" tab → **Heater Controls** (setpoint control of a resistive heater with the thermocouple as the controlled variable).
- **Reorder tabs by drag-and-drop**, or via a **right-click menu** (Move Left / Move Right / **Hide**). The right-click → Hide removes the need to open Settings just to hide a tab.
- **Persistent layout**: tab **order** *and* **visibility** now save to `localStorage` and survive a reload/restart. The loaders reconcile saved state against the current `TABS`, so a tab added in a future release is never silently dropped or hidden.
- **Permissive lock fix**: the control screens could silently lock — a request that hung (e.g. backend mid-restart) left the `busy` flag stuck `true`, disabling the permissive/setpoint/config controls with **no explanation**. All control fetches now use `fetchWithTimeout` (8 s) so `busy` always clears, and the permissive toggle renders **"APPLYING…"** while busy so a disabled control explains itself.

## Tests
`tsc` clean, `vite build` clean, **vitest 34 passed** (new TabBar tests cover provided-order rendering, right-click Hide → `onHide`, right-click Move Right → `onReorder`, and the Heater Controls rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)