### PR TITLE
fix(pressure-drop): collapse diverged friction-factor twin into a shim

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,7 +27,7 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | 1.1.0                                      |
-| **Spec Version**        | 1.1.603                                    |
+| **Spec Version**        | 1.1.612                                    |
 | **Last Spec Update**    | 2026-06-18                                 |
 
 ## 2. Purpose & Mission
@@ -38,6 +38,14 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 
 ### 2026-06-18 Update
 
+- Collapsed the diverged friction-factor twin in the pressure-drop engine.
+  `engine/friction_factors.py` is now a thin re-export of the canonical
+  `engine/_friction_factors.py` (the module the production engine imports), so
+  there is exactly one implementation of the `friction_factor_*` correlations
+  with a single `Re <= 0` laminar contract that raises (issue #3103) instead of
+  silently returning the 0.064 default. `test_pressure_drop_engine_split` now
+  resolves to the real `sidekick` engine path and asserts the shim re-exports
+  the canonical objects (#3659).
 - P1AM firmware first-boot defaults now keep `SignalBroker::Reset()` as the
   all-unmapped primitive but layer bench-safe routing after an invalid or
   erased flash configuration: thermocouples TC0-TC3 route to TAG_0-TAG_3,

--- a/src/shared/python/sidekick/process_calculators/pressure_drop_calculator/engine/friction_factors.py
+++ b/src/shared/python/sidekick/process_calculators/pressure_drop_calculator/engine/friction_factors.py
@@ -1,17 +1,27 @@
-"""Friction factor correlations for the pressure drop engine."""
+"""Friction factor correlations for the pressure drop engine.
+
+.. deprecated::
+    This module is a thin compatibility shim. The canonical implementation
+    lives in :mod:`._friction_factors`, which the production engine
+    (``pressure_drop_calculation_engine``) imports directly. This shim exists
+    only so older import paths keep working; do not add logic here.
+
+    Historically a byte-identical twin lived here that diverged from the
+    canonical module on the ``Re <= 0`` laminar contract (it silently returned
+    the 0.064 default instead of raising — the bug fixed in issue #3103). The
+    duplicate has been collapsed into this re-export so there is exactly one
+    implementation with the raising contract (issue #3659).
+"""
 
 from __future__ import annotations
 
-import logging
-import math
-
-from ...constants import (
-    CHURCHILL_B_COEFF,
-    COLEBROOK_ROUGHNESS_COEFF,
-    FRICTION_FACTOR_DEFAULT_LAMINAR,
-    LAMINAR_FRICTION_CONSTANT,
-    RE_LAMINAR_UPPER,
-    SWAMEE_JAIN_COEFF,
+from ._friction_factors import (
+    friction_factor_churchill,
+    friction_factor_colebrook,
+    friction_factor_haaland,
+    friction_factor_laminar,
+    friction_factor_swamee_jain,
+    select_friction_factor_method,
 )
 
 __all__ = [
@@ -22,129 +32,3 @@ __all__ = [
     "friction_factor_swamee_jain",
     "select_friction_factor_method",
 ]
-
-_logger = logging.getLogger(__name__)
-
-
-def friction_factor_laminar(reynolds_number: float) -> float:
-    """Calculate friction factor for laminar flow (Re < 2300)."""
-    if reynolds_number <= 0:
-        _logger.error("Reynolds number must be positive")
-        return FRICTION_FACTOR_DEFAULT_LAMINAR
-
-    result = LAMINAR_FRICTION_CONSTANT / reynolds_number
-    if not (result > 0):
-        raise ValueError(f"Friction factor must be positive, got {result}")
-    return result
-
-
-def friction_factor_colebrook(
-    reynolds_number: float,
-    relative_roughness: float,
-    max_iterations: int = 50,
-    tolerance: float = 1e-6,
-) -> float:
-    """Calculate friction factor using Colebrook-White equation (implicit)."""
-    if reynolds_number is None:
-        raise ValueError("reynolds_number must be provided")
-    if reynolds_number < RE_LAMINAR_UPPER:
-        return friction_factor_laminar(reynolds_number)
-
-    f = friction_factor_swamee_jain(reynolds_number, relative_roughness)
-    for iteration in range(max_iterations):
-        f_old = f
-        term1 = relative_roughness / COLEBROOK_ROUGHNESS_COEFF
-        term2 = 2.51 / (reynolds_number * math.sqrt(f))
-        f_new = 0.25 / (math.log10(term1 + term2) ** 2)
-        if abs(f_new - f_old) < tolerance:
-            _logger.debug(
-                "Colebrook converged in %s iterations: f = %.6f",
-                iteration + 1,
-                f_new,
-            )
-            return f_new
-        f = f_new
-
-    _logger.warning("Colebrook did not converge in %s iterations", max_iterations)
-    return f
-
-
-def friction_factor_swamee_jain(
-    reynolds_number: float, relative_roughness: float
-) -> float:
-    """Calculate friction factor using Swamee-Jain explicit approximation."""
-    if reynolds_number is None:
-        raise ValueError("reynolds_number must be provided")
-    if reynolds_number < RE_LAMINAR_UPPER:
-        return friction_factor_laminar(reynolds_number)
-
-    term1 = relative_roughness / COLEBROOK_ROUGHNESS_COEFF
-    term2 = SWAMEE_JAIN_COEFF / (reynolds_number**0.9)
-    f = 0.25 / (math.log10(term1 + term2) ** 2)
-    _logger.debug(
-        "Swamee-Jain: Re=%.0f, ε/D=%.6f, f=%.6f",
-        reynolds_number,
-        relative_roughness,
-        f,
-    )
-    return f
-
-
-def friction_factor_churchill(
-    reynolds_number: float, relative_roughness: float
-) -> float:
-    """Calculate friction factor using Churchill explicit correlation."""
-    if reynolds_number is None:
-        raise ValueError("reynolds_number must be provided")
-    if reynolds_number < 1:
-        return LAMINAR_FRICTION_CONSTANT
-
-    term1 = (7.0 / reynolds_number) ** 0.9 + 0.27 * relative_roughness
-    a_term = (-2.457 * math.log(term1)) ** 16
-    b_term = (CHURCHILL_B_COEFF / reynolds_number) ** 16
-    term2 = (8.0 / reynolds_number) ** 12
-    term3 = 1.0 / ((a_term + b_term) ** 1.5)
-    f = 8.0 * ((term2 + term3) ** (1.0 / 12.0))
-    _logger.debug(
-        "Churchill: Re=%.0f, ε/D=%.6f, f=%.6f",
-        reynolds_number,
-        relative_roughness,
-        f,
-    )
-    return float(f)
-
-
-def friction_factor_haaland(reynolds_number: float, relative_roughness: float) -> float:
-    """Calculate friction factor using Haaland explicit approximation."""
-    if reynolds_number is None:
-        raise ValueError("reynolds_number must be provided")
-    if reynolds_number < RE_LAMINAR_UPPER:
-        return friction_factor_laminar(reynolds_number)
-
-    term1 = (relative_roughness / COLEBROOK_ROUGHNESS_COEFF) ** 1.11
-    term2 = 6.9 / reynolds_number
-    inv_sqrt_f = -1.8 * math.log10(term1 + term2)
-    return 1.0 / (inv_sqrt_f**2)
-
-
-def select_friction_factor_method(
-    method: str, reynolds_number: float, relative_roughness: float
-) -> float:
-    """Select and calculate friction factor using the specified method."""
-    if method is None:
-        raise ValueError("method must be provided")
-
-    normalized = method.lower()
-    if normalized == "colebrook":
-        return friction_factor_colebrook(reynolds_number, relative_roughness)
-    if normalized in {"swamee-jain", "swamee_jain"}:
-        return friction_factor_swamee_jain(reynolds_number, relative_roughness)
-    if normalized == "churchill":
-        return friction_factor_churchill(reynolds_number, relative_roughness)
-    if normalized == "haaland":
-        return friction_factor_haaland(reynolds_number, relative_roughness)
-
-    available = ["colebrook", "swamee-jain", "churchill", "haaland"]
-    raise ValueError(
-        f"Unknown friction factor method '{method}'. Available: {available}"
-    )

--- a/tests/test_pressure_drop_engine_split.py
+++ b/tests/test_pressure_drop_engine_split.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from upstream_drift_tools.process_calculators.pressure_drop_calculator.engine import (
+    friction_factors as _friction_factors_shim,
+)
+from upstream_drift_tools.process_calculators.pressure_drop_calculator.engine._friction_factors import (  # noqa: E501
+    friction_factor_colebrook,
+    friction_factor_laminar,
+)
 from upstream_drift_tools.process_calculators.pressure_drop_calculator.engine.compressible_flow import (  # noqa: E501
     calculate_expansion_factor,
 )
@@ -14,9 +21,6 @@ from upstream_drift_tools.process_calculators.pressure_drop_calculator.engine.fi
 from upstream_drift_tools.process_calculators.pressure_drop_calculator.engine.flow_properties import (  # noqa: E501
     calculate_elevation_pressure_drop,
     classify_flow_regime,
-)
-from upstream_drift_tools.process_calculators.pressure_drop_calculator.engine.friction_factors import (  # noqa: E501
-    friction_factor_colebrook,
 )
 from upstream_drift_tools.process_calculators.pressure_drop_calculator.engine.pressure_drop_calculation_engine import (  # noqa: E501
     PressureDropCalculationEngine,
@@ -38,13 +42,13 @@ def test_pressure_drop_engine_is_split_into_domain_modules(repo_root: Path) -> N
         / "src"
         / "shared"
         / "python"
-        / "upstream_drift_tools"
+        / "sidekick"
         / "process_calculators"
         / "pressure_drop_calculator"
         / "engine"
     )
     for name in (
-        "friction_factors.py",
+        "_friction_factors.py",
         "flow_properties.py",
         "fittings.py",
         "compressible_flow.py",
@@ -73,3 +77,24 @@ def test_extracted_pressure_drop_modules_preserve_regression_values() -> None:
 def test_pressure_drop_engine_facade_remains_constructible() -> None:
     engine = PressureDropCalculationEngine()
     assert engine is not None
+
+
+def test_friction_factors_shim_reexports_canonical_module() -> None:
+    """The non-underscore friction_factors module is a thin shim that
+    re-exports the canonical _friction_factors objects (single source of
+    truth — issue #3659)."""
+    assert _friction_factors_shim.friction_factor_laminar is friction_factor_laminar
+    assert _friction_factors_shim.friction_factor_colebrook is friction_factor_colebrook
+
+
+def test_laminar_has_single_raising_re_contract() -> None:
+    """friction_factor_laminar raises on Re<=0 (issue #3103 contract) via the
+    canonical module AND via the shim — there is no silent 0.064 default twin
+    left (issue #3659)."""
+    with pytest.raises(ValueError, match="Reynolds number must be positive"):
+        friction_factor_laminar(0.0)
+    with pytest.raises(ValueError, match="Reynolds number must be positive"):
+        friction_factor_laminar(-5.0)
+    # The shim delegates to the same raising implementation.
+    with pytest.raises(ValueError, match="Reynolds number must be positive"):
+        _friction_factors_shim.friction_factor_laminar(-1.0)


### PR DESCRIPTION
## Summary
`engine/friction_factors.py` and `engine/_friction_factors.py` each defined the full `friction_factor_*` correlation set with byte-identical formulae but DIVERGED on the laminar `Re<=0` contract: the non-underscore copy silently returned the 0.064 default (the #3103 silent-default bug) while `_friction_factors` raises. Production imports `_friction_factors`; the stale twin remained reachable and the split regression test validated the WRONG copy.

## Fix
- `friction_factors.py` is now a thin re-export of `_friction_factors` — exactly one implementation, single raising `Re<=0` contract.
- Re-pointed `test_pressure_drop_engine_split` at the canonical `sidekick` engine path (the prior `upstream_drift_tools` physical path did not exist, so the architecture test was already failing) and added regression tests proving the shim re-exports the canonical objects and that `friction_factor_laminar` raises on `Re<=0` via both paths.

Verified locally: 5 passed. Note: `test_sidekick_public_api_stability` is pre-existing-failing on main (42 violations) and this change adds zero new violations (42 before, 42 after).

Closes #3659