### PR TITLE
⚡ Bolt: Cache Intl.NumberFormat to prevent expensive allocations

### DIFF
--- a/src/financial_calculator/web/src/components/FinancialCalculator.tsx
+++ b/src/financial_calculator/web/src/components/FinancialCalculator.tsx
@@ -28,6 +28,18 @@ interface Results {
   paybackYears: number
 }
 
+// ⚡ Bolt Optimization: Cache Intl.NumberFormat instances outside the component
+// to avoid expensive instantiation on every render/format call.
+const CURRENCY_FORMATTER = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  maximumFractionDigits: 0,
+});
+
+const NUMBER_FORMATTER = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0,
+});
+
 function FinancialCalculator() {
   const [plantCapacity, setPlantCapacity] = useState(100)
   const [operatingDays, setOperatingDays] = useState(330)
@@ -88,15 +100,11 @@ function FinancialCalculator() {
   }
 
   const formatCurrency = (value: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      maximumFractionDigits: 0,
-    }).format(value)
+    return CURRENCY_FORMATTER.format(value)
   }
 
   const formatNumber = (value: number) => {
-    return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value)
+    return NUMBER_FORMATTER.format(value)
   }
 
   return (


### PR DESCRIPTION
💡 What: Extracted and cached `Intl.NumberFormat` instances outside of the `FinancialCalculator` component.
🎯 Why: Creating new `Intl.NumberFormat` instances is a notoriously slow operation in JavaScript/V8. Instantiating them inside the render body or helper functions causes them to be recreated repeatedly (e.g., on every keystroke that triggers a re-render), adding unnecessary main-thread overhead.
📊 Impact: Speeds up number formatting and reduces main-thread blocking by eliminating expensive object instantiation on every render cycle.
🔬 Measurement: Verified using a Node.js benchmark comparing `new Intl.NumberFormat(...).format()` vs caching the formatter, which shows caching is significantly faster.

---
*PR created automatically by Jules for task [18328001201566781814](https://jules.google.com/task/18328001201566781814) started by @dieterolson*