### PR TITLE
⚡ Bolt: Combine adjacent useMemo hooks in AnalysisPlots

### DIFF
--- a/src/pendulum_simulator/pendulum-web/src/components/AnalysisPlots.tsx
+++ b/src/pendulum_simulator/pendulum-web/src/components/AnalysisPlots.tsx
@@ -161,40 +161,34 @@ export const AnalysisPlots: React.FC<AnalysisPlotsProps> = ({ result, units, det
         return res;
     }, [t, states, params, indices, units.torque]);
 
-    // ── Base force data ─────────────────────────────────────────────────
-    const baseForceData = useMemo(() => {
+    // ── Base force and Control vector data ──────────────────────────────
+    const { baseForceData, controlVectorData } = useMemo(() => {
         const len = indices.length;
-        const res = new Array(len);
+        const bfRes = new Array(len);
+        const cvRes = new Array(len);
         for (let j = 0; j < len; j++) {
             const i = indices[j];
+            // ⚡ Bolt Optimization: Combined adjacent useMemo hooks to prevent redundant
+            // expensive computeAccelerations calculation and reduce array iterations
             const qdd = computeAccelerations(states[i], t[i], params, torqueFunc, limits, clamp);
+
             const bf = baseForce(states[i], qdd, params);
-            res[j] = {
+            bfRes[j] = {
                 t: +t[i].toFixed(3),
                 'Fx': +forceFromSI(bf.fx, units.force).toFixed(2),
                 'Fy': +forceFromSI(bf.fy, units.force).toFixed(2),
                 '|F|': +forceFromSI(bf.magnitude, units.force).toFixed(2),
             };
-        }
-        return res;
-    }, [t, states, params, torqueFunc, limits, clamp, indices, units.force]);
 
-    // ── Control vector data ─────────────────────────────────────────────
-    const controlVectorData = useMemo(() => {
-        const len = indices.length;
-        const res = new Array(len);
-        for (let j = 0; j < len; j++) {
-            const i = indices[j];
-            const qdd = computeAccelerations(states[i], t[i], params, torqueFunc, limits, clamp);
             const cv = controlVector(states[i], qdd, params, limits);
-            res[j] = {
+            cvRes[j] = {
                 t: +t[i].toFixed(3),
                 'CVx': +forceFromSI(cv.cvx, units.force).toFixed(2),
                 'CVy': +forceFromSI(cv.cvy, units.force).toFixed(2),
                 '|CV|': +forceFromSI(cv.magnitude, units.force).toFixed(2),
             };
         }
-        return res;
+        return { baseForceData: bfRes, controlVectorData: cvRes };
     }, [t, states, params, torqueFunc, limits, clamp, indices, units.force]);
 
     // If detail mode, show just one plot in full height


### PR DESCRIPTION
💡 What: Combined the `baseForceData` and `controlVectorData` `useMemo` hooks in `AnalysisPlots.tsx` into a single hook.

🎯 Why: Both hooks were iterating over the same dataset and performing the exact same expensive `computeAccelerations` calculation for every point. This caused redundant computation and unnecessary memory allocation pressure. Combining them prevents this and saves processing time on every chart render update.

📊 Impact: Reduces array traversals and expensive intermediate physics calculations for the base force and control vector charts by half. Lowers main thread blocking time and decreases garbage collection overhead during UI re-renders.

🔬 Measurement: Verify by loading the simulation and reviewing the analysis plots. The charts should render correctly and UI responsiveness should be improved due to fewer array allocations and iterations. You can also run the test suite to ensure the data calculations still return the expected values.

---
*PR created automatically by Jules for task [3608942667116135608](https://jules.google.com/task/3608942667116135608) started by @dieterolson*