### PR TITLE
fix(scripting): close timeout async-exception race + scripting-sandbox test coverage

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,6 +38,15 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 
 ### 2026-06-20 Update
 
+- The scripting sandbox timeout (`scripting_env.ConsoleEnvironment`) now
+  delivers the daemon-thread fallback interrupt deterministically: a genuine
+  timeout is absorbed inside the timeout context and reported as a
+  `TimeoutError` instead of letting an injected `KeyboardInterrupt` leak past
+  the context boundary into host code (the Windows always-on path). The
+  `PyThreadState_SetAsyncExc` return code is checked and a multi-match result
+  is reverted. Added regression coverage for restricted-import /
+  restricted-builtins enforcement and for the safe-eval Subscript / Slice /
+  IfExp / BoolOp / Compare node types (#3702, #3700, #3704).
 - Release metadata now publishes Tools v1.5.0 across `VERSION` and
   `pyproject.toml`, and the generated changelog plus release PR body retain
   reference-only issue wording so historical release notes do not re-close

--- a/src/shared/python/scripting/scripting_env.py
+++ b/src/shared/python/scripting/scripting_env.py
@@ -410,11 +410,24 @@ def _raise_keyboard_interrupt_in_thread(thread_id: int) -> None:
     This is the Windows-compatible fallback for enforcing the execution
     timeout.  Only works with CPython; on other runtimes the call is a
     no-op.
+
+    ``PyThreadState_SetAsyncExc`` returns the number of thread states that
+    were modified: ``1`` on success, ``0`` if the target thread id was not
+    found, and ``>1`` if it (erroneously) matched multiple states — in which
+    case the CPython C-API contract requires reverting the pending exception
+    by calling it again with ``NULL`` so a stray ``KeyboardInterrupt`` is not
+    left queued in an unrelated thread.
     """
-    ctypes.pythonapi.PyThreadState_SetAsyncExc(
+    modified = ctypes.pythonapi.PyThreadState_SetAsyncExc(
         ctypes.c_ulong(thread_id),
         ctypes.py_object(KeyboardInterrupt),
     )
+    if modified > 1:
+        # Revert: clear the pending async exception we just set.
+        ctypes.pythonapi.PyThreadState_SetAsyncExc(
+            ctypes.c_ulong(thread_id),
+            ctypes.c_void_p(0),
+        )
 
 
 class ConsoleEnvironment:
@@ -584,10 +597,31 @@ class ConsoleEnvironment:
                 _signal.signal(_signal.SIGALRM, old_handler)  # type: ignore[attr-defined]
         else:
             # Windows / non-main-thread path — daemon thread fires KI.
+            #
+            # ``timer.cancel()`` only stops a Timer whose target has not yet
+            # *begun* running; once ``_fire`` has been entered, cancel() is a
+            # no-op and the async ``KeyboardInterrupt`` would still be queued —
+            # possibly landing AFTER ``yield`` returns and leaking into
+            # unrelated host code.  Guard delivery with a lock + done flag:
+            # the ``finally`` marks completion under the lock before cancelling,
+            # and ``_fire`` re-checks the flag under the same lock and skips the
+            # injection if the protected block already finished.  Because the
+            # async exception is raised while the lock is held, it cannot be
+            # delivered until ``_fire`` returns and releases the lock, so a
+            # late-but-still-pre-completion fire is fully serialized against the
+            # ``finally``.
             caller_id = threading.get_ident()
+            delivery_lock = threading.Lock()
+            state = {"completed": False, "fired": False}
 
             def _fire() -> None:
-                _raise_keyboard_interrupt_in_thread(caller_id)
+                with delivery_lock:
+                    if state["completed"]:
+                        # The guarded block already exited; do not inject a
+                        # stray interrupt into whatever the caller does next.
+                        return
+                    state["fired"] = True
+                    _raise_keyboard_interrupt_in_thread(caller_id)
 
             timer = threading.Timer(timeout, _fire)
             timer.daemon = True
@@ -596,6 +630,34 @@ class ConsoleEnvironment:
                 yield
             finally:
                 timer.cancel()
+                # Close the delivery race deterministically. Acquiring the lock
+                # serializes against ``_fire``: once we hold it, ``_fire`` has
+                # either already injected the KeyboardInterrupt (state["fired"]
+                # is True) or is now permanently disarmed by state["completed"].
+                fired = False
+                while True:
+                    try:
+                        with delivery_lock:
+                            state["completed"] = True
+                            fired = state["fired"]
+                        break
+                    except KeyboardInterrupt:
+                        # A timeout KI surfaced while we were finalizing. Absorb
+                        # it here so it cannot leak past the context boundary,
+                        # then retry the bookkeeping that the interrupt aborted.
+                        fired = True
+                if fired:
+                    # Drain any KI that ``_fire`` injected but that has not yet
+                    # surfaced, then re-raise the timeout deterministically as a
+                    # TimeoutError so it never escapes as a bare interrupt.
+                    try:
+                        # A no-op statement gives a pending async exception a
+                        # bytecode boundary to surface at, under our control.
+                        for _ in range(1):
+                            pass
+                    except KeyboardInterrupt:
+                        pass
+                    raise TimeoutError(f"Execution exceeded {timeout} s time limit")
 
     def execute(self, source: str | None) -> tuple[str, str]:
         """Execute a block of source code, capturing stdout and stderr.

--- a/src/shared/python/tests/test_safe_eval.py
+++ b/src/shared/python/tests/test_safe_eval.py
@@ -56,6 +56,52 @@ class TestValidateExpression:
         assert isinstance(tree, ast.Expression)
 
 
+class TestAllowlistedNodeEvaluation:
+    """Behavioral coverage for allowlisted AST node types (issue #3704).
+
+    ``_ALLOWED_NODE_TYPES`` permits Subscript, Slice, IfExp, BoolOp/boolop,
+    and Compare/cmpop, but the suite previously asserted no *evaluated*
+    result for any of them. These tests pin concrete return values so a
+    regression that broke (or an allowlist change that silently broadened)
+    any of these node types is caught.
+    """
+
+    def test_subscript_evaluates(self) -> Any:
+        assert safe_eval("x[0]", {"x": [10, 20]}) == 10
+        assert safe_eval("x[-1]", {"x": [10, 20, 30]}) == 30
+
+    def test_slice_evaluates(self) -> Any:
+        assert safe_eval("x[1:3]", {"x": [0, 1, 2, 3]}) == [1, 2]
+        assert safe_eval("x[::2]", {"x": [0, 1, 2, 3, 4]}) == [0, 2, 4]
+
+    def test_ifexp_evaluates(self) -> Any:
+        assert safe_eval("a if c else b", {"a": 1, "b": 2, "c": True}) == 1
+        assert safe_eval("a if c else b", {"a": 1, "b": 2, "c": False}) == 2
+
+    def test_boolop_evaluates(self) -> Any:
+        assert safe_eval("a and b", {"a": True, "b": False}) is False
+        assert safe_eval("a or b", {"a": False, "b": True}) is True
+        # Short-circuit semantics return the operand, not a coerced bool.
+        assert safe_eval("a and b", {"a": 1, "b": 2}) == 2
+
+    def test_compare_evaluates(self) -> Any:
+        assert safe_eval("x > 3", {"x": 5}) is True
+        assert safe_eval("x < 3", {"x": 5}) is False
+        # Chained comparison exercises multiple cmpop nodes in one Compare.
+        assert safe_eval("1 < x < 10", {"x": 5}) is True
+
+    def test_disallowed_constructs_still_rejected(self) -> Any:
+        # Adding evaluation coverage must not imply broadening the allowlist:
+        # comprehensions, dict/list/set literals, and assignment expressions
+        # remain rejected node types.
+        with pytest.raises(ValueError, match="Unsafe operation detected"):
+            validate_expression("[i for i in x]", {"x"})
+        with pytest.raises(ValueError, match="Unsafe operation detected"):
+            validate_expression("{1: 2}")
+        with pytest.raises(ValueError, match="Unsafe operation detected"):
+            validate_expression("(y := 5)")
+
+
 class TestSafeEval:
     def test_safe_eval_basic(self) -> Any:
         result = safe_eval("2 * x", {"x": 21})

--- a/tests/shared/python/scripting/test_scripting_env.py
+++ b/tests/shared/python/scripting/test_scripting_env.py
@@ -12,9 +12,13 @@ docstring; these tests pin the in-process screen behavior.
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from shared.python.scripting.scripting_env import (
+    _BLOCKED_BUILTINS,
+    _BLOCKED_IMPORT_MODULES,
     ConsoleEnvironment,
     SecurityError,
     _screen_source_for_escapes,
@@ -121,3 +125,150 @@ def test_execute_allows_safe_attribute_method(
     out, err = env.execute("int(np.array([1, 2, 3]).sum())")
     assert err == ""
     assert out.strip() == "6"
+
+
+# ---------------------------------------------------------------------------
+# Restricted builtins / restricted import enforcement (issue #3700)
+# ---------------------------------------------------------------------------
+# reset() installs _make_restricted_builtins() as the namespace __builtins__
+# (the "primary blast-radius guard"). These tests assert through execute()
+# that the guard actually denies file I/O, code injection, and host-module
+# imports — the load-bearing-but-previously-untested security layer.
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("blocked", sorted(_BLOCKED_BUILTINS))
+def test_blocked_builtins_absent_from_namespace(
+    env: ConsoleEnvironment, blocked: str
+) -> None:
+    """Each removed builtin (open/exec/eval/compile/breakpoint) is a NameError."""
+    out, err = env.execute(f"{blocked}")
+    assert out == ""
+    assert "NameError" in err
+
+
+@pytest.mark.unit
+def test_execute_open_is_nameerror(env: ConsoleEnvironment) -> None:
+    """File I/O via open() must not resolve — it is removed from builtins."""
+    out, err = env.execute("open('some-file')")
+    assert out == ""
+    assert "NameError" in err
+    assert "open" in err
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", sorted(_BLOCKED_IMPORT_MODULES))
+def test_blocked_modules_rejected_via_import_statement(
+    env: ConsoleEnvironment, module_name: str
+) -> None:
+    """Every module in the blocklist is rejected by an ``import`` statement."""
+    out, err = env.execute(f"import {module_name}")
+    assert out == ""
+    assert "ImportError" in err
+    assert "blocked in the scripting sandbox" in err
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module_name", ["os", "subprocess", "sys", "socket", "ctypes"])
+def test_blocked_modules_rejected_via_dunder_import_call(
+    env: ConsoleEnvironment, module_name: str
+) -> None:
+    """``__import__('os')`` is also blocked by the restricted import wrapper.
+
+    The dunder name literal is screened first; that screen itself blocks the
+    call before the import wrapper is reached, so either a SecurityError or
+    an ImportError is an acceptable denial — the key invariant is that the
+    host module never loads (no stdout leak).
+    """
+    out, err = env.execute(f"__import__({module_name!r})")
+    assert out == ""
+    assert "Error" in err
+
+
+@pytest.mark.unit
+def test_benign_numpy_import_and_use_still_works(
+    env: ConsoleEnvironment,
+) -> None:
+    """The blocklist must not break legitimate scientific imports."""
+    out, err = env.execute(
+        "import numpy as _np\nprint(int(_np.array([1, 2, 3]).sum()))"
+    )
+    assert err == ""
+    assert out.strip() == "6"
+
+
+@pytest.mark.unit
+def test_blocked_module_submodule_import_rejected(
+    env: ConsoleEnvironment,
+) -> None:
+    """A blocked top-level module cannot be reached via a submodule import."""
+    out, err = env.execute("import os.path")
+    assert out == ""
+    assert "ImportError" in err
+
+
+# ---------------------------------------------------------------------------
+# Timeout async-exception delivery race (issue #3702)
+# ---------------------------------------------------------------------------
+# On Windows (and any non-main thread) the timeout is enforced by a daemon
+# threading.Timer that injects a KeyboardInterrupt via the CPython C API.
+# A late-firing timer must never leak a KeyboardInterrupt past the context
+# boundary into unrelated host code.
+
+
+@pytest.mark.unit
+def test_quick_executes_never_leak_keyboard_interrupt() -> None:
+    """Many fast executes under a live timeout never surface a stray KI.
+
+    This drives the daemon-thread fallback path repeatedly: each execute()
+    starts and cancels a Timer. If the cancel/fire handshake were racy, a
+    borderline cancellation would occasionally inject a KeyboardInterrupt
+    that escapes execute(). It must not.
+    """
+    # Force the daemon-thread fallback by running off the main thread.
+    leaked: list[BaseException] = []
+
+    def worker() -> None:
+        environment = ConsoleEnvironment(max_execution_time=1)
+        try:
+            for _ in range(300):
+                out, err = environment.execute("1 + 1")
+                assert err == ""
+                assert out.strip() == "2"
+        except BaseException as exc:  # noqa: BLE001 — record any leak
+            leaked.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(timeout=30)
+    assert not thread.is_alive(), "worker hung — possible interrupt deadlock"
+    assert not leaked, f"execute() leaked an exception: {leaked!r}"
+
+
+@pytest.mark.unit
+def test_genuine_timeout_reported_as_timeouterror_not_interrupt() -> None:
+    """A real timeout surfaces deterministically as TimeoutError, not bare KI.
+
+    Runs an infinite loop on a non-main thread (the daemon-thread fallback
+    path). The interrupt injected by the timer must be absorbed inside the
+    timeout context and reported as a TimeoutError on stderr — it must not
+    propagate out of execute() as a KeyboardInterrupt.
+    """
+    result: dict[str, tuple[str, str]] = {}
+    escaped: list[BaseException] = []
+
+    def worker() -> None:
+        environment = ConsoleEnvironment(max_execution_time=1)
+        try:
+            result["value"] = environment.execute("n = 0\nwhile True:\n    n += 1")
+        except BaseException as exc:  # noqa: BLE001 — record any escape
+            escaped.append(exc)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    thread.join(timeout=15)
+    assert not thread.is_alive(), "timeout did not interrupt the busy loop"
+    assert not escaped, f"timeout escaped execute(): {escaped!r}"
+    out, err = result["value"]
+    assert out == ""
+    assert "TimeoutError" in err


### PR DESCRIPTION
## Summary

Hardens the scripting sandbox timeout and adds the missing regression coverage flagged by the 2026-06-18 assessment.

### #3702 — async-exception delivery race in `_timeout_context` fallback
On Windows (and any non-main thread) the per-call timeout is enforced by a daemon `threading.Timer` that injects a `KeyboardInterrupt` via `PyThreadState_SetAsyncExc`. `timer.cancel()` is a no-op once `_fire` has begun, so a late timer could queue an interrupt that lands **after** the `with`-block, leaking into unrelated host code (the always-on Windows path).

Fix in `src/shared/python/scripting/scripting_env.py`:
- Delivery is serialized by a lock + done flag. `_fire` only injects the interrupt while the guarded block is still running; once the `finally` marks completion under the same lock, `_fire` is permanently disarmed.
- The `finally` absorbs any in-flight `KeyboardInterrupt` and re-raises a deterministic `TimeoutError`, so a genuine timeout never escapes as a bare interrupt (matching the Unix `signal.alarm` path).
- `_raise_keyboard_interrupt_in_thread` now checks the `PyThreadState_SetAsyncExc` return code and reverts a `>1` (multi-match) result per the CPython C-API contract.

### #3700 — restricted-import / restricted-builtins enforcement coverage
Added tests through `execute()` (the load-bearing "primary blast-radius guard"):
- every name in `_BLOCKED_BUILTINS` (`open`/`exec`/`eval`/`compile`/`breakpoint`) resolves to a `NameError`;
- every module in `_BLOCKED_IMPORT_MODULES` is rejected via `import <m>` with `ImportError`, plus submodule (`import os.path`) and `__import__(...)` denial;
- benign `numpy` import + use still works.

### #3704 — safe_eval allowlisted-node evaluation coverage
Added value-asserting tests for Subscript, Slice, IfExp, BoolOp, and Compare (incl. chained comparison and short-circuit semantics), plus assertions that disallowed node types (comprehension, dict literal, walrus) remain rejected — so an accidental allowlist broadening is also caught.

## Validation
- `tests/shared/python/scripting/` + `tests/shared/python/test_safe_eval.py`: 112 passed, 1 skipped.
- `src/shared/python/tests/test_safe_eval.py`: 21 passed.
- `ruff check` / `ruff format --check`: clean.
- Verified the timeout fix at runtime: 200+ quick executes leak no `KeyboardInterrupt`; a real busy-loop timeout reports `TimeoutError`.

Closes #3704
Closes #3700
Closes #3702
