### PR TITLE
Extract Cohen-Coon PID math, decouple AnalysisPanel, cover inertia_from_mesh

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,6 +38,25 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 
 ### 2026-06-20 Update
 
+- Safety-critical PID auto-tuning math is now a pure, importable module
+  (`p1am_control_system.backend.pid_tuning`): FOPDT step-response
+  identification and Cohen-Coon tuning no longer live inline in the
+  `stop_pid_tuning` FastAPI route. Every Cohen-Coon coefficient is a named
+  constant, and a numerical test suite pins the recommended gains against the
+  reference formulas for known plants. The `/api/mpc/simulate` baseline reuses
+  the same `cohen_coon_pid` helper so the MPC comparison can no longer drift
+  from the live tuning recommendation (#3684).
+- The data-processor `AnalysisPanel` now exposes its own aggregate request
+  signals (`pca_requested`, `anova_requested`, `regression_requested`,
+  `surface_requested`, `nn_train_requested`) that forward from its internal
+  child widgets. `MainWindow` connects to these panel-level signals instead of
+  reaching through `analysis_panel.<widget>.<signal>` chains, so the panel's
+  internal composition can change without breaking its consumers (#3680).
+- Added real-trimesh success-path coverage for the model-generation
+  `inertia_from_mesh` endpoint: tests now load a generated unit-box mesh through
+  the actual trimesh loader and assert the returned mass, volume, center of
+  mass, and moment-of-inertia tensor on both the density and mass-scaling
+  branches (#3669).
 - The scripting sandbox timeout (`scripting_env.ConsoleEnvironment`) now
   delivers the daemon-thread fallback interrupt deterministically: a genuine
   timeout is absorbed inside the timeout context and reported as a

--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/analysis_widgets.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/analysis_widgets.py
@@ -17,6 +17,7 @@ import logging
 import pandas as pd
 
 try:
+    from PyQt6.QtCore import pyqtSignal
     from PyQt6.QtWidgets import (
         QTabWidget,
         QVBoxLayout,
@@ -57,11 +58,27 @@ logger = logging.getLogger(__name__)
 if PYQT6_AVAILABLE:
 
     class AnalysisPanel(QWidget):
-        """Main panel containing all analysis widgets."""
+        """Main panel containing all analysis widgets.
+
+        The panel re-exposes aggregate request signals that forward from its
+        internal child widgets. Consumers (e.g. ``MainWindow``) connect to
+        these panel-level signals instead of reaching through the panel into
+        its private child widgets, so the panel's internal composition can
+        change without breaking its consumers.
+        """
+
+        # Aggregate signals forwarded from the internal child widgets. Each
+        # carries the same ``dict`` payload as the originating child signal.
+        pca_requested = pyqtSignal(dict)
+        anova_requested = pyqtSignal(dict)
+        regression_requested = pyqtSignal(dict)
+        surface_requested = pyqtSignal(dict)
+        nn_train_requested = pyqtSignal(dict)
 
         def __init__(self, parent: QWidget | None = None) -> None:
             super().__init__(parent)
             self._setup_ui()
+            self._connect_child_signals()
 
         def _setup_ui(self) -> None:
             layout = QVBoxLayout(self)
@@ -88,6 +105,14 @@ if PYQT6_AVAILABLE:
             self.tabs.addTab(self.script_widget, "Script Generator")
 
             layout.addWidget(self.tabs)
+
+        def _connect_child_signals(self) -> None:
+            """Forward each child widget's request signal to a panel signal."""
+            self.pca_widget.analysis_requested.connect(self.pca_requested)
+            self.anova_widget.analysis_requested.connect(self.anova_requested)
+            self.regression_widget.analysis_requested.connect(self.regression_requested)
+            self.surface_widget.plot_requested.connect(self.surface_requested)
+            self.nn_widget.train_requested.connect(self.nn_train_requested)
 
         def set_dataframe(self, df: pd.DataFrame) -> None:
             """Update all widgets with new DataFrame."""

--- a/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py
+++ b/src/data_processing/data_processor/python/data_processor/ui/pyqt6/main_window.py
@@ -431,19 +431,13 @@ class DataProcessorMainWindow(
 
         # Analysis tab (PCA, ANOVA, Regression, Surface, Neural Network)
         self.analysis_panel = AnalysisPanel()
-        self.analysis_panel.pca_widget.analysis_requested.connect(
-            self._run_pca_analysis
-        )
-        self.analysis_panel.anova_widget.analysis_requested.connect(
-            self._run_anova_analysis
-        )
-        self.analysis_panel.regression_widget.analysis_requested.connect(
-            self._run_regression_analysis
-        )
-        self.analysis_panel.surface_widget.plot_requested.connect(
-            self._run_surface_analysis
-        )
-        self.analysis_panel.nn_widget.train_requested.connect(self._run_nn_analysis)
+        # Connect to the panel's aggregate signals rather than reaching
+        # through into its private child widgets (LoD / Orthogonality).
+        self.analysis_panel.pca_requested.connect(self._run_pca_analysis)
+        self.analysis_panel.anova_requested.connect(self._run_anova_analysis)
+        self.analysis_panel.regression_requested.connect(self._run_regression_analysis)
+        self.analysis_panel.surface_requested.connect(self._run_surface_analysis)
+        self.analysis_panel.nn_train_requested.connect(self._run_nn_analysis)
         self.tab_widget.addTab(self.analysis_panel, "Analysis")
 
         # DAT Import tab

--- a/src/data_processing/data_processor/python/tests/test_analysis_panel_signals.py
+++ b/src/data_processing/data_processor/python/tests/test_analysis_panel_signals.py
@@ -1,0 +1,62 @@
+"""Tests for AnalysisPanel aggregate signal forwarding.
+
+These guard the orthogonality contract: consumers connect to the panel's own
+signals, and the panel forwards them from its internal child widgets. Renaming
+or restructuring a child widget must not require touching the consumer.
+"""
+
+import sys
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+from PyQt6.QtWidgets import QApplication  # noqa: E402
+
+app = QApplication.instance()
+if app is None:
+    app = QApplication(sys.argv)
+
+from data_processor.ui.pyqt6.analysis_widgets import AnalysisPanel  # noqa: E402
+
+
+@pytest.fixture
+def panel(qtbot):
+    widget = AnalysisPanel()
+    qtbot.addWidget(widget)
+    return widget
+
+
+def test_panel_exposes_aggregate_signals(panel):
+    """The panel exposes a request signal for each analysis type."""
+    for name in (
+        "pca_requested",
+        "anova_requested",
+        "regression_requested",
+        "surface_requested",
+        "nn_train_requested",
+    ):
+        assert hasattr(panel, name), f"AnalysisPanel missing signal {name}"
+
+
+@pytest.mark.parametrize(
+    ("child_attr", "child_signal", "panel_signal"),
+    [
+        ("pca_widget", "analysis_requested", "pca_requested"),
+        ("anova_widget", "analysis_requested", "anova_requested"),
+        ("regression_widget", "analysis_requested", "regression_requested"),
+        ("surface_widget", "plot_requested", "surface_requested"),
+        ("nn_widget", "train_requested", "nn_train_requested"),
+    ],
+)
+def test_child_signal_forwards_to_panel_signal(
+    panel, child_attr, child_signal, panel_signal
+):
+    """Emitting a child signal re-emits the matching panel-level signal."""
+    received: list[dict] = []
+    getattr(panel, panel_signal).connect(received.append)
+
+    payload = {"marker": panel_signal}
+    getattr(getattr(panel, child_attr), child_signal).emit(payload)
+
+    assert received == [payload]

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -52,6 +52,7 @@ from models import (
     TagLog,
 )
 from mpc import simulate_pid_vs_mpc
+from pid_tuning import identify_fopdt_and_tune
 from plant_model import TagDefinition
 from plc_factory import PLCFactory
 from poll_runtime import _connect_once, _poll_once
@@ -956,85 +957,15 @@ async def stop_pid_tuning(pid_index: int) -> dict[str, Any]:
         )
 
     session = control_context.tuning_sessions.pop(pid_index)
-    history = session["history"]
-
-    if not history or not session["step_triggered"]:
-        return {
-            "status": "warning",
-            "message": "Tuning stopped, but no step change was executed or history is empty.",
-            "parameters": {"kp": 0.0, "tau": 0.0, "theta": 0.0},
-            "recommended_pid": {"kp": 0.0, "ki": 0.0, "kd": 0.0},
-        }
-
-    delta_cv = session["final_cv"] - session["initial_cv"]
-    if abs(delta_cv) < 0.01:
-        delta_cv = 1.0
-
-    n_samples = len(history)
-    last_samples = history[max(0, n_samples - 10) :]
-    final_pv = sum(h[2] for h in last_samples) / len(last_samples)
-    initial_pv = session["initial_pv"]
-    delta_pv = final_pv - initial_pv
-
-    kp_ident = delta_pv / delta_cv
-
-    threshold_10 = initial_pv + 0.10 * delta_pv
-    threshold_63 = initial_pv + 0.632 * delta_pv
-
-    t_step = session["step_time"]
-    t_10 = None
-    t_63 = None
-
-    for time_offset, _, pv_val in history:
-        if time_offset < t_step:
-            continue
-        if t_10 is None:
-            if (delta_pv > 0 and pv_val >= threshold_10) or (
-                delta_pv < 0 and pv_val <= threshold_10
-            ):
-                t_10 = time_offset
-        if t_63 is None:
-            if (delta_pv > 0 and pv_val >= threshold_63) or (
-                delta_pv < 0 and pv_val <= threshold_63
-            ):
-                t_63 = time_offset
-
-    if t_10 is None:
-        t_10 = t_step + 1.0
-    if t_63 is None:
-        t_63 = t_10 + 2.0
-
-    theta_ident = max(0.1, t_10 - t_step)
-    tau_ident = max(0.1, t_63 - t_10)
-
-    ratio = theta_ident / tau_ident
-    if abs(kp_ident) > 0.001:
-        kc = (1.0 / kp_ident) * (tau_ident / theta_ident) * (1.333 + 0.25 * ratio)
-        ti = theta_ident * (32.0 + 6.0 * ratio) / (13.0 + 8.0 * ratio)
-        td = theta_ident * 4.0 / (11.0 + 2.0 * ratio)
-
-        kp_recom = round(kc, 3)
-        ki_recom = round(kc / ti, 3)
-        kd_recom = round(kc * td, 3)
-    else:
-        kp_recom = 0.0
-        ki_recom = 0.0
-        kd_recom = 0.0
-
-    return {
-        "status": "success",
-        "message": "Tuning parameters identified successfully.",
-        "parameters": {
-            "kp": round(kp_ident, 3),
-            "tau": round(tau_ident, 2),
-            "theta": round(theta_ident, 2),
-        },
-        "recommended_pid": {
-            "kp": max(0.0, kp_recom),
-            "ki": max(0.0, ki_recom),
-            "kd": max(0.0, kd_recom),
-        },
-    }
+    result = identify_fopdt_and_tune(
+        session["history"],
+        step_triggered=session["step_triggered"],
+        initial_pv=session["initial_pv"],
+        initial_cv=session["initial_cv"],
+        final_cv=session["final_cv"],
+        step_time=session["step_time"],
+    )
+    return result.as_response()
 
 
 class MPCSimulatePayload(BaseModel):

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -965,7 +965,7 @@ async def stop_pid_tuning(pid_index: int) -> dict[str, Any]:
         final_cv=session["final_cv"],
         step_time=session["step_time"],
     )
-    return result.as_response()
+    return cast(dict[str, Any], result.as_response())
 
 
 class MPCSimulatePayload(BaseModel):

--- a/src/p1am_control_system/backend/mpc.py
+++ b/src/p1am_control_system/backend/mpc.py
@@ -1,6 +1,8 @@
 import math
 from typing import Any, Protocol
 
+from pid_tuning import cohen_coon_pid
+
 
 class MPCSimulationPayload(Protocol):
     prediction_horizon: int
@@ -20,13 +22,9 @@ def simulate_pid_vs_mpc(payload: MPCSimulationPayload) -> dict[str, Any]:
     dt = 0.5
     steps = 50
 
-    ratio = max(0.1, theta) / max(0.5, tau)
-    kc = (1.0 / kp_process) * (tau / max(0.1, theta)) * (1.333 + 0.25 * ratio)
-    ti = max(0.1, theta) * (32.0 + 6.0 * ratio) / (13.0 + 8.0 * ratio)
-    td = max(0.1, theta) * 4.0 / (11.0 + 2.0 * ratio)
-    pid_kp = kc
-    pid_ki = kc / ti
-    pid_kd = kc * td
+    # Reuse the canonical Cohen-Coon coefficients from pid_tuning so the MPC
+    # comparison baseline can never drift from the live tuning recommendation.
+    pid_kp, pid_ki, pid_kd = cohen_coon_pid(kp_process, max(0.5, tau), max(0.1, theta))
 
     pid_pv = [0.0] * steps
     pid_cv = [0.0] * steps

--- a/src/p1am_control_system/backend/pid_tuning.py
+++ b/src/p1am_control_system/backend/pid_tuning.py
@@ -1,0 +1,234 @@
+"""Pure FOPDT identification and Cohen-Coon PID tuning math.
+
+This module contains the safety-critical control-tuning arithmetic that was
+previously embedded inline in the ``stop_pid_tuning`` FastAPI route in
+``main.py``. Extracting it here makes the math importable and unit-testable
+with no FastAPI/HTTPException dependency, and gives every Cohen-Coon coefficient
+a named, documented constant so a typo cannot silently ship wrong gains to the
+P1AM PLC.
+
+The Cohen-Coon PID tuning rules for a first-order-plus-dead-time (FOPDT) plant
+with steady-state gain ``Kp``, time constant ``tau`` and dead time ``theta``
+(ratio ``r = theta / tau``) are::
+
+    Kc = (1 / Kp) * (tau / theta) * (1.333 + 0.25 * r)
+    Ti = theta * (32 + 6 * r) / (13 + 8 * r)
+    Td = theta * 4 / (11 + 2 * r)
+
+which are the canonical Cohen-Coon PID coefficients (Cohen & Coon, 1953).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# --- FOPDT step-response identification constants ---------------------------
+# Fraction of the total PV change used to mark the "process started moving"
+# point. The dead time ``theta`` is estimated as the time from the step to
+# this 10% crossing.
+PV_LOW_FRACTION = 0.10
+# Fraction of the total PV change that marks one process time constant for a
+# first-order response (1 - 1/e = 0.632). ``tau`` is estimated from the time
+# between the 10% and 63.2% crossings.
+PV_TAU_FRACTION = 0.632
+# Minimum |delta CV| treated as a real step; below this the CV change is
+# considered numerically negligible and normalised to 1.0.
+MIN_DELTA_CV = 0.01
+# Minimum |Kp| for which a tuning recommendation is produced. Below this the
+# identified process gain is too small to invert safely.
+MIN_PROCESS_GAIN = 0.001
+# Lower bound applied to identified theta/tau (seconds) to avoid divide-by-zero.
+MIN_TIME_PARAM = 0.1
+# Number of trailing history samples averaged to estimate the final PV.
+FINAL_PV_SAMPLE_COUNT = 10
+
+# --- Cohen-Coon PID coefficients --------------------------------------------
+CC_KC_BASE = 1.333
+CC_KC_RATIO = 0.25
+CC_TI_NUM_BASE = 32.0
+CC_TI_NUM_RATIO = 6.0
+CC_TI_DEN_BASE = 13.0
+CC_TI_DEN_RATIO = 8.0
+CC_TD_NUM = 4.0
+CC_TD_DEN_BASE = 11.0
+CC_TD_DEN_RATIO = 2.0
+
+# History samples are ``(time_offset, cv, pv)`` triples.
+HistorySample = tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class TuningResult:
+    """Identified FOPDT parameters and recommended PID gains.
+
+    ``status`` is ``"success"`` when a tuning recommendation was produced,
+    ``"warning"`` when there was insufficient data (no step / empty history).
+    The route layer maps this onto its HTTP response shape.
+    """
+
+    status: str
+    message: str
+    kp: float
+    tau: float
+    theta: float
+    rec_kp: float
+    rec_ki: float
+    rec_kd: float
+
+    def as_response(self) -> dict[str, Any]:
+        """Render this result into the route's JSON response shape."""
+        return {
+            "status": self.status,
+            "message": self.message,
+            "parameters": {
+                "kp": round(self.kp, 3),
+                "tau": round(self.tau, 2),
+                "theta": round(self.theta, 2),
+            },
+            "recommended_pid": {
+                "kp": max(0.0, round(self.rec_kp, 3)),
+                "ki": max(0.0, round(self.rec_ki, 3)),
+                "kd": max(0.0, round(self.rec_kd, 3)),
+            },
+        }
+
+
+def cohen_coon_pid(kp: float, tau: float, theta: float) -> tuple[float, float, float]:
+    """Return Cohen-Coon ``(Kc, Ki, Kd)`` gains for an FOPDT plant.
+
+    Parameters
+    ----------
+    kp:
+        Identified steady-state process gain. Must be non-zero.
+    tau:
+        Identified process time constant (seconds). Must be positive.
+    theta:
+        Identified process dead time (seconds). Must be positive.
+
+    Returns
+    -------
+    tuple of float
+        ``(Kc, Ki, Kd)`` where ``Ki = Kc / Ti`` and ``Kd = Kc * Td`` follow the
+        parallel-form PID gains used by the controller.
+    """
+    if kp == 0.0:
+        raise ValueError("process gain kp must be non-zero")
+    if tau <= 0.0:
+        raise ValueError("process time constant tau must be positive")
+    if theta <= 0.0:
+        raise ValueError("process dead time theta must be positive")
+
+    ratio = theta / tau
+    kc = (1.0 / kp) * (tau / theta) * (CC_KC_BASE + CC_KC_RATIO * ratio)
+    ti = (
+        theta
+        * (CC_TI_NUM_BASE + CC_TI_NUM_RATIO * ratio)
+        / (CC_TI_DEN_BASE + CC_TI_DEN_RATIO * ratio)
+    )
+    td = theta * CC_TD_NUM / (CC_TD_DEN_BASE + CC_TD_DEN_RATIO * ratio)
+
+    kc_gain = kc
+    ki_gain = kc / ti
+    kd_gain = kc * td
+    return kc_gain, ki_gain, kd_gain
+
+
+def identify_fopdt_and_tune(
+    history: list[HistorySample],
+    *,
+    step_triggered: bool,
+    initial_pv: float,
+    initial_cv: float,
+    final_cv: float,
+    step_time: float,
+) -> TuningResult:
+    """Identify FOPDT parameters from a step response and tune via Cohen-Coon.
+
+    This is the pure extraction of the math previously inline in the
+    ``stop_pid_tuning`` route. It performs a two-point (10% / 63.2%) FOPDT
+    identification on the recorded step-response ``history`` and applies the
+    Cohen-Coon PID rules.
+
+    Parameters
+    ----------
+    history:
+        Recorded ``(time_offset, cv, pv)`` samples for the tuning session.
+    step_triggered:
+        Whether a step change was actually executed during the session.
+    initial_pv:
+        Process value at the moment the step was applied.
+    initial_cv, final_cv:
+        Control value before and after the step change.
+    step_time:
+        Time offset (seconds, relative to session start) at which the step
+        was applied.
+    """
+    if not history or not step_triggered:
+        return TuningResult(
+            status="warning",
+            message=(
+                "Tuning stopped, but no step change was executed or history is empty."
+            ),
+            kp=0.0,
+            tau=0.0,
+            theta=0.0,
+            rec_kp=0.0,
+            rec_ki=0.0,
+            rec_kd=0.0,
+        )
+
+    delta_cv = final_cv - initial_cv
+    if abs(delta_cv) < MIN_DELTA_CV:
+        delta_cv = 1.0
+
+    n_samples = len(history)
+    last_samples = history[max(0, n_samples - FINAL_PV_SAMPLE_COUNT) :]
+    final_pv = sum(h[2] for h in last_samples) / len(last_samples)
+    delta_pv = final_pv - initial_pv
+
+    kp_ident = delta_pv / delta_cv
+
+    threshold_10 = initial_pv + PV_LOW_FRACTION * delta_pv
+    threshold_63 = initial_pv + PV_TAU_FRACTION * delta_pv
+
+    t_10: float | None = None
+    t_63: float | None = None
+
+    for time_offset, _, pv_val in history:
+        if time_offset < step_time:
+            continue
+        if t_10 is None and (
+            (delta_pv > 0 and pv_val >= threshold_10)
+            or (delta_pv < 0 and pv_val <= threshold_10)
+        ):
+            t_10 = time_offset
+        if t_63 is None and (
+            (delta_pv > 0 and pv_val >= threshold_63)
+            or (delta_pv < 0 and pv_val <= threshold_63)
+        ):
+            t_63 = time_offset
+
+    if t_10 is None:
+        t_10 = step_time + 1.0
+    if t_63 is None:
+        t_63 = t_10 + 2.0
+
+    theta_ident = max(MIN_TIME_PARAM, t_10 - step_time)
+    tau_ident = max(MIN_TIME_PARAM, t_63 - t_10)
+
+    if abs(kp_ident) > MIN_PROCESS_GAIN:
+        rec_kp, rec_ki, rec_kd = cohen_coon_pid(kp_ident, tau_ident, theta_ident)
+    else:
+        rec_kp = rec_ki = rec_kd = 0.0
+
+    return TuningResult(
+        status="success",
+        message="Tuning parameters identified successfully.",
+        kp=kp_ident,
+        tau=tau_ident,
+        theta=theta_ident,
+        rec_kp=rec_kp,
+        rec_ki=rec_ki,
+        rec_kd=rec_kd,
+    )

--- a/src/p1am_control_system/backend/tests/test_pid_tuning_math.py
+++ b/src/p1am_control_system/backend/tests/test_pid_tuning_math.py
@@ -1,0 +1,187 @@
+"""Numerical tests for the pure Cohen-Coon PID tuning math (pid_tuning.py).
+
+These guard the safety-critical tuning arithmetic that recommends PID gains
+pushed to the P1AM PLC. They pin the Cohen-Coon coefficients against the
+reference formulas and verify FOPDT identification recovers a known plant.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from pid_tuning import (
+    CC_KC_BASE,
+    CC_KC_RATIO,
+    CC_TD_DEN_BASE,
+    CC_TD_DEN_RATIO,
+    CC_TD_NUM,
+    CC_TI_DEN_BASE,
+    CC_TI_DEN_RATIO,
+    CC_TI_NUM_BASE,
+    CC_TI_NUM_RATIO,
+    cohen_coon_pid,
+    identify_fopdt_and_tune,
+)
+
+
+def _reference_cohen_coon(
+    kp: float, tau: float, theta: float
+) -> tuple[float, float, float]:
+    """Independent re-derivation of the Cohen-Coon PID gains."""
+    r = theta / tau
+    kc = (1.0 / kp) * (tau / theta) * (CC_KC_BASE + CC_KC_RATIO * r)
+    ti = (
+        theta
+        * (CC_TI_NUM_BASE + CC_TI_NUM_RATIO * r)
+        / (CC_TI_DEN_BASE + CC_TI_DEN_RATIO * r)
+    )
+    td = theta * CC_TD_NUM / (CC_TD_DEN_BASE + CC_TD_DEN_RATIO * r)
+    return kc, kc / ti, kc * td
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("kp", "tau", "theta"),
+    [
+        (2.0, 10.0, 2.0),
+        (1.0, 5.0, 1.0),
+        (0.5, 20.0, 4.0),
+        (-1.5, 8.0, 3.0),
+    ],
+)
+def test_cohen_coon_matches_reference(kp: float, tau: float, theta: float) -> None:
+    """Cohen-Coon gains equal the canonical FOPDT formulas to full precision."""
+    kc, ki, kd = cohen_coon_pid(kp, tau, theta)
+    ref_kc, ref_ki, ref_kd = _reference_cohen_coon(kp, tau, theta)
+    assert kc == pytest.approx(ref_kc, rel=1e-12)
+    assert ki == pytest.approx(ref_ki, rel=1e-12)
+    assert kd == pytest.approx(ref_kd, rel=1e-12)
+
+
+@pytest.mark.unit
+def test_cohen_coon_pinned_values() -> None:
+    """Pin a concrete known plant so a constant typo is caught.
+
+    Kp=2, tau=10, theta=2 -> ratio=0.2.
+    Kc = (1/2)*(10/2)*(1.333 + 0.25*0.2) = 2.5 * 1.383 = 3.4575
+    Ti = 2*(32 + 6*0.2)/(13 + 8*0.2) = 2*33.2/14.6 = 4.547945...
+    Td = 2*4/(11 + 2*0.2) = 8/11.4 = 0.701754...
+    """
+    kc, ki, kd = cohen_coon_pid(2.0, 10.0, 2.0)
+    assert kc == pytest.approx(3.4575, abs=1e-9)
+    assert ki == pytest.approx(3.4575 / 4.547945205479452, rel=1e-9)
+    assert kd == pytest.approx(3.4575 * 0.7017543859649122, rel=1e-9)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("kp", "tau", "theta"),
+    [(0.0, 10.0, 2.0), (2.0, 0.0, 2.0), (2.0, 10.0, 0.0)],
+)
+def test_cohen_coon_rejects_degenerate(kp: float, tau: float, theta: float) -> None:
+    with pytest.raises(ValueError):
+        cohen_coon_pid(kp, tau, theta)
+
+
+def _synthetic_step_history(
+    kp: float,
+    tau: float,
+    theta: float,
+    *,
+    initial_pv: float,
+    delta_cv: float,
+    dt: float = 0.5,
+    duration: float = 100.0,
+) -> list[tuple[float, float, float]]:
+    """Sample a noise-free FOPDT step response into (t, cv, pv) triples."""
+    final_cv = delta_cv
+    history: list[tuple[float, float, float]] = []
+    n = int(duration / dt)
+    for i in range(n):
+        t = i * dt
+        if t < theta:
+            pv = initial_pv
+        else:
+            pv = initial_pv + kp * delta_cv * (1.0 - math.exp(-(t - theta) / tau))
+        history.append((t, final_cv, pv))
+    return history
+
+
+@pytest.mark.unit
+def test_identify_recovers_process_gain() -> None:
+    """A clean first-order step recovers Kp exactly and gives positive gains."""
+    kp, tau, theta = 2.0, 10.0, 3.0
+    initial_pv, delta_cv = 20.0, 5.0
+    history = _synthetic_step_history(
+        kp, tau, theta, initial_pv=initial_pv, delta_cv=delta_cv
+    )
+
+    result = identify_fopdt_and_tune(
+        history,
+        step_triggered=True,
+        initial_pv=initial_pv,
+        initial_cv=0.0,
+        final_cv=delta_cv,
+        step_time=0.0,
+    )
+
+    assert result.status == "success"
+    # Process gain is the most robustly identified parameter.
+    assert result.kp == pytest.approx(kp, rel=0.02)
+    # Two-point (10%/63.2%) estimate recovers tau and theta within ~50%.
+    assert result.tau == pytest.approx(tau, rel=0.5)
+    assert result.theta == pytest.approx(theta, abs=2.0)
+    # Recommended gains must be positive and match Cohen-Coon for the
+    # *identified* parameters (i.e. the route applies the right formula).
+    ref_kc, ref_ki, ref_kd = cohen_coon_pid(result.kp, result.tau, result.theta)
+    assert result.rec_kp == pytest.approx(ref_kc, rel=1e-9)
+    assert result.rec_ki == pytest.approx(ref_ki, rel=1e-9)
+    assert result.rec_kd == pytest.approx(ref_kd, rel=1e-9)
+    assert result.rec_kp > 0.0
+
+
+@pytest.mark.unit
+def test_identify_no_step_returns_warning() -> None:
+    result = identify_fopdt_and_tune(
+        [(0.0, 0.0, 20.0)],
+        step_triggered=False,
+        initial_pv=20.0,
+        initial_cv=0.0,
+        final_cv=0.0,
+        step_time=0.0,
+    )
+    assert result.status == "warning"
+    assert result.rec_kp == 0.0
+    assert result.rec_ki == 0.0
+    assert result.rec_kd == 0.0
+
+
+@pytest.mark.unit
+def test_identify_empty_history_returns_warning() -> None:
+    result = identify_fopdt_and_tune(
+        [],
+        step_triggered=True,
+        initial_pv=20.0,
+        initial_cv=0.0,
+        final_cv=5.0,
+        step_time=0.0,
+    )
+    assert result.status == "warning"
+
+
+@pytest.mark.unit
+def test_response_shape_clamps_negative_gains() -> None:
+    """as_response never emits negative recommended gains."""
+    result = identify_fopdt_and_tune(
+        [],
+        step_triggered=False,
+        initial_pv=0.0,
+        initial_cv=0.0,
+        final_cv=0.0,
+        step_time=0.0,
+    )
+    payload = result.as_response()
+    assert set(payload["recommended_pid"]) == {"kp", "ki", "kd"}
+    assert all(v >= 0.0 for v in payload["recommended_pid"].values())
+    assert set(payload["parameters"]) == {"kp", "tau", "theta"}

--- a/tests/shared/python/model_generation/test_rest_api_routes.py
+++ b/tests/shared/python/model_generation/test_rest_api_routes.py
@@ -560,6 +560,72 @@ def test_inertia_from_mesh_density_branch_returns_volume_and_inertia(
 
 
 @pytest.mark.unit
+def test_inertia_from_mesh_real_trimesh_unit_box_density(
+    api: ModelGenerationAPI,
+) -> None:
+    """End-to-end through the real trimesh loader on a generated unit box.
+
+    Exercises the actual ``trimesh.load`` -> ``moment_inertia`` code path
+    (not a monkeypatched stub). For a solid unit cube (side 1, volume 1) of
+    uniform density rho, the centroidal principal moment of inertia about each
+    axis is I = (1/12) * m * (a^2 + a^2) = m / 6, with m = rho * volume.
+    """
+    trimesh = pytest.importorskip("trimesh")
+
+    box = trimesh.creation.box(extents=(1.0, 1.0, 1.0))
+    stl_bytes = box.export(file_type="stl")
+    if isinstance(stl_bytes, str):  # some exporters return ASCII text
+        stl_bytes = stl_bytes.encode()
+
+    density = 1000.0
+    resp = _post(
+        api,
+        "/api/v1/inertia/from-mesh",
+        body={"density": density, "filename": "box.stl"},
+        files={"mesh": stl_bytes},
+    )
+
+    assert resp.status_code == 200, resp.body
+    assert resp.body["volume"] == pytest.approx(1.0, rel=1e-3)
+    assert resp.body["mass"] == pytest.approx(density, rel=1e-3)
+    # Center of mass of a centered unit cube is the origin.
+    assert resp.body["center_of_mass"] == pytest.approx([0.0, 0.0, 0.0], abs=1e-6)
+    expected_i = density / 6.0
+    for axis in ("ixx", "iyy", "izz"):
+        assert resp.body["inertia"][axis] == pytest.approx(expected_i, rel=1e-3)
+    # A centered axis-aligned cube has zero products of inertia.
+    for axis in ("ixy", "ixz", "iyz"):
+        assert resp.body["inertia"][axis] == pytest.approx(0.0, abs=1e-6)
+
+
+@pytest.mark.unit
+def test_inertia_from_mesh_real_trimesh_unit_box_mass_scaling(
+    api: ModelGenerationAPI,
+) -> None:
+    """Real trimesh loader, mass branch: inertia scales to the requested mass."""
+    trimesh = pytest.importorskip("trimesh")
+
+    box = trimesh.creation.box(extents=(1.0, 1.0, 1.0))
+    stl_bytes = box.export(file_type="stl")
+    if isinstance(stl_bytes, str):
+        stl_bytes = stl_bytes.encode()
+
+    mass = 12.0
+    resp = _post(
+        api,
+        "/api/v1/inertia/from-mesh",
+        body={"mass": mass, "filename": "box.stl"},
+        files={"mesh": stl_bytes},
+    )
+
+    assert resp.status_code == 200, resp.body
+    assert resp.body["mass"] == pytest.approx(mass)
+    expected_i = mass / 6.0
+    for axis in ("ixx", "iyy", "izz"):
+        assert resp.body["inertia"][axis] == pytest.approx(expected_i, rel=1e-3)
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("field", ["mass", "density"])
 def test_inertia_from_mesh_rejects_non_positive_mass_inputs(
     api: ModelGenerationAPI,


### PR DESCRIPTION
## Summary

Three disjoint structure/coverage fixes from the 2026-06-18 A–O assessment.

### #3684 — Extract Cohen-Coon PID tuning math out of the FastAPI route (safety-critical)
- New pure module `p1am_control_system/backend/pid_tuning.py`: `identify_fopdt_and_tune()` and `cohen_coon_pid()` with **no FastAPI/HTTPException dependency**.
- Every Cohen-Coon coefficient (`1.333`, `0.25`, `32`, `6`, `13`, `8`, `4`, `11`, `2`) and identification literal (`0.10`, `0.632`, `0.01`, `0.001`) is now a **named module constant**.
- `stop_pid_tuning` route reduced to building the session args and calling the pure function.
- `mpc.py` now reuses `cohen_coon_pid` so the `/api/mpc/simulate` PID baseline can't drift from the live tuning recommendation (DRY).
- New `tests/test_pid_tuning_math.py` (12 tests): pins recommended `kp/ki/kd` numerically against the canonical Cohen-Coon formulas for known plants, verifies FOPDT identification recovers `Kp` from a synthetic step response, and guards degenerate inputs.

**PID math verified:** the Cohen-Coon formulas in the code match the canonical reference (Cohen & Coon 1953): `Kc=(1/K)(τ/θ)(1.333+0.25r)`, `Ti=θ(32+6r)/(13+8r)`, `Td=4θ/(11+2r)`. Pinned example (Kp=2, τ=10, θ=2 → r=0.2): Kc=3.4575, Ki=0.7602, Kd=2.4263, independently re-derived in tests.

### #3680 — Stop reaching through AnalysisPanel into child widgets
- `AnalysisPanel` exposes aggregate signals `pca_requested`, `anova_requested`, `regression_requested`, `surface_requested`, `nn_train_requested`, forwarded from its child widgets in `_connect_child_signals()`.
- `MainWindow` now connects to `self.analysis_panel.<signal>` — no more `analysis_panel.<widget>.<signal>` 3-level chains.
- New `tests/test_analysis_panel_signals.py` (6 tests): verifies each child signal re-emits the matching panel signal.

### #3669 — Real success-path tests for inertia_from_mesh
- Added two `inertia_from_mesh` tests that load a generated unit-box mesh through the **real trimesh loader** (gated with `importorskip`) and assert mass, volume, center of mass, and the full inertia tensor on **both** the density branch and the mass-scaling branch (`I = m/6` for a unit cube). This exercises the `mesh.mass` validation + scaling path the assessment flagged as untested. (The earlier UnboundLocalError noted in the issue was already resolved on `main`; this PR adds the guarding coverage.)

## Validation
- `pid_tuning` math: 12 passed.
- AnalysisPanel signals: 6 passed.
- `inertia_from_mesh` (incl. 2 new real-trimesh): 8 passed.
- `ruff check` + `ruff format --check`: clean on all touched files.
- Module size budget: passes (main.py shrank to 1180 lines; no new offenders).
- SPEC.md updated for the source changes.

Note: #3723 (plugin_manager coverage) was **omitted** — already covered by open PR #3819.

Closes #3684
Closes #3680
Closes #3669
