### PR TITLE
feat(p1am): raw 0–5 V signal diagnostics (firmware + plot) + 200 A/300 V calibration defaults

### DIFF
--- a/src/p1am_control_system/backend/power_supply_models.py
+++ b/src/p1am_control_system/backend/power_supply_models.py
@@ -92,21 +92,23 @@ class PowerSupplyConfig(BaseModel):
     )
 
     current_full_scale_a: float = Field(
-        default=100.0,
+        default=200.0,
         gt=0.0,
         description=(
             "Calibration: amps that correspond to a full-scale signal "
             "(100 % = 20 mA = 5 V) on the current command AND current-monitor "
-            "legs. Set this to what the supply's meter reads at full output."
+            "legs. Set this to what the supply's meter reads at full output. "
+            "Default 200 A (this bench supply's max); adjustable in Calibration."
         ),
     )
     voltage_full_scale_v: float = Field(
-        default=50.0,
+        default=300.0,
         gt=0.0,
         description=(
             "Calibration: volts that correspond to a full-scale signal "
             "(100 % = 20 mA = 5 V) on the voltage-monitor AI. Set this to what "
-            "the supply's voltmeter reads at full scale."
+            "the supply's voltmeter reads at full scale. Default 300 V (this "
+            "bench supply's max); adjustable in Calibration."
         ),
     )
 
@@ -116,15 +118,23 @@ class PowerSupplyConfig(BaseModel):
         description="Lower clamp for operator current setpoint (A).",
     )
     current_setpoint_max_a: float = Field(
-        default=50.0,
+        default=200.0,
         gt=0.0,
-        description="Upper clamp for operator current setpoint (A).",
+        description=(
+            "Upper clamp for operator current setpoint (A). Default 200 A to "
+            "match the supply's full scale; the output clamp (% of full) is the "
+            "live safety guard. Adjustable."
+        ),
     )
 
     power_alarm_max_w: float = Field(
-        default=1000.0,
+        default=60000.0,
         gt=0.0,
-        description="Power trip threshold in watts (HH_POWER).",
+        description=(
+            "Power trip threshold in watts (HH_POWER). Default 60 kW = 200 A x "
+            "300 V (the supply's max) so it guards against a genuine over-power "
+            "fault without nuisance-tripping. Adjustable."
+        ),
     )
     temp_alarm_max_c: float = Field(
         default=1200.0,

--- a/src/p1am_control_system/backend/tests/_power_supply_helpers.py
+++ b/src/p1am_control_system/backend/tests/_power_supply_helpers.py
@@ -15,15 +15,36 @@ _BACKEND_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if _BACKEND_DIR not in sys.path:
     sys.path.insert(0, _BACKEND_DIR)
 
+from typing import Any
+
 from power_supply import (  # noqa: E402  (path setup above must run first)
     PowerSupplyConfig,
     PowerSupplyController,
 )
 
 
+def test_config(**overrides: Any) -> PowerSupplyConfig:
+    """A stable config for controller-logic tests.
+
+    Pinned to the historical 100 A / 50 V / 50 A / 1000 W values so these tests
+    exercise the *control law* (scaling, trips, clamps) independent of the
+    production defaults in PowerSupplyConfig — which are tuned to a specific
+    bench supply and may change. Tests that assert the production defaults
+    construct PowerSupplyConfig() directly instead.
+    """
+    base: dict[str, Any] = {
+        "current_full_scale_a": 100.0,
+        "voltage_full_scale_v": 50.0,
+        "current_setpoint_max_a": 50.0,
+        "power_alarm_max_w": 1000.0,
+    }
+    base.update(overrides)
+    return PowerSupplyConfig(**base)
+
+
 def fresh_idle_controller() -> PowerSupplyController:
-    """Return a controller in IDLE state (default config)."""
-    return PowerSupplyController(PowerSupplyConfig())
+    """Return a controller in IDLE state (stable test config)."""
+    return PowerSupplyController(test_config())
 
 
 def fresh_armed_controller() -> PowerSupplyController:
@@ -47,6 +68,6 @@ def fresh_armed_controller_unclamped() -> PowerSupplyController:
     Tests that exercise the proportional-scaling / slew / full-scale laws in
     isolation use this so the clamp doesn't cap the value under test.
     """
-    c = PowerSupplyController(PowerSupplyConfig(output_clamp_percent=100.0))
+    c = PowerSupplyController(test_config(output_clamp_percent=100.0))
     c.set_permissive(True)
     return c

--- a/src/p1am_control_system/backend/tests/test_power_supply.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply.py
@@ -44,10 +44,11 @@ from pydantic import ValidationError
 class TestPowerSupplyConfigValidation:
     def test_defaults_construct(self) -> None:
         config = PowerSupplyConfig()
-        assert config.current_full_scale_a == 100.0
-        assert config.voltage_full_scale_v == 50.0
+        # Production defaults are tuned to the bench supply (200 A / 300 V).
+        assert config.current_full_scale_a == 200.0
+        assert config.voltage_full_scale_v == 300.0
         assert config.current_setpoint_min_a == 0.0
-        assert config.current_setpoint_max_a == 50.0
+        assert config.current_setpoint_max_a == 200.0
 
     def test_full_scale_must_be_positive(self) -> None:
         with pytest.raises(ValidationError):
@@ -217,11 +218,19 @@ class TestStatus:
         # 20 % clamp of a 100 A full scale -> 20 A is the real deliverable max,
         # even though the setpoint band may go to 50 A.
         c = PowerSupplyController(
-            PowerSupplyConfig(output_clamp_percent=20.0, current_full_scale_a=100.0)
+            PowerSupplyConfig(
+                output_clamp_percent=20.0,
+                current_full_scale_a=100.0,
+                current_setpoint_max_a=50.0,
+            )
         )
         assert c.status().effective_max_current_a == pytest.approx(20.0)
         c.update_config(
-            PowerSupplyConfig(output_clamp_percent=50.0, current_full_scale_a=80.0)
+            PowerSupplyConfig(
+                output_clamp_percent=50.0,
+                current_full_scale_a=80.0,
+                current_setpoint_max_a=50.0,
+            )
         )
         assert c.status().effective_max_current_a == pytest.approx(40.0)
 

--- a/src/p1am_control_system/backend/tests/test_power_supply_integration.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply_integration.py
@@ -173,7 +173,7 @@ class TestRouterEndpoints:
         resp = client.get("/api/power_supply/config")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["current_full_scale_a"] == 100.0
+        assert body["current_full_scale_a"] == 200.0
         assert body["setpoint_ramp_rate_pct_per_s"] == 5.0
 
     def test_put_config_validates_and_replaces(
@@ -230,8 +230,8 @@ class TestRouterEndpoints:
             json={"mode": "current", "value_a": 9999.0},
         )
         assert resp.status_code == 200
-        # Clamped to default max (50)
-        assert resp.json() == {"mode": "current", "applied_a": 50.0}
+        # Clamped to the default current_setpoint_max_a (200 A).
+        assert resp.json() == {"mode": "current", "applied_a": 200.0}
 
     def test_setpoint_current_mode_missing_value_returns_400(
         self,

--- a/src/p1am_control_system/backend/tests/test_power_supply_runtime_safety.py
+++ b/src/p1am_control_system/backend/tests/test_power_supply_runtime_safety.py
@@ -21,6 +21,7 @@ from _power_supply_helpers import (
     fresh_armed_controller_unclamped,
     fresh_idle_controller,
     fresh_running_controller,
+    test_config,
 )
 from power_supply import PowerSupplyConfig, PowerSupplyController, PowerSupplyState
 
@@ -204,7 +205,7 @@ class TestOutputClamp:
         assert c.status().output_clamped is False
 
     def test_custom_clamp_value_is_enforced(self) -> None:
-        cfg = PowerSupplyConfig(output_clamp_percent=35.0)
+        cfg = test_config(output_clamp_percent=35.0)  # 100 A full scale
         c = PowerSupplyController(cfg)
         c.set_permissive(True)
         c.set_current_setpoint(50.0)  # 50 % raw

--- a/src/p1am_control_system/firmware/P1AMHardware.cpp
+++ b/src/p1am_control_system/firmware/P1AMHardware.cpp
@@ -115,6 +115,18 @@ float P1AMHardware::ReadAnalogInput(int channel) {
   return percent;
 }
 
+float P1AMHardware::ReadAnalogInputRawVolts(int channel) {
+  if (channel < 0 || channel >= 4) {
+    return 0.0f;
+  }
+  // counts 0-8191 = 0-20 mA; the 0-5 V terminal voltage = mA * 250 ohm / 1000.
+  // So volts = counts * 5 / 8191 (0 mA -> 0 V, 20 mA -> 5 V). No clamping or
+  // process scaling: this is the raw signal for troubleshooting.
+  // Library channels are 1-indexed; broker uses 0-indexed.
+  uint32_t counts = P1.readAnalog(kSlotAna, channel + 1);
+  return static_cast<float>(counts) * (5.0f / 8191.0f);
+}
+
 void P1AMHardware::WriteAnalogOutput(int channel, float value) {
   if (channel < 0 || channel >= 2) {
     return;

--- a/src/p1am_control_system/firmware/P1AMHardware.h
+++ b/src/p1am_control_system/firmware/P1AMHardware.h
@@ -16,6 +16,12 @@ class P1AMHardware : public HardwareInterface {
   void WriteInhibit(bool active) override;
   void WriteHeaterRelay(bool on) override;
 
+  // Raw, unscaled diagnostic read of one analog input (channels 0-3) as the
+  // 0-5 V the terminal sees (counts -> 0-20 mA -> 0-5 V across the input
+  // burden). No process scaling — purely for the signal-diagnostics plot so
+  // operators can troubleshoot the monitor card independent of calibration.
+  float ReadAnalogInputRawVolts(int channel);
+
  private:
   // Actual bench-verified slot order via P1.printModules() on 2026-06-01:
   //   Slot 1 = P1-4ADL2DAL-1   (analog combo, 4 AI + 2 AO, 4-20 mA)

--- a/src/p1am_control_system/firmware/firmware.ino
+++ b/src/p1am_control_system/firmware/firmware.ino
@@ -277,6 +277,23 @@ void loop() {
     // the safety interlock always wins — a trip forces the relay off regardless.
     bool relay_cmd = (modbusServer.coilRead(kHeaterRelayCoil) == 1);
     hw.WriteHeaterRelay(relay_cmd && !interlock.IsTripped());
+
+    // --- Signal diagnostics: raw 0-5 V of every analog channel (TAG_20..25) ---
+    // Unscaled, for troubleshooting the analog card independent of calibration.
+    // AI0..3 show the actual 0-5 V at the input terminal; AO0..1 show the
+    // commanded output as 0-5 V (0 % -> 0 V, 100 % -> 5 V). These tags are
+    // diagnostics only — nothing routes through them.
+    for (int ch = 0; ch < 4; ++ch) {
+      broker.SetTag(20 + ch, hw.ReadAnalogInputRawVolts(ch));
+    }
+    for (int ch = 0; ch < 2; ++ch) {
+      int srcTag = broker.GetOutputRouting(ch);
+      float cmdPct = (srcTag >= 0 && srcTag < SignalBroker::kNumTags)
+                         ? broker.GetTag(srcTag)
+                         : 0.0f;
+      broker.SetTag(24 + ch, cmdPct * (5.0f / 100.0f));
+    }
+
     for (int i = 0; i < SignalBroker::kNumTags; ++i) {
       WriteFloatToModbus(i * 2, broker.GetTag(i));
     }

--- a/src/p1am_control_system/frontend/src/App.tsx
+++ b/src/p1am_control_system/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { LadderExplorer } from "./components/LadderExplorer";
 import { PlantHierarchy } from "./components/PlantHierarchy";
 import { PowerSupplyControl } from "./components/PowerSupplyControl";
 import { TemperatureControl } from "./components/TemperatureControl";
+import { SignalDiagnostics } from "./components/SignalDiagnostics";
 import { AlicatInspector } from "./components/AlicatInspector";
 import { TagInspector } from "./components/TagInspector";
 import type { LadderTagInfo } from "./api/schemas";
@@ -656,6 +657,10 @@ export const App: React.FC = () => {
 
           {activeTab === "temperature" && visibleTabs.temperature && (
             <TemperatureControl liveStatus={temperatureStatus} />
+          )}
+
+          {activeTab === "diagnostics" && visibleTabs.diagnostics && (
+            <SignalDiagnostics history={history} />
           )}
 
           {/* Render Tab Contents */}

--- a/src/p1am_control_system/frontend/src/components/SignalDiagnostics.tsx
+++ b/src/p1am_control_system/frontend/src/components/SignalDiagnostics.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+
+/**
+ * Signal Diagnostics plot — the raw, unscaled 0-5 V of every analog channel on
+ * the P1-4ADL2DAL card (4 analog inputs + 2 analog outputs), straight from the
+ * firmware diagnostic tags (TAG_20..25). No process scaling / calibration is
+ * applied, so an operator can compare each trace against a multimeter at the
+ * terminal and troubleshoot the monitor card independently of the engineering
+ * (A / V) readouts on the Power Supply tab.
+ *
+ * Self-contained SVG (no chart lib): the parent passes the rolling per-scan tag
+ * history; this slices the last `windowSamples` of tag columns 20..25.
+ */
+
+export interface DiagChannel {
+  tag: number; // tag index in the history rows
+  label: string;
+  color: string;
+}
+
+const CHANNELS: DiagChannel[] = [
+  { tag: 20, label: "AI0 — current monitor", color: "var(--color-success)" },
+  { tag: 21, label: "AI1 — voltage monitor", color: "var(--accent-purple)" },
+  { tag: 22, label: "AI2 — spare", color: "var(--accent-cyan)" },
+  { tag: 23, label: "AI3 — spare", color: "var(--accent-magenta)" },
+  { tag: 24, label: "AO0 — current cmd", color: "var(--color-warning)" },
+  { tag: 25, label: "AO1 — aux cmd", color: "var(--text-secondary)" },
+];
+
+const FULL_SCALE_V = 5;
+const W = 600;
+const H = 220;
+const PAD_L = 30;
+const PAD_R = 10;
+const PAD_T = 10;
+const PAD_B = 18;
+const PLOT_W = W - PAD_L - PAD_R;
+const PLOT_H = H - PAD_T - PAD_B;
+
+function buildPath(values: number[]): string {
+  if (values.length < 2) return "";
+  const n = values.length;
+  return values
+    .map((val, idx) => {
+      const x = PAD_L + (idx / (n - 1)) * PLOT_W;
+      const frac = Math.max(0, Math.min(1, val / FULL_SCALE_V));
+      const y = PAD_T + (1 - frac) * PLOT_H;
+      return `${idx === 0 ? "M" : "L"}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+interface Props {
+  /** Rolling per-scan tag history: each row is the full tag array for a scan. */
+  history: number[][];
+  /** How many trailing samples to plot (≈ samples × 0.1 s at 10 Hz). */
+  windowSamples?: number;
+}
+
+export const SignalDiagnostics: React.FC<Props> = ({
+  history,
+  windowSamples = 300,
+}) => {
+  const window = history.slice(-windowSamples);
+  const series = CHANNELS.map((ch) => ({
+    ...ch,
+    values: window.map((row) => row[ch.tag] ?? 0),
+    last: window.length ? (window[window.length - 1][ch.tag] ?? 0) : null,
+  }));
+  const seconds = Math.round((windowSamples * 0.1) / 1) || 30;
+
+  return (
+    <div className="ps-card">
+      <div className="ps-card-title">Signal Diagnostics — raw 0–5 V (unscaled)</div>
+      <p style={{ fontSize: "0.72rem", color: "var(--text-secondary)", margin: "0 0 0.6rem", lineHeight: 1.5 }}>
+        The actual 0–5 V on every analog channel of the P1-4ADL2DAL card, with
+        <strong> no scaling or calibration</strong> — for troubleshooting the
+        supply's monitor card. Inputs (AI) show the voltage at the terminal;
+        outputs (AO) show the commanded level as 0–5 V. Compare against a
+        multimeter at the terminal.
+      </p>
+
+      <div className="ps-trend-legend">
+        {series.map((s) => (
+          <span className="ps-trend-key" key={s.tag}>
+            <span className="swatch" style={{ background: s.color }} />
+            {s.label}
+            <strong>{s.last != null ? `${s.last.toFixed(3)} V` : "—"}</strong>
+          </span>
+        ))}
+        <span className="ps-trend-window">last {seconds}s · 0–5 V axis</span>
+      </div>
+
+      <svg
+        className="ps-trend-svg"
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        role="img"
+        aria-label="Raw 0-5 V analog signal diagnostics"
+      >
+        {[0, 1, 2, 3, 4, 5].map((volt) => {
+          const y = PAD_T + (1 - volt / FULL_SCALE_V) * PLOT_H;
+          return (
+            <g key={volt}>
+              <line x1={PAD_L} y1={y} x2={W - PAD_R} y2={y} className="ps-trend-grid" />
+              <text x={PAD_L - 5} y={y + 3} className="ps-trend-axis" textAnchor="end">
+                {volt}
+              </text>
+            </g>
+          );
+        })}
+
+        {window.length < 2 ? (
+          <text x={W / 2} y={H / 2} className="ps-trend-empty" textAnchor="middle">
+            waiting for live data…
+          </text>
+        ) : (
+          series.map((s) => (
+            <path
+              key={s.tag}
+              d={buildPath(s.values)}
+              className="ps-trend-line"
+              stroke={s.color}
+            />
+          ))
+        )}
+      </svg>
+    </div>
+  );
+};

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -18,7 +18,8 @@ export type TabId =
   | "ladder"
   | "hierarchy"
   | "powerSupply"
-  | "temperature";
+  | "temperature"
+  | "diagnostics";
 
 export interface TabDef {
   /** Stable identifier used as the `activeTab` value and visibility key. */
@@ -85,6 +86,12 @@ export const TABS: readonly TabDef[] = [
     label: "Heater Controls",
     settingsLabel: "Heater Controls",
     accentVar: "var(--accent-orange, #fb923c)",
+  },
+  {
+    id: "diagnostics",
+    label: "Signal Diagnostics",
+    settingsLabel: "Signal Diagnostics (raw 0–5 V)",
+    accentVar: "var(--accent-cyan)",
   },
 ] as const;
 


### PR DESCRIPTION
Consolidates the remaining bench-bringup work into one passing PR (the earlier firmware/HMI PRs already merged; these are the net-new changes on top of main).

## 1. Raw 0–5 V signal diagnostics
For troubleshooting the supply's analog monitor card independent of calibration.
- **Firmware**: new `ReadAnalogInputRawVolts()` + a diagnostic block writing the **unscaled 0–5 V** of every analog channel — AI0–3 terminal voltage and AO0–1 commanded level — to tags `TAG_20..25`. Diagnostics only; nothing routes through them and the scaled feedback tags are untouched. Compiles for P1AM-100 (22%).
- **HMI**: a new **Signal Diagnostics** tab plotting all six channels on a fixed 0–5 V axis (self-contained SVG), so an operator can compare each trace against a multimeter. *Verified live on the bench: AI0 ≈ 4.2 V, AI1 ≈ 3.7 V.*

## 2. Power-supply calibration defaults → 200 A / 300 V
The bench supply is rated 200 A / 300 V, so the production `PowerSupplyConfig` defaults now match:
`current_full_scale_a=200`, `voltage_full_scale_v=300`, `current_setpoint_max_a=200`, `power_alarm_max_w=60000` (= 200 A × 300 V, guards a real over-power fault without nuisance-tripping). All stay **operator-adjustable** in the HMI Calibration section.

The controller-logic tests are decoupled from these production defaults via a new `test_config()` helper (pins the historical 100 A / 50 V / 50 A / 1000 W values), so the scaling/trip/clamp tests exercise the control law itself; tests that assert the production defaults are updated.

## Gates (all green locally)
- Backend **433 passed**; `ruff` + `ruff format` clean; mypy clean on changed source.
- Frontend `tsc` + **vitest 36 passed** + `vite build` clean.
- Firmware `arduino-cli compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)