### PR TITLE
🎨 Palette: Add ARIA label to Swap Units button

### DIFF
--- a/src/flow_rate_converter/web/src/components/FlowRateConverter.tsx
+++ b/src/flow_rate_converter/web/src/components/FlowRateConverter.tsx
@@ -173,6 +173,7 @@ export function FlowRateConverter() {
             onClick={swapUnits}
             className="px-3 py-3 text-slate-400 hover:text-white transition-colors"
             title="Swap units"
+            aria-label="Swap units"
           >
             &#8646;
           </button>


### PR DESCRIPTION
💡 What: Added an explicit `aria-label="Swap units"` to the icon-only swap button in the Flow Rate Converter.
🎯 Why: The button previously relied on a `title` attribute and the raw unicode character `&#8646;` (left-right arrow), which can be read incorrectly by screen readers or not convey the actual action. The ARIA label provides clear, semantic meaning to assistive technologies.
📸 Before/After: Visuals remain unchanged; DOM now includes `aria-label="Swap units"`.
♿ Accessibility: Improves screen reader experience by properly identifying the button's purpose instead of relying on unicode character pronunciation.

---
*PR created automatically by Jules for task [14131679078939079499](https://jules.google.com/task/14131679078939079499) started by @dieterolson*