### PR TITLE
🎨 Palette: Enable native enter-key submission for calculator

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,7 @@
 ## 2024-06-25 - Custom Toggle Controls
 **Learning:** When using `<button>` elements to create custom ON/OFF toggles or mode switches (like the "Add" / "Subtract" operations) that rely entirely on background color changes for state, screen readers cannot determine their current state.
 **Action:** Always add `aria-pressed={isActive}` to custom toggle buttons, along with keyboard-accessible hover (`hover:bg-...`) and focus states (`focus-visible:ring-2`) to ensure both semantic state and visual focus are clear.
+
+## 2024-05-24 - Form Submissions for Keyboard Users
+**Learning:** Wrapping a collection of data entry fields in a native `<form>` element instead of a `<div>` instantly enables native "Enter" key form submission, which is critical for heavy data-entry applications. Users don't need to manually tab to the calculate button.
+**Action:** For all data-entry calculators or settings panels, always use a `<form onSubmit={...}>` structure instead of binding `onClick` directly to the submit button.

--- a/src/financial_calculator/web/src/components/FinancialCalculator.tsx
+++ b/src/financial_calculator/web/src/components/FinancialCalculator.tsx
@@ -58,7 +58,8 @@ function FinancialCalculator() {
   const [taxRate, setTaxRate] = useState(25)
   const [results, setResults] = useState<Results | null>(null)
 
-  const calculate = () => {
+  const calculate = (e?: React.FormEvent) => {
+    if (e) e.preventDefault()
     const util = utilization / 100
     const annualFeedstock = plantCapacity * operatingDays * util
     const productTons = annualFeedstock * 0.85
@@ -115,7 +116,7 @@ function FinancialCalculator() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Input Panel */}
-        <div className="space-y-6">
+        <form className="space-y-6" onSubmit={calculate}>
           {/* Plant Operations */}
           <div className="rounded-lg p-4" style={{ backgroundColor: colors.mantle, border: `1px solid ${colors.surface1}` }}>
             <h2 className="text-lg font-semibold mb-4" style={{ color: colors.lavender }}>
@@ -199,14 +200,14 @@ function FinancialCalculator() {
           </div>
 
           <button
-            onClick={calculate}
+            type="submit"
             aria-controls="results-panel"
             className="w-full py-3 rounded-lg font-bold text-lg transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#89b4fa] focus-visible:ring-offset-[#1e1e2e]"
             style={{ backgroundColor: colors.blue, color: colors.base }}
           >
             Calculate Financial Model
           </button>
-        </div>
+        </form>
 
         {/* Results Panel */}
         <div id="results-panel" className="space-y-6" aria-live="polite">


### PR DESCRIPTION
💡 What: Wrapped the input fields in a `<form>` element and bound the calculate action to the `onSubmit` event rather than the button's `onClick`. Added `type="submit"` to the calculate button.
🎯 Why: Data-entry applications like financial calculators benefit heavily from keyboard navigability. By using a native form, users can press "Enter" inside any input field to calculate the results without needing to manually tab to or click the button.
📸 Before/After: Visuals are unchanged. The improvement is strictly behavioral.
♿ Accessibility: Greatly improves keyboard accessibility for power users and screen-reader users by utilizing native HTML `<form>` semantics.

---
*PR created automatically by Jules for task [12631538951799398238](https://jules.google.com/task/12631538951799398238) started by @dieterolson*