### PR TITLE
🎨 Palette: Improve Accessibility of CSV Exporter Form

### DIFF
--- a/src/p1am_control_system/frontend/src/components/CsvExporter.tsx
+++ b/src/p1am_control_system/frontend/src/components/CsvExporter.tsx
@@ -65,10 +65,17 @@ export const CsvExporter: React.FC<{
         <FileText size={14} color="var(--accent-purple)" />
         <span>CSV Data Exporter</span>
       </h3>
-      <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+      <form
+        style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleDownloadCSV();
+        }}
+      >
         <div className="input-group">
-          <label className="input-label">Tags (comma-separated)</label>
+          <label htmlFor="csv-tags" className="input-label">Tags (comma-separated)</label>
           <input
+            id="csv-tags"
             type="text"
             className="form-input"
             value={exportTags}
@@ -77,8 +84,9 @@ export const CsvExporter: React.FC<{
           />
         </div>
         <div className="input-group">
-          <label className="input-label">Start Time</label>
+          <label htmlFor="csv-start" className="input-label">Start Time</label>
           <input
+            id="csv-start"
             type="datetime-local"
             className="form-input"
             value={exportStart}
@@ -86,8 +94,9 @@ export const CsvExporter: React.FC<{
           />
         </div>
         <div className="input-group">
-          <label className="input-label">End Time</label>
+          <label htmlFor="csv-end" className="input-label">End Time</label>
           <input
+            id="csv-end"
             type="datetime-local"
             className="form-input"
             value={exportEnd}
@@ -95,15 +104,14 @@ export const CsvExporter: React.FC<{
           />
         </div>
         <button
-          type="button"
-          onClick={handleDownloadCSV}
+          type="submit"
           className="btn"
           style={{ width: "100%", padding: "0.45rem", fontSize: "0.8rem" }}
         >
           <Download size={14} />
           Export Log Data
         </button>
-      </div>
+      </form>
     </div>
   );
 };


### PR DESCRIPTION
💡 What: Converted the CSV Exporter data-entry container from a `<div>` to a `<form>` with a `type="submit"` button, and added explicit `htmlFor` and `id` mappings between inputs and labels. Also added `spec-exempt` label.
🎯 Why: To enable seamless keyboard accessibility (allowing 'Enter' to submit the export form) and ensure inputs are properly described to screen readers.
📸 Before/After: N/A - Visuals are unchanged; purely structural.
♿ Accessibility: Screen readers will now correctly associate input labels, and keyboard-only users can now submit the form natively via the 'Enter' key without tabbing to the export button.

---
*PR created automatically by Jules for task [6122606322155387048](https://jules.google.com/task/6122606322155387048) started by @dieterolson*