### PR TITLE
🎨 Palette: Add accessibility and interaction polish to navigation tabs

### DIFF
--- a/src/rotation_converter/web/src/App.tsx
+++ b/src/rotation_converter/web/src/App.tsx
@@ -15,18 +15,20 @@ function App() {
           </p>
           <div className="mt-4 flex gap-2">
             <button
-              className={`px-3 py-1 rounded text-sm ${
-                activeTab === "rotation" ? "bg-blue-600 text-white" : "bg-slate-700 text-slate-200"
+              className={`px-3 py-1 rounded text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
+                activeTab === "rotation" ? "bg-blue-600 text-white" : "bg-slate-700 text-slate-200 hover:bg-slate-600"
               }`}
               onClick={() => setActiveTab("rotation")}
+              aria-pressed={activeTab === "rotation"}
             >
               Rotation Formats
             </button>
             <button
-              className={`px-3 py-1 rounded text-sm ${
-                activeTab === "reference" ? "bg-blue-600 text-white" : "bg-slate-700 text-slate-200"
+              className={`px-3 py-1 rounded text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
+                activeTab === "reference" ? "bg-blue-600 text-white" : "bg-slate-700 text-slate-200 hover:bg-slate-600"
               }`}
               onClick={() => setActiveTab("reference")}
+              aria-pressed={activeTab === "reference"}
             >
               Reference Frames & Lie Groups
             </button>


### PR DESCRIPTION
💡 What: Added `aria-pressed` states, hover effects, and keyboard focus rings to the top-level app navigation tabs.
🎯 Why: Ensures screen reader users know which tab is active, while mouse and keyboard users receive visual feedback during navigation.
📸 Before/After: Before, tabs lacked focus outlines and hover states, and were invisible to screen readers as stateful toggles. After, they provide clear visual and semantic feedback.
♿ Accessibility: Added `aria-pressed` to correctly announce the active tab state, and `focus-visible:ring-2` to support keyboard navigation.

---
*PR created automatically by Jules for task [8921667364968759879](https://jules.google.com/task/8921667364968759879) started by @dieterolson*