### PR TITLE
🎨 Palette: Link form labels to inputs dynamically

### DIFF
--- a/src/function_generator/web/src/components/FunctionGenerator.tsx
+++ b/src/function_generator/web/src/components/FunctionGenerator.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useMemo, useEffect, useId } from 'react';
 import {
   LineChart,
   Line,
@@ -1038,10 +1038,12 @@ interface ParamInputProps {
 }
 
 function ParamInput({ label, value, onChange, min, max, step = 0.1 }: ParamInputProps) {
+  const inputId = useId();
   return (
     <div>
-      <label className="block text-sm text-slate-400 mb-1">{label}</label>
+      <label htmlFor={inputId} className="block text-sm text-slate-400 mb-1">{label}</label>
       <input
+        id={inputId}
         type="number"
         value={value}
         onChange={e => onChange(parseFloat(e.target.value) || 0)}


### PR DESCRIPTION
💡 What: Updated the `ParamInput` component to generate dynamic ids utilizing the `useId()` react hook, linking the HTML label explicitly to its input control.
🎯 Why: Ensure proper semantic accessibility mapping without the risk of duplicate hard-coded IDs if a component is used multiple times, preventing screen reader users from not receiving context on inputs.
📸 Before/After: Inputs lacked an explicit id and the respective label an htmlFor attribute. Now, each label matches the dynamically generated id in the input, resolving a11y regressions.
♿ Accessibility: Enhanced semantic form accessibility for the `FunctionGenerator` settings.

---
*PR created automatically by Jules for task [11822533780567841488](https://jules.google.com/task/11822533780567841488) started by @dieterolson*