### PR TITLE
⚡ Bolt: Optimize defaultTabVisibility by replacing .reduce() with for...of loop

### DIFF
--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -97,13 +97,12 @@ export const TABS: readonly TabDef[] = [
 
 /** Default visibility map (all tabs visible) derived from {@link TABS}. */
 export function defaultTabVisibility(): Record<TabId, boolean> {
-  return TABS.reduce(
-    (acc, tab) => {
-      acc[tab.id] = true;
-      return acc;
-    },
-    {} as Record<TabId, boolean>,
-  );
+  // ⚡ Bolt Optimization: Replace .reduce() with a single-pass for...of loop to eliminate callback allocation and GC overhead when initializing objects
+  const visibility: Record<TabId, boolean> = {} as Record<TabId, boolean>;
+  for (const tab of TABS) {
+    visibility[tab.id] = true;
+  }
+  return visibility;
 }
 
 /** The canonical tab id order as declared in {@link TABS}. */


### PR DESCRIPTION
💡 What: Replaced `TABS.reduce()` with a pre-allocated object and `for...of` loop in `defaultTabVisibility`.
🎯 Why: Using `.reduce()` creates a callback and creates a new execution context on every iteration, which increases garbage collection pressure when allocating objects from arrays.
📊 Impact: Reduces GC overhead and eliminates function invocation overhead when deriving default visibility.
🔬 Measurement: Run unit tests to verify the structure matches.

---
*PR created automatically by Jules for task [7882762452200491971](https://jules.google.com/task/7882762452200491971) started by @dieterolson*