### PR TITLE
🎨 Palette: [UX improvement] Add ARIA attributes to Function Generator tabs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,6 @@
 ## 2024-06-25 - Custom Toggle Controls
 **Learning:** When using `<button>` elements to create custom ON/OFF toggles or mode switches (like the "Add" / "Subtract" operations) that rely entirely on background color changes for state, screen readers cannot determine their current state.
 **Action:** Always add `aria-pressed={isActive}` to custom toggle buttons, along with keyboard-accessible hover (`hover:bg-...`) and focus states (`focus-visible:ring-2`) to ensure both semantic state and visual focus are clear.
+## 2024-05-31 - Tab Roles vs aria-pressed
+**Learning:** When implementing custom tab components in React, use `role="tab"` paired strictly with `aria-selected` (not `aria-pressed`, which is intended for toggle buttons) and ensure `aria-controls` points to a valid `role="tabpanel"` container whose `aria-labelledby` points back to the tab.
+**Action:** When adding accessible properties to custom tabs, replace `aria-pressed` with `aria-selected`, ensure a `role="tablist"` wrapper is present, and correctly cross-reference `aria-controls` with the tab panel IDs.

--- a/src/function_generator/web/src/components/FunctionGenerator.tsx
+++ b/src/function_generator/web/src/components/FunctionGenerator.tsx
@@ -818,8 +818,12 @@ export function FunctionGenerator() {
       {/* Visualization Panel */}
       <div className="lg:col-span-2 space-y-4">
         {/* Tabs */}
-        <div className="flex space-x-2">
+        <div className="flex space-x-2" role="tablist" aria-label="Domain view tabs">
           <button
+            id="tab-time"
+            role="tab"
+            aria-selected={activeTab === 'time'}
+            aria-controls="panel-time"
             onClick={() => setActiveTab('time')}
             className={`px-4 py-2 rounded font-medium transition-colors ${
               activeTab === 'time'
@@ -830,6 +834,10 @@ export function FunctionGenerator() {
             Time Domain
           </button>
           <button
+            id="tab-frequency"
+            role="tab"
+            aria-selected={activeTab === 'frequency'}
+            aria-controls="panel-frequency"
             onClick={() => setActiveTab('frequency')}
             className={`px-4 py-2 rounded font-medium transition-colors ${
               activeTab === 'frequency'
@@ -843,7 +851,12 @@ export function FunctionGenerator() {
 
         {/* Time Domain Chart */}
         {activeTab === 'time' && (
-          <div className="bg-slate-800 rounded-lg p-4">
+          <div
+            id="panel-time"
+            role="tabpanel"
+            aria-labelledby="tab-time"
+            className="bg-slate-800 rounded-lg p-4"
+          >
             <h3 className="text-lg font-semibold text-white mb-4">
               {layers.length === 1
                 ? `${WAVEFORM_OPTIONS.find(o => o.value === waveformType)?.label} - Time Domain`
@@ -922,7 +935,12 @@ export function FunctionGenerator() {
 
         {/* Frequency Domain Chart */}
         {activeTab === 'frequency' && (
-          <div className="bg-slate-800 rounded-lg p-4">
+          <div
+            id="panel-frequency"
+            role="tabpanel"
+            aria-labelledby="tab-frequency"
+            className="bg-slate-800 rounded-lg p-4"
+          >
             <h3 className="text-lg font-semibold text-white mb-4">Frequency Spectrum</h3>
             <div className="h-96">
               <ResponsiveContainer width="100%" height="100%">


### PR DESCRIPTION
💡 What: Added accessible tab roles (tablist, tab, tabpanel) and aria attributes (aria-selected, aria-controls, aria-labelledby) to the Time/Frequency domain tabs.
🎯 Why: To ensure screen reader users have proper context when navigating the tabs.
📸 Before/After: Visuals are unchanged.
♿ Accessibility: Improved semantic structure for tabs, allowing screen readers to announce the tab list, which tab is currently selected, and properly associate the tab with its content panel.

---
*PR created automatically by Jules for task [3879697277242230810](https://jules.google.com/task/3879697277242230810) started by @dieterolson*