### PR TITLE
🎨 Palette: Add aria-pressed to signal toggle buttons

### DIFF
--- a/src/data_processing/data_processor/web/src/components/SignalList.tsx
+++ b/src/data_processing/data_processor/web/src/components/SignalList.tsx
@@ -192,6 +192,7 @@ export const SignalList = memo(function SignalList({ signals, selectedSignals, o
                 <button
                   key={signal}
                   onClick={() => toggleSignal(signal)}
+                  aria-pressed={isSelected}
                   className={`
                     w-full flex items-center gap-2 px-3 py-2 rounded-lg
                     text-left text-sm transition-colors duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500


### PR DESCRIPTION
💡 What: Added the `aria-pressed` attribute to the custom signal toggle buttons in `SignalList.tsx`.

🎯 Why: To ensure semantic state visibility for screen readers, allowing users relying on assistive technologies to know which signals are currently selected.

📸 Before/After: Before, screen readers might just announce 'button, [signal name]'. After, they will announce 'toggle button, [signal name], pressed' or 'not pressed'.

♿ Accessibility: Improves accessibility for screen reader users by properly semantically identifying the active/inactive state of the custom toggle buttons.

---
*PR created automatically by Jules for task [13054588528567572010](https://jules.google.com/task/13054588528567572010) started by @dieterolson*