### PR TITLE
⚡ Bolt: Prevent array allocation and O(N) lookup in PhaseTimeline filter

### DIFF
--- a/src/media_processing/video_processor/apps/web/components/golf/PhaseTimeline.tsx
+++ b/src/media_processing/video_processor/apps/web/components/golf/PhaseTimeline.tsx
@@ -9,6 +9,14 @@ interface PhaseTimelineProps {
   currentFrame?: number;
 }
 
+// ⚡ Bolt Optimization: Extracted key phases to a static Set outside the component to prevent array allocation on every render and O(N) lookup overhead.
+const KEY_PHASES = new Set([
+  SwingPhase.ADDRESS,
+  SwingPhase.TOP_OF_BACKSWING,
+  SwingPhase.IMPACT,
+  SwingPhase.FINISH,
+]);
+
 export default function PhaseTimeline({
   phases,
   totalDuration,
@@ -76,14 +84,7 @@ export default function PhaseTimeline({
   const activePhase = getCurrentPhase();
 
   // Key phases for simplified view
-  const keyPhases = phases.filter((p) =>
-    [
-      SwingPhase.ADDRESS,
-      SwingPhase.TOP_OF_BACKSWING,
-      SwingPhase.IMPACT,
-      SwingPhase.FINISH,
-    ].includes(p.phase)
-  );
+  const keyPhases = phases.filter((p) => KEY_PHASES.has(p.phase));
 
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">


### PR DESCRIPTION
💡 What: Extracted the key phases array into a static Set outside the PhaseTimeline component.
🎯 Why: Using an inline array with .includes() inside a .filter() callback creates unnecessary intermediate array allocations for every item in the array on every render cycle.
📊 Impact: Eliminates O(N) garbage collection overhead and O(M) array lookup overhead during timeline renders.
🔬 Measurement: Verify memory allocations and CPU time in React DevTools profiler during golf swing playback.

---
*PR created automatically by Jules for task [4916086702413109670](https://jules.google.com/task/4916086702413109670) started by @dieterolson*