### PR TITLE
⚡ Bolt: Optimize tab ordering and mapping loops in frontend

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -66,3 +66,6 @@
 ## 2024-05-24 - Array.prototype.sort Overhead in Hot Loops
 **Learning:** Discovered that for sorting tiny, statically-sized arrays (<= 20 elements) repeatedly inside high-frequency algorithmic hot loops (like Nelder-Mead optimization), `Array.prototype.sort()` incurs severe execution overhead due to callback invocation and closure allocation.
 **Action:** Replace `Array.prototype.sort()` with a manual in-place insertion sort for tiny arrays inside hot paths to eliminate function call overhead and improve execution speed.
+## 2026-07-08 - Avoid Typecast Clutter When Replacing Object.fromEntries
+**Learning:** When optimizing React initialization logic by replacing `Object.fromEntries()` with single-pass `for...of` loops and pre-allocated objects, typing the initial object as `Partial<Record<...>>` forces all subsequent usages in the component to use verbose typecasts (e.g., `(TAB_BY_ID as Record<...>)[id]`). This directly violates the principle of not sacrificing code readability for micro-optimizations.
+**Action:** When replacing `Object.fromEntries()`, type the pre-allocated empty object explicitly using a type assertion during initialization (e.g., `const obj = {} as Record<...>;`) to keep the call sites completely clean and readable.

--- a/src/p1am_control_system/frontend/src/components/TabBar.tsx
+++ b/src/p1am_control_system/frontend/src/components/TabBar.tsx
@@ -11,9 +11,11 @@ import { TABS, type TabId, defaultTabOrder } from "../lib/tabs";
  * be persisted; this component only emits change callbacks.
  */
 
-const TAB_BY_ID: Record<TabId, (typeof TABS)[number]> = Object.fromEntries(
-  TABS.map((tab) => [tab.id, tab]),
-) as Record<TabId, (typeof TABS)[number]>;
+// ⚡ Bolt Optimization: Replace `Object.fromEntries(TABS.map(...))` with single-pass `for...of` loop
+const TAB_BY_ID = {} as Record<TabId, (typeof TABS)[number]>;
+for (const tab of TABS) {
+  TAB_BY_ID[tab.id] = tab;
+}
 
 interface ContextMenuState {
   id: TabId;
@@ -40,7 +42,9 @@ export const TabBar: React.FC<{
   const effectiveOrder = useMemo<TabId[]>(() => {
     const base = order && order.length ? order : defaultTabOrder();
     const kept = base.filter((id) => TAB_BY_ID[id]);
-    const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+    // ⚡ Bolt Optimization: Replace `.filter(!kept.includes)` with O(1) Set lookup
+    const keptSet = new Set(kept);
+    const missing = defaultTabOrder().filter((id) => !keptSet.has(id));
     return [...kept, ...missing];
   }, [order]);
 

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -97,13 +97,12 @@ export const TABS: readonly TabDef[] = [
 
 /** Default visibility map (all tabs visible) derived from {@link TABS}. */
 export function defaultTabVisibility(): Record<TabId, boolean> {
-  return TABS.reduce(
-    (acc, tab) => {
-      acc[tab.id] = true;
-      return acc;
-    },
-    {} as Record<TabId, boolean>,
-  );
+  // ⚡ Bolt Optimization: Replace `.reduce()` with single-pass `for...of` loop
+  const visibility: Partial<Record<TabId, boolean>> = {};
+  for (const tab of TABS) {
+    visibility[tab.id] = true;
+  }
+  return visibility as Record<TabId, boolean>;
 }
 
 /** The canonical tab id order as declared in {@link TABS}. */
@@ -124,7 +123,9 @@ function reconcileOrder(saved: readonly unknown[]): TabId[] {
   const kept = saved.filter(
     (id): id is TabId => typeof id === "string" && known.has(id as TabId),
   );
-  const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+  // ⚡ Bolt Optimization: Replace `.filter(!kept.includes)` with O(1) Set lookup
+  const keptSet = new Set(kept);
+  const missing = defaultTabOrder().filter((id) => !keptSet.has(id));
   return [...kept, ...missing];
 }
 


### PR DESCRIPTION
💡 What: Replaced `.reduce()` and `Object.fromEntries(TABS.map(...))` with single-pass loops. Replaced `array.filter(item => !kept.includes(item))` with `Set.has()` for O(1) lookup.
🎯 Why: To reduce unnecessary array allocations, eliminate O(N²) overhead in tab reconciliation logic, and reduce garbage collection pressure on the main thread during component renders.
📊 Impact: Reduces memory allocation operations during tab initialization and reconciliations from O(N²) to O(N), resulting in faster and more stable initial rendering of the UI.
🔬 Measurement: Verified that tests continue to pass and no type errors are introduced. Profiling bundle loading will show fewer chained array iteration GC events during `TABS` module evaluation.

---
*PR created automatically by Jules for task [17132711878761331196](https://jules.google.com/task/17132711878761331196) started by @dieterolson*