### PR TITLE
⚡ Bolt: Replace O(N^2) .filter().includes() passes with Set lookups in p1am frontend

### DIFF
--- a/src/p1am_control_system/frontend/src/components/TabBar.tsx
+++ b/src/p1am_control_system/frontend/src/components/TabBar.tsx
@@ -40,7 +40,9 @@ export const TabBar: React.FC<{
   const effectiveOrder = useMemo<TabId[]>(() => {
     const base = order && order.length ? order : defaultTabOrder();
     const kept = base.filter((id) => TAB_BY_ID[id]);
-    const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+    // ⚡ Bolt Optimization: Pre-compute a Set from the target array and use .has() for O(1) constant-time lookups instead of chained .filter().includes() passes.
+    const keptSet = new Set(kept);
+    const missing = defaultTabOrder().filter((id) => !keptSet.has(id));
     return [...kept, ...missing];
   }, [order]);
 

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -124,7 +124,9 @@ function reconcileOrder(saved: readonly unknown[]): TabId[] {
   const kept = saved.filter(
     (id): id is TabId => typeof id === "string" && known.has(id as TabId),
   );
-  const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+  // ⚡ Bolt Optimization: Pre-compute a Set from the target array and use .has() for O(1) constant-time lookups instead of chained .filter().includes() passes.
+  const keptSet = new Set(kept);
+  const missing = defaultTabOrder().filter((id) => !keptSet.has(id));
   return [...kept, ...missing];
 }
 


### PR DESCRIPTION
💡 What: Replaced \`array.filter(item => !otherArray.includes(item))\` with a \`Set\` and \`.has()\` check in \`TabBar.tsx\` and \`tabs.ts\`.
🎯 Why: Chained \`.filter().includes()\` creates an O(N^2) complexity path and triggers unnecessary repeated array iterations during component render, leading to potential performance degradation and GC overhead.
📊 Impact: Reduces time complexity of tab reconciliation from O(N^2) to O(N) and eliminates repetitive intermediate passes.
🔬 Measurement: Verify rendering performance of the TabBar component and run the unit test suite.

---
*PR created automatically by Jules for task [1426144011247678395](https://jules.google.com/task/1426144011247678395) started by @dieterolson*