### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N^2) array.filter(array.includes) chains with O(N) Set lookups

### DIFF
--- a/src/data_processing/data_processor/web/src/components/SignalList.tsx
+++ b/src/data_processing/data_processor/web/src/components/SignalList.tsx
@@ -86,8 +86,10 @@ export const SignalList = memo(function SignalList({ signals, selectedSignals, o
           const content = event.target?.result as string;
           const signalSet = JSON.parse(content);
           if (signalSet.selected_signals && Array.isArray(signalSet.selected_signals)) {
+            // ⚡ Bolt Optimization: Use Set to avoid O(N^2) includes inside filter
+            const signalsSet = new Set(signals);
             const validSignals = signalSet.selected_signals.filter((s: string) =>
-              signals.includes(s)
+              signalsSet.has(s)
             );
             onSelectionChange(validSignals);
           }

--- a/src/p1am_control_system/frontend/src/components/TabBar.tsx
+++ b/src/p1am_control_system/frontend/src/components/TabBar.tsx
@@ -40,7 +40,9 @@ export const TabBar: React.FC<{
   const effectiveOrder = useMemo<TabId[]>(() => {
     const base = order && order.length ? order : defaultTabOrder();
     const kept = base.filter((id) => TAB_BY_ID[id]);
-    const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+    // ⚡ Bolt Optimization: Use Set to avoid O(N^2) includes inside filter
+    const keptSet = new Set(kept);
+    const missing = defaultTabOrder().filter((id) => !keptSet.has(id));
     return [...kept, ...missing];
   }, [order]);
 

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -124,7 +124,9 @@ function reconcileOrder(saved: readonly unknown[]): TabId[] {
   const kept = saved.filter(
     (id): id is TabId => typeof id === "string" && known.has(id as TabId),
   );
-  const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+  // ⚡ Bolt Optimization: Use Set to avoid O(N^2) includes inside filter
+  const keptSet = new Set(kept);
+  const missing = defaultTabOrder().filter((id) => !keptSet.has(id));
   return [...kept, ...missing];
 }
 


### PR DESCRIPTION
💡 What: Replaced occurrences of `array1.filter(item => !array2.includes(item))` with pre-computed `Set` based lookups (`.has()`) in `TabBar.tsx`, `tabs.ts`, and `SignalList.tsx`.
🎯 Why: When calculating subsets using chained `.filter()` and `.includes()`, we end up with O(N*M) complexity. Even for smaller configuration arrays, this causes unnecessary main-thread overhead, repeated iterations, and intermediate garbage collection which negatively affects performance during component re-renders.
📊 Impact: Reduces computational complexity from O(N^2) to O(N), cutting down on iterative processing times and preventing execution stalls.
🔬 Measurement: Measure the script execution time in React Profiler when loading user sets or toggling tabs, verifying there's less main-thread blocking time.

---
*PR created automatically by Jules for task [11713485244597618417](https://jules.google.com/task/11713485244597618417) started by @dieterolson*