### PR TITLE
⚡ Bolt: Replace chained .filter().includes() with Sets & eliminate Object.fromEntries allocation overhead

### DIFF
--- a/src/p1am_control_system/frontend/src/components/TabBar.tsx
+++ b/src/p1am_control_system/frontend/src/components/TabBar.tsx
@@ -11,9 +11,13 @@ import { TABS, type TabId, defaultTabOrder } from "../lib/tabs";
  * be persisted; this component only emits change callbacks.
  */
 
-const TAB_BY_ID: Record<TabId, (typeof TABS)[number]> = Object.fromEntries(
-  TABS.map((tab) => [tab.id, tab]),
-) as Record<TabId, (typeof TABS)[number]>;
+const TAB_BY_ID: Record<TabId, (typeof TABS)[number]> = (() => {
+  const obj: Partial<Record<TabId, (typeof TABS)[number]>> = {};
+  for (const tab of TABS) {
+    obj[tab.id] = tab;
+  }
+  return obj as Record<TabId, (typeof TABS)[number]>;
+})();
 
 interface ContextMenuState {
   id: TabId;
@@ -40,7 +44,8 @@ export const TabBar: React.FC<{
   const effectiveOrder = useMemo<TabId[]>(() => {
     const base = order && order.length ? order : defaultTabOrder();
     const kept = base.filter((id) => TAB_BY_ID[id]);
-    const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+    const keptSet = new Set(kept);
+    const missing = defaultTabOrder().filter((id) => !keptSet.has(id));
     return [...kept, ...missing];
   }, [order]);
 

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -97,13 +97,11 @@ export const TABS: readonly TabDef[] = [
 
 /** Default visibility map (all tabs visible) derived from {@link TABS}. */
 export function defaultTabVisibility(): Record<TabId, boolean> {
-  return TABS.reduce(
-    (acc, tab) => {
-      acc[tab.id] = true;
-      return acc;
-    },
-    {} as Record<TabId, boolean>,
-  );
+  const acc: Partial<Record<TabId, boolean>> = {};
+  for (const tab of TABS) {
+    acc[tab.id] = true;
+  }
+  return acc as Record<TabId, boolean>;
 }
 
 /** The canonical tab id order as declared in {@link TABS}. */
@@ -124,7 +122,8 @@ function reconcileOrder(saved: readonly unknown[]): TabId[] {
   const kept = saved.filter(
     (id): id is TabId => typeof id === "string" && known.has(id as TabId),
   );
-  const missing = defaultTabOrder().filter((id) => !kept.includes(id));
+  const keptSet = new Set(kept);
+  const missing = defaultTabOrder().filter((id) => !keptSet.has(id));
   return [...kept, ...missing];
 }
 


### PR DESCRIPTION
💡 What: Replaced chained `.filter().includes()` passes with `Set` lookups and replaced `.reduce()` & `Object.fromEntries(TABS.map())` object initializations with single-pass `for...of` loops in `TabBar.tsx` and `tabs.ts`
🎯 Why: In high-frequency render components and initialization paths, chained array map/filters create unnecessary intermediate array allocations, closures, and repetitive O(N^2) iterations over arrays.
📊 Impact: Reduces intermediate array allocation overhead per render, prevents redundant garbage collection passes, and drops tab order reconciliation from O(N^2) to O(N).
🔬 Measurement: Verifiable by monitoring memory heap allocation during rapid tab switching and ensuring full unit test suite passes cleanly.

---
*PR created automatically by Jules for task [9444380959874118466](https://jules.google.com/task/9444380959874118466) started by @dieterolson*