### PR TITLE
🎨 Palette: Enable native form submission for keyboard accessibility

### DIFF
--- a/src/financial_calculator/web/src/components/FinancialCalculator.tsx
+++ b/src/financial_calculator/web/src/components/FinancialCalculator.tsx
@@ -115,7 +115,7 @@ function FinancialCalculator() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Input Panel */}
-        <div className="space-y-6">
+        <form className="space-y-6" onSubmit={(e) => { e.preventDefault(); calculate(); }}>
           {/* Plant Operations */}
           <div className="rounded-lg p-4" style={{ backgroundColor: colors.mantle, border: `1px solid ${colors.surface1}` }}>
             <h2 className="text-lg font-semibold mb-4" style={{ color: colors.lavender }}>
@@ -199,14 +199,14 @@ function FinancialCalculator() {
           </div>
 
           <button
-            onClick={calculate}
+            type="submit"
             aria-controls="results-panel"
             className="w-full py-3 rounded-lg font-bold text-lg transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#89b4fa] focus-visible:ring-offset-[#1e1e2e]"
             style={{ backgroundColor: colors.blue, color: colors.base }}
           >
             Calculate Financial Model
           </button>
-        </div>
+        </form>
 
         {/* Results Panel */}
         <div id="results-panel" className="space-y-6" aria-live="polite">


### PR DESCRIPTION
💡 What: Wrapped the input panel in a native `<form>` element and changed the calculate button to `type="submit"`.
🎯 Why: To allow users to submit the form and calculate results by simply pressing the "Enter" key, which is standard expected behavior for forms.
📸 Before/After: No visual changes. The wrapper div was changed to a form.
♿ Accessibility: Greatly improves keyboard accessibility and screen reader experience by enabling native form submission semantics.

---
*PR created automatically by Jules for task [968191951172975442](https://jules.google.com/task/968191951172975442) started by @dieterolson*