### PR TITLE
🎨 Palette: [UX improvement] Wrap inputs in native form for enter key submission

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -25,3 +25,6 @@
 ## 2024-06-25 - Custom Toggle Controls
 **Learning:** When using `<button>` elements to create custom ON/OFF toggles or mode switches (like the "Add" / "Subtract" operations) that rely entirely on background color changes for state, screen readers cannot determine their current state.
 **Action:** Always add `aria-pressed={isActive}` to custom toggle buttons, along with keyboard-accessible hover (`hover:bg-...`) and focus states (`focus-visible:ring-2`) to ensure both semantic state and visual focus are clear.
+## 2024-07-18 - Wrap Inputs in Native Form
+**Learning:** For extensive data-entry panels or settings panels like in the financial calculator, binding `onClick` directly to the submit button prevents the native Enter key from submitting the form, degrading keyboard accessibility.
+**Action:** When implementing custom calculators or settings panels, wrap the inputs and submit button inside a native `<form onSubmit={...}>` element rather than a standard `<div>`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2575,3 +2575,7 @@ The command injection check logic in `cli_tools.py` has been fortified. The inpu
 ## 1.1.413 - Optimized Nelder-Mead loop in `optimizer.ts`
 
 - **2026-06-21**: perf(pendulum) — Replaced `Array.prototype.sort` with manual insertion sort in `nelderMead` loop in `src/pendulum_simulator/pendulum-web/src/optimizer.ts` to eliminate callback invocation overhead.
+
+## 1.1.414 - Financial Calculator Web Form Wrap
+
+- **2026-07-18**: feat(financial_calculator/web) - Added an HTML `<form>` tag around inputs to allow calculation execution by hitting 'Enter' via standard UI workflows. This is a small UX improvement for data entry flow.

--- a/src/financial_calculator/web/src/components/FinancialCalculator.tsx
+++ b/src/financial_calculator/web/src/components/FinancialCalculator.tsx
@@ -115,7 +115,13 @@ function FinancialCalculator() {
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Input Panel */}
-        <div className="space-y-6">
+        <form
+          className="space-y-6"
+          onSubmit={(e) => {
+            e.preventDefault()
+            calculate()
+          }}
+        >
           {/* Plant Operations */}
           <div className="rounded-lg p-4" style={{ backgroundColor: colors.mantle, border: `1px solid ${colors.surface1}` }}>
             <h2 className="text-lg font-semibold mb-4" style={{ color: colors.lavender }}>
@@ -199,14 +205,14 @@ function FinancialCalculator() {
           </div>
 
           <button
-            onClick={calculate}
+            type="submit"
             aria-controls="results-panel"
             className="w-full py-3 rounded-lg font-bold text-lg transition-colors hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[#89b4fa] focus-visible:ring-offset-[#1e1e2e]"
             style={{ backgroundColor: colors.blue, color: colors.base }}
           >
             Calculate Financial Model
           </button>
-        </div>
+        </form>
 
         {/* Results Panel */}
         <div id="results-panel" className="space-y-6" aria-live="polite">


### PR DESCRIPTION
💡 What: Wrapped the input fields and calculate button in the Financial Calculator inside a native `<form>` element, and updated the button to be a `type="submit"`.
🎯 Why: Previously, users could only trigger the calculation by explicitly clicking the "Calculate" button. This change enables native Enter key submission, providing a much smoother and faster workflow for users doing rapid data entry.
📸 Before/After: Visuals remain unchanged, but interaction is improved.
♿ Accessibility: Improves keyboard accessibility by enabling standard form submission behavior via the Enter key, reducing reliance on mouse/tab-and-space navigation.

---
*PR created automatically by Jules for task [17171081370227820396](https://jules.google.com/task/17171081370227820396) started by @dieterolson*