### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/src/media_processing/video_processor/apps/web/components/golf/PhaseTimeline.tsx
+++ b/src/media_processing/video_processor/apps/web/components/golf/PhaseTimeline.tsx
@@ -9,6 +9,15 @@ interface PhaseTimelineProps {
   currentFrame?: number;
 }
 
+// ⚡ Bolt Optimization: Extracted static array to a Set outside the render cycle
+// to prevent unnecessary memory allocations and O(N) .includes() overhead on every frame update.
+const KEY_PHASES_SET = new Set([
+  SwingPhase.ADDRESS,
+  SwingPhase.TOP_OF_BACKSWING,
+  SwingPhase.IMPACT,
+  SwingPhase.FINISH,
+]);
+
 export default function PhaseTimeline({
   phases,
   totalDuration,
@@ -76,14 +85,7 @@ export default function PhaseTimeline({
   const activePhase = getCurrentPhase();
 
   // Key phases for simplified view
-  const keyPhases = phases.filter((p) =>
-    [
-      SwingPhase.ADDRESS,
-      SwingPhase.TOP_OF_BACKSWING,
-      SwingPhase.IMPACT,
-      SwingPhase.FINISH,
-    ].includes(p.phase)
-  );
+  const keyPhases = phases.filter((p) => KEY_PHASES_SET.has(p.phase));
 
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">


### PR DESCRIPTION
💡 What: Extracted the inline array of key swing phases used in `PhaseTimeline` to a static module-level `Set`. Replaced the `.includes()` check inside the `.filter()` callback with `.has()`.
🎯 Why: The `PhaseTimeline` component re-renders frequently as the `currentFrame` updates during video playback. The previous implementation `[...].includes(p.phase)` allocated a new array literal on every render and performed an $O(N)$ lookup for each phase. Using a static `Set` eliminates array allocation during render and provides $O(1)$ constant-time lookups, satisfying the explicit anti-pattern warning for array literals in React filters.
📊 Impact: Eliminates redundant array memory allocations and reduces lookup time complexity during high-frequency render cycles.
🔬 Measurement: Run the test suite using `cd /app/src/media_processing/video_processor/apps/web && pnpm run test` or `npm run test` at the project root to verify the component functions without regressions. Profile rendering performance in the browser during video playback.

---
*PR created automatically by Jules for task [16409783873509224651](https://jules.google.com/task/16409783873509224651) started by @dieterolson*