### PR TITLE
⚡ Bolt: [performance improvement] Extracted array literal to a static Set in PhaseTimeline

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -66,3 +66,6 @@
 ## 2024-05-24 - Array.prototype.sort Overhead in Hot Loops
 **Learning:** Discovered that for sorting tiny, statically-sized arrays (<= 20 elements) repeatedly inside high-frequency algorithmic hot loops (like Nelder-Mead optimization), `Array.prototype.sort()` incurs severe execution overhead due to callback invocation and closure allocation.
 **Action:** Replace `Array.prototype.sort()` with a manual in-place insertion sort for tiny arrays inside hot paths to eliminate function call overhead and improve execution speed.
+## 2024-07-29 - Extract array literals from filter callbacks
+**Learning:** Using array literals with `.includes()` inside `.filter()` callbacks (e.g., `items.filter(i => [A, B].includes(i.prop))`) causes unnecessary array allocations on every render and for every iteration of the filter loop.
+**Action:** Always extract array literals used for filtering to a static constant or Set outside the component to eliminate this allocation overhead without sacrificing readability.

--- a/src/media_processing/video_processor/apps/web/components/golf/PhaseTimeline.tsx
+++ b/src/media_processing/video_processor/apps/web/components/golf/PhaseTimeline.tsx
@@ -9,6 +9,15 @@ interface PhaseTimelineProps {
   currentFrame?: number;
 }
 
+// ⚡ Bolt Optimization: Extracted array literal to a static Set outside the component
+// to prevent unnecessary array allocations on every render and filter iteration.
+const KEY_PHASES_SET = new Set([
+  SwingPhase.ADDRESS,
+  SwingPhase.TOP_OF_BACKSWING,
+  SwingPhase.IMPACT,
+  SwingPhase.FINISH,
+]);
+
 export default function PhaseTimeline({
   phases,
   totalDuration,
@@ -76,14 +85,7 @@ export default function PhaseTimeline({
   const activePhase = getCurrentPhase();
 
   // Key phases for simplified view
-  const keyPhases = phases.filter((p) =>
-    [
-      SwingPhase.ADDRESS,
-      SwingPhase.TOP_OF_BACKSWING,
-      SwingPhase.IMPACT,
-      SwingPhase.FINISH,
-    ].includes(p.phase)
-  );
+  const keyPhases = phases.filter((p) => KEY_PHASES_SET.has(p.phase));
 
   return (
     <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">


### PR DESCRIPTION
* 💡 What: Extracted the array literal from the `.filter()` callback into a static `Set` outside the component in `PhaseTimeline.tsx`.
* 🎯 Why: Using array literals inside `.filter()` callbacks allocates a new array for every item checked on every render, causing unnecessary memory allocation and garbage collection overhead.
* 📊 Impact: Eliminates O(N) array allocations per render during timeline rendering, reducing memory pressure and GC pauses.
* 🔬 Measurement: Observe memory profiles and render times in the profiler when dragging through the timeline; the reduced allocation overhead should lead to smoother framerates.

---
*PR created automatically by Jules for task [3200785560534029962](https://jules.google.com/task/3200785560534029962) started by @dieterolson*