### PR TITLE
🎨 Palette: Add focus rings to standard buttons for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -35,3 +35,7 @@
 ## 2024-05-24 - Semantic State for Custom Toggle Buttons
 **Learning:** In `SignalList.tsx`, custom toggle buttons used dynamic CSS classes to indicate their active state, but lacked ARIA attributes, making their state invisible to screen readers.
 **Action:** When implementing or modifying custom toggle buttons that rely on dynamic styling, always include `aria-pressed={isActive}` on the `<button>` element to ensure semantic state visibility for assistive technologies.
+
+## 2024-07-23 - Focus Rings on Core Buttons
+**Learning:** Discovered a pattern where standard buttons utilizing the `.btn` utility class lacked focus ring accessibility, despite inputs and tabs being styled properly.
+**Action:** Ensure global utility classes for interactive elements inherently contain standard `focus-visible` styling to enforce a baseline accessibility standard across the application.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,3 +39,7 @@
 ## 2024-07-23 - Focus Rings on Core Buttons
 **Learning:** Discovered a pattern where standard buttons utilizing the `.btn` utility class lacked focus ring accessibility, despite inputs and tabs being styled properly.
 **Action:** Ensure global utility classes for interactive elements inherently contain standard `focus-visible` styling to enforce a baseline accessibility standard across the application.
+
+## 2024-07-23 - Focus Rings on Core Buttons
+**Learning:** Discovered a pattern where standard buttons utilizing the `.btn` utility class lacked focus ring accessibility, despite inputs and tabs being styled properly.
+**Action:** Ensure global utility classes for interactive elements inherently contain standard `focus-visible` styling to enforce a baseline accessibility standard across the application.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2579,3 +2579,6 @@ The command injection check logic in `cli_tools.py` has been fortified. The inpu
 ## 1.1.414 - Security: Structural validation for SymPy parse_expr
 
 - **2026-07-14**: fix(security) — Added structural validation to the symbolic solver backend endpoints (`/solve`, `/derivative`, `/simplify`) before handing untrusted user input to `sympy.parse_expr`. This mitigates a critical code injection vulnerability where malicious AST constructs (e.g. `().__class__`) could be executed due to `parse_expr`'s internal use of `eval`.
+
+### Version 1.1.250
+- 2024-07-23: fix(ux, #3919) - Improve accessibility of standard buttons in data processor web app by adding `focus-visible` styling (focus rings) to the global `.btn` class.

--- a/src/data_processing/data_processor/web/src/index.css
+++ b/src/data_processing/data_processor/web/src/index.css
@@ -14,7 +14,8 @@
 
 @layer components {
   .btn {
-    @apply px-4 py-2 min-h-[48px] min-w-[48px] rounded-lg font-medium transition-colors duration-200 flex items-center justify-center;
+    @apply px-4 py-2 min-h-[48px] min-w-[48px] rounded-lg font-medium transition-colors duration-200 flex items-center justify-center
+           focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 focus-visible:ring-offset-dark-900;
   }
 
   .btn-primary {


### PR DESCRIPTION
💡 What: Added `focus-visible` styling (focus rings) to the global `.btn` class in `index.css`.
🎯 Why: Standard buttons lacking focus rings makes keyboard navigation difficult because users cannot see when a main button has focus, whereas other form elements had this applied.
📸 Before/After: Buttons now display a distinct blue focus ring when navigated via keyboard.
♿ Accessibility: Improves keyboard accessibility by ensuring interactive `.btn` elements have clear focus states, fulfilling WCAG guidelines.

---
*PR created automatically by Jules for task [11523325394801738255](https://jules.google.com/task/11523325394801738255) started by @dieterolson*