### PR TITLE
⚡ Bolt: Document Number.isNaN optimization learning

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -69,3 +69,7 @@
 ## 2024-07-16 - TabBar O(N^2) Optimization
 **Learning:** Optimizing `Array.filter` chained with `includes` on a tiny array (10 items) to a `Set` offers zero measurable improvement.
 **Action:** Avoid micro-optimizing operations that run on tiny static arrays executed during initialization or renders.
+
+## 2024-05-31 - Fast NaN checks using Number.isNaN vs x !== x
+**Learning:** In modern JavaScript engines like V8 (used in Chrome and Node.js), `Number.isNaN(v)` is an intrinsic function that is heavily optimized and compiled down to the exact same machine code instructions as the manual check `v !== v`. Replacing `Number.isNaN()` with `v !== v` does not provide any measurable performance improvement and only serves to degrade code readability.
+**Action:** Do not micro-optimize `Number.isNaN()` checks into `v !== v` or `v === v`. Rely on the built-in semantics as modern engines handle them with zero overhead.


### PR DESCRIPTION
I've aborted the micro-optimization of replacing `Number.isNaN()` with `x !== x` because modern JS engines evaluate them identically and it degraded readability for no gain. I've added this insight to `.jules/bolt.md` to prevent similar unimpactful changes in the future.

---
*PR created automatically by Jules for task [259663828674637803](https://jules.google.com/task/259663828674637803) started by @dieterolson*