### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix AST security gate bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,3 +31,7 @@
 **Vulnerability:** Code injection vulnerability found in `TI89Calculator._solve_differential_equation_cached` because it bypassed `_ast_security_gate` before passing input to `parse_expr` which runs `eval`.
 **Learning:** All paths taking untrusted math equations directly to SymPy parsers need structural validation.
 **Prevention:** Ensure all evaluation points explicitly invoke `_ast_security_gate`.
+## 2025-02-27 - Fail-Closed Security Boundary for Evaluated Untrusted Expressions
+**Vulnerability:** SymPy's `parse_expr` uses `eval()` and requires upstream validation. The `_ast_security_gate` structural validator was fail-open when encountering a `SyntaxError` while using `ast.parse(stripped, mode="eval")`, relying on `parse_expr` as a backstop. This could allow non-standard Python syntax (e.g. `x = y` or sympy specific forms) to bypass the security gate entirely.
+**Learning:** Security validation gates designed to protect `eval`-like functions must be fail-closed. If structural validation fails or raises an error, the input must be explicitly rejected rather than implicitly passed to a dangerous downstream execution context.
+**Prevention:** Catch parsing exceptions (like `SyntaxError` in AST gates) and explicitly raise a rejection error (e.g., `ValueError`) to ensure the security gate strictly enforces an allowlist.

--- a/src/web_applications/calculator/calculator.py
+++ b/src/web_applications/calculator/calculator.py
@@ -196,9 +196,8 @@ class TI89Calculator:
             tree = ast.parse(stripped, mode="eval")
         except SyntaxError:
             # Not valid Python surface syntax (e.g. an equation "x = y" or a
-            # sympy-specific form). Let parse_expr handle/raise on it; the
-            # restricted global_dict remains the backstop. We only *reject* here.
-            return
+            # sympy-specific form). The gate must be fail-closed, so we reject.
+            raise ValueError("Expression contains invalid syntax")
 
         node_count = 0
         for node in ast.walk(tree):


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SymPy's `parse_expr` uses `eval()`. The `_ast_security_gate` structural validator was fail-open when encountering a `SyntaxError` while using `ast.parse(..., mode="eval")`. It incorrectly relied on `parse_expr` and a restricted `global_dict` as a backstop, allowing non-standard Python syntax (e.g., equations `x = y` or sympy specific forms) to bypass the structure validation entirely.
🎯 Impact: This fail-open bypass allows untrusted inputs with non-standard syntax to skip the allowlist validation and be passed directly to SymPy's parser and subsequent `eval`, potentially allowing code injection.
🔧 Fix: Modified the `_ast_security_gate` to correctly fail-closed by catching the `SyntaxError` and explicitly raising a `ValueError("Expression contains invalid syntax")`.
✅ Verification: Ran `pytest` suite for the backend application and the monorepo `npm run test` suite successfully locally to confirm no regressions and that the new security boundary holds correctly.

---
*PR created automatically by Jules for task [10277150837842810408](https://jules.google.com/task/10277150837842810408) started by @dieterolson*