### PR TITLE
fix(sidekick): harden protected wheel and desktop smoke

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -26,9 +26,9 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.5.3                                      |
-| **Spec Version**        | 1.5.3                                      |
-| **Last Spec Update**    | 2026-07-26                                 |
+| **Current Version**     | 1.5.4                                      |
+| **Spec Version**        | 1.5.4                                      |
+| **Last Spec Update**    | 2026-07-27                                 |
 
 ## 2. Purpose & Mission
 
@@ -309,6 +309,11 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
   otherwise healthy protected checks depend on a second large network download.
   The matrix also installs Mypy with its runtime dependencies before enforcing
   `pip check`, so each isolated environment remains internally consistent.
+- The Python 3.10 compatibility lane keeps exercising supported source modules
+  but skips the installed-wheel Sidekick smoke because the published `ud-tools`
+  package contract requires Python 3.11 or newer. A repository contract pins
+  that boundary so future packaging tests cannot reintroduce an impossible
+  Python 3.10 wheel installation.
 - CI Standard now force-reinstalls `maturin` without using the pip cache before
   building the required Python 3.11 `tools_core` Rust wheel, repairing
   self-hosted runner tool-cache states where the package is present but its

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,8 +26,8 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.5.6                                      |
-| **Spec Version**        | 1.5.6                                      |
+| **Current Version**     | 1.5.7                                      |
+| **Spec Version**        | 1.5.7                                      |
 | **Last Spec Update**    | 2026-07-27                                 |
 
 ## 2. Purpose & Mission
@@ -49,6 +49,13 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
   emitting `session_loaded` before message-display controllers exist. Interactive
   session changes continue to emit normally, while source and packaged desktop
   startup remain safe when an active session is already present.
+
+### 2026-07-27 Sidekick Units warnings-as-errors compatibility
+
+- Sidekick calculator state initialization uses `get_state_manager()` instead
+  of the deprecated global singleton. Hosts that promote Sidekick deprecations
+  to errors therefore render the real PyQt6 Units converter rather than an
+  optional-tab placeholder (Tools issue #3950).
 
 ### 2026-07-23 P1AM Control System Trend Plot Optimization
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,8 +26,8 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.5.5                                      |
-| **Spec Version**        | 1.5.5                                      |
+| **Current Version**     | 1.5.6                                      |
+| **Spec Version**        | 1.5.6                                      |
 | **Last Spec Update**    | 2026-07-27                                 |
 
 ## 2. Purpose & Mission
@@ -35,6 +35,13 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+
+### 2026-07-27 Sidekick saved-session startup safety
+
+- The PyQt6 Sidekick panel restores its initial saved chat session without
+  emitting `session_loaded` before message-display controllers exist. Interactive
+  session changes continue to emit normally, while source and packaged desktop
+  startup remain safe when an active session is already present.
 
 ### 2026-07-23 P1AM Control System Trend Plot Optimization
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,8 +26,8 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.5.4                                      |
-| **Spec Version**        | 1.5.4                                      |
+| **Current Version**     | 1.5.5                                      |
+| **Spec Version**        | 1.5.5                                      |
 | **Last Spec Update**    | 2026-07-27                                 |
 
 ## 2. Purpose & Mission
@@ -314,6 +314,9 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
   package contract requires Python 3.11 or newer. A repository contract pins
   that boundary so future packaging tests cannot reintroduce an impossible
   Python 3.10 wheel installation.
+- Privileged-workflow hardening tests parse only trusted repository workflows
+  with `yaml.BaseLoader` so GitHub Actions' `on` key cannot be coerced under
+  YAML 1.1; the security-scanner exception is scoped to that exact load site.
 - CI Standard now force-reinstalls `maturin` without using the pip cache before
   building the required Python 3.11 `tools_core` Rust wheel, repairing
   self-hosted runner tool-cache states where the package is present but its

--- a/src/shared/python/ai/gui/assistant_panel.py
+++ b/src/shared/python/ai/gui/assistant_panel.py
@@ -254,7 +254,7 @@ class AIAssistantPanel(QWidget):
         active = [s for s in sessions if not s.get("archived", False)]
         if active:
             latest_id = active[0]["id"]
-            loaded = self._session_manager.load_session(latest_id)
+            loaded = self._session_manager.load_session(latest_id, emit=False)
             if loaded:
                 self._context = loaded
                 self._refresh_prompt_memory()

--- a/src/shared/python/sidekick/tests/test_state_manager_side_effects.py
+++ b/src/shared/python/sidekick/tests/test_state_manager_side_effects.py
@@ -52,3 +52,39 @@ def test_import_has_no_filesystem_side_effects() -> None:
         expected = "[]"
         actual = res.stdout.strip()
         assert actual == expected, f"Eager folders created: {actual}"
+
+
+def test_calculator_state_mixin_import_avoids_deprecated_global() -> None:
+    """Calculator widgets must import when Sidekick deprecations are errors."""
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    tools_root = os.path.abspath(os.path.join(tests_dir, "..", "..", "..", "..", ".."))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.path.pathsep.join(
+        [
+            os.path.join(tools_root, "src", "shared", "python"),
+            os.path.join(tools_root, "src", "python", "src"),
+            os.path.join(tools_root, "src"),
+        ]
+    )
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import warnings; "
+            "warnings.filterwarnings("
+            "'error', category=DeprecationWarning, module=r'sidekick(?:\\.|$)'); "
+            "from sidekick.ui.mixins.calculator_state_mixin "
+            "import CalculatorStateMixin; "
+            "assert CalculatorStateMixin"
+        ),
+    ]
+
+    result = subprocess.run(
+        command,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/src/shared/python/sidekick/ui/mixins/calculator_state_mixin.py
+++ b/src/shared/python/sidekick/ui/mixins/calculator_state_mixin.py
@@ -34,8 +34,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-# CHANGED: Import from shared library utils
-from ...utils.state_manager import state_manager
+from ...utils.state_manager import get_state_manager
 
 __all__ = [
     "CalculatorStateMixin",
@@ -68,7 +67,7 @@ class CalculatorStateMixin:
 
         """
         self.calculator_name = calculator_name or "UnknownCalculator"
-        self.state_manager = state_manager
+        self.state_manager = get_state_manager()
 
         # State management
         self.auto_save_enabled = True

--- a/tests/integration/sidekick/test_standalone_wheel.py
+++ b/tests/integration/sidekick/test_standalone_wheel.py
@@ -11,7 +11,14 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = [pytest.mark.integration, pytest.mark.headless_safe]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.headless_safe,
+    pytest.mark.skipif(
+        sys.version_info < (3, 11),
+        reason="ud-tools wheel requires Python >=3.11",
+    ),
+]
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _WHEEL_MODULES = {

--- a/tests/ops/test_anti_phantom_merge_guard.py
+++ b/tests/ops/test_anti_phantom_merge_guard.py
@@ -169,7 +169,8 @@ class TestPullRequestTargetWorkflowHardening:
     def test_pull_request_target_workflows_guard_untrusted_head_checkout(self) -> None:
         failures: list[str] = []
         for path in sorted((_REPO_ROOT / ".github" / "workflows").glob("*.yml")):
-            workflow = yaml.load(
+            # BaseLoader preserves GitHub Actions' ``on`` key under YAML 1.1.
+            workflow = yaml.load(  # nosec B506 - trusted repository workflow
                 path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader
             )
             if not isinstance(workflow, dict):

--- a/tests/ops/test_ci_standard_web_dependencies.py
+++ b/tests/ops/test_ci_standard_web_dependencies.py
@@ -9,6 +9,9 @@ PYTHON_TOOLCACHE_GUARD = REPO_ROOT / ".github" / "scripts" / "clean-python-toolc
 PYTHON_TOOLCACHE_RESTORE = (
     REPO_ROOT / ".github" / "scripts" / "restore-python-toolcache.sh"
 )
+STANDALONE_WHEEL_TEST = (
+    REPO_ROOT / "tests" / "integration" / "sidekick" / "test_standalone_wheel.py"
+)
 
 
 def test_ci_standard_installs_fastapi_multipart_parser() -> None:
@@ -205,6 +208,14 @@ def test_test_matrix_installs_mypy_runtime_dependencies() -> None:
             "python -m pip install --ignore-installed --no-deps mypy==1.13.0"
             not in install_step["run"]
         )
+
+
+def test_standalone_wheel_smoke_skips_unsupported_python() -> None:
+    """A wheel requiring 3.11 cannot be installed by the 3.10 matrix lane."""
+    test_source = STANDALONE_WHEEL_TEST.read_text(encoding="utf-8")
+
+    assert "requires Python >=3.11" in test_source
+    assert "sys.version_info < (3, 11)" in test_source
 
 
 def test_quality_gate_invokes_mypy_through_verified_python() -> None:

--- a/tests/shared/python/chat/test_assistant_panel_memory_sync.py
+++ b/tests/shared/python/chat/test_assistant_panel_memory_sync.py
@@ -7,6 +7,8 @@ import types
 from dataclasses import replace
 from logging import getLogger
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 ROOT = Path(__file__).resolve().parents[4]
 if str(ROOT) not in sys.path:
@@ -51,6 +53,32 @@ config_pkg.environment = environment
 import pytest
 
 pytest.importorskip("PyQt6.QtWidgets", reason="PyQt6.QtWidgets requires display server")
+
+
+def test_initial_history_load_does_not_emit_before_controllers_exist() -> None:
+    """Startup history restore must not invoke the session-loaded Qt slot."""
+    from src.shared.python.ai.gui.assistant_panel import AIAssistantPanel
+
+    restored_context = object()
+    session_manager = MagicMock()
+    session_manager.list_sessions.return_value = [
+        {"id": "active-session", "archived": False}
+    ]
+    session_manager.load_session.return_value = restored_context
+    panel = SimpleNamespace(
+        _session_manager=session_manager,
+        _context=None,
+        _refresh_prompt_memory=MagicMock(),
+    )
+
+    AIAssistantPanel._load_history(panel)
+
+    session_manager.load_session.assert_called_once_with(
+        "active-session",
+        emit=False,
+    )
+    assert panel._context is restored_context
+    panel._refresh_prompt_memory.assert_called_once()
 
 
 def test_memory_sync_loads_archived_sessions_without_switching_context(


### PR DESCRIPTION
## Summary
- skip the installed-wheel Sidekick smoke on Python 3.10 because the published package requires Python 3.11+
- retain the rest of the Python 3.10 source-compatibility suite
- document the trusted BaseLoader exception required to preserve GitHub Actions `on` keys
- restore saved PyQt6 Sidekick sessions without emitting `session_loaded` before message controllers exist

## Validation
- saved-session startup regression and memory-sync tests passed
- 15 focused CI and real wheel build/install tests passed
- 44 workflow-security and CI contract tests passed
- Ruff lint and format passed
- Bandit and mypy passed
- repository pre-push unit, dependency-audit, and fleet guardrails passed

Follow-up to #3937 after its protected merge exposed the Python-floor mismatch and the saved-session desktop startup crash.
## Additional PyQt6 QA repair
- replace the deprecated global Sidekick state singleton with `get_state_manager()` so the real Units tab loads when host deprecations are promoted to errors
- add an isolated warnings-as-errors import regression
- computer-controlled retest rendered all six converter rows and converted `100 °C` to `212 °F`

Additional validation: 30 focused tests passed; Ruff lint/format, Black check, mypy, Bandit, dependency audit, unit pre-push suite, and fleet guardrails passed.

Closes #3950