### PR TITLE
⚡ Bolt: Replace Math.min/max spread with for-loop in trend axis

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -76,3 +76,6 @@
 ## 2026-06-12 - Eliminate map/reduce overhead for parsing assignments
 **Learning:** Parsing simple string formats using `.split().reduce().map()` chains creates unnecessary array allocations, function calls, and closures on every pass, which adds noticeable garbage collection pressure when executing hot paths or frequent input changes.
 **Action:** Replace string processing array chains with single-pass `for` loops and standard `indexOf`/`substring` operations to eliminate closure allocations and minimize object creations.
+## 2025-02-14 - Replace Math.min/max spread with for-loop in trend axis
+**Learning:** Using the spread operator (`...`) with `Math.min` and `Math.max` on large arrays (like chart data points in `trendAxis.ts`) can throw a `RangeError: Maximum call stack size exceeded` because the engine tries to push every array element onto the call stack as a distinct function argument.
+**Action:** Replace `Math.min(...values)` and `Math.max(...values)` with a single-pass `for` loop to compute the `lo` and `hi` dynamically without spread overhead.

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,13 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i];
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
💡 What: Replaced `Math.min(...values)` and `Math.max(...values)` with a single-pass `for` loop in `trendAxis.ts`'s `resolveRange` function.
🎯 Why: Using the spread operator (`...`) on potentially large arrays can result in "Maximum call stack size exceeded" errors and allocates unnecessary intermediate memory. A single-pass loop prevents stack overflows and avoids allocating arguments.
📊 Impact: Eliminates the risk of stack overflow on large datasets and reduces memory allocation.
🔬 Measurement: Check the updated `resolveRange` in `trendAxis.ts` to confirm it avoids spread operations.

---
*PR created automatically by Jules for task [10181584902268745531](https://jules.google.com/task/10181584902268745531) started by @dieterolson*