### PR TITLE
🎨 Palette: [UX improvement] Add focus-visible states to interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -39,7 +39,3 @@
 ## 2024-07-23 - Focus Rings on Core Buttons
 **Learning:** Discovered a pattern where standard buttons utilizing the `.btn` utility class lacked focus ring accessibility, despite inputs and tabs being styled properly.
 **Action:** Ensure global utility classes for interactive elements inherently contain standard `focus-visible` styling to enforce a baseline accessibility standard across the application.
-
-## 2024-07-23 - Focus Rings on Core Buttons
-**Learning:** Discovered a pattern where standard buttons utilizing the `.btn` utility class lacked focus ring accessibility, despite inputs and tabs being styled properly.
-**Action:** Ensure global utility classes for interactive elements inherently contain standard `focus-visible` styling to enforce a baseline accessibility standard across the application.

--- a/src/p1am_control_system/frontend/src/index.css
+++ b/src/p1am_control_system/frontend/src/index.css
@@ -267,6 +267,11 @@ body {
   border-color: var(--text-muted);
 }
 
+.btn:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 2px;
+}
+
 .btn-primary {
   background: var(--accent-cyan);
   border-color: var(--accent-cyan);
@@ -289,6 +294,11 @@ body {
 .btn-estop:hover {
   background: #b91c1c;
   border-color: #b91c1c;
+}
+
+.btn-estop:focus-visible {
+  outline: 2px solid var(--color-error);
+  outline-offset: 2px;
 }
 
 /* Pulse indicators */
@@ -399,6 +409,16 @@ body {
 .tab-button.active-tab {
   color: var(--accent-cyan);
   border-bottom-color: var(--accent-cyan);
+}
+
+.tab-btn:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: -2px;
+}
+
+.tab-button:focus-visible {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: -2px;
 }
 
 /* --- Tuning & Comparison Grid --- */


### PR DESCRIPTION
💡 What: Added `focus-visible` outlines to `.btn`, `.btn-estop`, `.tab-button`, and `.tab-btn` CSS utility classes.
🎯 Why: Keyboard users previously lacked visual indicators of focus on these interactive elements.
📸 Before/After: Before, tabbing through the interface left users lost. After, clear cyan (or red for E-Stop) outlines highlight the focused element.
♿ Accessibility: Fixes missing focus indicators, enabling keyboard navigation support (tab order, focus states) across the app.

---
*PR created automatically by Jules for task [12811279743193658755](https://jules.google.com/task/12811279743193658755) started by @dieterolson*