### PR TITLE
⚡ Bolt: [performance improvement] Replace spread operator with loop for Math.min/max

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,7 @@
 ## 2024-07-26 - Single-pass loops for high-frequency React UI rendering
 **Learning:** In high-frequency React UI rendering paths (e.g., pointer move events for SVG crosshairs), using chained `.map()` and `.reduce()` operations creates unnecessary garbage collection pressure due to intermediate array allocations and closure overhead.
 **Action:** Replace chained `.map()` and `.reduce()` operations with a single-pass `for` loop to eliminate closure allocations and intermediate arrays, leading to smoother UI interactions.
+
+## 2024-07-28 - [Avoid Spread Operator with Math.min/Math.max]
+**Learning:** Using the spread operator with Math.min/Math.max (e.g., `Math.min(...values)`) on large arrays (like chart data points) allocates intermediate memory and can throw a 'Maximum call stack size exceeded' RangeError.
+**Action:** Use a single-pass `for` loop instead when determining min/max values for large arrays to prevent call stack overflow and reduce memory allocation overhead.

--- a/src/p1am_control_system/frontend/src/components/data_explorer/SourcePanel.tsx
+++ b/src/p1am_control_system/frontend/src/components/data_explorer/SourcePanel.tsx
@@ -71,7 +71,12 @@ export const SourcePanel: React.FC<SourcePanelProps> = ({
       const starts = signals
         .map((s) => (s.start_time ? Date.parse(s.start_time) : NaN))
         .filter((t) => Number.isFinite(t));
-      const start = starts.length ? Math.min(...starts) : now - 3600_000;
+      // ⚡ Bolt Optimization: Avoid spread operator in Math.min to prevent call stack overflow
+      let startMin = starts[0];
+      for (let i = 1; i < starts.length; i++) {
+        if (starts[i] < startMin) startMin = starts[i];
+      }
+      const start = starts.length ? startMin : now - 3600_000;
       onHistorianChange({
         ...historian,
         start: toLocalInput(start),

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,16 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  // ⚡ Bolt Optimization: Replace Math.min(...values) and Math.max(...values)
+  // with a single-pass for loop. This prevents 'Maximum call stack size exceeded'
+  // errors on large datasets and eliminates intermediate array allocation.
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i];
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
- 💡 What: Replaced `Math.min(...values)` and `Math.max(...values)` with a single-pass `for` loop in `trendAxis.ts` and `SourcePanel.tsx`.
- 🎯 Why: Using the spread operator with `Math.min`/`Math.max` on large arrays (like chart data points) allocates intermediate memory and can throw a 'Maximum call stack size exceeded' RangeError.
- 📊 Impact: Eliminates intermediate array allocation and prevents potential call stack overflow crashes on large datasets, reducing garbage collection pressure.
- 🔬 Measurement: Observe memory usage profiling and verify that rendering charts with large datasets does not throw a call stack size exceeded error.

---
*PR created automatically by Jules for task [7213895765248396198](https://jules.google.com/task/7213895765248396198) started by @dieterolson*