### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,6 @@
 ## 2024-07-26 - Single-pass loops for high-frequency React UI rendering
 **Learning:** In high-frequency React UI rendering paths (e.g., pointer move events for SVG crosshairs), using chained `.map()` and `.reduce()` operations creates unnecessary garbage collection pressure due to intermediate array allocations and closure overhead.
 **Action:** Replace chained `.map()` and `.reduce()` operations with a single-pass `for` loop to eliminate closure allocations and intermediate arrays, leading to smoother UI interactions.
+## 2024-07-28 - Replace Math.min/max spread with loops for dynamic scales
+**Learning:** Using `Math.min(...activeValues)` and `Math.max(...activeValues)` on large streams of extracted subset data frequently leads to "Maximum call stack size exceeded" errors.
+**Action:** When calculating min/max bounds across historically tracked subsets, avoid `.flatMap`, `.map`, and the `Math.min(...spread)` syntax entirely. Use a single-pass `for` loop that computes `realMin` and `realMax` dynamically, avoiding massive call stack allocations and garbage collection pressure.

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,12 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] < lo) lo = values[i];
+    if (values[i] > hi) hi = values[i];
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
💡 What: Replaced `Math.min(...values)` and `Math.max(...values)` spread operators with a single-pass `for` loop in `resolveRange` of `trendAxis.ts`.

🎯 Why: Using spread operator `...` on potentially large data arrays allocates intermediate arrays in the call stack and can cause "Maximum call stack size exceeded" exceptions on large streams of historically tracked subsets, resulting in garbage collection overhead.

📊 Impact: Removes the call stack limit constraint for trend bounds calculation and prevents intermediate array garbage collection overhead by replacing it with an O(n) single pass iteration.

🔬 Measurement: Verify by rendering large trend plots and confirming smooth interactions without maximum call stack errors or lag caused by large array spreading.

---
*PR created automatically by Jules for task [13794855202945425119](https://jules.google.com/task/13794855202945425119) started by @dieterolson*