### PR TITLE
⚡ Bolt: Replace Math.min/max spread with single-pass loop in trendAxis

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,6 @@
 ## 2024-07-26 - Single-pass loops for high-frequency React UI rendering
 **Learning:** In high-frequency React UI rendering paths (e.g., pointer move events for SVG crosshairs), using chained `.map()` and `.reduce()` operations creates unnecessary garbage collection pressure due to intermediate array allocations and closure overhead.
 **Action:** Replace chained `.map()` and `.reduce()` operations with a single-pass `for` loop to eliminate closure allocations and intermediate arrays, leading to smoother UI interactions.
+## 2024-10-25 - Array spread operator stack overflow on large datasets
+**Learning:** Using `Math.max(...values)` and `Math.min(...values)` on very large arrays like chart data points can allocate an intermediate parameter list large enough to throw a 'Maximum call stack size exceeded' RangeError, crashing the application.
+**Action:** Replace the spread operator with a single-pass `for` loop to compute array extremes safely and efficiently without intermediate allocations, reducing memory overhead and avoiding call stack crashes.

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,13 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i];
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
💡 What: Replaced the spread operator in Math.min(...values) and Math.max(...values) with a single-pass for loop in the trendAxis bounds resolution.
🎯 Why: Spreading very large arrays (common in chart data like trend views) into Math.min/max causes 'Maximum call stack size exceeded' RangeErrors in V8 and allocates intermediate memory.
📊 Impact: Eliminates the risk of stack overflow crashes on large datasets and improves performance by converting two O(N) array traversals (with large allocations) into a single O(N) traversal with zero allocation.
🔬 Measurement: Verified by reviewing unit test completion and confirming zero RangeErrors when resolving limits for synthetic arrays of >200,000 items.

---
*PR created automatically by Jules for task [10324721736788795874](https://jules.google.com/task/10324721736788795874) started by @dieterolson*