### PR TITLE
fix(c3d): default missing point units

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -35,13 +35,21 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+
+### 2026-07-28 C3D POINT:UNITS metadata defaulting
+
+- `shared.python.sidekick.lab.bio.c3d_reader.C3DDataReader` treats missing,
+  empty, or blank `POINT:UNITS` metadata as millimetres (`mm`) when building
+  C3D metadata. This preserves compatibility with legacy and generated C3D
+  fixtures that omit the optional units parameter while retaining downstream
+  unit-conversion behavior for explicit units.
+
 ### 2026-07-26 P1AM Control System Trend Crosshair Optimization
 
 - `src/p1am_control_system/frontend/src/components/TrendPlotOverlays.tsx` and `PlotCrosshair.tsx` reduce
   garbage collection pressure during high-frequency pointer move events by
   replacing chained `.map()` and `.reduce()` operations with single-pass `for` loops.
   This eliminates intermediate array allocations and closure overhead for SVG crosshair rendering.
-
 
 ### 2026-07-23 P1AM Control System Trend Plot Optimization
 

--- a/src/shared/python/sidekick/lab/bio/c3d_reader.py
+++ b/src/shared/python/sidekick/lab/bio/c3d_reader.py
@@ -66,6 +66,7 @@ C3DMapping = dict[str, Any]
 SCHEMA_VERSION = "1.0"
 C3D_HEADER_MAGIC_BYTE = 0x50
 C3D_HEADER_LENGTH = 2
+DEFAULT_POINT_UNITS = "mm"
 
 # Guideline P1: Biomechanical marker validation thresholds [m]
 # Source: NIST - Human body dimensions range from
@@ -169,7 +170,7 @@ class C3DDataReader:
             ]
             frame_count = int(point_parameters["FRAMES"]["value"][0])
             frame_rate = float(point_parameters["RATE"]["value"][0])
-            units = str(point_parameters["UNITS"]["value"][0])
+            units = self._point_units(point_parameters)
             analog_labels, analog_rate, analog_units = self._get_analog_details()
             events = self._get_events()
             self._metadata = C3DMetadata(
@@ -726,6 +727,15 @@ class C3DDataReader:
             units = units[: len(labels)]
 
         return labels, analog_rate, units
+
+    @staticmethod
+    def _point_units(point_parameters: dict[str, Any]) -> str:
+        """Return POINT units, defaulting malformed legacy C3D metadata to mm."""
+        values = point_parameters.get("UNITS", {}).get("value", [])
+        if not values:
+            return DEFAULT_POINT_UNITS
+        units = str(values[0]).strip()
+        return units or DEFAULT_POINT_UNITS
 
     def _get_events(self) -> list[C3DEvent]:
         """Extract event markers from the C3D file."""

--- a/src/shared/python/sidekick/tests/lab/bio/test_c3d_edge_cases.py
+++ b/src/shared/python/sidekick/tests/lab/bio/test_c3d_edge_cases.py
@@ -125,6 +125,66 @@ class TestC3DMetadataValidation:
         )
         assert meta.analog_count == 2
 
+    @pytest.fixture()
+    def c3d_point_metadata(self) -> dict[str, Any]:
+        return {
+            "parameters": {
+                "POINT": {
+                    "LABELS": {"value": ["M1"]},
+                    "FRAMES": {"value": [10]},
+                    "RATE": {"value": [100.0]},
+                    "UNITS": {"value": ["cm"]},
+                },
+                "ANALOG": {
+                    "LABELS": {"value": []},
+                    "UNITS": {"value": []},
+                    "RATE": {"value": [0.0]},
+                },
+                "EVENT": {
+                    "LABELS": {"value": []},
+                    "TIMES": {"value": [[], []]},
+                },
+            },
+            "data": {
+                "points": np.random.rand(4, 1, 10),
+                "analogs": np.empty((1, 0, 0)),
+            },
+        }
+
+    @pytest.fixture()
+    def valid_c3d_path(self, tmp_path: Path) -> Path:
+        c3d_path = tmp_path / "test.c3d"
+        c3d_path.write_bytes(b"\x02\x50")
+        return c3d_path
+
+    def test_metadata_defaults_absent_point_units_to_mm(
+        self,
+        c3d_point_metadata: dict[str, Any],
+        valid_c3d_path: Path,
+    ) -> None:
+        """C3D files without POINT:UNITS still build actionable metadata."""
+        del c3d_point_metadata["parameters"]["POINT"]["UNITS"]
+
+        with patch("sidekick.lab.bio.c3d_reader.ezc3d") as mock_ezc3d:
+            mock_ezc3d.c3d.return_value = c3d_point_metadata
+            metadata = C3DDataReader(valid_c3d_path).get_metadata()
+
+        assert metadata.units == "mm"
+
+    def test_metadata_defaults_empty_point_units_to_mm(
+        self,
+        c3d_point_metadata: dict[str, Any],
+        valid_c3d_path: Path,
+    ) -> None:
+        """Empty POINT:UNITS values use the same default as absent units."""
+        c3d_point_metadata["parameters"]["POINT"]["UNITS"]["value"] = []
+
+        with patch("sidekick.lab.bio.c3d_reader.ezc3d") as mock_ezc3d:
+            mock_ezc3d.c3d.return_value = c3d_point_metadata
+            metadata = C3DDataReader(valid_c3d_path).get_metadata()
+
+        assert metadata.units == "mm"
+
 
 # ---------------------------------------------------------------------------
 # C3DDataReader contract tests


### PR DESCRIPTION
## Summary
- Default missing, empty, or blank C3D `POINT:UNITS` metadata to `mm` in the canonical sidekick C3D reader.
- Add reader-level regressions for absent and empty `POINT:UNITS` metadata.
- Update `SPEC.md` for the new C3D metadata compatibility behavior.

## Validation
- `py -3.13 -m pytest -q src\shared\python\sidekick\tests\lab\bio\test_c3d_reader_fixed.py src\shared\python\sidekick\tests\lab\bio\test_c3d_edge_cases.py`
- `py -3.13 -m ruff check src\shared\python\sidekick\lab\bio\c3d_reader.py src\shared\python\sidekick\tests\lab\bio\test_c3d_edge_cases.py`
- `py -3.13 -m ruff format --check src\shared\python\sidekick\lab\bio\c3d_reader.py src\shared\python\sidekick\tests\lab\bio\test_c3d_edge_cases.py`
- `npx prettier --check SPEC.md`
- `git diff --check`
- `git push` pre-push hooks: ruff, ruff format, no wildcard imports, no debug statements, no print in src, fleet fast guardrails, SPEC freshness warning, code quality report-only, prettier, mypy, bandit, pytest, pip-audit, fleet pre-push guardrails

Mirrors the UpstreamDrift child-copy fix for D-sorganization/UpstreamDrift#8082.