### PR TITLE
fix(ui): guard optional PyQt submodule imports

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -28,20 +28,32 @@
 | **License**             | MIT                                        |
 | **Current Version**     | 1.5.3                                      |
 | **Spec Version**        | 1.5.3                                      |
-| **Last Spec Update**    | 2026-07-26                                 |
+| **Last Spec Update**    | 2026-07-28                                 |
 
 ## 2. Purpose & Mission
 
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+
+### 2026-07-28 Optional PyQt Submodule Import Guards
+
+- Shared Qt UI imports now guard exact PyQt6 submodules instead of assuming a
+  successful top-level `PyQt6` import proves `QtWidgets`, `QtWebSockets`, or
+  `QtSvg` are loadable. Chat workspace widget tests skip cleanly when
+  `QtWebSockets` is unavailable, autocomplete tests set offscreen mode before
+  importing PyQt and use pytest-qt ownership, and `shared.python.ui` lazily
+  exposes optional widgets so importing the package no longer imports the
+  hover-copy `QtSvg` dependency unless that widget is requested. The touched
+  chat workspace test also drops stale mypy suppression comments so changed-file
+  type checks remain clean.
+
 ### 2026-07-26 P1AM Control System Trend Crosshair Optimization
 
 - `src/p1am_control_system/frontend/src/components/TrendPlotOverlays.tsx` and `PlotCrosshair.tsx` reduce
   garbage collection pressure during high-frequency pointer move events by
   replacing chained `.map()` and `.reduce()` operations with single-pass `for` loops.
   This eliminates intermediate array allocations and closure overhead for SVG crosshair rendering.
-
 
 ### 2026-07-23 P1AM Control System Trend Plot Optimization
 

--- a/src/shared/python/chat/tests/test_workspace_bridge.py
+++ b/src/shared/python/chat/tests/test_workspace_bridge.py
@@ -14,6 +14,7 @@ so the module still collects on CI lanes without Qt installed.
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import sys
@@ -108,7 +109,7 @@ class TestWorkspaceVariableInfo:
         # frozen dataclasses raise FrozenInstanceError (a TypeError
         # subclass) on attribute assignment.
         with pytest.raises((TypeError, AttributeError)):
-            info.name = "y"  # type: ignore[misc]
+            info.name = "y"
 
 
 class TestWorkspaceContextProtocol:
@@ -146,7 +147,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 @pytest.fixture(scope="module")
 def qapp() -> Any:
-    pytest.importorskip("PyQt6")
+    _require_qt_submodules("PyQt6.QtWidgets")
     from PyQt6.QtWidgets import QApplication
 
     app = QApplication.instance() or QApplication(sys.argv)
@@ -155,9 +156,19 @@ def qapp() -> Any:
 
 @pytest.fixture
 def chat_module(qapp: Any) -> Any:
+    _require_qt_submodules("PyQt6.QtWebSockets")
     from chat import _chat_dock_widget_qt
 
     return _chat_dock_widget_qt
+
+
+def _require_qt_submodules(*module_names: str) -> None:
+    """Skip when a required PyQt6 submodule cannot be loaded."""
+    for module_name in module_names:
+        try:
+            importlib.import_module(module_name)
+        except (ImportError, OSError) as exc:
+            pytest.skip(f"{module_name} not loadable: {exc}")
 
 
 def _make_dock(chat_module: Any, **kwargs: Any) -> Any:
@@ -169,6 +180,23 @@ def _make_dock(chat_module: Any, **kwargs: Any) -> Any:
     # The dock subclasses QDockWidget; connect-on-show defers networking,
     # so simply constructing it does not hit the network.
     return dock
+
+
+def test_chat_qt_guard_skips_broken_websockets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A partial PyQt6 install must skip before importing chat widgets."""
+    real_import_module = importlib.import_module
+
+    def fake_import_module(name: str) -> Any:
+        if name == "PyQt6.QtWebSockets":
+            raise OSError("QtWebSockets DLL failed to load")
+        return real_import_module(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+
+    with pytest.raises(pytest.skip.Exception, match="QtWebSockets"):
+        _require_qt_submodules("PyQt6.QtWebSockets")
 
 
 class TestChatDockWidgetConstruction:
@@ -323,7 +351,7 @@ class TestSlashCommandRouting:
         sent: list[dict[str, Any]] = []
         dock = _make_dock(chat_module)
         try:
-            dock._send_ws = sent.append  # type: ignore[method-assign]
+            dock._send_ws = sent.append
             dock._handle_slash_command("/condense")
         finally:
             dock.close()

--- a/src/shared/python/tests/ui/test_auto_complete.py
+++ b/src/shared/python/tests/ui/test_auto_complete.py
@@ -2,40 +2,52 @@
 
 from __future__ import annotations
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QKeyEvent
-from PyQt6.QtWidgets import QApplication
+import os
+from typing import Any
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PyQt6.QtCore import Qt
+    from PyQt6.QtGui import QKeyEvent
+except (ImportError, OSError) as exc:
+    pytest.skip(
+        f"PyQt6 autocomplete dependencies not loadable: {exc}",
+        allow_module_level=True,
+    )
 
 from src.shared.python.ui.auto_complete import AutoCompleteLineEdit
 
 
-def get_app():
-    return QApplication.instance() or QApplication([])
-
-
-def test_auto_complete_line_edit_initialization() -> None:
-    """Test that AutoCompleteLineEdit initializes correctly with words."""
-    get_app()
-    words = ["gravity", "velocity", "acceleration"]
+def _make_widget(qtbot: Any, words: list[str] | None = None) -> AutoCompleteLineEdit:
+    """Create an autocomplete widget owned by pytest-qt."""
     widget = AutoCompleteLineEdit(words=words)
+    qtbot.addWidget(widget)
+    return widget
+
+
+def test_auto_complete_line_edit_initialization(qtbot: Any) -> None:
+    """Test that AutoCompleteLineEdit initializes correctly with words."""
+    words = ["gravity", "velocity", "acceleration"]
+    widget = _make_widget(qtbot, words)
     assert widget.completer_words == words
     assert widget.completer() is not None
 
 
-def test_auto_complete_set_completion_words() -> None:
+def test_auto_complete_set_completion_words(qtbot: Any) -> None:
     """Test dynamically updating the completion words."""
-    get_app()
-    widget = AutoCompleteLineEdit()
+    widget = _make_widget(qtbot)
     assert widget.completer_words == []
 
     widget.set_completion_words(["mass", "force"])
     assert widget.completer_words == ["mass", "force"]
 
 
-def test_auto_complete_add_completion_words() -> None:
+def test_auto_complete_add_completion_words(qtbot: Any) -> None:
     """Test adding words to the completion dictionary."""
-    get_app()
-    widget = AutoCompleteLineEdit(words=["gravity"])
+    widget = _make_widget(qtbot, ["gravity"])
     widget.add_completion_words(["mass"])
 
     assert "gravity" in widget.completer_words
@@ -43,10 +55,9 @@ def test_auto_complete_add_completion_words() -> None:
     assert len(widget.completer_words) == 2
 
 
-def test_auto_complete_tab_key() -> None:
+def test_auto_complete_tab_key(qtbot: Any) -> None:
     """Test that the Tab key accepts the current completion."""
-    get_app()
-    widget = AutoCompleteLineEdit(words=["acceleration"])
+    widget = _make_widget(qtbot, ["acceleration"])
     widget.setText("acc")
 
     # Simulate completer state

--- a/src/shared/python/ui/__init__.py
+++ b/src/shared/python/ui/__init__.py
@@ -28,6 +28,7 @@ Usage:
     panel.model_selected.connect(on_select)
 """
 
+import importlib
 from typing import Any
 
 from .window_icon import (
@@ -36,25 +37,34 @@ from .window_icon import (
     set_app_user_model_id,
 )
 
-# PyQt6-dependent imports - only available when PyQt6 is installed.
-# Guarded so the package imports cleanly in headless environments without
-# PyQt6 (mirrors theme/__init__), exposing the Qt widgets only when present.
-_AutoCompleteLineEdit: Any = None
-_HoverCopyTextBrowser: Any = None
-try:
-    from .auto_complete import AutoCompleteLineEdit as _ImportedAutoCompleteLineEdit
-    from .hover_copy_browser import (
-        HoverCopyTextBrowser as _ImportedHoverCopyTextBrowser,
-    )
+_PYQT6_AVAILABLE = False
+_OPTIONAL_WIDGETS = {
+    "AutoCompleteLineEdit": (".auto_complete", "AutoCompleteLineEdit"),
+    "HoverCopyTextBrowser": (".hover_copy_browser", "HoverCopyTextBrowser"),
+}
 
-    _PYQT6_AVAILABLE = True
-    _AutoCompleteLineEdit = _ImportedAutoCompleteLineEdit
-    _HoverCopyTextBrowser = _ImportedHoverCopyTextBrowser
-except ImportError:
-    _PYQT6_AVAILABLE = False
 
-AutoCompleteLineEdit: Any = _AutoCompleteLineEdit
-HoverCopyTextBrowser: Any = _HoverCopyTextBrowser
+def _load_optional_widget(public_name: str) -> Any:
+    """Return an optional Qt widget class, or None when its Qt stack is absent."""
+    module_name, class_name = _OPTIONAL_WIDGETS[public_name]
+    try:
+        module = importlib.import_module(module_name, __name__)
+    except (ImportError, OSError):
+        globals()[public_name] = None
+        return None
+
+    widget = getattr(module, class_name)
+    globals()[public_name] = widget
+    globals()["_PYQT6_AVAILABLE"] = True
+    return widget
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose optional Qt widgets without importing unrelated submodules."""
+    if name in _OPTIONAL_WIDGETS:
+        return _load_optional_widget(name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Auto Complete

--- a/tests/shared/python/ui/test_headless_import.py
+++ b/tests/shared/python/ui/test_headless_import.py
@@ -57,6 +57,52 @@ def test_ui_imports_without_pyqt6() -> None:
     assert "HEADLESS_UI_IMPORT_OK" in result.stdout
 
 
+def test_ui_import_does_not_load_hover_copy_browser() -> None:
+    """Importing ``ui`` should not require QtSvg unless hover-copy is used."""
+    script = textwrap.dedent(
+        """
+        import importlib.abc
+        import sys
+
+        HOVER_COPY_MODULES = {
+            "ui.hover_copy_browser",
+            "shared.python.ui.hover_copy_browser",
+            "src.shared.python.ui.hover_copy_browser",
+        }
+
+        class _BlockHoverCopy(importlib.abc.MetaPathFinder):
+            def find_spec(self, name, path=None, target=None):
+                if name in HOVER_COPY_MODULES:
+                    raise OSError(f"hover copy import blocked: {name}")
+                return None
+
+        for _mod in list(sys.modules):
+            if _mod == "ui" or _mod.startswith("ui."):
+                del sys.modules[_mod]
+        sys.meta_path.insert(0, _BlockHoverCopy())
+
+        import ui
+
+        assert "HoverCopyTextBrowser" not in ui.__dict__
+        _ = ui.AutoCompleteLineEdit
+        assert "HoverCopyTextBrowser" not in ui.__dict__
+        print("UI_IMPORT_DID_NOT_LOAD_HOVER_COPY")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=_repo_src_dir(),
+    )
+    assert result.returncode == 0, (
+        "ui import touched hover_copy_browser unexpectedly:\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "UI_IMPORT_DID_NOT_LOAD_HOVER_COPY" in result.stdout
+
+
 def _repo_src_dir() -> str:
     """Return the ``src/shared/python`` dir so ``import ui`` resolves."""
     from pathlib import Path


### PR DESCRIPTION
## Summary
- guard chat workspace tests on the exact PyQt6.QtWidgets and PyQt6.QtWebSockets submodules before importing Qt chat widgets
- make `shared.python.ui` lazily expose optional Qt widgets so importing `ui` does not load the hover-copy QtSvg dependency unless requested
- run autocomplete widget tests under offscreen Qt with pytest-qt ownership and module-level skip on ImportError/OSError
- update SPEC for the optional PyQt submodule import contract

Fixes D-sorganization/UpstreamDrift#8198.

## Validation
- `py -3.13 -m pytest -n 0 tests\shared\python\ui\test_headless_import.py src\shared\python\tests\ui\test_auto_complete.py src\shared\python\chat\tests\test_workspace_bridge.py -q` (30 passed)
- `py -3.13 -m ruff check src\shared\python\chat\tests\test_workspace_bridge.py src\shared\python\ui\__init__.py src\shared\python\tests\ui\test_auto_complete.py tests\shared\python\ui\test_headless_import.py`
- `py -3.13 -m ruff format --check src\shared\python\chat\tests\test_workspace_bridge.py src\shared\python\ui\__init__.py src\shared\python\tests\ui\test_auto_complete.py tests\shared\python\ui\test_headless_import.py`
- `git diff --check`
- push pre-push hooks: ruff, ruff format, wildcard/debug/print guards, fleet fast guardrails, SPEC freshness, code quality report, prettier, mypy, bandit, pytest, pip-audit, fleet pre-push guardrails

## Notes
- The same stale child-copy issue remains in UpstreamDrift until its Tools sync/vendor update process brings this Tools commit into the consumer repo.