### PR TITLE
fix(humanoid): restore shared preview test collectability

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -28,20 +28,33 @@
 | **License**             | MIT                                        |
 | **Current Version**     | 1.5.3                                      |
 | **Spec Version**        | 1.5.3                                      |
-| **Last Spec Update**    | 2026-07-26                                 |
+| **Last Spec Update**    | 2026-07-28                                 |
 
 ## 2. Purpose & Mission
 
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+
+### 2026-07-28 Shared CORS and Humanoid Preview Contracts
+
+- `src/shared/python/tests/test_cors.py` now asserts the current secure CORS
+  default of `allow_credentials=False` while retaining coverage for the shared
+  origin, method, and header constants.
+- `src/shared/python/humanoid_character_builder/interfaces/__init__.py`
+  re-exports `BodyParameters` from the public interfaces package so preview
+  tests and downstream users can rely on the documented facade import.
+- `src/shared/python/humanoid_character_builder/core/model.py` aligns
+  `HumanoidModel.__init__` DbC preconditions with method argument binding,
+  including the default `root_link_name`, so model construction is validated
+  without misinterpreting `self` as the links dictionary.
+
 ### 2026-07-26 P1AM Control System Trend Crosshair Optimization
 
 - `src/p1am_control_system/frontend/src/components/TrendPlotOverlays.tsx` and `PlotCrosshair.tsx` reduce
   garbage collection pressure during high-frequency pointer move events by
   replacing chained `.map()` and `.reduce()` operations with single-pass `for` loops.
   This eliminates intermediate array allocations and closure overhead for SVG crosshair rendering.
-
 
 ### 2026-07-23 P1AM Control System Trend Plot Optimization
 

--- a/src/shared/python/humanoid_character_builder/core/model.py
+++ b/src/shared/python/humanoid_character_builder/core/model.py
@@ -129,11 +129,11 @@ class HumanoidModel:
     """Representation of the complete humanoid model."""
 
     @precondition(
-        lambda links, joints: len(links) > 0,
+        lambda self, links, joints: len(links) > 0,
         "Model must have at least one link",
     )
     @precondition(
-        lambda links, joints, root_link_name: root_link_name in links,
+        lambda self, links, joints, root_link_name="pelvis": root_link_name in links,
         "Root link must exist in links",
     )
     def __init__(

--- a/src/shared/python/humanoid_character_builder/interfaces/__init__.py
+++ b/src/shared/python/humanoid_character_builder/interfaces/__init__.py
@@ -5,6 +5,7 @@ Provides the clean, user-facing API for character building.
 """
 
 from shared.python.humanoid_character_builder.interfaces.api import (
+    BodyParameters,
     CharacterBuilder,
     CharacterBuildResult,
     ExportOptions,
@@ -12,6 +13,7 @@ from shared.python.humanoid_character_builder.interfaces.api import (
 )
 
 __all__ = [
+    "BodyParameters",
     "CharacterBuilder",
     "CharacterBuildResult",
     "SegmentMeshInfo",

--- a/src/shared/python/humanoid_character_builder/tests/test_preview.py
+++ b/src/shared/python/humanoid_character_builder/tests/test_preview.py
@@ -2,7 +2,7 @@ import sys
 from typing import Any
 from unittest.mock import patch
 
-from humanoid_character_builder.interfaces.api import BodyParameters, CharacterBuilder
+from humanoid_character_builder.interfaces import BodyParameters, CharacterBuilder
 
 
 def test_simulation_missing_mujoco() -> Any:

--- a/src/shared/python/tests/test_cors.py
+++ b/src/shared/python/tests/test_cors.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any
+from collections.abc import Generator
+from typing import Any, cast
 
 import pytest
 from cors import (
@@ -20,7 +21,7 @@ from contracts import (
 
 
 @pytest.fixture
-def clean_env() -> Any:
+def clean_env() -> Generator[None]:
     old_contract_level = get_contract_level()
     set_contract_level(ContractLevel.ENFORCE)
     old = os.environ.get("CORS_ORIGINS")
@@ -35,35 +36,37 @@ def clean_env() -> Any:
 def get_cors_origins(app: FastAPI) -> list[str]:
     for middleware in app.user_middleware:
         if middleware.cls == CORSMiddleware:
-            return middleware.kwargs.get("allow_origins", [])
+            return cast(list[str], middleware.kwargs.get("allow_origins", []))
     return []
 
 
-def get_cors_kwargs(app: FastAPI) -> dict:
+def get_cors_kwargs(app: FastAPI) -> dict[str, Any]:
     for middleware in app.user_middleware:
         if middleware.cls == CORSMiddleware:
-            return middleware.kwargs
+            return cast(dict[str, Any], middleware.kwargs)
     return {}
 
 
-def test_add_cors_middleware_default(clean_env) -> Any:
+def test_add_cors_middleware_default(clean_env: None) -> Any:
     app = FastAPI()
     add_cors_middleware(app)
     kwargs = get_cors_kwargs(app)
     assert kwargs["allow_origins"] == DEFAULT_ORIGINS
     assert kwargs["allow_methods"] == DEFAULT_ALLOW_METHODS
     assert kwargs["allow_headers"] == DEFAULT_ALLOW_HEADERS
-    assert kwargs["allow_credentials"] is True
+    assert kwargs["allow_credentials"] is False
 
 
-def test_add_cors_middleware_explicit_origins(clean_env) -> Any:
+def test_add_cors_middleware_explicit_origins(clean_env: None) -> Any:
     app = FastAPI()
     origins = ["http://my-domain.com"]
     add_cors_middleware(app, origins=origins)
     assert get_cors_origins(app) == origins
 
 
-def test_add_cors_middleware_env_override(clean_env, monkeypatch) -> Any:
+def test_add_cors_middleware_env_override(
+    clean_env: None, monkeypatch: pytest.MonkeyPatch
+) -> Any:
     monkeypatch.setenv("CORS_ORIGINS", "http://env1.com, http://env2.com ,")
     app = FastAPI()
     # It should override even if explicit origins are provided
@@ -72,7 +75,7 @@ def test_add_cors_middleware_env_override(clean_env, monkeypatch) -> Any:
     assert origins == ["http://env1.com", "http://env2.com"]
 
 
-def test_add_cors_middleware_kwargs(clean_env) -> Any:
+def test_add_cors_middleware_kwargs(clean_env: None) -> Any:
     app = FastAPI()
     add_cors_middleware(
         app,
@@ -86,12 +89,12 @@ def test_add_cors_middleware_kwargs(clean_env) -> Any:
     assert kwargs["expose_headers"] == ["X-Exposed"]
 
 
-def test_add_cors_middleware_invalid_app(clean_env) -> Any:
+def test_add_cors_middleware_invalid_app(clean_env: None) -> Any:
     with pytest.raises(PreconditionError):
         add_cors_middleware("not_an_app")
 
 
-def test_add_cors_middleware_invalid_origins(clean_env) -> Any:
+def test_add_cors_middleware_invalid_origins(clean_env: None) -> Any:
     app = FastAPI()
     with pytest.raises(PreconditionError):
         add_cors_middleware(app, origins="not_a_list")


### PR DESCRIPTION
## Summary
- re-export `BodyParameters` from `humanoid_character_builder.interfaces` so documented facade imports collect cleanly
- align `HumanoidModel.__init__` DbC preconditions with method argument binding
- update shared CORS regression expectations for the current secure `allow_credentials=False` default
- document the shared CORS and humanoid preview contract refresh in SPEC.md

## Validation
- `py -3.13 -m pytest -n 0 src\shared\python\tests\test_cors.py src\shared\python\humanoid_character_builder\tests\test_preview.py src\shared\python\humanoid_character_builder\tests\test_physics_validator.py -q`
- `py -3.13 -m ruff check src\shared\python\tests\test_cors.py src\shared\python\humanoid_character_builder\interfaces\__init__.py src\shared\python\humanoid_character_builder\core\model.py src\shared\python\humanoid_character_builder\tests\test_preview.py`
- `py -3.13 -m ruff format --check src\shared\python\tests\test_cors.py src\shared\python\humanoid_character_builder\interfaces\__init__.py src\shared\python\humanoid_character_builder\core\model.py src\shared\python\humanoid_character_builder\tests\test_preview.py`
- `py -3.13 -m mypy src\shared\python\humanoid_character_builder\interfaces\__init__.py src\shared\python\humanoid_character_builder\core\model.py src\shared\python\humanoid_character_builder\tests\test_preview.py src\shared\python\tests\test_cors.py`
- pre-push hooks: ruff, ruff format, wildcard/debug/print guards, fleet fast guardrails, SPEC freshness, code quality report, prettier, mypy, bandit, pytest, pip-audit, fleet pre-push guardrails

Closes D-sorganization/UpstreamDrift#8199 after UpstreamDrift syncs the Tools child copy.