### PR TITLE
⚡ Bolt: Replace Math.min/max spread with loops for dynamic scales

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,6 @@
 ## 2024-07-26 - Single-pass loops for high-frequency React UI rendering
 **Learning:** In high-frequency React UI rendering paths (e.g., pointer move events for SVG crosshairs), using chained `.map()` and `.reduce()` operations creates unnecessary garbage collection pressure due to intermediate array allocations and closure overhead.
 **Action:** Replace chained `.map()` and `.reduce()` operations with a single-pass `for` loop to eliminate closure allocations and intermediate arrays, leading to smoother UI interactions.
+## 2024-07-28 - Replace Math.min/max spread with loops for dynamic scales
+**Learning:** Using `Math.min(...activeValues)` and `Math.max(...activeValues)` on large streams of extracted subset data (e.g., when determining Y-axis scales in React charts) frequently leads to "Maximum call stack size exceeded" errors. Additionally, chaining operations like `flatMap` and `.map` to prepare this data dynamically creates massive memory pressure across high-frequency re-renders.
+**Action:** When calculating min/max bounds across historically tracked subsets, avoid `.flatMap`, `.map`, and the `Math.min(...spread)` syntax entirely. Use a single-pass `for` loop that computes `realMin` and `realMax` dynamically, avoiding massive call stack allocations and garbage collection pressure.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2670,3 +2670,7 @@ The command injection check logic in `cli_tools.py` has been fortified. The inpu
 
 - Removed chained array maps and reduces in the parseVariableAssignments function within `src/web_applications/calculator/static/app.js`.
 - Improved execution speed by using standard single pass for loop and string `indexOf` / `substring` techniques.
+
+### Version 1.1.242
+
+- **Performance**: Replaced `Math.min(...values)` and `Math.max(...values)` spreads with single-pass `for` loops in `trendAxis.ts` and `SourcePanel.tsx` within the `p1am_control_system` frontend, avoiding call stack overflows on large datasets and eliminating intermediate array allocations (`.map().filter()`).

--- a/src/p1am_control_system/frontend/src/components/data_explorer/SourcePanel.tsx
+++ b/src/p1am_control_system/frontend/src/components/data_explorer/SourcePanel.tsx
@@ -68,10 +68,20 @@ export const SourcePanel: React.FC<SourcePanelProps> = ({
   const applyPreset = (seconds: number | "all") => {
     const now = Date.now();
     if (seconds === "all") {
-      const starts = signals
-        .map((s) => (s.start_time ? Date.parse(s.start_time) : NaN))
-        .filter((t) => Number.isFinite(t));
-      const start = starts.length ? Math.min(...starts) : now - 3600_000;
+      let start = now - 3600_000;
+      let minStart = Infinity;
+      for (let i = 0; i < signals.length; i++) {
+        const s = signals[i];
+        if (s.start_time) {
+          const t = Date.parse(s.start_time);
+          if (Number.isFinite(t) && t < minStart) {
+            minStart = t;
+          }
+        }
+      }
+      if (minStart !== Infinity) {
+        start = minStart;
+      }
       onHistorianChange({
         ...historian,
         start: toLocalInput(start),

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,13 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i];
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
- 💡 What: Replaced `Math.min(...values)` and `Math.max(...values)` spreads with single-pass `for` loops in `trendAxis.ts` and `SourcePanel.tsx`, and removed intermediate array allocations (`.map().filter()`).
- 🎯 Why: Using the spread operator on large arrays (like chart data points) allocates intermediate memory and frequently causes "Maximum call stack size exceeded" RangeErrors. Chaining array methods also exacerbates memory pressure and garbage collection pauses across re-renders.
- 📊 Impact: Prevents call stack overflows, eliminates closure and intermediate array allocations, and reduces garbage collection pressure during high-frequency re-renders.
- 🔬 Measurement: Verify memory usage and performance by observing lower GC pauses and the elimination of crash errors when parsing very large historical data samples.

---
*PR created automatically by Jules for task [10204564396805090261](https://jules.google.com/task/10204564396805090261) started by @dieterolson*