### PR TITLE
⚡ Bolt: Optimize CSV parsing single-pass loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -79,3 +79,6 @@
 ## 2024-07-26 - Single-pass loops for high-frequency React UI rendering
 **Learning:** In high-frequency React UI rendering paths (e.g., pointer move events for SVG crosshairs), using chained `.map()` and `.reduce()` operations creates unnecessary garbage collection pressure due to intermediate array allocations and closure overhead.
 **Action:** Replace chained `.map()` and `.reduce()` operations with a single-pass `for` loop to eliminate closure allocations and intermediate arrays, leading to smoother UI interactions.
+## 2024-05-24 - Avoid chained map and every array iterations for parsing
+**Learning:** Multiple array methods (`.map()`, `.every()`, `.filter()`) chained together for iterating over datasets cause unnecessary intermediate array allocations, adding up to increased garbage collection pressure.
+**Action:** Replace multiple chained array passes with a single-pass `for` loop that pre-allocates arrays or calculates results inline.

--- a/src/p1am_control_system/frontend/src/lib/explorer/csv.ts
+++ b/src/p1am_control_system/frontend/src/lib/explorer/csv.ts
@@ -177,9 +177,13 @@ export function parseCsv(text: string): CsvTable {
   const colCount = header.length;
 
   // Materialize each source column's raw cells (padding short rows).
-  const rawColumns: string[][] = [];
-  for (let c = 0; c < colCount; c += 1) {
-    rawColumns.push(dataRows.map((r) => (c < r.length ? r[c] : "")));
+  // ⚡ Bolt Optimization: Replace dataRows.map() per column with a single-pass loop
+  const rawColumns: string[][] = Array.from({ length: colCount }, () => new Array(dataRows.length));
+  for (let r = 0; r < dataRows.length; r += 1) {
+    const row = dataRows[r];
+    for (let c = 0; c < colCount; c += 1) {
+      rawColumns[c][r] = c < row.length ? row[c] : "";
+    }
   }
 
   // Pick the index column: prefer a name match, else a date-parseable column.
@@ -201,11 +205,20 @@ export function parseCsv(text: string): CsvTable {
 
   let index: number[] | null = null;
   if (timeCol !== -1) {
-    const times = rawColumns[timeCol].map(parseTime);
-    // Only honor the index if every populated cell parsed to a time.
-    const allValid = times.every((t) => t !== null);
+    // ⚡ Bolt Optimization: Replace multiple passes (.map, .every) with single pass
+    const rawTimes = rawColumns[timeCol];
+    const times = new Array(rawTimes.length);
+    let allValid = true;
+    for (let i = 0; i < rawTimes.length; i++) {
+      const t = parseTime(rawTimes[i]);
+      if (t === null) {
+        allValid = false;
+        break;
+      }
+      times[i] = t as number;
+    }
     if (allValid) {
-      index = times.map((t) => t as number);
+      index = times;
     } else {
       timeCol = -1;
     }
@@ -214,9 +227,17 @@ export function parseCsv(text: string): CsvTable {
   const columns: CsvColumn[] = [];
   for (let c = 0; c < colCount; c += 1) {
     if (c === timeCol) continue;
+
+    // ⚡ Bolt Optimization: Replace rawColumns[c].map with single-pass loop pre-allocating the array
+    const rawCells = rawColumns[c];
+    const values = new Array(rawCells.length);
+    for (let i = 0; i < rawCells.length; i++) {
+      values[i] = parseNumber(rawCells[i]);
+    }
+
     columns.push({
       name: header[c] === "" ? `column_${c + 1}` : header[c],
-      values: rawColumns[c].map(parseNumber),
+      values,
     });
   }
 


### PR DESCRIPTION
- 💡 What: Replaced chained `.map()`, `.every()` array passes with single-pass `for` loops in the CSV parser.
- 🎯 Why: Reduces unnecessary intermediate array allocation and garbage collection pressure when reading large CSV files.
- 📊 Impact: Faster and lower-memory CSV importing by avoiding O(N) multi-pass array manipulation.
- 🔬 Measurement: Verified via unit test pass of CSV module.

---
*PR created automatically by Jules for task [16525377277122256477](https://jules.google.com/task/16525377277122256477) started by @dieterolson*