### PR TITLE
🎨 Palette: Add focus-visible states to Rotation Converter

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -43,3 +43,6 @@
 ## 2024-07-23 - Focus Rings on Core Buttons
 **Learning:** Discovered a pattern where standard buttons utilizing the `.btn` utility class lacked focus ring accessibility, despite inputs and tabs being styled properly.
 **Action:** Ensure global utility classes for interactive elements inherently contain standard `focus-visible` styling to enforce a baseline accessibility standard across the application.
+## 2024-07-30 - Added focus-visible states to Rotation Converter
+**Learning:** Found an accessibility issue pattern where inputs and buttons in Rotation Converter have `outline-none` but lack focus indicators, making keyboard navigation difficult.
+**Action:** Replace `outline-none` with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` to preserve keyboard accessibility while styling interactive elements.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2193,6 +2193,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | 2026-05-18 | 1.1.2 | Optimize PCA mathematical matrix calculations in AnalyticsSuite to use column-wise typed Float64Array to prevent large O(N) allocation overhead. |
 | 2026-05-18 | 1.1.3 | Optimize linear regression calculation in AnalyticsSuite using single-pass loops instead of map/reduce to minimize garbage collection pauses. |
 | 2026-05-19 | 1.1.4 | Add inline error message handling to SignalList to avoid blocking native alert dialogs and added comprehensive focus-visible states across all signal list interface buttons for enhanced keyboard accessibility. |
+| 2026-07-30 | 1.1.49 | Added focus-visible states to inputs, selects, and buttons in the Rotation Converter application to improve keyboard accessibility. |
 | 2026-04-04 | 1.1.5 | Replace print statements with logger calls in lower_body_model main entry point to comply with no-print policy and improve production logging. |
 | 2026-04-05 | 1.1.6 | Optimize DataChart point extraction loop to explicitly map selected properties instead of using an object spread on the entire row in `src/data_processing/data_processor/web/src/components/DataChart.tsx`. |
 | 2026-04-05 | 1.1.7 | Improve HelpPanel accessibility by adding ARIA expanded states and control links to accordion toggles, and adding explicit focus-visible rings for keyboard users. |

--- a/src/rotation_converter/web/src/components/ReferenceFrameConverter.tsx
+++ b/src/rotation_converter/web/src/components/ReferenceFrameConverter.tsx
@@ -87,7 +87,7 @@ export function ReferenceFrameConverter() {
           <select
             value={operation}
             onChange={(event) => setOperation(event.target.value as Operation)}
-            className="w-full bg-slate-700 rounded px-3 py-2 border border-slate-600 outline-none"
+            className="w-full bg-slate-700 rounded px-3 py-2 border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
           >
             <option value="twist_frame_conversion">Twist Frame Conversion (Adjoint)</option>
             <option value="homogeneous_transform">Homogeneous Transform Builder</option>
@@ -106,7 +106,7 @@ export function ReferenceFrameConverter() {
                     type="number"
                     value={entry}
                     onChange={(event) => updateMatrix(setTransform, transform, i, j, Number(event.target.value))}
-                    className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                    className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   />
                 )),
               )}
@@ -123,7 +123,7 @@ export function ReferenceFrameConverter() {
                     next[i] = Number(event.target.value);
                     setTwist(next);
                   }}
-                  className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                  className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 />
               ))}
             </div>
@@ -143,7 +143,7 @@ export function ReferenceFrameConverter() {
                     onChange={(event) =>
                       updateMatrix(setRotationMatrix, rotationMatrix, i, j, Number(event.target.value))
                     }
-                    className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                    className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   />
                 )),
               )}
@@ -160,7 +160,7 @@ export function ReferenceFrameConverter() {
                     next[i] = Number(event.target.value);
                     setTranslation(next);
                   }}
-                  className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                  className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 />
               ))}
             </div>
@@ -181,7 +181,7 @@ export function ReferenceFrameConverter() {
                     next[i] = Number(event.target.value);
                     setSo3Vector(next);
                   }}
-                  className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                  className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 />
               ))}
             </div>
@@ -190,7 +190,7 @@ export function ReferenceFrameConverter() {
 
         <button
           onClick={handleCompute}
-          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded transition-colors"
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800"
         >
           Compute
         </button>

--- a/src/rotation_converter/web/src/components/RotationConverter.tsx
+++ b/src/rotation_converter/web/src/components/RotationConverter.tsx
@@ -84,7 +84,7 @@ export function RotationConverter() {
                     <select
                         value={inputType}
                         onChange={(e) => setInputType(e.target.value)}
-                        className="w-full bg-slate-700 rounded px-3 py-2 border border-slate-600 focus:border-blue-500 outline-none"
+                        className="w-full bg-slate-700 rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                     >
                         <option value="quaternion">Quaternion (w, x, y, z)</option>
                         <option value="euler">Euler Angles</option>
@@ -107,7 +107,7 @@ export function RotationConverter() {
                                         setQuaternion(newQ);
                                     }}
                                     step="0.01"
-                                    className="w-full bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                                    className="w-full bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                                 />
                             </div>
                         ))}
@@ -123,7 +123,7 @@ export function RotationConverter() {
                                 value={eulerConvention}
                                 onChange={(e) => setEulerConvention(e.target.value)}
                                 placeholder="xyz"
-                                className="w-full bg-slate-700 rounded px-3 py-2 text-sm border border-slate-600 outline-none"
+                                className="w-full bg-slate-700 rounded px-3 py-2 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                             />
                         </div>
                         <div className="grid grid-cols-3 gap-2">
@@ -139,7 +139,7 @@ export function RotationConverter() {
                                             setEuler(newE);
                                         }}
                                         step="0.01"
-                                        className="w-full bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                                        className="w-full bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                                     />
                                 </div>
                             ))}
@@ -161,7 +161,7 @@ export function RotationConverter() {
                                         setAxisAngle(newA);
                                     }}
                                     step="0.01"
-                                    className="w-full bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                                    className="w-full bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                                 />
                             </div>
                         ))}
@@ -182,7 +182,7 @@ export function RotationConverter() {
                                         setRodrigues(newR);
                                     }}
                                     step="0.01"
-                                    className="w-full bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 outline-none"
+                                    className="w-full bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                                 />
                             </div>
                         ))}
@@ -192,7 +192,7 @@ export function RotationConverter() {
                 <div className="pt-4">
                     <button
                         onClick={handleCalculate}
-                        className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded transition-colors"
+                        className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800"
                     >
                         Compute Equivalents
                     </button>


### PR DESCRIPTION
- 💡 What: Added focus-visible states to inputs, selects, and buttons in the Rotation Converter application.
- 🎯 Why: To improve keyboard accessibility by providing visual feedback when interacting with elements.
- 📸 Before/After: Before, there was no visual feedback when navigating elements via keyboard because they used `outline-none`. After, they display a focus ring.
- ♿ Accessibility: Improved keyboard navigation by adding focus indicators.

---
*PR created automatically by Jules for task [2008843781557172200](https://jules.google.com/task/2008843781557172200) started by @dieterolson*