### PR TITLE
⚡ Bolt: Prevent call stack overflow in trend axis bounds

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,6 @@
 ## 2024-05-24 - Avoid chained map and every array iterations for parsing
 **Learning:** Multiple array methods (`.map()`, `.every()`, `.filter()`) chained together for iterating over datasets cause unnecessary intermediate array allocations, adding up to increased garbage collection pressure.
 **Action:** Replace multiple chained array passes with a single-pass `for` loop that pre-allocates arrays or calculates results inline.
+## 2025-02-28 - Avoid Math.min/max spread with large arrays in trend axes
+**Learning:** Using `Math.min(...values)` and `Math.max(...values)` on large trend arrays (like telemetry data) can throw a "Maximum call stack size exceeded" error and allocates unnecessary intermediate memory, causing runtime crashes or garbage collection pressure.
+**Action:** Replace `Math.min/max` with the spread operator with a single-pass `for` loop to compute the bounds dynamically when processing large array datasets.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,4 +1,4 @@
-# SPEC.md — Repository Specification Document
+- 2026-07-31: perf(p1am frontend) — replace Math.min/max spread with single-pass for loop in resolveRange to prevent call stack overflow on large datasets.\n# SPEC.md — Repository Specification Document
 
 <!--
   TEMPLATE VERSION: 1.0.0

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,13 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const val = values[i];
+    if (val < lo) lo = val;
+    if (val > hi) hi = val;
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
💡 What: Replaced `Math.min(...values)` and `Math.max(...values)` with a single-pass `for` loop in `resolveRange`.
🎯 Why: Using the spread operator with `Math.min/max` on large arrays (like trend values) can throw a "Maximum call stack size exceeded" error and allocates intermediate memory.
📊 Impact: Prevents runtime crashes on large datasets and eliminates intermediate memory allocation for the spread operation, improving memory efficiency and robustness during high-frequency trend updates.
🔬 Measurement: Verify that `resolveRange` continues to return correct min/max bounds via unit tests and observe improved memory stability with large arrays.

---
*PR created automatically by Jules for task [3664564190957951526](https://jules.google.com/task/3664564190957951526) started by @dieterolson*