### PR TITLE
⚡ Bolt: Optimize trend axis min/max calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,6 @@
 ## 2024-05-24 - Avoid chained map and every array iterations for parsing
 **Learning:** Multiple array methods (`.map()`, `.every()`, `.filter()`) chained together for iterating over datasets cause unnecessary intermediate array allocations, adding up to increased garbage collection pressure.
 **Action:** Replace multiple chained array passes with a single-pass `for` loop that pre-allocates arrays or calculates results inline.
+## 2024-07-31 - Avoid spread operator with Math.min/max on large data arrays
+**Learning:** Using `Math.min(...values)` or `Math.max(...values)` on large arrays (like chart data points) allocates intermediate memory and can throw a 'Maximum call stack size exceeded' RangeError.
+**Action:** Replace `Math.min(...array)` and `Math.max(...array)` with a single-pass `for` loop when parsing large numeric data arrays to improve performance and stability.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1717,6 +1717,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-07-31 | 1.1.999 | perf(trendAxis): avoid spread operator with Math.min/max on large data arrays by replacing them with a single-pass `for` loop in `src/p1am_control_system/frontend/src/lib/trendAxis.ts` to prevent Maximum call stack size exceeded errors. |
 | 2026-07-26 | 1.5.3 | fix(test): create the standalone-wheel smoke environment from the real base interpreter rather than nesting it under the active CI virtualenv, keeping installed-artifact validation portable across relocated self-hosted Python 3.10 runtimes. |
 | 2026-07-26 | 1.5.3 | fix(ci): isolate both protected Python jobs in per-job virtual environments after validating the persistent setup-python runtime; repair and import-probe the matrix NumPy/SciPy stack with compatible bounds, and reinstall OpenCV without dependency resolution so it cannot replace the verified NumPy wheel. |
 | 2026-07-26 | 1.5.3 | fix(import-aliases, #3936): make canonical shared-module aliases satisfy `runpy` code lookup so packaged compatibility commands such as `python -m sidekick` execute their parent-owned `shared.python` implementation; include `contracts` in the identity-coalescing alias set and keep Sidekick agent DbC imports on the canonical shared path. |

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,13 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i];
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
💡 What: Replaced `Math.min(...values)` and `Math.max(...values)` with a single-pass `for` loop in the trend axis range resolution.
🎯 Why: Using the spread operator on potentially large chart data arrays allocates intermediate memory and risks throwing a 'Maximum call stack size exceeded' RangeError.
📊 Impact: Eliminates array allocation overhead during min/max calculations and prevents crashes on very large datasets.
🔬 Measurement: Verify by rendering trends with large datasets and checking that performance is smooth without maximum call stack errors.

---
*PR created automatically by Jules for task [1983672473731662107](https://jules.google.com/task/1983672473731662107) started by @dieterolson*