### PR TITLE
P1AM firmware safety: comms watchdog, correct trip tier, bumpless setpoints

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -36,6 +36,31 @@ Comprehensive monorepo housing 45+ utility tools for data processing, scientific
 
 ## 3. Goals & Non-Goals
 
+### 2026-07-31 P1AM Firmware Safety: Comms Watchdog, Trip Tier, Bumpless Setpoints
+
+- `firmware/CommsWatchdog.{h,cpp}` is a new dead-man timer on the SCADA link.
+  If neither a Modbus TCP connection nor a change to the new host heartbeat
+  register (holding register 560) is seen for 2 s, the firmware drives all
+  analog outputs to 0 %, opens the heater relay, asserts Inhibit, and holds the
+  PID loops. Previously the PLC held its last command forever once the host
+  died. Rollover-safe across the ~49.7-day `millis()` wrap.
+- `SafetyInterlock::Evaluate` now trips on the **hihi/lolo** band instead of
+  low/high, and skips tags that are not routed as an input or output. The stock
+  config writes `low=5.0` to all 32 tags, so the previous behaviour latched the
+  plant off — unrecoverably — the moment that config was deployed.
+- Modbus coil 1 (E-stop reset) is now read and clears the trip latch, written
+  back to 0 as a pulse acknowledgement. It was previously never read, making a
+  trip unrecoverable without a power cycle.
+- `SafetyInterlock::IsLimitEffective` exposes the reachable-limit domain so the
+  host can reject a limit that could never be crossed (broker tags are clamped
+  to `[0, 100]`; a limit entered in engineering units silently disabled its trip).
+- `PIDController::SetSetpoint` clears the integrator on a setpoint change
+  (bumpless transfer), and `Hold()`/`Release()` freeze the loops while tripped
+  or blind. A wound-up integrator previously held the analog output at 100 %
+  for tens of seconds after a commanded E-stop.
+- The scan loop now integrates against the **measured** interval rather than a
+  hardcoded 0.1 s, bounded to `[1 ms, 1 s]`.
+
 ### 2026-07-31 P1AM Firmware Test Harness Repaired and Gated in CI
 
 - `tests/p1am_control_system/firmware/` (Makefile + `MockHardware.h` + `test_dcs.cpp`)

--- a/src/p1am_control_system/firmware/CommsWatchdog.cpp
+++ b/src/p1am_control_system/firmware/CommsWatchdog.cpp
@@ -1,0 +1,31 @@
+#include "CommsWatchdog.h"
+
+namespace {
+// A zero or negative timeout would disable the watchdog entirely, which is the
+// failure this class exists to prevent. Fall back to a conservative default
+// rather than accepting a configuration that silently does nothing.
+const unsigned long kFallbackTimeoutMs = 2000UL;
+}  // namespace
+
+CommsWatchdog::CommsWatchdog(unsigned long timeout_ms)
+    : timeout_ms_(timeout_ms > 0UL ? timeout_ms : kFallbackTimeoutMs),
+      last_activity_ms_(0UL) {}
+
+void CommsWatchdog::Begin(unsigned long now_ms) {
+  last_activity_ms_ = now_ms;
+}
+
+void CommsWatchdog::RecordActivity(unsigned long now_ms) {
+  last_activity_ms_ = now_ms;
+}
+
+bool CommsWatchdog::IsExpired(unsigned long now_ms) const {
+  // Unsigned subtraction wraps with the counter, so this stays correct when
+  // millis() rolls over past 0xFFFFFFFF.
+  const unsigned long elapsed = now_ms - last_activity_ms_;
+  return elapsed >= timeout_ms_;
+}
+
+unsigned long CommsWatchdog::TimeoutMs() const {
+  return timeout_ms_;
+}

--- a/src/p1am_control_system/firmware/CommsWatchdog.h
+++ b/src/p1am_control_system/firmware/CommsWatchdog.h
@@ -1,0 +1,42 @@
+#ifndef P1AM_CONTROL_SYSTEM_FIRMWARE_COMMS_WATCHDOG_H_
+#define P1AM_CONTROL_SYSTEM_FIRMWARE_COMMS_WATCHDOG_H_
+
+// Dead-man timer on the Modbus link to the SCADA host.
+//
+// Without this the PLC holds its last commanded state forever: the heater
+// relay stays closed and the analog outputs keep driving whatever the host
+// last wrote, even after the host has lost power, been killed, or been
+// unplugged. The host cannot cover this case because the host is the thing
+// that died (issue #3999).
+//
+// Deliberately free of Arduino headers so it is unit-testable on the host:
+// the caller supplies `millis()` rather than the class reading it. That also
+// makes the rollover behaviour testable, which matters because millis() wraps
+// roughly every 49.7 days and a naive comparison would disarm the watchdog for
+// another 49 days at the wrap.
+class CommsWatchdog {
+ public:
+  // Precondition: timeout_ms > 0. Should be several scan periods so ordinary
+  // jitter does not trip it, but short enough to be a meaningful backstop.
+  explicit CommsWatchdog(unsigned long timeout_ms);
+
+  // Arm the watchdog at boot. Until the host talks to us the timer is running,
+  // so a PLC that boots into a dead network safes itself rather than waiting.
+  void Begin(unsigned long now_ms);
+
+  // Record that the host was heard from.
+  void RecordActivity(unsigned long now_ms);
+
+  // True once `timeout_ms` has elapsed since the last activity.
+  // Correct across millis() rollover: the unsigned subtraction wraps with the
+  // counter. Elapsed == timeout counts as expired -- fail safe, not fail late.
+  bool IsExpired(unsigned long now_ms) const;
+
+  unsigned long TimeoutMs() const;
+
+ private:
+  unsigned long timeout_ms_;
+  unsigned long last_activity_ms_;
+};
+
+#endif  // P1AM_CONTROL_SYSTEM_FIRMWARE_COMMS_WATCHDOG_H_

--- a/src/p1am_control_system/firmware/PIDController.cpp
+++ b/src/p1am_control_system/firmware/PIDController.cpp
@@ -29,9 +29,33 @@ void PIDController::Reset() {
   integral_ = 0.0f;
   last_error_ = 0.0f;
   first_run_ = true;
+  held_ = false;
+}
+
+void PIDController::Hold() {
+  held_ = true;
+  ResetDynamicState();
+}
+
+void PIDController::Release() {
+  held_ = false;
+  ResetDynamicState();
+}
+
+bool PIDController::IsHeld() const {
+  return held_;
+}
+
+void PIDController::ResetDynamicState() {
+  integral_ = 0.0f;
+  last_error_ = 0.0f;
+  first_run_ = true;
 }
 
 void PIDController::Compute(SignalBroker& broker, float dt) {
+  if (held_) {
+    return;
+  }
   if (!std::isfinite(dt) || dt <= 0.0f) {
     return;
   }
@@ -115,7 +139,16 @@ float PIDController::GetSetpoint() const {
 }
 
 void PIDController::SetSetpoint(float setpoint) {
-  setpoint_ = FiniteOrZero(setpoint);
+  const float next = FiniteOrZero(setpoint);
+  if (next != setpoint_) {
+    // Bumpless transfer: carrying the old integral across a setpoint change
+    // means the accumulated term still reflects the previous target. On an
+    // E-stop -- whose only effect that reaches the plant is zeroing these
+    // setpoints -- a wound-up integral held the analog output at 100% for tens
+    // of seconds after the operator commanded a stop (issue #4002).
+    ResetDynamicState();
+  }
+  setpoint_ = next;
 }
 
 float PIDController::GetKp() const {

--- a/src/p1am_control_system/firmware/PIDController.h
+++ b/src/p1am_control_system/firmware/PIDController.h
@@ -12,7 +12,18 @@ class PIDController {
 
   // Compute PID output and write it to CV Tag in the SignalBroker.
   // Precondition: dt > 0.0f
+  // No-op while held (see Hold()).
   void Compute(SignalBroker& broker, float dt);
+
+  // Freeze the loop and shed accumulated state. Called while the safety
+  // interlock is tripped so a latched plant cannot wind up a controller that
+  // would then slam the output the moment the trip clears (issue #4002).
+  void Hold();
+
+  // Resume control from a clean integral.
+  void Release();
+
+  bool IsHeld() const;
 
   // Getters and Setters
   int GetPvTagId() const;
@@ -34,6 +45,9 @@ class PIDController {
   void SetKd(float kd);
 
  private:
+  // Clear integral/derivative history without touching tuning or routing.
+  void ResetDynamicState();
+
   int pv_tag_id_;
   int cv_tag_id_;
   float setpoint_;
@@ -44,6 +58,7 @@ class PIDController {
   float integral_;
   float last_error_;
   bool first_run_;
+  bool held_;
 };
 
 #endif  // P1AM_CONTROL_SYSTEM_FIRMWARE_PID_CONTROLLER_H_

--- a/src/p1am_control_system/firmware/README.md
+++ b/src/p1am_control_system/firmware/README.md
@@ -90,18 +90,41 @@ breaks Ethernet SPI.
 
 ## Modbus register map
 
-| Range    | Width | Purpose                                                                    |
-| -------- | ----- | -------------------------------------------------------------------------- |
-| 0..63    | 64    | Tag values — TAG_i is at regs (i*2, i*2+1) as little-endian IEEE-754 float |
-| 100..105 | 6     | Input routing — channel -> tag id; slots 0-3 = TC0-3, 4-5 = AI0-1          |
-| 110..111 | 2     | Output routing — channel -> tag id; slots 0-1 = AO0-1                      |
-| 200..239 | 40    | PID config — 4 PIDs x 10 regs = (pv_tag, cv_tag, sp, kp, ki, kd)           |
-| 300..555 | 256   | Interlock limits — 32 tags x 8 regs = (lolo, low, high, hihi) IEEE-754     |
-| coil 0   | 1     | Save-to-flash trigger (firmware writes EEPROM on falling edge of write)    |
+| Range    | Width | Purpose                                                                     |
+| -------- | ----- | --------------------------------------------------------------------------- |
+| 0..63    | 64    | Tag values — TAG_i is at regs (i*2, i*2+1) as little-endian IEEE-754 float  |
+| 100..105 | 6     | Input routing — channel -> tag id; slots 0-3 = TC0-3, 4-5 = AI0-1           |
+| 110..111 | 2     | Output routing — channel -> tag id; slots 0-1 = AO0-1                       |
+| 200..239 | 40    | PID config — 4 PIDs x 10 regs = (pv_tag, cv_tag, sp, kp, ki, kd)            |
+| 300..555 | 256   | Interlock limits — 32 tags x 8 regs = (lolo, low, high, hihi) IEEE-754      |
+| 560      | 1     | Host heartbeat — backend bumps this every scan; feeds the comms watchdog    |
+| coil 0   | 1     | Save-to-flash trigger (firmware writes EEPROM on falling edge of write)     |
+| coil 1   | 1     | E-stop reset — firmware clears the trip latch and writes the coil back to 0 |
+| coil 2   | 1     | Heater relay command (interlock and comms watchdog both override it off)    |
+| coil 3   | 1     | Thermocouple burnout direction (see below)                                  |
 
 Tag values are clamped 0.0–100.0 by the broker. AO outputs scale linearly:
 0.0% -> 4.000 mA, 100.0% -> 20.000 mA. AI readings are pre-scaled by the P1AM
 library before reaching the broker.
+
+### Interlock trip semantics
+
+The firmware trips on the **hihi/lolo** band only. `low`/`high` is the warning
+tier and is stored for host-side annunciation. Because broker tags are clamped
+to `[0, 100]`, a limit outside that range can never be crossed — the firmware
+treats such a limit as absent rather than comparing against an unreachable
+threshold, and the host should reject it at the API boundary. Only tags that
+are routed as an input or output are evaluated; an unrouted tag sits at 0.0 and
+is not a measurement.
+
+### Comms watchdog
+
+If neither a Modbus TCP connection nor a change to the heartbeat register is
+seen for 2 s, the firmware drives every analog output to 0 %, opens the heater
+relay, asserts the Inhibit GPIO, and holds the PID loops with their integrators
+cleared. This is the only protection that survives the host being absent
+entirely — a powered-off Pi, a killed backend, or an unplugged cable. Control
+resumes automatically when the link returns, starting from a clean integrator.
 
 ## Thermocouple module configuration
 

--- a/src/p1am_control_system/firmware/SafetyInterlock.cpp
+++ b/src/p1am_control_system/firmware/SafetyInterlock.cpp
@@ -24,12 +24,33 @@ void SafetyInterlock::Reset() {
   }
 }
 
+bool SafetyInterlock::IsLimitEffective(float limit) {
+  if (!std::isfinite(limit)) {
+    return false;
+  }
+  // Matches the broker's tag domain; see SignalBroker::SetTag.
+  return limit >= 0.0f && limit <= 100.0f;
+}
+
 void SafetyInterlock::Evaluate(SignalBroker& broker, HardwareInterface& hw) {
   bool trip_detected = false;
 
   for (int i = 0; i < SignalBroker::kNumTags; ++i) {
+    // An unrouted tag holds 0.0 and is not a measurement of anything. The
+    // stock config writes a lolo floor to all 32 tags, so evaluating unrouted
+    // tags latched the plant off the moment that config was deployed.
+    if (!broker.IsTagRouted(i)) {
+      continue;
+    }
     float val = broker.GetTag(i);
-    if (val > high_limits_[i] || val < low_limits_[i]) {
+    // Trip on the hihi/lolo tier. A limit outside the tag domain is either the
+    // "never trip" sentinel or an unreachable entry; skip it either way rather
+    // than comparing against a threshold that can never be crossed.
+    if (IsLimitEffective(hihi_limits_[i]) && val >= hihi_limits_[i]) {
+      trip_detected = true;
+      break;
+    }
+    if (IsLimitEffective(lolo_limits_[i]) && val <= lolo_limits_[i]) {
       trip_detected = true;
       break;
     }

--- a/src/p1am_control_system/firmware/SafetyInterlock.h
+++ b/src/p1am_control_system/firmware/SafetyInterlock.h
@@ -12,12 +12,33 @@ class SafetyInterlock {
   void Reset();
 
   // Evaluate tags against trip limits. If tripped, forces outputs to 0 and inhibits hardware.
+  //
+  // Trips on the HIHI/LOLO tier only. low/high is the SCADA layer's
+  // severity-1 *warning* band; tripping the plant on a warning is what made
+  // the stock config (low=5.0 on every tag) unrunnable (issue #4001).
+  //
+  // Only tags that are routed as an input or an output are evaluated. An
+  // unrouted tag sits at 0.0 and is not a process measurement, so it must not
+  // be able to latch the plant off.
+  //
   // Precondition: broker is a valid reference, hw is a valid reference
   void Evaluate(SignalBroker& broker, HardwareInterface& hw);
 
+  // True if `limit` is a value the interlock can actually act on.
+  //
+  // Broker tags are clamped to [0, 100], so a limit outside that range can
+  // never be crossed. Reset() uses +/-99999 as a deliberate "never trip"
+  // sentinel; anything else out of range is an unreachable operator entry --
+  // typically a limit typed in engineering units (900 meaning 900 degC) on a
+  // percent-scaled tag, which silently disables the trip (issue #4032).
+  //
+  // The host uses this to reject such a configuration at the API boundary
+  // rather than accepting a limit that does nothing.
+  static bool IsLimitEffective(float limit);
+
   // Four-limit accessors: lolo/low/high/hihi.
-  // Only low/high trip Evaluate(); lolo/hihi are stored for host visibility
-  // and reserved for future alarm-vs-trip semantics.
+  // lolo/hihi are the trip band evaluated by Evaluate(); low/high are stored
+  // for host-side warning annunciation.
   float GetLoloLimit(int tag_id) const;
   void SetLoloLimit(int tag_id, float val);
 

--- a/src/p1am_control_system/firmware/SignalBroker.cpp
+++ b/src/p1am_control_system/firmware/SignalBroker.cpp
@@ -91,6 +91,23 @@ int SignalBroker::GetOutputRouting(int channel) const {
   return output_routing_[channel];
 }
 
+bool SignalBroker::IsTagRouted(int tag_id) const {
+  if (!IsValidTagId(tag_id)) {
+    return false;
+  }
+  for (int i = 0; i < kNumInputs; ++i) {
+    if (input_routing_[i] == tag_id) {
+      return true;
+    }
+  }
+  for (int i = 0; i < kNumOutputs; ++i) {
+    if (output_routing_[i] == tag_id) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void SignalBroker::ReadHardwareInputs(HardwareInterface& hw) {
   // Read and scale 4 Thermocouples (channels 0 to 3).
   // Full scale is declared once in SignalBroker.h; see the contract note there.

--- a/src/p1am_control_system/firmware/SignalBroker.h
+++ b/src/p1am_control_system/firmware/SignalBroker.h
@@ -34,6 +34,12 @@ class SignalBroker {
   // Postcondition: The tag value is updated and clamped to [0.0, 100.0]
   void SetTag(int tag_id, float value);
 
+  // True if this tag is the target of an input route or the source of an
+  // output route -- i.e. it carries a real signal rather than sitting at its
+  // 0.0 default. The interlock uses this to avoid tripping on unrouted tags.
+  // Precondition: none. Out-of-range ids are simply not routed.
+  bool IsTagRouted(int tag_id) const;
+
   // Set input routing: map hardware input channel to tag ID.
   // Precondition: 0 <= channel < kNumInputs
   // Precondition: tag_id is in [0, kNumTags-1] OR is kUnmappedTag

--- a/src/p1am_control_system/firmware/firmware.ino
+++ b/src/p1am_control_system/firmware/firmware.ino
@@ -8,6 +8,7 @@
 #include "PIDController.h"
 #include "SafetyInterlock.h"
 #include "StorageManager.h"
+#include "CommsWatchdog.h"
 
 // Ethernet Configuration (P1AM-ETH shield)
 byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
@@ -31,6 +32,26 @@ const unsigned long kScanIntervalMs = 100;
 // (Coil 0 = save-to-flash, coil 1 = E-stop reset, coil 3 = THM burnout
 // direction -- see kThmBurnoutCoil in P1AMHardware.h.)
 const int kHeaterRelayCoil = 2;
+const int kEstopResetCoil = 1;
+
+// Dead-man timer on the SCADA link (issue #3999). Without it the heater relay
+// and analog outputs held their last command forever once the host died, with
+// no operator visibility -- the HMI is exactly what died.
+//
+// Two independent activity signals, because each misses a case the other
+// catches:
+//   * a live Modbus TCP client, which covers host power loss, a killed
+//     backend and a pulled cable (all drop the socket);
+//   * a host heartbeat register, which additionally catches a wedged backend
+//     that holds an idle socket open.
+// Either one re-arms the watchdog.
+// Sits immediately after the interlock block (300..555) and inside the
+// configured holding-register map -- see configureHoldingRegisters() in setup.
+const int kHostHeartbeatReg = 560;
+const unsigned long kCommsTimeoutMs = 2000;  // 20 scans at the nominal 100 ms
+CommsWatchdog commsWatchdog(kCommsTimeoutMs);
+uint16_t lastHeartbeatValue = 0;
+bool commsLostLatched = false;
 
 // Count of signed-on backplane modules (captured at boot, published to TAG_26).
 uint8_t g_moduleCount = 0;
@@ -183,8 +204,9 @@ void setup() {
   modbusServer.configureCoils(0, 10);
   // Holding-register window: tag values (0..63), input routing (100..105),
   // output routing (110..111), PID config (200..239), 4-limit interlocks
-  // (300..555 = 32 tags x 8 regs). Bump end to 560 with margin.
-  modbusServer.configureHoldingRegisters(0, 560);
+  // (300..555 = 32 tags x 8 regs), host heartbeat (560).
+  // Count is one past the highest address, so 561 makes 560 addressable.
+  modbusServer.configureHoldingRegisters(0, kHostHeartbeatReg + 1);
   Serial.println(F("[mb] Modbus TCP server started"));
 
   // Load saved NVRAM configuration; fall back to defaults on first boot.
@@ -237,6 +259,13 @@ void setup() {
 
   // Publish current config to Modbus registers.
   SyncDCSToModbus();
+  // Arm the comms watchdog before entering the loop. It starts running rather
+  // than waiting for first contact, so a PLC that boots into a dead network
+  // safes itself instead of sitting energized waiting for a host that is not
+  // coming.
+  commsWatchdog.Begin(millis());
+  lastHeartbeatValue = modbusServer.holdingRegisterRead(kHostHeartbeatReg);
+
   Serial.println(F("[setup] complete -- entering control loop"));
 }
 
@@ -245,8 +274,27 @@ void loop() {
   EthernetClient newClient = ethServer.available();
   if (newClient) {
     modbusServer.accept(newClient);
+    commsWatchdog.RecordActivity(millis());
   }
   modbusServer.poll();
+
+  // Host heartbeat: the backend bumps this register every scan. Any change is
+  // proof the host is alive even if the socket has been idle.
+  uint16_t heartbeat = modbusServer.holdingRegisterRead(kHostHeartbeatReg);
+  if (heartbeat != lastHeartbeatValue) {
+    lastHeartbeatValue = heartbeat;
+    commsWatchdog.RecordActivity(millis());
+  }
+
+  // E-stop reset (Modbus coil 1). Previously this coil was never read, so a
+  // latched trip was unrecoverable short of a power cycle and the host's
+  // "Clear E-stop" wrote to nothing (issue #4001). Treated as a pulse: the
+  // coil is written back to 0 so the host can see the reset was consumed, and
+  // Evaluate() re-trips on the next scan if the condition is still present.
+  if (modbusServer.coilRead(kEstopResetCoil) == 1) {
+    interlock.ClearTrip();
+    modbusServer.coilWrite(kEstopResetCoil, 0);
+  }
 
   // Save-to-flash trigger
   if (modbusServer.coilRead(0) == 1) {
@@ -268,19 +316,69 @@ void loop() {
   // timer so the SAMD21 USB CDC and Modbus library aren't starved.
   unsigned long now = millis();
   if (now - lastScanTime >= kScanIntervalMs) {
+    // Measure the interval actually elapsed rather than assuming the nominal
+    // one. This scan also does ~300 register reads, SPI thermocouple reads and
+    // (on a config deploy) a blocking flash write, so the real period runs
+    // well past 100 ms. Integrating as if 100 ms had passed understated Ki and
+    // overstated Kd whenever the scan overran (issue #4009).
+    float dt = static_cast<float>(now - lastScanTime) / 1000.0f;
+    // Bound dt so a long stall cannot inject a huge integral step or a
+    // near-zero derivative divisor.
+    if (dt < 0.001f) {
+      dt = 0.001f;
+    } else if (dt > 1.0f) {
+      dt = 1.0f;
+    }
     lastScanTime = now;
 
     SyncModbusToDCS();
     hw.Update();
     broker.ReadHardwareInputs(hw);
+
+    // Comms watchdog. A tripped interlock and a dead host are different
+    // conditions but demand the same output state, so both drive the same
+    // safe-state path below.
+    const bool comms_lost = commsWatchdog.IsExpired(now);
+    if (comms_lost && !commsLostLatched) {
+      commsLostLatched = true;
+      Serial.println(F("[watchdog] SCADA link lost -- forcing outputs safe"));
+    } else if (!comms_lost && commsLostLatched) {
+      commsLostLatched = false;
+      Serial.println(F("[watchdog] SCADA link restored"));
+    }
+
+    // While tripped or blind, freeze the loops and shed their accumulated
+    // state so recovery does not slam the outputs with a wound-up integral.
+    const bool outputs_inhibited = interlock.IsTripped() || comms_lost;
     for (int i = 0; i < 4; ++i) {
-      pids[i].Compute(broker, 0.1f);
+      if (outputs_inhibited) {
+        pids[i].Hold();
+      } else if (pids[i].IsHeld()) {
+        pids[i].Release();
+      }
+      pids[i].Compute(broker, dt);
     }
     interlock.Evaluate(broker, hw);
+
+    if (comms_lost) {
+      // The host is gone and cannot be trusted to have left a safe command
+      // behind. Drive every actuator to its de-energized state directly --
+      // this is the only protection that survives the host being absent.
+      for (int i = 0; i < SignalBroker::kNumOutputs; ++i) {
+        int tag_id = broker.GetOutputRouting(i);
+        if (tag_id != SignalBroker::kUnmappedTag) {
+          broker.SetTag(tag_id, 0.0f);
+        }
+        hw.WriteAnalogOutput(i, 0.0f);
+      }
+      hw.WriteHeaterRelay(false);
+      hw.WriteInhibit(true);
+    }
+
     // Heater relay (Modbus coil 2): the temperature controller commands it, but
     // the safety interlock always wins — a trip forces the relay off regardless.
     bool relay_cmd = (modbusServer.coilRead(kHeaterRelayCoil) == 1);
-    hw.WriteHeaterRelay(relay_cmd && !interlock.IsTripped());
+    hw.WriteHeaterRelay(relay_cmd && !interlock.IsTripped() && !comms_lost);
 
     // Thermocouple burnout direction (Modbus coil 3): an operator/HMI toggle
     // that flips the open-circuit fail direction. LOW-side (coil = 0) makes an

--- a/tests/p1am_control_system/firmware/Makefile
+++ b/tests/p1am_control_system/firmware/Makefile
@@ -5,7 +5,7 @@ CXXFLAGS += -I$(FIRMWARE_SRC_DIR)
 vpath %.cpp $(FIRMWARE_SRC_DIR)
 vpath %.h $(FIRMWARE_SRC_DIR)
 
-SRCS = test_dcs.cpp SignalBroker.cpp PIDController.cpp SafetyInterlock.cpp StorageManager.cpp
+SRCS = test_dcs.cpp SignalBroker.cpp PIDController.cpp SafetyInterlock.cpp StorageManager.cpp CommsWatchdog.cpp
 OBJS = $(SRCS:.cpp=.o)
 TARGET = test_dcs
 

--- a/tests/p1am_control_system/firmware/test_dcs.cpp
+++ b/tests/p1am_control_system/firmware/test_dcs.cpp
@@ -15,6 +15,7 @@
 #include "PIDController.h"
 #include "SafetyInterlock.h"
 #include "StorageManager.h"
+#include "CommsWatchdog.h"
 
 // Helper to check approximate equality for floats
 bool FloatEquals(float a, float b, float epsilon = 0.001f) {
@@ -115,9 +116,13 @@ void TestSafetyInterlock() {
   broker.SetOutputRouting(0, 10);
   broker.SetTag(10, 80.0f);
 
-  // Set limits for Tag 5
-  interlock.SetHighLimit(5, 75.0f);
-  interlock.SetLowLimit(5, 10.0f);
+  // Tag 5 must be routed to be evaluated at all (issue #4001).
+  broker.SetInputRouting(0, 5);
+
+  // Set the trip band for Tag 5. This test previously used the low/high pair;
+  // those are the warning tier and no longer trip (issue #4001).
+  interlock.SetHihiLimit(5, 75.0f);
+  interlock.SetLoloLimit(5, 10.0f);
 
   // Tag 5 is 50.0 (OK)
   broker.SetTag(5, 50.0f);
@@ -288,6 +293,225 @@ void TestSoftFailRuntimeContracts() {
   std::cout << "TestSoftFailRuntimeContracts PASSED!" << std::endl;
 }
 
+// --------------------------------------------------------------------------
+// Safety regressions (issues #3999, #4001, #4002, #4032)
+// --------------------------------------------------------------------------
+
+// #4001: the trip must fire on the HIHI/LOLO tier, not on low/high.
+// low/high is the SCADA layer's severity-1 *warning* band; tripping the plant
+// on a warning is what made the stock config unrunnable.
+void TestInterlockTripsOnHihiLoloNotHighLow() {
+  std::cout << "Running TestInterlockTripsOnHihiLoloNotHighLow..." << std::endl;
+  MockHardware hw;
+  SignalBroker broker;
+  SafetyInterlock interlock;
+
+  // Route tag 5 as a measurement so it is eligible for evaluation.
+  broker.SetInputRouting(0, 5);
+  broker.SetOutputRouting(0, 10);
+  broker.SetTag(10, 80.0f);
+
+  interlock.SetLoloLimit(5, 2.0f);
+  interlock.SetLowLimit(5, 10.0f);
+  interlock.SetHighLimit(5, 90.0f);
+  interlock.SetHihiLimit(5, 95.0f);
+
+  // Inside the warning band (above high, below hihi): must NOT trip.
+  broker.SetTag(5, 92.0f);
+  interlock.Evaluate(broker, hw);
+  assert(!interlock.IsTripped());
+  assert(!hw.GetInhibitActive());
+
+  // Below low but above lolo: still a warning, must NOT trip.
+  broker.SetTag(5, 5.0f);
+  interlock.Evaluate(broker, hw);
+  assert(!interlock.IsTripped());
+
+  // Above hihi: MUST trip.
+  broker.SetTag(5, 96.0f);
+  interlock.Evaluate(broker, hw);
+  assert(interlock.IsTripped());
+  assert(hw.GetInhibitActive());
+  assert(FloatEquals(hw.GetAnalogOutput(0), 0.0f));
+
+  std::cout << "TestInterlockTripsOnHihiLoloNotHighLow PASSED!" << std::endl;
+}
+
+// #4001: an unrouted tag sits at 0.0 and is not a process measurement. The
+// stock config writes lolo=0/low=5 to all 32 tags, so evaluating unrouted tags
+// latched the plant off the moment that config was deployed.
+void TestInterlockIgnoresUnroutedTags() {
+  std::cout << "Running TestInterlockIgnoresUnroutedTags..." << std::endl;
+  MockHardware hw;
+  SignalBroker broker;
+  SafetyInterlock interlock;
+
+  // Stock-config shape: a lolo floor on every tag.
+  for (int i = 0; i < SignalBroker::kNumTags; ++i) {
+    interlock.SetLoloLimit(i, 5.0f);
+    interlock.SetHihiLimit(i, 95.0f);
+  }
+
+  // Only tag 4 is routed, and it reads healthily.
+  broker.SetInputRouting(0, 4);
+  broker.SetTag(4, 50.0f);
+
+  interlock.Evaluate(broker, hw);
+
+  // Every other tag is unrouted and reads 0.0 (below the 5.0 lolo) but must
+  // not be able to trip the plant.
+  assert(!interlock.IsTripped());
+  assert(!hw.GetInhibitActive());
+
+  std::cout << "TestInterlockIgnoresUnroutedTags PASSED!" << std::endl;
+}
+
+// #4001: ClearTrip must actually be reachable and must restore control once
+// the condition is gone -- and must NOT clear while the condition persists.
+void TestInterlockTripIsRecoverable() {
+  std::cout << "Running TestInterlockTripIsRecoverable..." << std::endl;
+  MockHardware hw;
+  SignalBroker broker;
+  SafetyInterlock interlock;
+
+  broker.SetInputRouting(0, 5);
+  broker.SetOutputRouting(0, 10);
+  interlock.SetHihiLimit(5, 95.0f);
+
+  broker.SetTag(5, 99.0f);
+  interlock.Evaluate(broker, hw);
+  assert(interlock.IsTripped());
+
+  // Clearing while still over-limit must re-trip on the very next scan.
+  interlock.ClearTrip();
+  interlock.Evaluate(broker, hw);
+  assert(interlock.IsTripped());
+
+  // With the condition removed, clearing sticks and outputs are driven again.
+  broker.SetTag(5, 50.0f);
+  interlock.ClearTrip();
+  broker.SetTag(10, 42.0f);
+  interlock.Evaluate(broker, hw);
+  assert(!interlock.IsTripped());
+  assert(!hw.GetInhibitActive());
+  assert(FloatEquals(hw.GetAnalogOutput(0), 42.0f));
+
+  std::cout << "TestInterlockTripIsRecoverable PASSED!" << std::endl;
+}
+
+// #4002: zeroing the setpoint is the only part of the host E-stop that reaches
+// the plant. If the integral survives, the AO holds full output for tens of
+// seconds after a commanded emergency stop.
+void TestPidResetsIntegralOnSetpointChange() {
+  std::cout << "Running TestPidResetsIntegralOnSetpointChange..." << std::endl;
+  SignalBroker broker;
+  PIDController pid;
+
+  pid.SetPvTagId(3);
+  pid.SetCvTagId(4);
+  pid.SetSetpoint(100.0f);
+  pid.SetKp(0.0f);
+  pid.SetKi(1.0f);  // integral-only, so the wind-up is unambiguous
+  pid.SetKd(0.0f);
+
+  // Wind the integral to its clamp against a large sustained error.
+  broker.SetTag(3, 0.0f);
+  for (int i = 0; i < 200; ++i) {
+    pid.Compute(broker, 0.1f);
+  }
+  assert(FloatEquals(broker.GetTag(4), 100.0f));
+
+  // Commanding the setpoint to zero must drop the output on the NEXT scan,
+  // not decay towards it over many seconds.
+  pid.SetSetpoint(0.0f);
+  pid.Compute(broker, 0.1f);
+  assert(FloatEquals(broker.GetTag(4), 0.0f));
+
+  std::cout << "TestPidResetsIntegralOnSetpointChange PASSED!" << std::endl;
+}
+
+// #4002: a tripped plant must not wind up a controller that would then slam
+// the output the moment the trip clears.
+void TestPidDoesNotIntegrateWhileTripped() {
+  std::cout << "Running TestPidDoesNotIntegrateWhileTripped..." << std::endl;
+  SignalBroker broker;
+  PIDController pid;
+
+  pid.SetPvTagId(3);
+  pid.SetCvTagId(4);
+  pid.SetSetpoint(100.0f);
+  pid.SetKp(0.0f);
+  pid.SetKi(1.0f);
+  pid.SetKd(0.0f);
+  broker.SetTag(3, 0.0f);
+
+  pid.Hold();  // interlock tripped: freeze the loop and shed accumulated state
+  for (int i = 0; i < 200; ++i) {
+    pid.Compute(broker, 0.1f);
+  }
+  assert(FloatEquals(broker.GetTag(4), 0.0f));
+
+  // Releasing the hold starts from a clean integral, so the first scan after
+  // recovery contributes one step -- not 200 scans' worth.
+  pid.Release();
+  pid.Compute(broker, 0.1f);
+  assert(FloatEquals(broker.GetTag(4), 10.0f));  // ki * error * dt = 1*100*0.1
+
+  std::cout << "TestPidDoesNotIntegrateWhileTripped PASSED!" << std::endl;
+}
+
+// #3999: no dead-man timer meant the heater relay and analog outputs held
+// their last command forever once the host died.
+void TestCommsWatchdog() {
+  std::cout << "Running TestCommsWatchdog..." << std::endl;
+  CommsWatchdog watchdog(2000);  // 2 s against a nominal 100 ms scan
+
+  watchdog.Begin(1000);
+  assert(!watchdog.IsExpired(1000));
+  assert(!watchdog.IsExpired(2999));
+
+  // Exactly at the timeout counts as expired -- fail safe, not fail late.
+  assert(watchdog.IsExpired(3000));
+  assert(watchdog.IsExpired(50000));
+
+  // Traffic re-arms it.
+  watchdog.RecordActivity(50000);
+  assert(!watchdog.IsExpired(51999));
+  assert(watchdog.IsExpired(52000));
+
+  // millis() wraps at ~49.7 days. Unsigned subtraction must carry the
+  // watchdog across the wrap rather than disarming it for another 49 days.
+  const unsigned long kNearWrap = 0xFFFFFF00UL;
+  watchdog.RecordActivity(kNearWrap);
+  assert(!watchdog.IsExpired(kNearWrap + 1999UL));
+  assert(watchdog.IsExpired(kNearWrap + 2000UL));  // wraps past zero
+
+  std::cout << "TestCommsWatchdog PASSED!" << std::endl;
+}
+
+// #4032: broker tags are clamped to [0,100], so a limit above 100 can never be
+// crossed and its trip is silently dead. The firmware must be able to tell a
+// deliberate "disabled" sentinel from an unreachable operator entry.
+void TestInterlockLimitDomain() {
+  std::cout << "Running TestInterlockLimitDomain..." << std::endl;
+
+  // The disabled sentinels are legitimate: they mean "never trip".
+  assert(SafetyInterlock::IsLimitEffective(99999.0f) == false);
+  assert(SafetyInterlock::IsLimitEffective(-99999.0f) == false);
+
+  // Anything inside the broker's tag domain is a real, reachable limit.
+  assert(SafetyInterlock::IsLimitEffective(0.0f));
+  assert(SafetyInterlock::IsLimitEffective(95.0f));
+  assert(SafetyInterlock::IsLimitEffective(100.0f));
+
+  // A limit outside the tag domain but not a sentinel is unreachable -- e.g.
+  // an operator entering 900 meaning 900 degC on a percent-scaled tag.
+  assert(SafetyInterlock::IsLimitEffective(900.0f) == false);
+  assert(SafetyInterlock::IsLimitEffective(-5.0f) == false);
+
+  std::cout << "TestInterlockLimitDomain PASSED!" << std::endl;
+}
+
 int main() {
   std::cout << "=== DCS CORE FIRMWARE TDD TEST RUNNER ===" << std::endl;
   TestSignalBroker();
@@ -295,6 +519,13 @@ int main() {
   TestSafetyInterlock();
   TestStorageManager();
   TestSoftFailRuntimeContracts();
+  TestInterlockTripsOnHihiLoloNotHighLow();
+  TestInterlockIgnoresUnroutedTags();
+  TestInterlockTripIsRecoverable();
+  TestPidResetsIntegralOnSetpointChange();
+  TestPidDoesNotIntegrateWhileTripped();
+  TestCommsWatchdog();
+  TestInterlockLimitDomain();
   std::cout << "All C++ Core Firmware Tests Passed Successfully!" << std::endl;
   return 0;
 }


### PR DESCRIPTION
Closes #3999. Closes #4001. Closes #4002. Closes #4032. Refs #4009.

**Stacked on #4043** (the harness repair) — that PR is what makes any of this testable. Merge #4043 first; this targets its branch and will retarget to `main` automatically.

Every fix here has a failing host test written first.

## #3999 — no dead-man timer on the SCADA link

The heater relay is a coil read and the analog outputs are driven from broker tags. Both held their last commanded value **forever** once the host died, and the host cannot cover this case because the host is the thing that died.

New `CommsWatchdog` (`firmware/CommsWatchdog.{h,cpp}`) drives all analog outputs to 0 %, opens the heater relay, asserts Inhibit, and holds the PID loops after 2 s of silence. Two independent activity signals, because each misses a case the other catches:

- a live Modbus TCP connection — covers host power loss, a killed backend, a pulled cable (all drop the socket);
- a host heartbeat register (holding register **560**) — covers a wedged backend holding an idle socket open.

Either re-arms it. It is armed in `setup()` *before* the loop, so a PLC that boots into a dead network safes itself rather than sitting energized waiting for a host that is not coming.

The class is deliberately free of Arduino headers — the caller supplies `millis()`. That is what makes the rollover behaviour testable, and it matters: `millis()` wraps roughly every 49.7 days, and a naive comparison would disarm the watchdog for another 49 days at the wrap. `TestCommsWatchdog` asserts the wrap explicitly.

## #4001 — the trip fired on the warning band, over unrouted tags, unrecoverably

Three compounding problems:

- `Evaluate()` compared against `low`/`high`, which is the SCADA layer's severity-1 **warning** tier.
- It evaluated all 32 tags, including unrouted ones sitting at 0.0.
- `ClearTrip()` had zero call sites and coil 1 was never read, so the latch was unrecoverable short of a power cycle — after which the flash-saved config tripped it again on the first scan.

Since the stock config writes `low=5.0` to every tag, deploying it latched the plant off permanently.

Now: `Evaluate()` trips on **hihi/lolo**, and skips tags that are not routed as an input or output. The routing predicate is `SignalBroker::IsTagRouted` — the broker owns routing, so it lives there rather than being duplicated in the interlock. Coil 1 clears the latch and is written back to 0 as a pulse acknowledgement, so the host can see the reset was consumed; `Evaluate()` re-trips on the next scan if the condition persists, which `TestInterlockTripIsRecoverable` pins.

## #4002 — a wound-up integrator survived the E-stop

`SetSetpoint` did not touch the integrator, and `Compute()` ran even while tripped. Zeroing the PID setpoints is the *only* part of the host E-stop that reaches the plant, so the integral term alone held the analog output at 100 % of its 4-20 mA span for tens of seconds after the operator commanded a stop.

`SetSetpoint` now clears integral and derivative history on a change — bumpless transfer, which is the right behaviour for ordinary retargeting too, not just E-stop. `Hold()`/`Release()` freeze the loops while tripped or blind so recovery starts from a clean integrator instead of slamming the output the moment the trip clears.

## #4032 — limits outside the tag domain silently disabled their trip

Broker tags are clamped to `[0, 100]`, so any limit above 100 could never be crossed. An operator entering `900` meaning 900 °C on a percent-scaled tag disabled the interlock with no indication, and the HMI displayed the limit exactly as configured.

`SafetyInterlock::IsLimitEffective` distinguishes a deliberate ±99999 "never trip" sentinel from an unreachable entry. `Evaluate()` skips both rather than comparing against a threshold that cannot be crossed, and the host can call the same predicate to reject the configuration at the API boundary — that backend half is tracked separately.

## Also: firmware half of #4009

The scan integrated against a hardcoded `0.1f` while the real period runs well past that — the same iteration does ~300 register reads, SPI thermocouple reads, and on a config deploy a blocking flash write. Understating `dt` understates `Ki` and overstates `Kd` for exactly the scans that overran. It now uses the **measured** interval, bounded to `[1 ms, 1 s]` so a long stall cannot inject a huge integral step or a near-zero derivative divisor.

## Note on a changed test

`TestSafetyInterlock` encoded the old warning-band-trips behaviour (high=75, tag at 80 → trip, on an unrouted tag). That is the defect, not the contract, so the test is updated to the corrected semantics rather than the behaviour being preserved to keep it passing.

## Register map

Holding register **560** is new (host heartbeat). `configureHoldingRegisters` is widened accordingly — the count argument is one past the highest address, so it is now `kHostHeartbeatReg + 1`. The firmware README register-map table is updated, and documents the trip semantics and watchdog behaviour.

## Verification

All 12 host suites pass under g++ 11.4 (WSL Ubuntu-22.04):

```
TestSignalBroker / TestPIDController / TestSafetyInterlock / TestStorageManager
TestSoftFailRuntimeContracts / TestInterlockTripsOnHihiLoloNotHighLow
TestInterlockIgnoresUnroutedTags / TestInterlockTripIsRecoverable
TestPidResetsIntegralOnSetpointChange / TestPidDoesNotIntegrateWhileTripped
TestCommsWatchdog / TestInterlockLimitDomain
All C++ Core Firmware Tests Passed Successfully!
```

The four non-Arduino translation units also pass `g++ -fsyntax-only -Wall -Wextra`. The sketch itself is covered by the `arduino-cli` gate added in #4043 — it cannot be compiled locally without the board package.

## Backend work this unblocks

- The backend must write the heartbeat register each scan, or the watchdog falls back to socket liveness alone.
- The backend should call `IsLimitEffective`'s equivalent at `/api/routing` to reject unreachable limits.
- `clear_estop()` can now read the coil back to confirm the reset actually happened, instead of returning `True` on a write to a coil nothing read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)