### PR TITLE
ci: gate comment-dispatch jobs so they stop consuming fleet runners

### DIFF
--- a/.github/workflows/Jules-Issue-Mention-Handler.yml
+++ b/.github/workflows/Jules-Issue-Mention-Handler.yml
@@ -19,6 +19,13 @@ concurrency:
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
+    # Cheap pre-filter, evaluated by GitHub before any runner is requested: a
+    # skipped job consumes no fleet capacity. Without it, EVERY issue comment
+    # in this repo occupied two d-sorg-fleet runners (pick-runner, then
+    # check-mention) just to discover the comment did not mention @jules.
+    # `contains` is case-insensitive and deliberately looser than the
+    # word-boundary grep in check-mention, which remains the precise arbiter.
+    if: contains(github.event.comment.body, '@jules')
     runs-on: d-sorg-fleet
     timeout-minutes: 2
     outputs:

--- a/.github/workflows/PR-Comment-Responder.yml
+++ b/.github/workflows/PR-Comment-Responder.yml
@@ -23,6 +23,12 @@ concurrency:
 jobs:
   # ── Dispatcher: route to self-hosted if available ──────────────────────────
   pick-runner:
+    # Same pre-filter as collect-comment below, hoisted so a plain issue
+    # comment never occupies a fleet runner just to be skipped one job later.
+    # Evaluated by GitHub before scheduling, so a skip costs no capacity.
+    if: |
+      (github.event_name == 'pull_request_review_comment') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null)
     runs-on: d-sorg-fleet
     timeout-minutes: 2
     outputs:


### PR DESCRIPTION
## Problem

Both `issue_comment`-triggered workflows request a `d-sorg-fleet` runner for their `pick-runner` dispatcher **unconditionally**, then discover a job or two later that there was nothing to do. So every comment on any issue in this repo occupies fleet capacity purely to answer "no".

`Jules Issue Mention Handler` is the worst case. Its `pick-runner` takes a runner to decide which pool to use, `check-mention` takes a *second* runner to run this grep —

```bash
grep -iqE "(^|[^a-zA-Z0-9_])@jules([^a-zA-Z0-9_]|$)"
```

— and only then does `fix-issue` correctly skip. Two fleet allocations spent to compute a string match.

At the time of writing there are **42 such runs queued, up from 34 two hours earlier** (oldest queued ~10.5 h). That is on the order of 80 pending runner allocations whose entire purpose is to conclude that nobody said `@jules`. Meanwhile the fleet is saturated and other repos' CI is starving — `Tools` alone holds ≥100 of roughly 144 queued runs org-wide.

`PR-Comment-Responder` has the same shape: `pick-runner` is ungated, while `collect-comment` right below it already carries the correct "is this a PR comment?" condition.

## Fix

A job-level `if:` is evaluated by GitHub *before* the job is scheduled, so a skipped job requests no runner and creates no queue entry — it costs nothing. This hoists each workflow's existing condition up to its dispatcher:

- **Jules-Issue-Mention-Handler** — gate `pick-runner` on `contains(github.event.comment.body, '@jules')`.
- **PR-Comment-Responder** — gate `pick-runner` with the same condition `collect-comment` already used.

13 added lines, all `if:` plus explanatory comments. No logic moved, no steps changed.

## Why this is safe

- **Real mentions are unaffected.** GitHub's `contains()` is case-insensitive, so `@Jules` and `@JULES` still match.
- **The precise test is unchanged.** `contains()` is deliberately *looser* than the word-boundary grep — `@julesverne` still passes the gate and is then correctly rejected by `check-mention`, which remains the sole arbiter of whether `fix-issue` runs. The pre-filter can only over-admit, never under-admit.
- **The skip cascades correctly.** `check-mention` declares `needs: pick-runner` and `fix-issue` declares `needs: [pick-runner, check-mention]`, so skipping the dispatcher skips the rest — no orphaned jobs, no `always()` escape hatches involved.
- **No injection risk.** `github.event.comment.body` is attacker-controlled, but an `if:` expression is evaluated by the expression engine and never interpolated into a shell. (`check-mention` already handles it correctly by passing it via `env:`.)

## Verification

Both files parse under `yaml.safe_load`, and the `needs` graph plus resulting `if:` conditions were inspected after the edit:

```
Jules-Issue-Mention-Handler.yml
   pick-runner     runs-on=d-sorg-fleet  if=contains(github.event.comment.body, '@jules')
   check-mention   runs-on=d-sorg-fleet  needs=pick-runner
   fix-issue       runs-on=d-sorg-fleet  needs=[pick-runner, check-mention]
```

Found while diagnosing why CI could not get a runner for D-sorganization/Gasification_Model#4642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
