### PR TITLE
⚡ Bolt: Replace Math.min/max spread with single-pass loops to prevent stack overflow

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,6 @@
 ## 2024-05-24 - Avoid chained map and every array iterations for parsing
 **Learning:** Multiple array methods (`.map()`, `.every()`, `.filter()`) chained together for iterating over datasets cause unnecessary intermediate array allocations, adding up to increased garbage collection pressure.
 **Action:** Replace multiple chained array passes with a single-pass `for` loop that pre-allocates arrays or calculates results inline.
+## 2025-02-17 - Avoid Math.min/max spread for large data arrays
+**Learning:** Using `Math.min(...values)` and `Math.max(...values)` on large dynamically loaded arrays (like chart data points or signals) allocates intermediate memory for the arguments array and frequently throws 'Maximum call stack size exceeded' RangeErrors in JavaScript engines.
+**Action:** Always replace the spread operator in `Math.min/max` with a single-pass `for` loop that manually computes the bounds when working with potentially large numeric arrays.

--- a/src/p1am_control_system/frontend/src/components/data_explorer/SourcePanel.tsx
+++ b/src/p1am_control_system/frontend/src/components/data_explorer/SourcePanel.tsx
@@ -68,10 +68,17 @@ export const SourcePanel: React.FC<SourcePanelProps> = ({
   const applyPreset = (seconds: number | "all") => {
     const now = Date.now();
     if (seconds === "all") {
-      const starts = signals
-        .map((s) => (s.start_time ? Date.parse(s.start_time) : NaN))
-        .filter((t) => Number.isFinite(t));
-      const start = starts.length ? Math.min(...starts) : now - 3600_000;
+      let minStart = Infinity;
+      for (let i = 0; i < signals.length; i++) {
+        const s = signals[i];
+        if (s.start_time) {
+          const t = Date.parse(s.start_time);
+          if (Number.isFinite(t) && t < minStart) {
+            minStart = t;
+          }
+        }
+      }
+      const start = minStart !== Infinity ? minStart : now - 3600_000;
       onHistorianChange({
         ...historian,
         start: toLocalInput(start),

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,13 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i];
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
- **💡 What**: Replaced `Math.min(...values)` and `Math.max(...values)` spread usage with a single-pass `for` loop in `trendAxis.ts` and `SourcePanel.tsx`. Also eliminated a chained `.map().filter()` operation in `SourcePanel.tsx`.
- **🎯 Why**: Spreading large arrays into function arguments allocates intermediate memory for the spread argument list and leads to 'Maximum call stack size exceeded' errors when the data exceeds engine limits (commonly around 100k-125k items). Single-pass loops avoid both the call stack limits and unnecessary intermediate array creation.
- **📊 Impact**: Prevents application crashes on large datasets, removes O(N) memory allocations for the argument spread and intermediate array creation, and reduces garbage collection pressure during UI operations.
- **🔬 Measurement**: Verify that large time series datasets render without throwing a `RangeError` and that memory profiling shows a reduction in short-lived array allocations.

---
*PR created automatically by Jules for task [13527380483209613963](https://jules.google.com/task/13527380483209613963) started by @dieterolson*