### PR TITLE
⚡ Bolt: Optimize trend axis min/max calculation to prevent stack overflow

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -82,3 +82,6 @@
 ## 2024-05-24 - Avoid chained map and every array iterations for parsing
 **Learning:** Multiple array methods (`.map()`, `.every()`, `.filter()`) chained together for iterating over datasets cause unnecessary intermediate array allocations, adding up to increased garbage collection pressure.
 **Action:** Replace multiple chained array passes with a single-pass `for` loop that pre-allocates arrays or calculates results inline.
+## 2024-08-02 - Spread Operator Bottleneck in Chart Trends
+**Learning:** The `p1am_control_system` trend charts process very large arrays of data points (e.g. in `trendAxis.ts`). Using the spread operator (`Math.min(...values)`) on these arrays allocates significant intermediate memory and can trigger a 'Maximum call stack size exceeded' RangeError.
+**Action:** When calculating min/max bounds for trend axes or parsing large data arrays in the charting utilities, always use a single-pass `for` loop instead of `Math.min(...values)` or `Math.max(...values)`.

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,13 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  // ⚡ Bolt Optimization: Avoid spread operator on large arrays to prevent Maximum call stack size exceeded and intermediate allocations.
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] < lo) lo = values[i];
+    if (values[i] > hi) hi = values[i];
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
- 💡 What: Replace `Math.min(...values)` and `Math.max(...values)` with a single-pass `for` loop in `trendAxis.ts`.
- 🎯 Why: To avoid intermediate memory allocations and 'Maximum call stack size exceeded' RangeErrors when processing large trend chart data arrays.
- 📊 Impact: Eliminates the risk of stack overflow on large arrays and improves execution speed by computing min and max simultaneously in a single pass without spread operator overhead.
- 🔬 Measurement: Observe trend chart rendering performance with large datasets and verify automated test pass rates.

---
*PR created automatically by Jules for task [178333674606999334](https://jules.google.com/task/178333674606999334) started by @dieterolson*