### PR TITLE
feat(scada): add professional Phase B operator experience

### DIFF
--- a/docs/development/professional-scada-epic.md
+++ b/docs/development/professional-scada-epic.md
@@ -89,15 +89,33 @@ than inferred from an available wall clock.
 
 ### Phase B — Professional operator experience
 
-- [ ] F06 generic process overview and reusable high-performance faceplates
-- [ ] F07 interlock, permissive, first-out, and managed-bypass view
-- [ ] F08 historian context, annotations, comparisons, and reporting
-- [ ] F10 asset health, calibration, and maintenance workspace
-- [ ] F13 shift log, run/campaign context, and handover reporting
+- [x] F06 generic process overview and reusable high-performance faceplates
+- [x] F07 interlock, permissive, first-out, and managed-bypass view
+- [x] F08 historian context, annotations, comparisons, and reporting
+- [x] F10 asset health, calibration, and maintenance workspace
+- [x] F13 shift log, run/campaign context, and handover reporting
 
 Exit criterion: an operator can navigate the synthetic process from overview
 to cause, understand abnormal conditions, and hand off unresolved work with
 traceable context.
+
+#### Phase B verification — 2026-08-03
+
+| Feature | Direct evidence |
+| --- | --- |
+| F06 | The machine-marked synthetic feed, reaction, and separation areas use a reusable accessible faceplate contract with value, timestamp, quality, mode, alarm, interlock, asset-detail, and trend-drill-down context. |
+| F07 | Protection definitions preserve control/interlock/independent-protection categories, deterministic group first-out and consequences, and managed bypasses with engineer role, reason, 24-hour maximum expiry, persistent banner flag, automatic expiry, audit-covered REST mutation, and a non-bypassable policy. |
+| F08 | Immutable SQLite-backed saved investigations reproduce time-bounded queries, tag metadata, transformations, charts, annotations, exact events, context, and an explicit preserve-or-exclude bad-data policy. Deterministic ZIP exports carry entry and package SHA-256 values; interpolation is not an accepted policy. |
+| F10 | Deterministic reports cover calibration due, drift, flatline, command/feedback mismatch, noise, runtime, starts, and device statistics. Every finding is explicitly a maintenance advisory with `authoritative_trip=false`. |
+| F13 | SQLite-backed entries attribute author, shift, run, unresolved actions, exact event times, and investigation checksums; search is deterministic. Sign-off hashes the entry and installs database guards against update/delete, while handover acknowledgment is a separate attributable append. |
+
+Phase B release-gate evidence: Ruff, formatting, and strict mypy checks for all
+new domain, persistence, and API modules pass; the complete backend suite passes
+with 995 tests and 6 CI-only dependency checks skipped; all 394 frontend tests,
+TypeScript, and the production bundle pass; ESLint has zero errors and two
+unchanged pre-existing hook warnings. The operator workspace and every new
+record are explicitly synthetic and not a representation of confidential plant
+logic, identifiers, limits, or operating values.
 
 ### Phase C — Reusable control product
 

--- a/src/p1am_control_system/backend/asset_health.py
+++ b/src/p1am_control_system/backend/asset_health.py
@@ -1,0 +1,215 @@
+"""Deterministic synthetic asset statistics and maintenance advisories."""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Callable, Sequence
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("timestamps must include a UTC offset")
+    return value
+
+
+class AdvisoryCode(StrEnum):
+    CALIBRATION_DUE = "calibration_due"
+    DRIFT = "drift"
+    FLATLINE = "flatline"
+    COMMAND_FEEDBACK_MISMATCH = "command_feedback_mismatch"
+    NOISY_SIGNAL = "noisy_signal"
+
+
+class AssetHealthPolicy(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    drift_limit: float = Field(default=2.0, gt=0)
+    flatline_duration: timedelta = timedelta(minutes=5)
+    flatline_span: float = Field(default=0.01, ge=0)
+    mismatch_duration: timedelta = timedelta(seconds=30)
+    noise_standard_deviation: float = Field(default=5.0, gt=0)
+
+    @model_validator(mode="after")
+    def _positive_durations(self) -> AssetHealthPolicy:
+        if self.flatline_duration <= timedelta(0):
+            raise ValueError("flatline_duration must be positive")
+        if self.mismatch_duration <= timedelta(0):
+            raise ValueError("mismatch_duration must be positive")
+        return self
+
+
+class AssetObservation(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    observed_at: datetime
+    value: float
+    reference: float
+    command: bool
+    feedback: bool
+    running: bool
+
+    @field_validator("observed_at")
+    @classmethod
+    def _timestamp_is_aware(cls, value: datetime) -> datetime:
+        return _aware(value)
+
+    @field_validator("value", "reference")
+    @classmethod
+    def _finite_values(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("observation values must be finite")
+        return value
+
+
+class AssetCounters(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    runtime_seconds: float = Field(ge=0)
+    start_count: int = Field(ge=0)
+
+
+class DeviceStatistics(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    sample_count: int = Field(gt=0)
+    minimum: float
+    maximum: float
+    mean: float
+    standard_deviation: float = Field(ge=0)
+
+
+class MaintenanceAdvisory(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    code: AdvisoryCode
+    asset_id: str
+    detected_at: datetime
+    detail: str
+    classification: Literal["maintenance_advisory"] = "maintenance_advisory"
+    authoritative_trip: Literal[False] = False
+
+
+class AssetHealthReport(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    asset_id: str
+    generated_at: datetime
+    counters: AssetCounters
+    statistics: DeviceStatistics
+    advisories: tuple[MaintenanceAdvisory, ...]
+    data_classification: Literal["synthetic"] = "synthetic"
+
+
+class AssetHealthService:
+    def __init__(
+        self,
+        policy: AssetHealthPolicy,
+        now: Callable[[], datetime],
+    ) -> None:
+        self._policy = policy
+        self._now = now
+
+    @staticmethod
+    def _validate_observations(
+        observations: Sequence[AssetObservation],
+    ) -> tuple[AssetObservation, ...]:
+        normalized = tuple(observations)
+        if len(normalized) < 2:
+            raise ValueError("at least two observations are required")
+        if any(
+            current.observed_at <= previous.observed_at
+            for previous, current in zip(normalized, normalized[1:], strict=False)
+        ):
+            raise ValueError("observations must be strictly time ordered")
+        return normalized
+
+    @staticmethod
+    def _counters(observations: tuple[AssetObservation, ...]) -> AssetCounters:
+        runtime = sum(
+            (current.observed_at - previous.observed_at).total_seconds()
+            for previous, current in zip(observations, observations[1:], strict=False)
+            if previous.running
+        )
+        starts = int(observations[0].running) + sum(
+            int(current.running and not previous.running)
+            for previous, current in zip(observations, observations[1:], strict=False)
+        )
+        return AssetCounters(runtime_seconds=runtime, start_count=starts)
+
+    @staticmethod
+    def _mismatch_span(observations: tuple[AssetObservation, ...]) -> timedelta:
+        mismatched = [item for item in observations if item.command != item.feedback]
+        if len(mismatched) < 2:
+            return timedelta(0)
+        trailing: list[AssetObservation] = []
+        for item in reversed(observations):
+            if item.command == item.feedback:
+                break
+            trailing.append(item)
+        if len(trailing) < 2:
+            return timedelta(0)
+        return trailing[0].observed_at - trailing[-1].observed_at
+
+    def assess(
+        self,
+        asset_id: str,
+        observations: Sequence[AssetObservation],
+        *,
+        calibration_due_at: datetime,
+    ) -> AssetHealthReport:
+        if not asset_id.startswith("SYNTHETIC."):
+            raise ValueError("asset_id must begin with SYNTHETIC.")
+        normalized = self._validate_observations(observations)
+        generated_at = _aware(self._now())
+        calibration_due_at = _aware(calibration_due_at)
+        values = [item.value for item in normalized]
+        stats = DeviceStatistics(
+            sample_count=len(values),
+            minimum=min(values),
+            maximum=max(values),
+            mean=statistics.fmean(values),
+            standard_deviation=statistics.pstdev(values),
+        )
+        advisories: list[MaintenanceAdvisory] = []
+
+        def add(code: AdvisoryCode, detail: str) -> None:
+            advisories.append(
+                MaintenanceAdvisory(
+                    code=code,
+                    asset_id=asset_id,
+                    detected_at=generated_at,
+                    detail=detail,
+                )
+            )
+
+        if generated_at >= calibration_due_at:
+            add(AdvisoryCode.CALIBRATION_DUE, "Calibration due date has passed")
+        latest = normalized[-1]
+        if abs(latest.value - latest.reference) > self._policy.drift_limit:
+            add(AdvisoryCode.DRIFT, "Value-to-reference deviation exceeds policy")
+        duration = normalized[-1].observed_at - normalized[0].observed_at
+        if (
+            duration >= self._policy.flatline_duration
+            and stats.maximum - stats.minimum <= self._policy.flatline_span
+        ):
+            add(AdvisoryCode.FLATLINE, "Signal span remains below flatline policy")
+        if self._mismatch_span(normalized) >= self._policy.mismatch_duration:
+            add(
+                AdvisoryCode.COMMAND_FEEDBACK_MISMATCH,
+                "Command and feedback remain inconsistent",
+            )
+        if stats.standard_deviation > self._policy.noise_standard_deviation:
+            add(AdvisoryCode.NOISY_SIGNAL, "Signal variability exceeds noise policy")
+        return AssetHealthReport(
+            asset_id=asset_id,
+            generated_at=generated_at,
+            counters=self._counters(normalized),
+            statistics=stats,
+            advisories=tuple(advisories),
+        )

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -79,6 +79,7 @@ from models import (
     TagLog,
 )
 from mpc import simulate_pid_vs_mpc
+from operator_router import create_operator_router
 from performance import PerformanceConfig, PerformanceController, PerformanceMode
 from pid_tuning import identify_fopdt_and_tune
 from plant_model import TagDefinition
@@ -86,6 +87,7 @@ from plc_factory import PLCFactory
 from poll_runtime import _connect_once, _poll_once
 from power_supply_integration import PowerSupplyService, create_power_supply_router
 from project_import import import_project_archive
+from protection_management import ProtectionService, representative_protections
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from recovery_package import RecoveryPackageService
@@ -326,6 +328,9 @@ control_context = SystemState(alarm_engine_factory=build_alarm_engine)
 control_context.attach_clients(plc_client, backup_simulator)
 professional_alarm_service = AlarmService(
     manager_from_routing(control_context.active_config)
+)
+protection_service = ProtectionService(
+    representative_protections(), now=lambda: datetime.now(UTC)
 )
 
 
@@ -609,6 +614,12 @@ app.include_router(
     create_alarm_router(
         professional_alarm_service,
         operator_dependency=require_api_key,
+        engineer_dependency=require_engineer_key,
+    )
+)
+app.include_router(
+    create_operator_router(
+        protection_service,
         engineer_dependency=require_engineer_key,
     )
 )

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -377,7 +377,9 @@ investigation_service = InvestigationService(
     SqliteInvestigationRepository(_config_session)
 )
 shift_log_service = ShiftLogService(SqliteShiftLogRepository(_config_session))
-asset_health_service = AssetHealthService(AssetHealthPolicy(), now=lambda: datetime.now(UTC))
+asset_health_service = AssetHealthService(
+    AssetHealthPolicy(), now=lambda: datetime.now(UTC)
+)
 
 
 def _representative_asset_health() -> AssetHealthReport:
@@ -406,6 +408,8 @@ def _representative_asset_health() -> AssetHealthReport:
         observations,
         calibration_due_at=now - timedelta(days=1),
     )
+
+
 software_revision = os.environ.get("P1AM_SOFTWARE_REVISION", "development-unidentified")
 recovery_service = RecoveryPackageService(
     configuration_workflow,

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -5,7 +5,7 @@ import shutil
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 try:
     from datetime import UTC
@@ -17,6 +17,12 @@ import historian
 from alarm_router import create_alarm_router
 from alarm_service import AlarmService, manager_from_routing
 from alicat_manager import AlicatManager, AlicatMFC
+from asset_health import (
+    AssetHealthPolicy,
+    AssetHealthReport,
+    AssetHealthService,
+    AssetObservation,
+)
 from audit_middleware import MutationAuditMiddleware
 from audit_router import create_audit_router
 from auth_config import (
@@ -79,6 +85,7 @@ from models import (
     TagLog,
 )
 from mpc import simulate_pid_vs_mpc
+from operations_router import create_operations_router
 from operator_router import create_operator_router
 from performance import PerformanceConfig, PerformanceController, PerformanceMode
 from pid_tuning import identify_fopdt_and_tune
@@ -91,8 +98,11 @@ from protection_management import ProtectionService, representative_protections
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from recovery_package import RecoveryPackageService
+from saved_investigation import InvestigationService, SqliteInvestigationRepository
 from scenario_router import create_scenario_router
 from settings import get_settings
+from shift_log import ShiftLogService
+from shift_log_repository import SqliteShiftLogRepository
 from signal_quality import SignalFrame
 from simulator_client import SimulatedPLCClient
 from sqlmodel import Session, col, select
@@ -363,6 +373,39 @@ configuration_workflow = ConfigurationWorkflow(
     SqliteRevisionRepository(_config_session),
     _deploy_approved_routing,
 )
+investigation_service = InvestigationService(
+    SqliteInvestigationRepository(_config_session)
+)
+shift_log_service = ShiftLogService(SqliteShiftLogRepository(_config_session))
+asset_health_service = AssetHealthService(AssetHealthPolicy(), now=lambda: datetime.now(UTC))
+
+
+def _representative_asset_health() -> AssetHealthReport:
+    """Return invented maintenance context; no field identity or value is used."""
+    now = datetime.now(UTC)
+    observations = (
+        AssetObservation(
+            observed_at=now - timedelta(minutes=10),
+            value=15.0,
+            reference=10.0,
+            command=True,
+            feedback=False,
+            running=True,
+        ),
+        AssetObservation(
+            observed_at=now,
+            value=15.0,
+            reference=10.0,
+            command=True,
+            feedback=False,
+            running=True,
+        ),
+    )
+    return asset_health_service.assess(
+        "SYNTHETIC.FEED.PUMP",
+        observations,
+        calibration_due_at=now - timedelta(days=1),
+    )
 software_revision = os.environ.get("P1AM_SOFTWARE_REVISION", "development-unidentified")
 recovery_service = RecoveryPackageService(
     configuration_workflow,
@@ -621,6 +664,14 @@ app.include_router(
     create_operator_router(
         protection_service,
         engineer_dependency=require_engineer_key,
+    )
+)
+app.include_router(
+    create_operations_router(
+        investigation_service,
+        shift_log_service,
+        asset_report_provider=_representative_asset_health,
+        operator_dependency=require_api_key,
     )
 )
 app.include_router(

--- a/src/p1am_control_system/backend/operations_router.py
+++ b/src/p1am_control_system/backend/operations_router.py
@@ -1,0 +1,132 @@
+"""REST adapter for investigations, asset advisories, and shift handover."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Callable
+
+from asset_health import AssetHealthReport
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from identity import Principal
+from pydantic import BaseModel, ConfigDict, Field
+from saved_investigation import (
+    InvestigationService,
+    InvestigationSpec,
+    SavedInvestigation,
+)
+from shift_log import (
+    HandoverAcknowledgment,
+    ShiftEntry,
+    ShiftEntryDraft,
+    ShiftLogService,
+    ShiftSignoff,
+)
+
+
+class HandoverBody(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    note: str = Field(min_length=1, max_length=1000)
+
+
+def _domain_call(operation: Callable[[], object]) -> object:
+    try:
+        return operation()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+def create_operations_router(
+    investigations: InvestigationService,
+    shifts: ShiftLogService,
+    asset_report_provider: Callable[[], AssetHealthReport],
+    operator_dependency: Callable[..., Principal],
+) -> APIRouter:
+    if not isinstance(investigations, InvestigationService):
+        raise TypeError("investigations must be an InvestigationService")
+    if not isinstance(shifts, ShiftLogService):
+        raise TypeError("shifts must be a ShiftLogService")
+    if not callable(asset_report_provider) or not callable(operator_dependency):
+        raise TypeError("operations providers and dependencies must be callable")
+    router = APIRouter(prefix="/api/operator", tags=["operator-operations"])
+
+    @router.post("/investigations")
+    async def save_investigation(
+        spec: InvestigationSpec,
+        principal: Principal = Depends(operator_dependency),  # noqa: B008
+    ) -> SavedInvestigation:
+        result = _domain_call(lambda: investigations.save(spec, principal))
+        assert isinstance(result, SavedInvestigation)
+        return result
+
+    @router.get("/investigations/{investigation_id}")
+    async def get_investigation(investigation_id: str) -> SavedInvestigation:
+        result = _domain_call(lambda: investigations.get(investigation_id))
+        assert isinstance(result, SavedInvestigation)
+        return result
+
+    @router.get("/investigations/{investigation_id}/export")
+    async def export_investigation(investigation_id: str) -> StreamingResponse:
+        try:
+            artifact = investigations.export(investigation_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return StreamingResponse(
+            io.BytesIO(artifact.payload),
+            media_type="application/zip",
+            headers={
+                "Content-Disposition": (
+                    f'attachment; filename="{investigation_id}-investigation.zip"'
+                ),
+                "X-Artifact-SHA256": artifact.sha256,
+                "X-Investigation-ID": investigation_id,
+            },
+        )
+
+    @router.get("/assets/health/representative")
+    async def representative_asset_health() -> AssetHealthReport:
+        return asset_report_provider()
+
+    @router.post("/shift-log")
+    async def append_shift_entry(
+        draft: ShiftEntryDraft,
+        principal: Principal = Depends(operator_dependency),  # noqa: B008
+    ) -> ShiftEntry:
+        result = _domain_call(lambda: shifts.append(draft, principal))
+        assert isinstance(result, ShiftEntry)
+        return result
+
+    @router.get("/shift-log")
+    async def search_shift_entries(
+        query: str = Query(default="", max_length=200),
+    ) -> list[ShiftEntry]:
+        entries: list[ShiftEntry] = shifts.search(query)
+        return entries
+
+    @router.post("/shift-log/{entry_id}/signoff")
+    async def sign_off_shift_entry(
+        entry_id: str,
+        principal: Principal = Depends(operator_dependency),  # noqa: B008
+    ) -> ShiftSignoff:
+        result = _domain_call(lambda: shifts.sign_off(entry_id, principal))
+        assert isinstance(result, ShiftSignoff)
+        return result
+
+    @router.post("/shift-log/{entry_id}/handover")
+    async def acknowledge_handover(
+        entry_id: str,
+        body: HandoverBody,
+        principal: Principal = Depends(operator_dependency),  # noqa: B008
+    ) -> HandoverAcknowledgment:
+        result = _domain_call(
+            lambda: shifts.acknowledge_handover(entry_id, principal, body.note)
+        )
+        assert isinstance(result, HandoverAcknowledgment)
+        return result
+
+    return router

--- a/src/p1am_control_system/backend/operator_router.py
+++ b/src/p1am_control_system/backend/operator_router.py
@@ -1,0 +1,105 @@
+"""REST adapter for the non-confidential synthetic operator workspace."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from identity import Principal
+from process_overview import ProcessOverview, synthetic_process_overview
+from protection_management import (
+    BypassRequest,
+    ManagedBypass,
+    ProtectionDefinition,
+    ProtectionService,
+    TripRecord,
+)
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TripRequest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    group_id: str = Field(min_length=1, max_length=100)
+
+
+class BypassBody(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    reason: str = Field(min_length=8, max_length=500)
+    expires_at: datetime
+
+
+class ProtectionSnapshot(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    definitions: list[ProtectionDefinition]
+    trips: list[TripRecord]
+    active_bypasses: list[ManagedBypass]
+
+
+def _translate_domain(
+    operation: Callable[[], TripRecord | ManagedBypass],
+) -> TripRecord | ManagedBypass:
+    try:
+        return operation()
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+def create_operator_router(
+    protections: ProtectionService,
+    engineer_dependency: Callable[..., Principal],
+) -> APIRouter:
+    """Build the bounded representative operator API."""
+    if not isinstance(protections, ProtectionService):
+        raise TypeError("protections must be a ProtectionService")
+    if not callable(engineer_dependency):
+        raise TypeError("engineer_dependency must be callable")
+    router = APIRouter(prefix="/api/operator", tags=["operator"])
+
+    @router.get("/overview")
+    async def overview() -> ProcessOverview:
+        return synthetic_process_overview()
+
+    @router.get("/protections")
+    async def protection_snapshot() -> ProtectionSnapshot:
+        return ProtectionSnapshot(
+            definitions=protections.definitions(),
+            trips=protections.trips(),
+            active_bypasses=protections.active_bypasses(),
+        )
+
+    @router.post("/protections/{protection_id}/trips")
+    async def trip(
+        protection_id: str,
+        request: TripRequest,
+        _principal: Principal = Depends(engineer_dependency),  # noqa: B008
+    ) -> TripRecord:
+        return _translate_domain(
+            lambda: protections.trip(protection_id, group_id=request.group_id)
+        )
+
+    @router.post("/protections/{protection_id}/bypasses")
+    async def bypass(
+        protection_id: str,
+        request: BypassBody,
+        principal: Principal = Depends(engineer_dependency),  # noqa: B008
+    ) -> ManagedBypass:
+        return _translate_domain(
+            lambda: protections.request_bypass(
+                BypassRequest(
+                    protection_id=protection_id,
+                    reason=request.reason,
+                    expires_at=request.expires_at,
+                ),
+                principal,
+            )
+        )
+
+    return router

--- a/src/p1am_control_system/backend/process_overview.py
+++ b/src/p1am_control_system/backend/process_overview.py
@@ -1,0 +1,151 @@
+"""Synthetic multi-area process and reusable high-performance faceplate contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+try:
+    from datetime import UTC
+except ImportError:
+    UTC = timezone.utc  # noqa: UP017
+
+SignalQuality = Literal["good", "uncertain", "bad", "stale", "simulated"]
+OperatingMode = Literal["off", "manual", "automatic", "unavailable"]
+AlarmState = Literal["normal", "active", "shelved", "suppressed"]
+InterlockState = Literal["clear", "permissive_missing", "tripped"]
+
+
+def _synthetic_identifier(value: str) -> str:
+    normalized = value.strip()
+    if not normalized.startswith("SYNTHETIC."):
+        raise ValueError("identifiers must begin with SYNTHETIC.")
+    return normalized
+
+
+class FaceplateValue(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    value: float
+    unit: str = Field(min_length=1, max_length=24)
+    source_timestamp: datetime
+
+
+class AssetFaceplate(BaseModel):
+    """One reusable operator-facing asset summary."""
+
+    model_config = ConfigDict(frozen=True)
+
+    asset_id: str
+    label: str = Field(min_length=1, max_length=100)
+    asset_type: Literal["pump", "valve", "vessel", "heater", "separator"]
+    primary_value: FaceplateValue
+    quality: SignalQuality
+    mode: OperatingMode
+    alarm_state: AlarmState
+    interlock_state: InterlockState
+    detail_route: str = Field(pattern=r"^/operator/assets/[A-Za-z0-9._-]+$")
+    trend_tags: tuple[str, ...] = Field(min_length=1)
+
+    _validate_asset_id = field_validator("asset_id")(_synthetic_identifier)
+
+    @field_validator("trend_tags")
+    @classmethod
+    def _validate_trend_tags(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(_synthetic_identifier(value) for value in values)
+
+
+class ProcessArea(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    area_id: str
+    label: str = Field(min_length=1, max_length=100)
+    detail_route: str = Field(pattern=r"^/operator/areas/[A-Za-z0-9._-]+$")
+    assets: tuple[AssetFaceplate, ...] = Field(min_length=1)
+
+    _validate_area_id = field_validator("area_id")(_synthetic_identifier)
+
+
+class ProcessOverview(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    overview_id: str
+    title: str = Field(min_length=1, max_length=200)
+    areas: tuple[ProcessArea, ...] = Field(min_length=2)
+    data_classification: Literal["synthetic"]
+    not_for_live_control: Literal[True]
+
+    _validate_overview_id = field_validator("overview_id")(_synthetic_identifier)
+
+
+def _asset(
+    asset_id: str,
+    label: str,
+    asset_type: Literal["pump", "valve", "vessel", "heater", "separator"],
+    value: float,
+    unit: str,
+    *,
+    mode: OperatingMode = "automatic",
+) -> AssetFaceplate:
+    return AssetFaceplate(
+        asset_id=asset_id,
+        label=label,
+        asset_type=asset_type,
+        primary_value=FaceplateValue(
+            value=value,
+            unit=unit,
+            source_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        ),
+        quality="simulated",
+        mode=mode,
+        alarm_state="normal",
+        interlock_state="clear",
+        detail_route=f"/operator/assets/{asset_id}",
+        trend_tags=(f"{asset_id}.PV", f"{asset_id}.SP"),
+    )
+
+
+def synthetic_process_overview() -> ProcessOverview:
+    """Return the fixed representative process; it contains no plant identifiers."""
+    return ProcessOverview(
+        overview_id="SYNTHETIC.PROCESS",
+        title="Representative Process Overview",
+        data_classification="synthetic",
+        not_for_live_control=True,
+        areas=(
+            ProcessArea(
+                area_id="SYNTHETIC.FEED",
+                label="Feed Preparation",
+                detail_route="/operator/areas/SYNTHETIC.FEED",
+                assets=(
+                    _asset("SYNTHETIC.FEED.PUMP", "Feed Pump", "pump", 62.0, "%"),
+                    _asset("SYNTHETIC.FEED.VALVE", "Feed Valve", "valve", 58.0, "%"),
+                ),
+            ),
+            ProcessArea(
+                area_id="SYNTHETIC.REACTOR",
+                label="Reaction",
+                detail_route="/operator/areas/SYNTHETIC.REACTOR",
+                assets=(
+                    _asset("SYNTHETIC.REACTOR.VESSEL", "Reactor", "vessel", 72.0, "°C"),
+                    _asset("SYNTHETIC.REACTOR.HEATER", "Heater", "heater", 41.0, "%"),
+                ),
+            ),
+            ProcessArea(
+                area_id="SYNTHETIC.SEPARATION",
+                label="Separation",
+                detail_route="/operator/areas/SYNTHETIC.SEPARATION",
+                assets=(
+                    _asset(
+                        "SYNTHETIC.SEPARATION.VESSEL",
+                        "Separator",
+                        "separator",
+                        48.0,
+                        "%",
+                    ),
+                ),
+            ),
+        ),
+    )

--- a/src/p1am_control_system/backend/protection_management.py
+++ b/src/p1am_control_system/backend/protection_management.py
@@ -1,0 +1,168 @@
+"""Synthetic first-out, consequence, and managed-bypass domain."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Literal
+
+from identity import Principal, Role
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def _required_text(value: str, name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} is required")
+    return normalized
+
+
+class ProtectionCategory(StrEnum):
+    CONTROL = "control"
+    INTERLOCK = "interlock"
+    INDEPENDENT_PROTECTION = "independent_protection"
+
+
+class ProtectionDefinition(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    protection_id: str
+    category: ProtectionCategory
+    consequences: tuple[str, ...] = Field(min_length=1)
+    bypassable: bool
+
+    @field_validator("protection_id")
+    @classmethod
+    def _synthetic_only(cls, value: str) -> str:
+        normalized = _required_text(value, "protection_id")
+        if not normalized.startswith("SYNTHETIC."):
+            raise ValueError("protection_id must begin with SYNTHETIC.")
+        return normalized
+
+
+class BypassRequest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    protection_id: str
+    reason: str = Field(min_length=8, max_length=500)
+    expires_at: datetime
+
+    @field_validator("reason")
+    @classmethod
+    def _normalize_reason(cls, value: str) -> str:
+        return _required_text(value, "reason")
+
+
+class TripRecord(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    protection_id: str
+    group_id: str
+    category: ProtectionCategory
+    consequences: tuple[str, ...]
+    occurred_at: datetime
+    first_out: bool
+
+
+class ManagedBypass(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    protection_id: str
+    actor: str
+    reason: str
+    requested_at: datetime
+    expires_at: datetime
+    banner_required: Literal[True] = True
+    active: Literal[True] = True
+
+
+class ProtectionService:
+    """Thread-local domain service; API audit middleware supplies durable audit."""
+
+    def __init__(
+        self,
+        definitions: Sequence[ProtectionDefinition],
+        now: Callable[[], datetime],
+    ) -> None:
+        indexed = {definition.protection_id: definition for definition in definitions}
+        if len(indexed) != len(definitions):
+            raise ValueError("protection identifiers must be unique")
+        self._definitions = indexed
+        self._now = now
+        self._trips: list[TripRecord] = []
+        self._bypasses: list[ManagedBypass] = []
+
+    def _definition(self, protection_id: str) -> ProtectionDefinition:
+        try:
+            return self._definitions[protection_id]
+        except KeyError as exc:
+            raise KeyError(f"unknown protection: {protection_id}") from exc
+
+    def trip(self, protection_id: str, *, group_id: str) -> TripRecord:
+        definition = self._definition(protection_id)
+        normalized_group = _required_text(group_id, "group_id")
+        first_out = not any(
+            record.group_id == normalized_group for record in self._trips
+        )
+        record = TripRecord(
+            protection_id=definition.protection_id,
+            group_id=normalized_group,
+            category=definition.category,
+            consequences=definition.consequences,
+            occurred_at=self._now(),
+            first_out=first_out,
+        )
+        self._trips.append(record)
+        return record
+
+    def request_bypass(
+        self, request: BypassRequest, principal: Principal
+    ) -> ManagedBypass:
+        if principal.role not in {Role.ENGINEER, Role.ADMIN}:
+            raise PermissionError("engineer or admin role required")
+        definition = self._definition(request.protection_id)
+        if not definition.bypassable:
+            raise ValueError("protection policy is non-bypassable")
+        requested_at = self._now()
+        if request.expires_at <= requested_at:
+            raise ValueError("bypass expiry must be in the future")
+        if request.expires_at - requested_at > timedelta(hours=24):
+            raise ValueError("bypass duration cannot exceed 24 hours")
+        bypass = ManagedBypass(
+            protection_id=request.protection_id,
+            actor=principal.subject,
+            reason=request.reason,
+            requested_at=requested_at,
+            expires_at=request.expires_at,
+        )
+        self._bypasses.append(bypass)
+        return bypass
+
+    def active_bypasses(self) -> list[ManagedBypass]:
+        now = self._now()
+        return [bypass for bypass in self._bypasses if bypass.expires_at > now]
+
+    def definitions(self) -> list[ProtectionDefinition]:
+        return list(self._definitions.values())
+
+    def trips(self) -> list[TripRecord]:
+        return list(self._trips)
+
+
+def representative_protections() -> tuple[ProtectionDefinition, ...]:
+    """Non-confidential protection examples for the synthetic process."""
+    return (
+        ProtectionDefinition(
+            protection_id="SYNTHETIC.REACTOR.HIGH_PRESSURE",
+            category=ProtectionCategory.INTERLOCK,
+            consequences=("SYNTHETIC.FEED stops", "SYNTHETIC.VENT opens"),
+            bypassable=True,
+        ),
+        ProtectionDefinition(
+            protection_id="SYNTHETIC.REACTOR.INDEPENDENT_TRIP",
+            category=ProtectionCategory.INDEPENDENT_PROTECTION,
+            consequences=("Synthetic heater power removed",),
+            bypassable=False,
+        ),
+    )

--- a/src/p1am_control_system/backend/saved_investigation.py
+++ b/src/p1am_control_system/backend/saved_investigation.py
@@ -1,0 +1,268 @@
+"""Durable, reproducible historian investigations with explicit bad-data policy."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import uuid
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Literal, Protocol
+
+from identity import Principal, Role
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from sqlmodel import Field as SqlField
+from sqlmodel import Session, SQLModel
+
+try:
+    from datetime import UTC
+except ImportError:
+    UTC = timezone.utc  # noqa: UP017
+
+
+def _synthetic_tag(value: str) -> str:
+    normalized = value.strip()
+    if not normalized.startswith("SYNTHETIC."):
+        raise ValueError("tags and linked records must begin with SYNTHETIC.")
+    return normalized
+
+
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("timestamps must include a UTC offset")
+    return value
+
+
+def _canonical_bytes(model: BaseModel) -> bytes:
+    return json.dumps(
+        model.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+
+
+class BadDataPolicy(StrEnum):
+    PRESERVE = "preserve"
+    EXCLUDE = "exclude"
+
+
+class InvestigationQuery(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    tags: tuple[str, ...] = Field(min_length=1, max_length=64)
+    start: datetime
+    end: datetime
+    max_points: int = Field(ge=10, le=100_000)
+
+    @field_validator("tags")
+    @classmethod
+    def _tags_are_synthetic(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(_synthetic_tag(value) for value in values)
+        if len(set(normalized)) != len(normalized):
+            raise ValueError("query tags must be unique")
+        return normalized
+
+    @field_validator("start", "end")
+    @classmethod
+    def _timestamps_are_aware(cls, value: datetime) -> datetime:
+        return _aware(value)
+
+    @model_validator(mode="after")
+    def _ordered_window(self) -> InvestigationQuery:
+        if self.end <= self.start:
+            raise ValueError("end must be after start")
+        return self
+
+
+class TagMetadata(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    tag: str
+    description: str = Field(min_length=1, max_length=300)
+    unit: str = Field(min_length=1, max_length=24)
+    source: str = Field(min_length=1, max_length=100)
+
+    _tag_is_synthetic = field_validator("tag")(_synthetic_tag)
+
+
+class Transformation(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    operation: Literal["moving_average", "difference", "scale", "offset"]
+    parameters: dict[str, float | int]
+
+
+class ChartDefinition(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    chart_id: str = Field(min_length=1, max_length=100)
+    kind: Literal["trend", "scatter", "histogram"]
+    tags: tuple[str, ...] = Field(min_length=1)
+
+    @field_validator("tags")
+    @classmethod
+    def _chart_tags_are_synthetic(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(_synthetic_tag(value) for value in values)
+
+
+class InvestigationSpec(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    schema_id: Literal["p1am.synthetic-investigation/v1"] = (
+        "p1am.synthetic-investigation/v1"
+    )
+    title: str = Field(min_length=1, max_length=200)
+    query: InvestigationQuery
+    tag_metadata: tuple[TagMetadata, ...] = Field(min_length=1)
+    transformations: tuple[Transformation, ...] = ()
+    charts: tuple[ChartDefinition, ...] = Field(min_length=1)
+    annotations: tuple[str, ...] = ()
+    event_ids: tuple[str, ...] = ()
+    bad_data_policy: BadDataPolicy
+    context: str = Field(min_length=1, max_length=2000)
+    data_classification: Literal["synthetic"] = "synthetic"
+    not_for_live_control: Literal[True] = True
+
+    @field_validator("event_ids")
+    @classmethod
+    def _event_ids_are_synthetic(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(_synthetic_tag(value) for value in values)
+
+    @model_validator(mode="after")
+    def _metadata_covers_query(self) -> InvestigationSpec:
+        metadata_tags = {item.tag for item in self.tag_metadata}
+        if not set(self.query.tags).issubset(metadata_tags):
+            raise ValueError("tag_metadata must cover every query tag")
+        query_tags = set(self.query.tags)
+        if any(not set(chart.tags).issubset(query_tags) for chart in self.charts):
+            raise ValueError("chart tags must be present in the query")
+        return self
+
+
+class SavedInvestigation(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    investigation_id: str
+    version: int = Field(gt=0)
+    spec: InvestigationSpec
+    created_by: str
+    created_at: datetime
+    content_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class InvestigationRecord(SQLModel, table=True):
+    investigation_id: str = SqlField(primary_key=True)
+    created_at: datetime = SqlField(index=True)
+    created_by: str
+    content_sha256: str
+    document_json: str
+
+
+class InvestigationRepository(Protocol):
+    def save(self, investigation: SavedInvestigation) -> None: ...
+
+    def get(self, investigation_id: str) -> SavedInvestigation: ...
+
+
+class SqliteInvestigationRepository:
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session_factory = session_factory
+
+    def save(self, investigation: SavedInvestigation) -> None:
+        record = InvestigationRecord(
+            investigation_id=investigation.investigation_id,
+            created_at=investigation.created_at,
+            created_by=investigation.created_by,
+            content_sha256=investigation.content_sha256,
+            document_json=_canonical_bytes(investigation).decode(),
+        )
+        with self._session_factory() as session:
+            session.add(record)
+            session.commit()
+
+    def get(self, investigation_id: str) -> SavedInvestigation:
+        with self._session_factory() as session:
+            record = session.get(InvestigationRecord, investigation_id)
+            if record is None:
+                raise KeyError(f"unknown investigation: {investigation_id}")
+            return SavedInvestigation.model_validate_json(record.document_json)
+
+
+class InvestigationExportManifest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    schema_id: Literal["p1am.synthetic-investigation-package/v1"] = (
+        "p1am.synthetic-investigation-package/v1"
+    )
+    investigation_id: str
+    entries: dict[str, str]
+    data_classification: Literal["synthetic"] = "synthetic"
+
+
+@dataclass(frozen=True)
+class InvestigationArtifact:
+    payload: bytes = field(repr=False)
+    sha256: str
+    manifest: InvestigationExportManifest
+
+
+def _zip_entry(name: str, payload: bytes) -> tuple[zipfile.ZipInfo, bytes]:
+    info = zipfile.ZipInfo(name, date_time=(1980, 1, 1, 0, 0, 0))
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o600 << 16
+    return info, payload
+
+
+class InvestigationService:
+    def __init__(
+        self,
+        repository: InvestigationRepository,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._repository = repository
+        self._now = now or (lambda: datetime.now(UTC))
+
+    def save(self, spec: InvestigationSpec, principal: Principal) -> SavedInvestigation:
+        if principal.role is Role.VIEWER:
+            raise PermissionError("operator, engineer, or admin role required")
+        created_at = _aware(self._now())
+        content_sha256 = hashlib.sha256(_canonical_bytes(spec)).hexdigest()
+        saved = SavedInvestigation(
+            investigation_id=f"inv-{uuid.uuid4().hex}",
+            version=1,
+            spec=spec,
+            created_by=principal.subject,
+            created_at=created_at,
+            content_sha256=content_sha256,
+        )
+        self._repository.save(saved)
+        return saved
+
+    def get(self, investigation_id: str) -> SavedInvestigation:
+        return self._repository.get(investigation_id)
+
+    def export(self, investigation_id: str) -> InvestigationArtifact:
+        investigation = self.get(investigation_id)
+        investigation_bytes = _canonical_bytes(investigation)
+        manifest = InvestigationExportManifest(
+            investigation_id=investigation_id,
+            entries={
+                "investigation.json": hashlib.sha256(investigation_bytes).hexdigest()
+            },
+        )
+        manifest_bytes = _canonical_bytes(manifest)
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as archive:
+            archive.writestr(*_zip_entry("manifest.json", manifest_bytes))
+            archive.writestr(*_zip_entry("investigation.json", investigation_bytes))
+        payload = buffer.getvalue()
+        return InvestigationArtifact(
+            payload=payload,
+            sha256=hashlib.sha256(payload).hexdigest(),
+            manifest=manifest,
+        )

--- a/src/p1am_control_system/backend/shift_log.py
+++ b/src/p1am_control_system/backend/shift_log.py
@@ -1,0 +1,237 @@
+"""Durable attributable shift entries, sign-off, and handover acknowledgment."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import Literal, Protocol
+
+from identity import Principal, Role
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlmodel import Field as SqlField
+from sqlmodel import SQLModel
+
+try:
+    from datetime import UTC
+except ImportError:
+    UTC = timezone.utc  # noqa: UP017
+
+
+def _synthetic_id(value: str) -> str:
+    normalized = value.strip()
+    if not normalized.startswith("SYNTHETIC."):
+        raise ValueError("linked identifiers must begin with SYNTHETIC.")
+    return normalized
+
+
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("timestamps must include a UTC offset")
+    return value
+
+
+def _restore_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value
+
+
+def _required_text(value: str, name: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} is required")
+    return normalized
+
+
+def _canonical_bytes(model: BaseModel) -> bytes:
+    return json.dumps(
+        model.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+
+
+class EventReference(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    event_id: str
+    occurred_at: datetime
+
+    _event_is_synthetic = field_validator("event_id")(_synthetic_id)
+    _timestamp_is_aware = field_validator("occurred_at")(_aware)
+
+
+class TrendReference(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    investigation_id: str
+    content_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    _investigation_is_synthetic = field_validator("investigation_id")(_synthetic_id)
+
+
+class ShiftEntryDraft(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    shift_id: str
+    run_id: str
+    summary: str = Field(min_length=1, max_length=4000)
+    unresolved_actions: tuple[str, ...] = ()
+    event_references: tuple[EventReference, ...] = ()
+    trend_references: tuple[TrendReference, ...] = ()
+
+    _shift_is_synthetic = field_validator("shift_id")(_synthetic_id)
+    _run_is_synthetic = field_validator("run_id")(_synthetic_id)
+
+    @field_validator("summary")
+    @classmethod
+    def _summary_required(cls, value: str) -> str:
+        return _required_text(value, "summary")
+
+    @field_validator("unresolved_actions")
+    @classmethod
+    def _actions_required(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        return tuple(_required_text(value, "unresolved action") for value in values)
+
+
+class ShiftEntry(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    entry_id: str
+    shift_id: str
+    run_id: str
+    summary: str
+    unresolved_actions: tuple[str, ...]
+    event_references: tuple[EventReference, ...]
+    trend_references: tuple[TrendReference, ...]
+    created_by: str
+    created_at: datetime
+    data_classification: Literal["synthetic"] = "synthetic"
+
+
+class ShiftSignoff(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    entry_id: str
+    signed_by: str
+    signed_at: datetime
+    content_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class HandoverAcknowledgment(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    entry_id: str
+    acknowledged_by: str
+    acknowledged_at: datetime
+    note: str
+
+
+class ShiftEntryRecord(SQLModel, table=True):
+    entry_id: str = SqlField(primary_key=True)
+    shift_id: str = SqlField(index=True)
+    run_id: str = SqlField(index=True)
+    summary: str
+    unresolved_actions_json: str
+    event_references_json: str
+    trend_references_json: str
+    created_by: str = SqlField(index=True)
+    created_at: datetime = SqlField(index=True)
+
+
+class ShiftSignoffRecord(SQLModel, table=True):
+    entry_id: str = SqlField(primary_key=True, foreign_key="shiftentryrecord.entry_id")
+    signed_by: str
+    signed_at: datetime
+    content_sha256: str
+
+
+class HandoverAcknowledgmentRecord(SQLModel, table=True):
+    entry_id: str = SqlField(primary_key=True, foreign_key="shiftentryrecord.entry_id")
+    acknowledged_by: str
+    acknowledged_at: datetime
+    note: str
+
+
+class ShiftLogRepository(Protocol):
+    def append(self, entry: ShiftEntry) -> None: ...
+
+    def get(self, entry_id: str) -> ShiftEntry: ...
+
+    def search(self, query: str) -> list[ShiftEntry]: ...
+
+    def sign_off(self, signoff: ShiftSignoff) -> None: ...
+
+    def signoff(self, entry_id: str) -> ShiftSignoff | None: ...
+
+    def acknowledge(self, acknowledgment: HandoverAcknowledgment) -> None: ...
+
+    def handover(self, entry_id: str) -> HandoverAcknowledgment | None: ...
+
+
+class ShiftLogService:
+    def __init__(
+        self,
+        repository: ShiftLogRepository,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._repository = repository
+        self._now = now or (lambda: datetime.now(UTC))
+
+    @staticmethod
+    def _authorize(principal: Principal) -> None:
+        if principal.role is Role.VIEWER:
+            raise PermissionError("operator, engineer, or admin role required")
+
+    def append(self, draft: ShiftEntryDraft, principal: Principal) -> ShiftEntry:
+        self._authorize(principal)
+        entry = ShiftEntry(
+            entry_id=f"shift-entry-{uuid.uuid4().hex}",
+            **draft.model_dump(),
+            created_by=principal.subject,
+            created_at=_aware(self._now()),
+        )
+        self._repository.append(entry)
+        return entry
+
+    def search(self, query: str) -> list[ShiftEntry]:
+        return self._repository.search(query)
+
+    def sign_off(self, entry_id: str, principal: Principal) -> ShiftSignoff:
+        self._authorize(principal)
+        if self._repository.signoff(entry_id) is not None:
+            raise ValueError("shift entry is already signed off")
+        entry = self._repository.get(entry_id)
+        signoff = ShiftSignoff(
+            entry_id=entry_id,
+            signed_by=principal.subject,
+            signed_at=_aware(self._now()),
+            content_sha256=hashlib.sha256(_canonical_bytes(entry)).hexdigest(),
+        )
+        self._repository.sign_off(signoff)
+        return signoff
+
+    def acknowledge_handover(
+        self,
+        entry_id: str,
+        principal: Principal,
+        note: str,
+    ) -> HandoverAcknowledgment:
+        self._authorize(principal)
+        if self._repository.signoff(entry_id) is None:
+            raise ValueError("shift entry must be signed off before handover")
+        if self._repository.handover(entry_id) is not None:
+            raise ValueError("handover is already acknowledged")
+        acknowledgment = HandoverAcknowledgment(
+            entry_id=entry_id,
+            acknowledged_by=principal.subject,
+            acknowledged_at=_aware(self._now()),
+            note=_required_text(note, "handover note"),
+        )
+        self._repository.acknowledge(acknowledgment)
+        return acknowledgment
+
+    def handover(self, entry_id: str) -> HandoverAcknowledgment | None:
+        return self._repository.handover(entry_id)

--- a/src/p1am_control_system/backend/shift_log_repository.py
+++ b/src/p1am_control_system/backend/shift_log_repository.py
@@ -1,0 +1,150 @@
+"""SQLite persistence and database guards for the shift-log domain."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from shift_log import (
+    EventReference,
+    HandoverAcknowledgment,
+    HandoverAcknowledgmentRecord,
+    ShiftEntry,
+    ShiftEntryRecord,
+    ShiftSignoff,
+    ShiftSignoffRecord,
+    TrendReference,
+    _restore_utc,
+)
+from sqlalchemy import text
+from sqlmodel import Session, col, select
+
+_GUARDS = (
+    """CREATE TRIGGER IF NOT EXISTS signed_shift_entry_no_update
+    BEFORE UPDATE ON shiftentryrecord
+    WHEN EXISTS (SELECT 1 FROM shiftsignoffrecord WHERE entry_id = OLD.entry_id)
+    BEGIN SELECT RAISE(ABORT, 'signed shift entries are append-only'); END""",
+    """CREATE TRIGGER IF NOT EXISTS signed_shift_entry_no_delete
+    BEFORE DELETE ON shiftentryrecord
+    WHEN EXISTS (SELECT 1 FROM shiftsignoffrecord WHERE entry_id = OLD.entry_id)
+    BEGIN SELECT RAISE(ABORT, 'signed shift entries are append-only'); END""",
+    """CREATE TRIGGER IF NOT EXISTS shift_signoff_no_update
+    BEFORE UPDATE ON shiftsignoffrecord
+    BEGIN SELECT RAISE(ABORT, 'shift signoffs are append-only'); END""",
+    """CREATE TRIGGER IF NOT EXISTS shift_signoff_no_delete
+    BEFORE DELETE ON shiftsignoffrecord
+    BEGIN SELECT RAISE(ABORT, 'shift signoffs are append-only'); END""",
+)
+
+
+class SqliteShiftLogRepository:
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session_factory = session_factory
+
+    @staticmethod
+    def _ensure_guards(session: Session) -> None:
+        for statement in _GUARDS:
+            session.execute(text(statement))
+
+    @staticmethod
+    def _entry(record: ShiftEntryRecord) -> ShiftEntry:
+        return ShiftEntry(
+            entry_id=record.entry_id,
+            shift_id=record.shift_id,
+            run_id=record.run_id,
+            summary=record.summary,
+            unresolved_actions=tuple(json.loads(record.unresolved_actions_json)),
+            event_references=tuple(
+                EventReference.model_validate(item)
+                for item in json.loads(record.event_references_json)
+            ),
+            trend_references=tuple(
+                TrendReference.model_validate(item)
+                for item in json.loads(record.trend_references_json)
+            ),
+            created_by=record.created_by,
+            created_at=_restore_utc(record.created_at),
+        )
+
+    def append(self, entry: ShiftEntry) -> None:
+        record = ShiftEntryRecord(
+            entry_id=entry.entry_id,
+            shift_id=entry.shift_id,
+            run_id=entry.run_id,
+            summary=entry.summary,
+            unresolved_actions_json=json.dumps(entry.unresolved_actions),
+            event_references_json=json.dumps(
+                [item.model_dump(mode="json") for item in entry.event_references]
+            ),
+            trend_references_json=json.dumps(
+                [item.model_dump(mode="json") for item in entry.trend_references]
+            ),
+            created_by=entry.created_by,
+            created_at=entry.created_at,
+        )
+        with self._session_factory() as session:
+            self._ensure_guards(session)
+            session.add(record)
+            session.commit()
+
+    def get(self, entry_id: str) -> ShiftEntry:
+        with self._session_factory() as session:
+            record = session.get(ShiftEntryRecord, entry_id)
+            if record is None:
+                raise KeyError(f"unknown shift entry: {entry_id}")
+            return self._entry(record)
+
+    def search(self, query: str) -> list[ShiftEntry]:
+        needle = query.strip().casefold()
+        with self._session_factory() as session:
+            records = session.exec(
+                select(ShiftEntryRecord).order_by(
+                    col(ShiftEntryRecord.created_at).desc()
+                )
+            ).all()
+        entries = [self._entry(record) for record in records]
+        if not needle:
+            return entries
+        return [
+            entry
+            for entry in entries
+            if needle
+            in " ".join(
+                (entry.summary, entry.shift_id, entry.run_id, *entry.unresolved_actions)
+            ).casefold()
+        ]
+
+    def sign_off(self, signoff: ShiftSignoff) -> None:
+        with self._session_factory() as session:
+            self._ensure_guards(session)
+            session.add(ShiftSignoffRecord(**signoff.model_dump()))
+            session.commit()
+
+    def signoff(self, entry_id: str) -> ShiftSignoff | None:
+        with self._session_factory() as session:
+            record = session.get(ShiftSignoffRecord, entry_id)
+            if record is None:
+                return None
+            return ShiftSignoff(
+                entry_id=record.entry_id,
+                signed_by=record.signed_by,
+                signed_at=_restore_utc(record.signed_at),
+                content_sha256=record.content_sha256,
+            )
+
+    def acknowledge(self, acknowledgment: HandoverAcknowledgment) -> None:
+        with self._session_factory() as session:
+            session.add(HandoverAcknowledgmentRecord(**acknowledgment.model_dump()))
+            session.commit()
+
+    def handover(self, entry_id: str) -> HandoverAcknowledgment | None:
+        with self._session_factory() as session:
+            record = session.get(HandoverAcknowledgmentRecord, entry_id)
+            if record is None:
+                return None
+            return HandoverAcknowledgment(
+                entry_id=record.entry_id,
+                acknowledged_by=record.acknowledged_by,
+                acknowledged_at=_restore_utc(record.acknowledged_at),
+                note=record.note,
+            )

--- a/src/p1am_control_system/backend/tests/test_asset_health.py
+++ b/src/p1am_control_system/backend/tests/test_asset_health.py
@@ -1,0 +1,126 @@
+"""F10 contracts for maintainable asset-health advisories."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from asset_health import (
+    AdvisoryCode,
+    AssetHealthPolicy,
+    AssetHealthService,
+    AssetObservation,
+)
+
+
+def _observation(
+    at: datetime,
+    value: float,
+    *,
+    reference: float = 10.0,
+    command: bool = True,
+    feedback: bool = True,
+    running: bool = True,
+) -> AssetObservation:
+    return AssetObservation(
+        observed_at=at,
+        value=value,
+        reference=reference,
+        command=command,
+        feedback=feedback,
+        running=running,
+    )
+
+
+def test_report_detects_calibration_drift_flatline_and_mismatch_as_advisories() -> None:
+    start = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    observations = tuple(
+        _observation(start + timedelta(seconds=index * 10), 15.0, feedback=False)
+        for index in range(7)
+    )
+    service = AssetHealthService(
+        AssetHealthPolicy(
+            drift_limit=2.0,
+            flatline_duration=timedelta(seconds=30),
+            flatline_span=0.01,
+            mismatch_duration=timedelta(seconds=30),
+            noise_standard_deviation=3.0,
+        ),
+        now=lambda: start + timedelta(minutes=2),
+    )
+
+    report = service.assess(
+        "SYNTHETIC.FEED.PUMP",
+        observations,
+        calibration_due_at=start - timedelta(days=1),
+    )
+
+    assert {advisory.code for advisory in report.advisories} == {
+        AdvisoryCode.CALIBRATION_DUE,
+        AdvisoryCode.DRIFT,
+        AdvisoryCode.FLATLINE,
+        AdvisoryCode.COMMAND_FEEDBACK_MISMATCH,
+    }
+    assert all(
+        advisory.classification == "maintenance_advisory"
+        for advisory in report.advisories
+    )
+    assert all(advisory.authoritative_trip is False for advisory in report.advisories)
+    assert report.counters.runtime_seconds == 60
+    assert report.counters.start_count == 1
+    assert report.statistics.sample_count == 7
+
+
+def test_noisy_signal_and_device_statistics_are_reproducible() -> None:
+    start = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    values = (0.0, 20.0, 0.0, 20.0, 0.0)
+    observations = tuple(
+        _observation(start + timedelta(seconds=index), value, reference=value)
+        for index, value in enumerate(values)
+    )
+    service = AssetHealthService(
+        AssetHealthPolicy(
+            drift_limit=2.0,
+            flatline_duration=timedelta(seconds=30),
+            flatline_span=0.01,
+            mismatch_duration=timedelta(seconds=30),
+            noise_standard_deviation=5.0,
+        ),
+        now=lambda: start + timedelta(seconds=5),
+    )
+
+    report = service.assess(
+        "SYNTHETIC.REACTOR.TEMPERATURE",
+        observations,
+        calibration_due_at=start + timedelta(days=1),
+    )
+
+    assert [advisory.code for advisory in report.advisories] == [
+        AdvisoryCode.NOISY_SIGNAL
+    ]
+    assert report.statistics.minimum == 0
+    assert report.statistics.maximum == 20
+    assert report.statistics.mean == 8
+    assert report.statistics.standard_deviation > 5
+
+
+def test_start_counter_distinguishes_transitions_from_runtime() -> None:
+    start = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    observations = (
+        _observation(start, 10, running=False),
+        _observation(start + timedelta(seconds=10), 10, running=True),
+        _observation(start + timedelta(seconds=20), 10, running=True),
+        _observation(start + timedelta(seconds=30), 10, running=False),
+        _observation(start + timedelta(seconds=40), 10, running=True),
+    )
+    service = AssetHealthService(
+        AssetHealthPolicy(), now=lambda: start + timedelta(seconds=40)
+    )
+
+    report = service.assess(
+        "SYNTHETIC.FEED.PUMP",
+        observations,
+        calibration_due_at=start + timedelta(days=1),
+    )
+
+    assert report.counters.start_count == 2
+    assert report.counters.runtime_seconds == 20

--- a/src/p1am_control_system/backend/tests/test_operations_router.py
+++ b/src/p1am_control_system/backend/tests/test_operations_router.py
@@ -1,0 +1,149 @@
+"""REST integration for investigations, asset health, and shift handover."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from asset_health import AssetHealthPolicy, AssetHealthService, AssetObservation
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from identity import Principal, Role
+from operations_router import create_operations_router
+from saved_investigation import InvestigationService, SqliteInvestigationRepository
+from shift_log import ShiftLogService
+from shift_log_repository import SqliteShiftLogRepository
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+
+def _client() -> TestClient:
+    now = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    def factory() -> Session:
+        return Session(engine)
+
+    investigations = InvestigationService(
+        SqliteInvestigationRepository(factory), now=lambda: now
+    )
+    shifts = ShiftLogService(SqliteShiftLogRepository(factory), now=lambda: now)
+    health = AssetHealthService(AssetHealthPolicy(), now=lambda: now)
+    observations = (
+        AssetObservation(
+            observed_at=now - timedelta(minutes=10),
+            value=10,
+            reference=10,
+            command=True,
+            feedback=True,
+            running=True,
+        ),
+        AssetObservation(
+            observed_at=now,
+            value=10,
+            reference=10,
+            command=True,
+            feedback=True,
+            running=True,
+        ),
+    )
+    app = FastAPI()
+    app.include_router(
+        create_operations_router(
+            investigations,
+            shifts,
+            asset_report_provider=lambda: health.assess(
+                "SYNTHETIC.FEED.PUMP",
+                observations,
+                calibration_due_at=now + timedelta(days=1),
+            ),
+            operator_dependency=lambda: Principal(
+                "operator.one", "Operator One", Role.OPERATOR
+            ),
+        )
+    )
+    return TestClient(app)
+
+
+def _investigation() -> dict[str, object]:
+    start = datetime(2026, 8, 3, 19, 0, tzinfo=UTC)
+    return {
+        "title": "Synthetic feed review",
+        "query": {
+            "tags": ["SYNTHETIC.FEED.FLOW"],
+            "start": start.isoformat(),
+            "end": (start + timedelta(hours=1)).isoformat(),
+            "max_points": 1000,
+        },
+        "tag_metadata": [
+            {
+                "tag": "SYNTHETIC.FEED.FLOW",
+                "description": "Representative flow",
+                "unit": "%",
+                "source": "synthetic_driver",
+            }
+        ],
+        "charts": [
+            {
+                "chart_id": "flow",
+                "kind": "trend",
+                "tags": ["SYNTHETIC.FEED.FLOW"],
+            }
+        ],
+        "bad_data_policy": "preserve",
+        "context": "Synthetic only",
+    }
+
+
+def test_investigation_create_fetch_and_checksum_export() -> None:
+    client = _client()
+
+    created = client.post("/api/operator/investigations", json=_investigation())
+    investigation_id = created.json()["investigation_id"]
+    fetched = client.get(f"/api/operator/investigations/{investigation_id}")
+    exported = client.get(f"/api/operator/investigations/{investigation_id}/export")
+
+    assert created.status_code == 200
+    assert fetched.json() == created.json()
+    assert len(exported.headers["X-Artifact-SHA256"]) == 64
+    assert exported.headers["X-Investigation-ID"] == investigation_id
+    assert exported.content.startswith(b"PK")
+
+
+def test_asset_health_report_is_advisory_not_trip() -> None:
+    response = _client().get("/api/operator/assets/health/representative")
+
+    assert response.status_code == 200
+    assert response.json()["asset_id"] == "SYNTHETIC.FEED.PUMP"
+    assert response.json()["data_classification"] == "synthetic"
+
+
+def test_shift_entry_signoff_and_handover_workflow() -> None:
+    client = _client()
+    created = client.post(
+        "/api/operator/shift-log",
+        json={
+            "shift_id": "SYNTHETIC.SHIFT.NIGHT",
+            "run_id": "SYNTHETIC.RUN.0042",
+            "summary": "Synthetic handover entry",
+            "unresolved_actions": ["Review representative calibration"],
+            "event_references": [],
+            "trend_references": [],
+        },
+    )
+    entry_id = created.json()["entry_id"]
+    signoff = client.post(f"/api/operator/shift-log/{entry_id}/signoff")
+    handover = client.post(
+        f"/api/operator/shift-log/{entry_id}/handover",
+        json={"note": "Accepted by receiving synthetic shift"},
+    )
+    search = client.get("/api/operator/shift-log", params={"query": "handover"})
+
+    assert created.status_code == 200
+    assert len(signoff.json()["content_sha256"]) == 64
+    assert handover.json()["acknowledged_by"] == "operator.one"
+    assert search.json()[0]["entry_id"] == entry_id

--- a/src/p1am_control_system/backend/tests/test_operator_router.py
+++ b/src/p1am_control_system/backend/tests/test_operator_router.py
@@ -1,0 +1,78 @@
+"""REST contracts for the synthetic operator workspace."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from identity import Principal, Role
+from operator_router import create_operator_router
+from protection_management import ProtectionService, representative_protections
+
+
+def _client(role: Role = Role.ENGINEER) -> tuple[TestClient, ProtectionService]:
+    now = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    service = ProtectionService(representative_protections(), now=lambda: now)
+    app = FastAPI()
+    app.include_router(
+        create_operator_router(
+            service,
+            engineer_dependency=lambda: Principal("engineer", "Engineer", role),
+        )
+    )
+    return TestClient(app), service
+
+
+def test_overview_is_explicitly_synthetic_and_multi_area() -> None:
+    client, _ = _client()
+
+    response = client.get("/api/operator/overview")
+
+    assert response.status_code == 200
+    assert response.json()["data_classification"] == "synthetic"
+    assert len(response.json()["areas"]) == 3
+
+
+def test_trip_and_bypass_endpoints_return_operator_context() -> None:
+    client, _ = _client()
+
+    trip = client.post(
+        "/api/operator/protections/SYNTHETIC.REACTOR.HIGH_PRESSURE/trips",
+        json={"group_id": "fat-trip-1"},
+    )
+    bypass = client.post(
+        "/api/operator/protections/SYNTHETIC.REACTOR.HIGH_PRESSURE/bypasses",
+        json={
+            "reason": "Synthetic FAT verification",
+            "expires_at": (
+                datetime(2026, 8, 3, 20, 0, tzinfo=UTC) + timedelta(hours=1)
+            ).isoformat(),
+        },
+    )
+    snapshot = client.get("/api/operator/protections")
+
+    assert trip.status_code == 200
+    assert trip.json()["first_out"] is True
+    assert bypass.status_code == 200
+    assert bypass.json()["banner_required"] is True
+    assert (
+        snapshot.json()["active_bypasses"][0]["reason"] == "Synthetic FAT verification"
+    )
+
+
+def test_non_bypassable_endpoint_maps_policy_conflict() -> None:
+    client, _ = _client()
+
+    response = client.post(
+        "/api/operator/protections/SYNTHETIC.REACTOR.INDEPENDENT_TRIP/bypasses",
+        json={
+            "reason": "Attempted synthetic bypass",
+            "expires_at": (
+                datetime(2026, 8, 3, 20, 0, tzinfo=UTC) + timedelta(hours=1)
+            ).isoformat(),
+        },
+    )
+
+    assert response.status_code == 409
+    assert "non-bypassable" in response.json()["detail"]

--- a/src/p1am_control_system/backend/tests/test_process_overview.py
+++ b/src/p1am_control_system/backend/tests/test_process_overview.py
@@ -1,0 +1,56 @@
+"""F06 contracts for a reusable, synthetic process navigation model."""
+
+from __future__ import annotations
+
+import pytest
+from process_overview import (
+    AssetFaceplate,
+    ProcessOverview,
+    synthetic_process_overview,
+)
+
+
+def test_synthetic_overview_supports_progressive_multi_area_navigation() -> None:
+    overview = synthetic_process_overview()
+
+    assert overview.data_classification == "synthetic"
+    assert overview.not_for_live_control is True
+    assert [area.area_id for area in overview.areas] == [
+        "SYNTHETIC.FEED",
+        "SYNTHETIC.REACTOR",
+        "SYNTHETIC.SEPARATION",
+    ]
+    assert all(area.assets for area in overview.areas)
+    assert all(
+        asset.detail_route.startswith("/operator/assets/")
+        for area in overview.areas
+        for asset in area.assets
+    )
+    assert all(asset.trend_tags for area in overview.areas for asset in area.assets)
+
+
+def test_faceplate_exposes_consistent_operator_context() -> None:
+    asset = synthetic_process_overview().areas[1].assets[0]
+
+    assert asset.quality in {"good", "uncertain", "bad", "stale", "simulated"}
+    assert asset.mode in {"off", "manual", "automatic", "unavailable"}
+    assert asset.alarm_state in {"normal", "active", "shelved", "suppressed"}
+    assert asset.interlock_state in {"clear", "permissive_missing", "tripped"}
+    assert asset.primary_value.unit
+    assert asset.primary_value.source_timestamp is not None
+
+
+def test_overview_rejects_non_synthetic_identifiers() -> None:
+    asset = synthetic_process_overview().areas[0].assets[0]
+
+    with pytest.raises(ValueError, match="SYNTHETIC"):
+        ProcessOverview(
+            overview_id="PLANT.CONFIDENTIAL",
+            title="Invalid",
+            areas=synthetic_process_overview().areas,
+            data_classification="synthetic",
+            not_for_live_control=True,
+        )
+
+    with pytest.raises(ValueError, match="SYNTHETIC"):
+        AssetFaceplate(**{**asset.model_dump(), "asset_id": "REAL.TAG"})

--- a/src/p1am_control_system/backend/tests/test_protection_management.py
+++ b/src/p1am_control_system/backend/tests/test_protection_management.py
@@ -1,0 +1,125 @@
+"""F07 contracts for first-out capture and managed synthetic bypasses."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from identity import Principal, Role
+from protection_management import (
+    BypassRequest,
+    ProtectionCategory,
+    ProtectionDefinition,
+    ProtectionService,
+)
+
+UTC = UTC
+
+
+def principal(role: Role) -> Principal:
+    return Principal(subject=f"user.{role}", display_name=str(role).title(), role=role)
+
+
+def service(now: datetime) -> ProtectionService:
+    return ProtectionService(
+        definitions=(
+            ProtectionDefinition(
+                protection_id="SYNTHETIC.REACTOR.HIGH_PRESSURE",
+                category=ProtectionCategory.INTERLOCK,
+                consequences=("SYNTHETIC.FEED stops", "SYNTHETIC.VENT opens"),
+                bypassable=True,
+            ),
+            ProtectionDefinition(
+                protection_id="SYNTHETIC.REACTOR.INDEPENDENT_TRIP",
+                category=ProtectionCategory.INDEPENDENT_PROTECTION,
+                consequences=("Synthetic heater power removed",),
+                bypassable=False,
+            ),
+        ),
+        now=lambda: now,
+    )
+
+
+def test_trip_group_preserves_first_out_and_consequences() -> None:
+    now = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    protections = service(now)
+
+    first = protections.trip("SYNTHETIC.REACTOR.HIGH_PRESSURE", group_id="trip-1")
+    second = protections.trip("SYNTHETIC.REACTOR.INDEPENDENT_TRIP", group_id="trip-1")
+
+    assert first.first_out is True
+    assert second.first_out is False
+    assert first.consequences == ("SYNTHETIC.FEED stops", "SYNTHETIC.VENT opens")
+    assert second.category is ProtectionCategory.INDEPENDENT_PROTECTION
+
+
+def test_managed_bypass_requires_role_reason_expiry_and_banner() -> None:
+    now = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    protections = service(now)
+    request = BypassRequest(
+        protection_id="SYNTHETIC.REACTOR.HIGH_PRESSURE",
+        reason="Synthetic FAT verification",
+        expires_at=now + timedelta(hours=2),
+    )
+
+    with pytest.raises(PermissionError):
+        protections.request_bypass(request, principal(Role.OPERATOR))
+
+    bypass = protections.request_bypass(request, principal(Role.ENGINEER))
+
+    assert bypass.active is True
+    assert bypass.banner_required is True
+    assert bypass.actor == "user.engineer"
+    assert bypass.reason == "Synthetic FAT verification"
+    assert protections.active_bypasses() == [bypass]
+
+
+def test_non_bypassable_policy_and_expiry_are_fail_closed() -> None:
+    now = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    protections = service(now)
+
+    with pytest.raises(ValueError, match="non-bypassable"):
+        protections.request_bypass(
+            BypassRequest(
+                protection_id="SYNTHETIC.REACTOR.INDEPENDENT_TRIP",
+                reason="Not permitted",
+                expires_at=now + timedelta(minutes=5),
+            ),
+            principal(Role.ADMIN),
+        )
+
+    with pytest.raises(ValueError, match="future"):
+        protections.request_bypass(
+            BypassRequest(
+                protection_id="SYNTHETIC.REACTOR.HIGH_PRESSURE",
+                reason="Expired request",
+                expires_at=now,
+            ),
+            principal(Role.ENGINEER),
+        )
+
+
+def test_expired_bypass_is_not_reported_active() -> None:
+    clock = [datetime(2026, 8, 3, 20, 0, tzinfo=UTC)]
+    protections = ProtectionService(
+        definitions=(
+            ProtectionDefinition(
+                protection_id="SYNTHETIC.PUMP.LOW_FLOW",
+                category=ProtectionCategory.INTERLOCK,
+                consequences=("Synthetic pump stops",),
+                bypassable=True,
+            ),
+        ),
+        now=lambda: clock[0],
+    )
+    protections.request_bypass(
+        BypassRequest(
+            protection_id="SYNTHETIC.PUMP.LOW_FLOW",
+            reason="Timed synthetic test",
+            expires_at=clock[0] + timedelta(minutes=1),
+        ),
+        principal(Role.ENGINEER),
+    )
+
+    clock[0] += timedelta(minutes=2)
+    assert protections.active_bypasses() == []

--- a/src/p1am_control_system/backend/tests/test_saved_investigation.py
+++ b/src/p1am_control_system/backend/tests/test_saved_investigation.py
@@ -1,0 +1,138 @@
+"""F08 reproducible historian-investigation contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import zipfile
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from identity import Principal, Role
+from saved_investigation import (
+    BadDataPolicy,
+    ChartDefinition,
+    InvestigationQuery,
+    InvestigationService,
+    InvestigationSpec,
+    SqliteInvestigationRepository,
+    TagMetadata,
+    Transformation,
+)
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+
+def _service() -> InvestigationService:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    return InvestigationService(SqliteInvestigationRepository(lambda: Session(engine)))
+
+
+def _spec() -> InvestigationSpec:
+    start = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    return InvestigationSpec(
+        title="Synthetic temperature excursion review",
+        query=InvestigationQuery(
+            tags=("SYNTHETIC.REACTOR.TEMPERATURE", "SYNTHETIC.REACTOR.SETPOINT"),
+            start=start,
+            end=start + timedelta(hours=1),
+            max_points=4000,
+        ),
+        tag_metadata=(
+            TagMetadata(
+                tag="SYNTHETIC.REACTOR.TEMPERATURE",
+                description="Representative reactor temperature",
+                unit="°C",
+                source="synthetic_driver",
+            ),
+            TagMetadata(
+                tag="SYNTHETIC.REACTOR.SETPOINT",
+                description="Representative target",
+                unit="°C",
+                source="synthetic_driver",
+            ),
+        ),
+        transformations=(
+            Transformation(operation="moving_average", parameters={"window": 5}),
+        ),
+        charts=(
+            ChartDefinition(
+                chart_id="temperature-context",
+                kind="trend",
+                tags=("SYNTHETIC.REACTOR.TEMPERATURE",),
+            ),
+        ),
+        annotations=("Synthetic trip at 20:23 UTC",),
+        event_ids=("SYNTHETIC.EVENT.0001",),
+        bad_data_policy=BadDataPolicy.PRESERVE,
+        context="Representative demonstration; no plant records.",
+    )
+
+
+def test_saved_investigation_round_trip_reproduces_complete_context() -> None:
+    service = _service()
+    principal = Principal("analyst", "Analyst", Role.ENGINEER)
+
+    saved = service.save(_spec(), principal)
+    restored = service.get(saved.investigation_id)
+
+    assert restored == saved
+    assert restored.created_by == "analyst"
+    assert restored.spec.query.tags == _spec().query.tags
+    assert restored.spec.tag_metadata == _spec().tag_metadata
+    assert restored.spec.transformations == _spec().transformations
+    assert restored.spec.charts == _spec().charts
+    assert restored.spec.annotations == _spec().annotations
+    assert restored.spec.event_ids == _spec().event_ids
+    assert restored.spec.bad_data_policy is BadDataPolicy.PRESERVE
+    assert len(restored.content_sha256) == 64
+
+
+def test_export_package_has_reproducible_checksums() -> None:
+    service = _service()
+    saved = service.save(_spec(), Principal("analyst", "Analyst", Role.ENGINEER))
+
+    artifact = service.export(saved.investigation_id)
+
+    assert hashlib.sha256(artifact.payload).hexdigest() == artifact.sha256
+    with zipfile.ZipFile(io.BytesIO(artifact.payload)) as archive:
+        assert set(archive.namelist()) == {"manifest.json", "investigation.json"}
+        investigation_bytes = archive.read("investigation.json")
+        assert (
+            hashlib.sha256(investigation_bytes).hexdigest()
+            == artifact.manifest.entries["investigation.json"]
+        )
+        assert b"Synthetic temperature excursion review" in investigation_bytes
+
+
+def test_bad_data_cannot_be_silently_interpolated() -> None:
+    payload = _spec().model_dump()
+    payload["bad_data_policy"] = "interpolate"
+
+    with pytest.raises(ValueError):
+        InvestigationSpec.model_validate(payload)
+
+
+def test_query_rejects_non_synthetic_tags_and_inverted_time() -> None:
+    start = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+
+    with pytest.raises(ValueError, match="SYNTHETIC"):
+        InvestigationQuery(
+            tags=("REAL.PLANT.TAG",),
+            start=start,
+            end=start + timedelta(minutes=1),
+            max_points=100,
+        )
+
+    with pytest.raises(ValueError, match="after start"):
+        InvestigationQuery(
+            tags=("SYNTHETIC.TAG",),
+            start=start,
+            end=start,
+            max_points=100,
+        )

--- a/src/p1am_control_system/backend/tests/test_shift_log.py
+++ b/src/p1am_control_system/backend/tests/test_shift_log.py
@@ -1,0 +1,121 @@
+"""F13 attributable shift-log and handover contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from identity import Principal, Role
+from shift_log import (
+    EventReference,
+    ShiftEntryDraft,
+    ShiftLogService,
+    TrendReference,
+)
+from shift_log_repository import SqliteShiftLogRepository
+from sqlalchemy import text
+from sqlalchemy.exc import DatabaseError
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+
+def _fixture() -> tuple[ShiftLogService, object, callable]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    def factory() -> Session:
+        return Session(engine)
+
+    service = ShiftLogService(
+        SqliteShiftLogRepository(factory),
+        now=lambda: datetime(2026, 8, 3, 20, 0, tzinfo=UTC),
+    )
+    return service, engine, factory
+
+
+def _draft() -> ShiftEntryDraft:
+    return ShiftEntryDraft(
+        shift_id="SYNTHETIC.SHIFT.2026-08-03-NIGHT",
+        run_id="SYNTHETIC.RUN.0042",
+        summary="Representative reactor temperature excursion reviewed.",
+        unresolved_actions=("Verify synthetic temperature calibration",),
+        event_references=(
+            EventReference(
+                event_id="SYNTHETIC.EVENT.0001",
+                occurred_at=datetime(2026, 8, 3, 19, 50, tzinfo=UTC),
+            ),
+        ),
+        trend_references=(
+            TrendReference(
+                investigation_id="SYNTHETIC.INVESTIGATION.0001",
+                content_sha256="a" * 64,
+            ),
+        ),
+    )
+
+
+def _principal(subject: str) -> Principal:
+    return Principal(subject, subject.title(), Role.OPERATOR)
+
+
+def test_entry_is_attributable_searchable_and_exactly_linked() -> None:
+    service, _, _ = _fixture()
+
+    entry = service.append(_draft(), _principal("operator.one"))
+    results = service.search("temperature")
+
+    assert results == [entry]
+    assert entry.created_by == "operator.one"
+    assert entry.event_references[0].event_id == "SYNTHETIC.EVENT.0001"
+    assert entry.trend_references[0].content_sha256 == "a" * 64
+    assert entry.unresolved_actions == ("Verify synthetic temperature calibration",)
+
+
+def test_signoff_makes_entry_append_only_even_below_service_layer() -> None:
+    service, _, factory = _fixture()
+    entry = service.append(_draft(), _principal("operator.one"))
+
+    signoff = service.sign_off(entry.entry_id, _principal("operator.one"))
+
+    assert len(signoff.content_sha256) == 64
+    with factory() as session:
+        with pytest.raises(DatabaseError, match="signed shift entries are append-only"):
+            session.exec(
+                text(
+                    "UPDATE shiftentryrecord SET summary='tampered' WHERE entry_id=:id"
+                ),
+                params={"id": entry.entry_id},
+            )
+            session.commit()
+
+
+def test_handover_acknowledgment_is_explicit_and_attributable() -> None:
+    service, _, _ = _fixture()
+    entry = service.append(_draft(), _principal("operator.one"))
+    service.sign_off(entry.entry_id, _principal("operator.one"))
+
+    acknowledgment = service.acknowledge_handover(
+        entry.entry_id,
+        _principal("operator.two"),
+        "Unresolved calibration check accepted",
+    )
+
+    assert acknowledgment.acknowledged_by == "operator.two"
+    assert acknowledgment.note == "Unresolved calibration check accepted"
+    assert service.handover(entry.entry_id) == acknowledgment
+
+
+def test_unsigned_entry_cannot_be_acknowledged() -> None:
+    service, _, _ = _fixture()
+    entry = service.append(_draft(), _principal("operator.one"))
+
+    with pytest.raises(ValueError, match="signed off"):
+        service.acknowledge_handover(
+            entry.entry_id,
+            _principal("operator.two"),
+            "Premature acknowledgment",
+        )

--- a/src/p1am_control_system/frontend/src/App.tsx
+++ b/src/p1am_control_system/frontend/src/App.tsx
@@ -88,6 +88,11 @@ const PlantHierarchy = lazy(() =>
     default: m.PlantHierarchy,
   })),
 );
+const OperatorWorkspace = lazy(() =>
+  import("./components/OperatorWorkspace").then((m) => ({
+    default: m.OperatorWorkspace,
+  })),
+);
 
 // Re-export domain types for back-compat with existing importers (AlarmsHeader,
 // EventLogView, InterlocksPanel, RoutingMatrix, ControlDashboard).
@@ -796,6 +801,10 @@ export const App: React.FC = () => {
               </div>
             }
           >
+          {activeTab === "operator" && visibleTabs.operator && (
+            <OperatorWorkspace />
+          )}
+
           {activeTab === "powerSupply" && visibleTabs.powerSupply && (
             <PowerSupplyControl
               liveStatus={powerSupplyStatus}

--- a/src/p1am_control_system/frontend/src/api/endpoints.ts
+++ b/src/p1am_control_system/frontend/src/api/endpoints.ts
@@ -17,6 +17,8 @@ import {
   configurationRevisionSchema,
   configurationRevisionsSchema,
   systemHealthSchema,
+  processOverviewSchema,
+  protectionSnapshotSchema,
   type CaptureStatus,
   type CaptureClearResult,
   type CaptureConfig,
@@ -33,6 +35,8 @@ import {
   type ConfigurationDiffEntry,
   type ConfigurationRevision,
   type SystemHealth,
+  type ProcessOverview,
+  type ProtectionSnapshot,
 } from "./schemas";
 
 /**
@@ -117,6 +121,16 @@ export function rollbackConfiguration(
 
 export function getSystemHealth(): Promise<SystemHealth> {
   return apiFetch("/system/health", { schema: systemHealthSchema });
+}
+
+// --- Representative operator workspace -------------------------------------
+
+export function getOperatorOverview(): Promise<ProcessOverview> {
+  return apiFetch("/operator/overview", { schema: processOverviewSchema });
+}
+
+export function getProtectionSnapshot(): Promise<ProtectionSnapshot> {
+  return apiFetch("/operator/protections", { schema: protectionSnapshotSchema });
 }
 
 export type RecoveryDownload = {

--- a/src/p1am_control_system/frontend/src/api/endpoints.ts
+++ b/src/p1am_control_system/frontend/src/api/endpoints.ts
@@ -19,6 +19,8 @@ import {
   systemHealthSchema,
   processOverviewSchema,
   protectionSnapshotSchema,
+  assetHealthReportSchema,
+  shiftEntriesSchema,
   type CaptureStatus,
   type CaptureClearResult,
   type CaptureConfig,
@@ -37,6 +39,8 @@ import {
   type SystemHealth,
   type ProcessOverview,
   type ProtectionSnapshot,
+  type AssetHealthReport,
+  type ShiftEntry,
 } from "./schemas";
 
 /**
@@ -131,6 +135,18 @@ export function getOperatorOverview(): Promise<ProcessOverview> {
 
 export function getProtectionSnapshot(): Promise<ProtectionSnapshot> {
   return apiFetch("/operator/protections", { schema: protectionSnapshotSchema });
+}
+
+export function getRepresentativeAssetHealth(): Promise<AssetHealthReport> {
+  return apiFetch("/operator/assets/health/representative", {
+    schema: assetHealthReportSchema,
+  });
+}
+
+export function getShiftEntries(query = ""): Promise<ShiftEntry[]> {
+  return apiFetch(`/operator/shift-log?query=${encodeURIComponent(query)}`, {
+    schema: shiftEntriesSchema,
+  });
 }
 
 export type RecoveryDownload = {

--- a/src/p1am_control_system/frontend/src/api/schemas.ts
+++ b/src/p1am_control_system/frontend/src/api/schemas.ts
@@ -246,6 +246,61 @@ export type AssetFaceplate = z.infer<typeof assetFaceplateSchema>;
 export type ProcessOverview = z.infer<typeof processOverviewSchema>;
 export type ProtectionSnapshot = z.infer<typeof protectionSnapshotSchema>;
 
+export const assetHealthReportSchema = z.object({
+  asset_id: z.string().startsWith("SYNTHETIC."),
+  generated_at: z.string(),
+  counters: z.object({
+    runtime_seconds: z.number().nonnegative(),
+    start_count: z.number().int().nonnegative(),
+  }),
+  statistics: z.object({
+    sample_count: z.number().int().positive(),
+    minimum: z.number(),
+    maximum: z.number(),
+    mean: z.number(),
+    standard_deviation: z.number().nonnegative(),
+  }),
+  advisories: z.array(
+    z.object({
+      code: z.enum([
+        "calibration_due",
+        "drift",
+        "flatline",
+        "command_feedback_mismatch",
+        "noisy_signal",
+      ]),
+      asset_id: z.string().startsWith("SYNTHETIC."),
+      detected_at: z.string(),
+      detail: z.string(),
+      classification: z.literal("maintenance_advisory"),
+      authoritative_trip: z.literal(false),
+    }),
+  ),
+  data_classification: z.literal("synthetic"),
+});
+export const shiftEntrySchema = z.object({
+  entry_id: z.string(),
+  shift_id: z.string().startsWith("SYNTHETIC."),
+  run_id: z.string().startsWith("SYNTHETIC."),
+  summary: z.string(),
+  unresolved_actions: z.array(z.string()),
+  event_references: z.array(
+    z.object({ event_id: z.string().startsWith("SYNTHETIC."), occurred_at: z.string() }),
+  ),
+  trend_references: z.array(
+    z.object({
+      investigation_id: z.string().startsWith("SYNTHETIC."),
+      content_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+    }),
+  ),
+  created_by: z.string(),
+  created_at: z.string(),
+  data_classification: z.literal("synthetic"),
+});
+export const shiftEntriesSchema = z.array(shiftEntrySchema);
+export type AssetHealthReport = z.infer<typeof assetHealthReportSchema>;
+export type ShiftEntry = z.infer<typeof shiftEntrySchema>;
+
 /**
  * Live telemetry frame pushed over the `/api/stream` WebSocket.
  *

--- a/src/p1am_control_system/frontend/src/api/schemas.ts
+++ b/src/p1am_control_system/frontend/src/api/schemas.ts
@@ -181,6 +181,71 @@ export const systemHealthSchema = z.object({
 export type DeploymentIdentity = z.infer<typeof deploymentIdentitySchema>;
 export type SystemHealth = z.infer<typeof systemHealthSchema>;
 
+// --- Representative operator workspace -------------------------------------
+
+export const faceplateValueSchema = z.object({
+  value: z.number(),
+  unit: z.string().min(1),
+  source_timestamp: z.string(),
+});
+export const assetFaceplateSchema = z.object({
+  asset_id: z.string().startsWith("SYNTHETIC."),
+  label: z.string(),
+  asset_type: z.enum(["pump", "valve", "vessel", "heater", "separator"]),
+  primary_value: faceplateValueSchema,
+  quality: z.enum(["good", "uncertain", "bad", "stale", "simulated"]),
+  mode: z.enum(["off", "manual", "automatic", "unavailable"]),
+  alarm_state: z.enum(["normal", "active", "shelved", "suppressed"]),
+  interlock_state: z.enum(["clear", "permissive_missing", "tripped"]),
+  detail_route: z.string(),
+  trend_tags: z.array(z.string().startsWith("SYNTHETIC.")).min(1),
+});
+export const processOverviewSchema = z.object({
+  overview_id: z.string().startsWith("SYNTHETIC."),
+  title: z.string(),
+  areas: z.array(
+    z.object({
+      area_id: z.string().startsWith("SYNTHETIC."),
+      label: z.string(),
+      detail_route: z.string(),
+      assets: z.array(assetFaceplateSchema),
+    }),
+  ),
+  data_classification: z.literal("synthetic"),
+  not_for_live_control: z.literal(true),
+});
+export const protectionDefinitionSchema = z.object({
+  protection_id: z.string().startsWith("SYNTHETIC."),
+  category: z.enum(["control", "interlock", "independent_protection"]),
+  consequences: z.array(z.string()).min(1),
+  bypassable: z.boolean(),
+});
+export const tripRecordSchema = z.object({
+  protection_id: z.string().startsWith("SYNTHETIC."),
+  group_id: z.string(),
+  category: z.enum(["control", "interlock", "independent_protection"]),
+  consequences: z.array(z.string()),
+  occurred_at: z.string(),
+  first_out: z.boolean(),
+});
+export const managedBypassSchema = z.object({
+  protection_id: z.string().startsWith("SYNTHETIC."),
+  actor: z.string(),
+  reason: z.string(),
+  requested_at: z.string(),
+  expires_at: z.string(),
+  banner_required: z.literal(true),
+  active: z.literal(true),
+});
+export const protectionSnapshotSchema = z.object({
+  definitions: z.array(protectionDefinitionSchema),
+  trips: z.array(tripRecordSchema),
+  active_bypasses: z.array(managedBypassSchema),
+});
+export type AssetFaceplate = z.infer<typeof assetFaceplateSchema>;
+export type ProcessOverview = z.infer<typeof processOverviewSchema>;
+export type ProtectionSnapshot = z.infer<typeof protectionSnapshotSchema>;
+
 /**
  * Live telemetry frame pushed over the `/api/stream` WebSocket.
  *

--- a/src/p1am_control_system/frontend/src/components/OperatorWorkspace.test.tsx
+++ b/src/p1am_control_system/frontend/src/components/OperatorWorkspace.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "../api/endpoints";
+import { OperatorWorkspace } from "./OperatorWorkspace";
+
+vi.mock("../api/endpoints", () => ({
+  getOperatorOverview: vi.fn(),
+  getProtectionSnapshot: vi.fn(),
+}));
+
+const overview = {
+  overview_id: "SYNTHETIC.PROCESS",
+  title: "Representative Process Overview",
+  data_classification: "synthetic" as const,
+  not_for_live_control: true as const,
+  areas: [
+    {
+      area_id: "SYNTHETIC.FEED",
+      label: "Feed Preparation",
+      detail_route: "/operator/areas/SYNTHETIC.FEED",
+      assets: [
+        {
+          asset_id: "SYNTHETIC.FEED.PUMP",
+          label: "Feed Pump",
+          asset_type: "pump" as const,
+          primary_value: {
+            value: 62,
+            unit: "%",
+            source_timestamp: "2026-08-03T20:00:00Z",
+          },
+          quality: "simulated" as const,
+          mode: "automatic" as const,
+          alarm_state: "normal" as const,
+          interlock_state: "clear" as const,
+          detail_route: "/operator/assets/SYNTHETIC.FEED.PUMP",
+          trend_tags: ["SYNTHETIC.FEED.PUMP.PV"],
+        },
+      ],
+    },
+    {
+      area_id: "SYNTHETIC.REACTOR",
+      label: "Reaction",
+      detail_route: "/operator/areas/SYNTHETIC.REACTOR",
+      assets: [],
+    },
+    {
+      area_id: "SYNTHETIC.SEPARATION",
+      label: "Separation",
+      detail_route: "/operator/areas/SYNTHETIC.SEPARATION",
+      assets: [],
+    },
+  ],
+};
+
+const protections = {
+  definitions: [
+    {
+      protection_id: "SYNTHETIC.REACTOR.HIGH_PRESSURE",
+      category: "interlock" as const,
+      consequences: ["SYNTHETIC.FEED stops"],
+      bypassable: true,
+    },
+    {
+      protection_id: "SYNTHETIC.REACTOR.INDEPENDENT_TRIP",
+      category: "independent_protection" as const,
+      consequences: ["Synthetic heater power removed"],
+      bypassable: false,
+    },
+  ],
+  trips: [
+    {
+      protection_id: "SYNTHETIC.REACTOR.HIGH_PRESSURE",
+      group_id: "trip-1",
+      category: "interlock" as const,
+      consequences: ["SYNTHETIC.FEED stops"],
+      occurred_at: "2026-08-03T20:00:00Z",
+      first_out: true,
+    },
+  ],
+  active_bypasses: [
+    {
+      protection_id: "SYNTHETIC.REACTOR.HIGH_PRESSURE",
+      actor: "engineer",
+      reason: "Synthetic FAT verification",
+      requested_at: "2026-08-03T20:00:00Z",
+      expires_at: "2026-08-03T21:00:00Z",
+      banner_required: true as const,
+      active: true as const,
+    },
+  ],
+};
+
+describe("OperatorWorkspace", () => {
+  beforeEach(() => {
+    vi.mocked(api.getOperatorOverview).mockResolvedValue(overview);
+    vi.mocked(api.getProtectionSnapshot).mockResolvedValue(protections);
+  });
+
+  it("navigates from a multi-area overview to a consistent faceplate", async () => {
+    render(<OperatorWorkspace />);
+
+    expect(await screen.findByText("Feed Preparation")).toBeInTheDocument();
+    expect(screen.getByText("Reaction")).toBeInTheDocument();
+    expect(screen.getByText("Separation")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Feed Pump/ }));
+
+    expect(screen.getByRole("dialog", { name: "Feed Pump faceplate" })).toHaveTextContent(
+      "Quality simulated",
+    );
+    expect(screen.getByRole("dialog")).toHaveTextContent("Mode automatic");
+    expect(screen.getByRole("dialog")).toHaveTextContent("Alarm normal");
+    expect(screen.getByRole("dialog")).toHaveTextContent("Interlock clear");
+    expect(screen.getByRole("button", { name: "Open trend drill-down" })).toBeInTheDocument();
+  });
+
+  it("keeps protection categories and active bypass status unmistakable", async () => {
+    render(<OperatorWorkspace />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Synthetic FAT verification");
+    expect(screen.getByText("FIRST OUT")).toBeInTheDocument();
+    expect(screen.getByText("interlock", { selector: "strong" })).toBeInTheDocument();
+    expect(screen.getByText("independent protection", { selector: "strong" })).toBeInTheDocument();
+    expect(screen.getByText("Non-bypassable")).toBeInTheDocument();
+  });
+});

--- a/src/p1am_control_system/frontend/src/components/OperatorWorkspace.test.tsx
+++ b/src/p1am_control_system/frontend/src/components/OperatorWorkspace.test.tsx
@@ -6,6 +6,8 @@ import { OperatorWorkspace } from "./OperatorWorkspace";
 vi.mock("../api/endpoints", () => ({
   getOperatorOverview: vi.fn(),
   getProtectionSnapshot: vi.fn(),
+  getRepresentativeAssetHealth: vi.fn(),
+  getShiftEntries: vi.fn(),
 }));
 
 const overview = {
@@ -90,10 +92,36 @@ const protections = {
   ],
 };
 
+const assetHealth = {
+  asset_id: "SYNTHETIC.FEED.PUMP",
+  generated_at: "2026-08-03T20:00:00Z",
+  counters: { runtime_seconds: 600, start_count: 1 },
+  statistics: {
+    sample_count: 2,
+    minimum: 15,
+    maximum: 15,
+    mean: 15,
+    standard_deviation: 0,
+  },
+  advisories: [
+    {
+      code: "calibration_due" as const,
+      asset_id: "SYNTHETIC.FEED.PUMP",
+      detected_at: "2026-08-03T20:00:00Z",
+      detail: "Calibration due date has passed",
+      classification: "maintenance_advisory" as const,
+      authoritative_trip: false as const,
+    },
+  ],
+  data_classification: "synthetic" as const,
+};
+
 describe("OperatorWorkspace", () => {
   beforeEach(() => {
     vi.mocked(api.getOperatorOverview).mockResolvedValue(overview);
     vi.mocked(api.getProtectionSnapshot).mockResolvedValue(protections);
+    vi.mocked(api.getRepresentativeAssetHealth).mockResolvedValue(assetHealth);
+    vi.mocked(api.getShiftEntries).mockResolvedValue([]);
   });
 
   it("navigates from a multi-area overview to a consistent faceplate", async () => {
@@ -122,5 +150,8 @@ describe("OperatorWorkspace", () => {
     expect(screen.getByText("interlock", { selector: "strong" })).toBeInTheDocument();
     expect(screen.getByText("independent protection", { selector: "strong" })).toBeInTheDocument();
     expect(screen.getByText("Non-bypassable")).toBeInTheDocument();
+    expect(screen.getByText(/calibration due date has passed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Saved synthetic investigations retain/i)).toBeInTheDocument();
+    expect(screen.getByText(/Signed entries are append-only/i)).toBeInTheDocument();
   });
 });

--- a/src/p1am_control_system/frontend/src/components/OperatorWorkspace.tsx
+++ b/src/p1am_control_system/frontend/src/components/OperatorWorkspace.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import { getOperatorOverview, getProtectionSnapshot } from "../api/endpoints";
+import type {
+  AssetFaceplate,
+  ProcessOverview,
+  ProtectionSnapshot,
+} from "../api/schemas";
+
+const cardStyle = {
+  border: "1px solid var(--panel-border)",
+  borderRadius: "0.65rem",
+  background: "var(--panel-bg)",
+  padding: "0.8rem",
+} as const;
+
+function Faceplate({ asset, onClose }: { asset: AssetFaceplate; onClose: () => void }) {
+  return (
+    <section
+      role="dialog"
+      aria-label={`${asset.label} faceplate`}
+      aria-modal="true"
+      style={{ ...cardStyle, position: "fixed", right: "1rem", top: "5rem", zIndex: 30, minWidth: 300 }}
+    >
+      <header style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
+        <div>
+          <strong>{asset.label}</strong>
+          <div style={{ color: "var(--text-muted)", fontSize: "0.75rem" }}>{asset.asset_id}</div>
+        </div>
+        <button type="button" onClick={onClose} aria-label="Close faceplate">×</button>
+      </header>
+      <p style={{ fontSize: "1.7rem", margin: "0.8rem 0" }}>
+        {asset.primary_value.value} {asset.primary_value.unit}
+      </p>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.4rem" }}>
+        <div>Quality {asset.quality}</div>
+        <div>Mode {asset.mode}</div>
+        <div>Alarm {asset.alarm_state}</div>
+        <div>Interlock {asset.interlock_state}</div>
+      </div>
+      <button type="button" style={{ marginTop: "0.75rem" }}>
+        Open trend drill-down
+      </button>
+    </section>
+  );
+}
+
+function ProtectionView({ snapshot }: { snapshot: ProtectionSnapshot }) {
+  return (
+    <section aria-labelledby="protection-heading" style={{ marginTop: "1rem" }}>
+      <h3 id="protection-heading">Protection, permissive, and first-out context</h3>
+      {snapshot.active_bypasses.map((bypass) => (
+        <div key={bypass.protection_id} role="alert" style={{ ...cardStyle, borderColor: "var(--color-warning)" }}>
+          <strong>ACTIVE MANAGED BYPASS</strong> — {bypass.protection_id}: {bypass.reason}. Expires {bypass.expires_at}.
+        </div>
+      ))}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))", gap: "0.7rem", marginTop: "0.7rem" }}>
+        {snapshot.definitions.map((definition) => {
+          const trip = snapshot.trips.find((item) => item.protection_id === definition.protection_id);
+          return (
+            <article key={definition.protection_id} style={cardStyle}>
+              <strong>{definition.category.replace("_", " ")}</strong>
+              {trip?.first_out && <div style={{ color: "var(--color-error)", fontWeight: 800 }}>FIRST OUT</div>}
+              <div>{definition.protection_id}</div>
+              <ul>{definition.consequences.map((item) => <li key={item}>{item}</li>)}</ul>
+              {!definition.bypassable && <span>Non-bypassable</span>}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export function OperatorWorkspace() {
+  const [overview, setOverview] = useState<ProcessOverview | null>(null);
+  const [protections, setProtections] = useState<ProtectionSnapshot | null>(null);
+  const [selected, setSelected] = useState<AssetFaceplate | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([getOperatorOverview(), getProtectionSnapshot()])
+      .then(([nextOverview, nextProtections]) => {
+        if (active) {
+          setOverview(nextOverview);
+          setProtections(nextProtections);
+        }
+      })
+      .catch((reason: unknown) => {
+        if (active) setError(reason instanceof Error ? reason.message : "Operator workspace unavailable");
+      });
+    return () => { active = false; };
+  }, []);
+
+  if (error) return <div role="alert">{error}</div>;
+  if (!overview || !protections) return <div>Loading representative operator workspace…</div>;
+
+  return (
+    <main aria-labelledby="operator-workspace-heading">
+      <header>
+        <h2 id="operator-workspace-heading">{overview.title}</h2>
+        <p><strong>Synthetic demonstration only.</strong> Not for live control.</p>
+      </header>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: "0.8rem" }}>
+        {overview.areas.map((area) => (
+          <section key={area.area_id} style={cardStyle} aria-labelledby={`${area.area_id}-heading`}>
+            <h3 id={`${area.area_id}-heading`}>{area.label}</h3>
+            {area.assets.map((asset) => (
+              <button
+                key={asset.asset_id}
+                type="button"
+                onClick={() => setSelected(asset)}
+                style={{ display: "block", width: "100%", textAlign: "left", marginTop: "0.45rem", padding: "0.65rem" }}
+              >
+                {asset.label} — {asset.primary_value.value} {asset.primary_value.unit}
+              </button>
+            ))}
+          </section>
+        ))}
+      </div>
+      <ProtectionView snapshot={protections} />
+      {selected && <Faceplate asset={selected} onClose={() => setSelected(null)} />}
+    </main>
+  );
+}

--- a/src/p1am_control_system/frontend/src/components/OperatorWorkspace.tsx
+++ b/src/p1am_control_system/frontend/src/components/OperatorWorkspace.tsx
@@ -1,9 +1,16 @@
 import { useEffect, useState } from "react";
-import { getOperatorOverview, getProtectionSnapshot } from "../api/endpoints";
+import {
+  getOperatorOverview,
+  getProtectionSnapshot,
+  getRepresentativeAssetHealth,
+  getShiftEntries,
+} from "../api/endpoints";
 import type {
   AssetFaceplate,
+  AssetHealthReport,
   ProcessOverview,
   ProtectionSnapshot,
+  ShiftEntry,
 } from "../api/schemas";
 
 const cardStyle = {
@@ -75,15 +82,24 @@ export function OperatorWorkspace() {
   const [overview, setOverview] = useState<ProcessOverview | null>(null);
   const [protections, setProtections] = useState<ProtectionSnapshot | null>(null);
   const [selected, setSelected] = useState<AssetFaceplate | null>(null);
+  const [assetHealth, setAssetHealth] = useState<AssetHealthReport | null>(null);
+  const [shiftEntries, setShiftEntries] = useState<ShiftEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let active = true;
-    Promise.all([getOperatorOverview(), getProtectionSnapshot()])
-      .then(([nextOverview, nextProtections]) => {
+    Promise.all([
+      getOperatorOverview(),
+      getProtectionSnapshot(),
+      getRepresentativeAssetHealth(),
+      getShiftEntries(),
+    ])
+      .then(([nextOverview, nextProtections, nextHealth, nextEntries]) => {
         if (active) {
           setOverview(nextOverview);
           setProtections(nextProtections);
+          setAssetHealth(nextHealth);
+          setShiftEntries(nextEntries);
         }
       })
       .catch((reason: unknown) => {
@@ -93,7 +109,7 @@ export function OperatorWorkspace() {
   }, []);
 
   if (error) return <div role="alert">{error}</div>;
-  if (!overview || !protections) return <div>Loading representative operator workspace…</div>;
+  if (!overview || !protections || !assetHealth) return <div>Loading representative operator workspace…</div>;
 
   return (
     <main aria-labelledby="operator-workspace-heading">
@@ -119,6 +135,34 @@ export function OperatorWorkspace() {
         ))}
       </div>
       <ProtectionView snapshot={protections} />
+      <section aria-labelledby="maintenance-heading" style={{ marginTop: "1rem" }}>
+        <h3 id="maintenance-heading">Asset health & maintenance</h3>
+        <p>
+          {assetHealth.asset_id}: {assetHealth.counters.runtime_seconds} runtime seconds, {assetHealth.counters.start_count} starts.
+          Advisories are maintenance records, never authoritative trips.
+        </p>
+        <ul>
+          {assetHealth.advisories.map((advisory) => (
+            <li key={advisory.code}><strong>{advisory.code.replace(/_/g, " ")}</strong>: {advisory.detail}</li>
+          ))}
+        </ul>
+      </section>
+      <section aria-labelledby="investigation-heading" style={{ marginTop: "1rem" }}>
+        <h3 id="investigation-heading">Investigations & reporting</h3>
+        <p>
+          Saved synthetic investigations retain query bounds, tag metadata, transformations,
+          charts, annotations, event context, explicit bad-data handling, and export checksums.
+        </p>
+      </section>
+      <section aria-labelledby="handover-heading" style={{ marginTop: "1rem" }}>
+        <h3 id="handover-heading">Shift log & handover</h3>
+        {shiftEntries.length === 0 ? (
+          <p>No synthetic handover entries.</p>
+        ) : (
+          <ul>{shiftEntries.map((entry) => <li key={entry.entry_id}>{entry.summary}</li>)}</ul>
+        )}
+        <p>Signed entries are append-only; receiving operators acknowledge unresolved work explicitly.</p>
+      </section>
       {selected && <Faceplate asset={selected} onClose={() => setSelected(null)} />}
     </main>
   );

--- a/src/p1am_control_system/frontend/src/help/helpContent.ts
+++ b/src/p1am_control_system/frontend/src/help/helpContent.ts
@@ -30,6 +30,20 @@ live data to this browser HMI over a WebSocket.
 in/out (power-supply monitor and command). Full details are in \`USER_MANUAL.md\`.`;
 
 export const HELP: Record<TabId, HelpDoc> = {
+  operator: {
+    title: "Representative Operator Overview",
+    body: `A **synthetic, non-live-control** workspace demonstrating professional
+overview-to-detail navigation without plant names, parameters, or control logic.
+
+### Navigation and state
+- Select a generic asset to open its reusable faceplate with value, quality,
+mode, alarm, interlock, and trend-drill-down context.
+- Protection cards keep control, interlock, and independent-protection
+categories distinct and show deterministic first-out consequences.
+- Any managed bypass is displayed in a persistent banner with actor, reason,
+and expiry. Items marked **Non-bypassable** cannot be bypassed through this UI.`,
+  },
+
   temperature: {
     title: "Heater Controls",
     body: `Controls the **110 V resistive crucible heater** through a single 24 V

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -10,6 +10,7 @@
  */
 
 export type TabId =
+  | "operator"
   | "trends"
   | "explorer"
   | "controllers"
@@ -34,6 +35,12 @@ export interface TabDef {
 }
 
 export const TABS: readonly TabDef[] = [
+  {
+    id: "operator",
+    label: "Operator Overview",
+    settingsLabel: "Representative Operator Workspace",
+    accentVar: "var(--accent-cyan)",
+  },
   {
     id: "trends",
     label: "Trends & Monitors",


### PR DESCRIPTION
## Phase B — professional operator experience

Closes #4086. Part of #4089. Stacked on #4091.

### Delivered

- F06 synthetic multi-area overview with reusable accessible faceplates, consistent value/quality/mode/alarm/interlock state, and trend drill-down context
- F07 distinct control/interlock/independent-protection categories, deterministic first-out and consequences, and managed role/reason/expiry/banner/audit bypasses with non-bypassable policy
- F08 immutable saved investigations with query/tag/transformation/chart/annotation/event context, explicit bad-data policy, and deterministic checksummed exports
- F10 calibration, drift, flatline, command-feedback mismatch, runtime/start/noise/statistics maintenance advisories explicitly separate from trips
- F13 attributable searchable shift/run logs, signed-entry database immutability, unresolved actions, exact evidence links, and explicit handover acknowledgement

### Engineering evidence

All behavior followed RED → GREEN → REFACTOR. Domain, repository, API, and UI responsibilities remain separate; constructors and mutation boundaries validate contracts; shared models and deterministic serialization keep the implementation DRY.

### Verification

- Backend: 995 passed; 6 CI-only dependency checks skipped
- Frontend: 394 passed
- Ruff, formatter, strict mypy, TypeScript, ESLint, and production bundle passed
- Safety, append-only persistence, bad-data, export-integrity, and confidentiality regressions passed

### Safety boundary

All process areas, tags, values, trips, bypasses, runs, investigations, and maintenance findings are synthetic. This PR contains no confidential plant logic and adds no live control authority.