### PR TITLE
feat(scada): add reusable Phase C product contracts

### DIFF
--- a/docs/development/professional-scada-epic.md
+++ b/docs/development/professional-scada-epic.md
@@ -119,14 +119,29 @@ logic, identifiers, limits, or operating values.
 
 ### Phase C — Reusable control product
 
-- [ ] F09 generic sequence/state and procedure demonstration
-- [ ] F11 driver/plugin framework and device diagnostics
-- [ ] F14 notification and escalation policies
-- [ ] F15 high availability, time synchronization, and disaster-recovery mode
+- [x] F09 generic sequence/state and procedure demonstration
+- [x] F11 driver/plugin framework and device diagnostics
+- [x] F14 notification and escalation policies
+- [x] F15 high availability, time synchronization, and disaster-recovery mode
 
 Exit criterion: a representative unit and connector can be added through
 documented contracts, commissioned with scenarios, and operated through defined
 infrastructure faults.
+
+#### Phase C verification — 2026-08-03
+
+| Feature | Direct evidence |
+| --- | --- |
+| F09 | A simulator-only state machine deterministically covers start, run, hold, resume, stop, completion, abort, recovery, and timeout. Transitional states have explicit deadlines; invalid transitions and viewer commands fail closed; every event carries actor, reason, sequence, before/after, and synthetic/non-live markings. |
+| F11 | Versioned connector descriptors declare owned read/write tags. Poll and command boundaries isolate exceptions, degrade only owned tags, reject unknown/failed commands closed, identify the responsible connector, validate finite values/tag ownership, and redact diagnostic secret fields. |
+| F14 | Deterministic policy tests prove initial delay, designed suppression, escalation, acknowledgment cancellation, rate limiting, secret redaction, and an audit record for every delivery or policy outcome. The representative channel has no external delivery side effect. |
+| F15 | Availability contracts enforce one command-authority lease, strictly ordered sequences/timestamps, bounded offline buffering and one-time reconciliation, clock-skew reliability, explicit RTO/RPO, and rejection of energizing commands while the HMI is unavailable. The UI states that these contracts do not claim deployed redundant hardware. |
+
+Phase C release-gate evidence: Ruff, formatting, and strict mypy checks for all
+new procedure, connector, notification, availability, composition, and API
+modules pass; the complete backend suite passes with 1,010 tests and 6 CI-only
+dependency checks skipped; all 394 frontend tests, TypeScript, and the production
+bundle pass; ESLint has zero errors and two unchanged pre-existing hook warnings.
 
 ### Phase D — Advanced differentiation
 

--- a/src/p1am_control_system/backend/availability.py
+++ b/src/p1am_control_system/backend/availability.py
@@ -1,0 +1,188 @@
+"""Single command authority, ordered buffering, recovery, and HMI-loss policy."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def _synthetic(value: str) -> str:
+    if not value.startswith("SYNTHETIC."):
+        raise ValueError("identifiers must begin with SYNTHETIC.")
+    return value
+
+
+class AvailabilityPolicy(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    recovery_time_objective: timedelta
+    recovery_point_objective: timedelta
+    max_clock_skew: timedelta
+    buffer_capacity: int = Field(gt=0)
+
+    @model_validator(mode="after")
+    def _positive_contracts(self) -> AvailabilityPolicy:
+        if any(
+            value <= timedelta(0)
+            for value in (
+                self.recovery_time_objective,
+                self.recovery_point_objective,
+                self.max_clock_skew,
+            )
+        ):
+            raise ValueError("recovery and clock contracts must be positive")
+        return self
+
+
+class AuthorityLease(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    lease_id: str
+    holder: str
+
+    _holder_is_synthetic = field_validator("holder")(_synthetic)
+
+
+class BufferedSample(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    sequence: int = Field(gt=0)
+    timestamp: datetime
+    value: float
+
+    @field_validator("timestamp")
+    @classmethod
+    def _aware_timestamp(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("sample timestamp must include a UTC offset")
+        return value
+
+
+class AvailabilityCommandResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    target: str
+    energizing: bool
+    accepted: bool
+    fail_closed: bool
+    reason: str
+
+
+class AvailabilityHealth(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    recovery_time_objective_seconds: float
+    recovery_point_objective_seconds: float
+    clock_ordering_reliable: bool
+    command_authority: str | None
+    transport_available: bool
+    hmi_available: bool
+    buffered_samples: int
+    data_classification: Literal["synthetic"] = "synthetic"
+
+
+class AvailabilityService:
+    def __init__(self, policy: AvailabilityPolicy) -> None:
+        self._policy = policy
+        self._authority: AuthorityLease | None = None
+        self._transport_available = True
+        self._hmi_available = True
+        self._clock_skew = timedelta(0)
+        self._buffer: list[BufferedSample] = []
+        self._last_sequence = 0
+        self._last_timestamp: datetime | None = None
+
+    @property
+    def authority(self) -> AuthorityLease | None:
+        return self._authority
+
+    def acquire_authority(self, holder: str) -> AuthorityLease:
+        if self._authority is not None:
+            raise PermissionError(
+                f"command authority is already held by {self._authority.holder}"
+            )
+        lease = AuthorityLease(lease_id=uuid.uuid4().hex, holder=holder)
+        self._authority = lease
+        return lease
+
+    def release_authority(self, lease_id: str) -> None:
+        if self._authority is None or self._authority.lease_id != lease_id:
+            raise PermissionError("only the active lease may release authority")
+        self._authority = None
+
+    def set_transport_available(self, available: bool) -> None:
+        self._transport_available = available
+
+    def ingest(self, sample: BufferedSample) -> None:
+        if sample.sequence <= self._last_sequence:
+            raise ValueError("sample sequences must strictly increase")
+        if (
+            self._last_timestamp is not None
+            and sample.timestamp <= self._last_timestamp
+        ):
+            raise ValueError("sample timestamps must strictly increase")
+        if (
+            not self._transport_available
+            and len(self._buffer) >= self._policy.buffer_capacity
+        ):
+            raise OverflowError("offline buffer capacity exceeded")
+        self._last_sequence = sample.sequence
+        self._last_timestamp = sample.timestamp
+        if not self._transport_available:
+            self._buffer.append(sample)
+
+    def reconcile(self) -> list[BufferedSample]:
+        if not self._transport_available:
+            raise RuntimeError("transport must recover before reconciliation")
+        reconciled = list(self._buffer)
+        self._buffer.clear()
+        return reconciled
+
+    def inject_fault(self, fault: Literal["hmi_unavailable", "authority_loss"]) -> None:
+        if fault == "hmi_unavailable":
+            self._hmi_available = False
+        elif fault == "authority_loss":
+            self._authority = None
+
+    def report_clock_skew(self, skew: timedelta) -> None:
+        self._clock_skew = abs(skew)
+
+    def command(self, target: str, *, energizing: bool) -> AvailabilityCommandResult:
+        target = _synthetic(target)
+        if self._authority is None:
+            return AvailabilityCommandResult(
+                target=target,
+                energizing=energizing,
+                accepted=False,
+                fail_closed=True,
+                reason="No command authority",
+            )
+        if energizing and not self._hmi_available:
+            return AvailabilityCommandResult(
+                target=target,
+                energizing=True,
+                accepted=False,
+                fail_closed=True,
+                reason="Energizing commands are blocked while the HMI is unavailable",
+            )
+        return AvailabilityCommandResult(
+            target=target,
+            energizing=energizing,
+            accepted=True,
+            fail_closed=False,
+            reason="Accepted by the single synthetic command authority",
+        )
+
+    def health(self) -> AvailabilityHealth:
+        return AvailabilityHealth(
+            recovery_time_objective_seconds=self._policy.recovery_time_objective.total_seconds(),
+            recovery_point_objective_seconds=self._policy.recovery_point_objective.total_seconds(),
+            clock_ordering_reliable=self._clock_skew <= self._policy.max_clock_skew,
+            command_authority=self._authority.holder if self._authority else None,
+            transport_available=self._transport_available,
+            hmi_available=self._hmi_available,
+            buffered_samples=len(self._buffer),
+        )

--- a/src/p1am_control_system/backend/connector_plugins.py
+++ b/src/p1am_control_system/backend/connector_plugins.py
@@ -1,0 +1,196 @@
+"""Isolated connector plugin contracts with fail-closed commands and redaction."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from enum import StrEnum
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+_SECRET_FRAGMENTS = ("password", "secret", "token", "api_key", "credential")
+
+
+def _synthetic(value: str) -> str:
+    normalized = value.strip()
+    if not normalized.startswith("SYNTHETIC."):
+        raise ValueError("connector and tag identifiers must begin with SYNTHETIC.")
+    return normalized
+
+
+class ConnectorDescriptor(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    connector_id: str
+    version: str = Field(min_length=1, max_length=100)
+    tags: tuple[str, ...] = Field(min_length=1)
+    writable_tags: tuple[str, ...] = ()
+
+    _connector_is_synthetic = field_validator("connector_id")(_synthetic)
+
+    @field_validator("tags", "writable_tags")
+    @classmethod
+    def _tags_are_synthetic(cls, values: tuple[str, ...]) -> tuple[str, ...]:
+        normalized = tuple(_synthetic(value) for value in values)
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("connector tags must be unique")
+        return normalized
+
+    @model_validator(mode="after")
+    def _read_write_tags_do_not_overlap(self) -> ConnectorDescriptor:
+        if set(self.tags) & set(self.writable_tags):
+            raise ValueError("read and writable tags must not overlap")
+        return self
+
+
+class ConnectorPlugin(Protocol):
+    descriptor: ConnectorDescriptor
+
+    def read(self) -> dict[str, float]: ...
+
+    def write(self, tag: str, value: float) -> None: ...
+
+    def diagnostics(self) -> dict[str, object]: ...
+
+
+class ConnectorSample(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    value: float | None
+    quality: Literal["good", "bad"]
+    diagnostic: str
+    connector_id: str
+
+
+class CommandDisposition(StrEnum):
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
+class ConnectorCommandResult(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    tag: str
+    connector_id: str | None
+    disposition: CommandDisposition
+    fail_closed: bool
+    diagnostic: str
+
+
+class ConnectorDiagnostic(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    connector_id: str
+    version: str
+    details: dict[str, object]
+
+
+def _redact(details: Mapping[str, object]) -> dict[str, object]:
+    return {
+        key: "[REDACTED]"
+        if any(fragment in key.casefold() for fragment in _SECRET_FRAGMENTS)
+        else value
+        for key, value in details.items()
+    }
+
+
+class ConnectorManager:
+    def __init__(self, connectors: Sequence[ConnectorPlugin]) -> None:
+        self._connectors = tuple(connectors)
+        connector_ids = [item.descriptor.connector_id for item in self._connectors]
+        if len(connector_ids) != len(set(connector_ids)):
+            raise ValueError("connector identifiers must be unique")
+        all_tags = [
+            tag
+            for item in self._connectors
+            for tag in (*item.descriptor.tags, *item.descriptor.writable_tags)
+        ]
+        if len(all_tags) != len(set(all_tags)):
+            raise ValueError("tags may belong to only one connector")
+        self._writers = {
+            tag: connector
+            for connector in self._connectors
+            for tag in connector.descriptor.writable_tags
+        }
+
+    def poll(self) -> dict[str, ConnectorSample]:
+        samples: dict[str, ConnectorSample] = {}
+        for connector in self._connectors:
+            descriptor = connector.descriptor
+            try:
+                values = connector.read()
+                if set(values) != set(descriptor.tags):
+                    raise ValueError("connector returned an unexpected tag set")
+                for tag, value in values.items():
+                    if not math.isfinite(value):
+                        raise ValueError("connector returned a non-finite value")
+                    samples[tag] = ConnectorSample(
+                        value=value,
+                        quality="good",
+                        diagnostic="",
+                        connector_id=descriptor.connector_id,
+                    )
+            except (
+                Exception
+            ) as exc:  # Connector boundary intentionally isolates plugins.
+                diagnostic = (
+                    f"{descriptor.connector_id} read failed ({type(exc).__name__})"
+                )
+                for tag in descriptor.tags:
+                    samples[tag] = ConnectorSample(
+                        value=None,
+                        quality="bad",
+                        diagnostic=diagnostic,
+                        connector_id=descriptor.connector_id,
+                    )
+        return samples
+
+    def command(self, tag: str, value: float) -> ConnectorCommandResult:
+        connector = self._writers.get(tag)
+        if connector is None:
+            return ConnectorCommandResult(
+                tag=tag,
+                connector_id=None,
+                disposition=CommandDisposition.REJECTED,
+                fail_closed=True,
+                diagnostic="No connector owns this writable tag",
+            )
+        try:
+            if not math.isfinite(value):
+                raise ValueError("command value must be finite")
+            connector.write(tag, value)
+        except Exception as exc:  # Connector boundary intentionally isolates plugins.
+            return ConnectorCommandResult(
+                tag=tag,
+                connector_id=connector.descriptor.connector_id,
+                disposition=CommandDisposition.REJECTED,
+                fail_closed=True,
+                diagnostic=(
+                    f"{connector.descriptor.connector_id} command failed "
+                    f"({type(exc).__name__})"
+                ),
+            )
+        return ConnectorCommandResult(
+            tag=tag,
+            connector_id=connector.descriptor.connector_id,
+            disposition=CommandDisposition.ACCEPTED,
+            fail_closed=False,
+            diagnostic="",
+        )
+
+    def diagnostics(self) -> list[ConnectorDiagnostic]:
+        results: list[ConnectorDiagnostic] = []
+        for connector in self._connectors:
+            try:
+                details = _redact(connector.diagnostics())
+            except Exception as exc:
+                details = {"error": f"diagnostics failed ({type(exc).__name__})"}
+            results.append(
+                ConnectorDiagnostic(
+                    connector_id=connector.descriptor.connector_id,
+                    version=connector.descriptor.version,
+                    details=details,
+                )
+            )
+        return results

--- a/src/p1am_control_system/backend/connector_plugins.py
+++ b/src/p1am_control_system/backend/connector_plugins.py
@@ -88,9 +88,11 @@ class ConnectorDiagnostic(BaseModel):
 
 def _redact(details: Mapping[str, object]) -> dict[str, object]:
     return {
-        key: "[REDACTED]"
-        if any(fragment in key.casefold() for fragment in _SECRET_FRAGMENTS)
-        else value
+        key: (
+            "[REDACTED]"
+            if any(fragment in key.casefold() for fragment in _SECRET_FRAGMENTS)
+            else value
+        )
         for key, value in details.items()
     }
 

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -93,11 +93,13 @@ from plant_model import TagDefinition
 from plc_factory import PLCFactory
 from poll_runtime import _connect_once, _poll_once
 from power_supply_integration import PowerSupplyService, create_power_supply_router
+from product_router import create_product_router
 from project_import import import_project_archive
 from protection_management import ProtectionService, representative_protections
 from pydantic import BaseModel
 from pydantic import Field as PydanticField
 from recovery_package import RecoveryPackageService
+from representative_product import build_representative_product
 from saved_investigation import InvestigationService, SqliteInvestigationRepository
 from scenario_router import create_scenario_router
 from settings import get_settings
@@ -342,6 +344,7 @@ professional_alarm_service = AlarmService(
 protection_service = ProtectionService(
     representative_protections(), now=lambda: datetime.now(UTC)
 )
+representative_product = build_representative_product(lambda: datetime.now(UTC))
 
 
 def _apply_control_config(config: RoutingConfig) -> None:
@@ -671,6 +674,15 @@ app.include_router(
         investigation_service,
         shift_log_service,
         asset_report_provider=_representative_asset_health,
+        operator_dependency=require_api_key,
+    )
+)
+app.include_router(
+    create_product_router(
+        representative_product.procedure,
+        representative_product.connectors,
+        representative_product.notifications,
+        representative_product.availability,
         operator_dependency=require_api_key,
     )
 )

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -380,7 +380,9 @@ investigation_service = InvestigationService(
     SqliteInvestigationRepository(_config_session)
 )
 shift_log_service = ShiftLogService(SqliteShiftLogRepository(_config_session))
-asset_health_service = AssetHealthService(AssetHealthPolicy(), now=lambda: datetime.now(UTC))
+asset_health_service = AssetHealthService(
+    AssetHealthPolicy(), now=lambda: datetime.now(UTC)
+)
 
 
 def _representative_asset_health() -> AssetHealthReport:
@@ -409,6 +411,8 @@ def _representative_asset_health() -> AssetHealthReport:
         observations,
         calibration_due_at=now - timedelta(days=1),
     )
+
+
 software_revision = os.environ.get("P1AM_SOFTWARE_REVISION", "development-unidentified")
 recovery_service = RecoveryPackageService(
     configuration_workflow,

--- a/src/p1am_control_system/backend/notification_policy.py
+++ b/src/p1am_control_system/backend/notification_policy.py
@@ -1,0 +1,178 @@
+"""Deterministic alarm notification, escalation, rate-limit, and audit policy."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+_SECRET = re.compile(
+    r"(?i)\b(password|secret|token|api[_-]?key|credential)\s*[:=]\s*\S+"
+)
+
+
+def _redact(message: str) -> str:
+    return _SECRET.sub(lambda match: f"{match.group(1)}=[REDACTED]", message)
+
+
+class AlarmNotice(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    alarm_id: str
+    priority: Literal["high", "critical"]
+    occurred_at: datetime
+    message: str = Field(min_length=1, max_length=1000)
+
+    @field_validator("alarm_id")
+    @classmethod
+    def _synthetic_alarm(cls, value: str) -> str:
+        if not value.startswith("SYNTHETIC."):
+            raise ValueError("alarm_id must begin with SYNTHETIC.")
+        return value
+
+
+class NotificationPolicy(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    initial_delay: timedelta
+    escalation_delay: timedelta
+    primary_recipient: str = Field(min_length=1)
+    escalation_recipient: str = Field(min_length=1)
+    suppressed_alarm_ids: frozenset[str] = frozenset()
+    max_deliveries: int = Field(default=20, gt=0)
+    rate_limit_window: timedelta = timedelta(minutes=5)
+
+    @model_validator(mode="after")
+    def _valid_delays(self) -> NotificationPolicy:
+        if self.initial_delay < timedelta(0):
+            raise ValueError("initial_delay must be nonnegative")
+        if self.escalation_delay < self.initial_delay:
+            raise ValueError("escalation_delay cannot precede initial_delay")
+        if self.rate_limit_window <= timedelta(0):
+            raise ValueError("rate_limit_window must be positive")
+        return self
+
+
+class NotificationChannel(Protocol):
+    def send(self, recipient: str, message: str) -> None: ...
+
+
+class NotificationAudit(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    alarm_id: str
+    recipient: str | None
+    stage: Literal["primary", "escalation", "policy", "acknowledgment"]
+    outcome: Literal["delivered", "suppressed", "cancelled", "rate_limited"]
+    occurred_at: datetime
+    message: str
+    actor: str | None = None
+
+
+class NotificationService:
+    def __init__(
+        self,
+        policy: NotificationPolicy,
+        channel: NotificationChannel,
+        now: Callable[[], datetime],
+    ) -> None:
+        self._policy = policy
+        self._channel = channel
+        self._now = now
+        self._active: dict[str, AlarmNotice] = {}
+        self._completed_stages: set[tuple[str, str]] = set()
+        self._delivery_times: list[datetime] = []
+        self._audit: list[NotificationAudit] = []
+
+    @property
+    def policy(self) -> NotificationPolicy:
+        return self._policy
+
+    @staticmethod
+    def _message(notice: AlarmNotice) -> str:
+        return _redact(f"{notice.alarm_id}: {notice.message}")
+
+    def raise_alarm(self, notice: AlarmNotice) -> None:
+        if notice.alarm_id in self._active:
+            raise ValueError("alarm is already active")
+        if notice.alarm_id in self._policy.suppressed_alarm_ids:
+            self._audit.append(
+                NotificationAudit(
+                    alarm_id=notice.alarm_id,
+                    recipient=None,
+                    stage="policy",
+                    outcome="suppressed",
+                    occurred_at=self._now(),
+                    message=self._message(notice),
+                )
+            )
+            return
+        self._active[notice.alarm_id] = notice
+
+    def acknowledge(self, alarm_id: str, actor: str) -> None:
+        try:
+            notice = self._active.pop(alarm_id)
+        except KeyError as exc:
+            raise KeyError(f"unknown active alarm: {alarm_id}") from exc
+        self._audit.append(
+            NotificationAudit(
+                alarm_id=alarm_id,
+                recipient=None,
+                stage="acknowledgment",
+                outcome="cancelled",
+                occurred_at=self._now(),
+                message=self._message(notice),
+                actor=actor,
+            )
+        )
+
+    def _rate_limited(self, now: datetime) -> bool:
+        cutoff = now - self._policy.rate_limit_window
+        self._delivery_times = [
+            value for value in self._delivery_times if value > cutoff
+        ]
+        return len(self._delivery_times) >= self._policy.max_deliveries
+
+    def tick(self) -> list[NotificationAudit]:
+        now = self._now()
+        delivered: list[NotificationAudit] = []
+        stages: tuple[tuple[Literal["primary", "escalation"], timedelta, str], ...] = (
+            ("primary", self._policy.initial_delay, self._policy.primary_recipient),
+            (
+                "escalation",
+                self._policy.escalation_delay,
+                self._policy.escalation_recipient,
+            ),
+        )
+        for notice in self._active.values():
+            for stage, delay, recipient in stages:
+                key = (notice.alarm_id, stage)
+                if key in self._completed_stages or now - notice.occurred_at < delay:
+                    continue
+                outcome: Literal["delivered", "rate_limited"]
+                message = self._message(notice)
+                if self._rate_limited(now):
+                    outcome = "rate_limited"
+                else:
+                    self._channel.send(recipient, message)
+                    self._delivery_times.append(now)
+                    outcome = "delivered"
+                audit = NotificationAudit(
+                    alarm_id=notice.alarm_id,
+                    recipient=recipient,
+                    stage=stage,
+                    outcome=outcome,
+                    occurred_at=now,
+                    message=message,
+                )
+                self._audit.append(audit)
+                self._completed_stages.add(key)
+                if outcome == "delivered":
+                    delivered.append(audit)
+        return delivered
+
+    def audit(self) -> list[NotificationAudit]:
+        return list(self._audit)

--- a/src/p1am_control_system/backend/product_router.py
+++ b/src/p1am_control_system/backend/product_router.py
@@ -1,0 +1,94 @@
+"""REST adapter for the reusable synthetic control-product contracts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Literal
+
+from availability import AvailabilityHealth, AvailabilityService
+from connector_plugins import (
+    ConnectorDiagnostic,
+    ConnectorManager,
+    ConnectorSample,
+)
+from fastapi import APIRouter, Depends, HTTPException
+from identity import Principal
+from notification_policy import (
+    NotificationAudit,
+    NotificationPolicy,
+    NotificationService,
+)
+from pydantic import BaseModel, ConfigDict, Field
+from synthetic_procedure import (
+    ProcedureCommand,
+    ProcedureEvent,
+    ProcedureState,
+    SyntheticProcedure,
+)
+
+
+class ProcedureCommandBody(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    reason: str = Field(min_length=1, max_length=500)
+
+
+class ProductStatus(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    procedure_state: ProcedureState
+    procedure_events: list[ProcedureEvent]
+    connectors: list[ConnectorDiagnostic]
+    samples: dict[str, ConnectorSample]
+    notification_policy: NotificationPolicy
+    notification_audit: list[NotificationAudit]
+    availability: AvailabilityHealth
+    data_classification: Literal["synthetic"] = "synthetic"
+    not_for_live_control: Literal[True] = True
+
+
+def create_product_router(
+    procedure: SyntheticProcedure,
+    connectors: ConnectorManager,
+    notifications: NotificationService,
+    availability: AvailabilityService,
+    operator_dependency: Callable[..., Principal],
+) -> APIRouter:
+    if not all(
+        (
+            isinstance(procedure, SyntheticProcedure),
+            isinstance(connectors, ConnectorManager),
+            isinstance(notifications, NotificationService),
+            isinstance(availability, AvailabilityService),
+            callable(operator_dependency),
+        )
+    ):
+        raise TypeError("product router dependencies do not satisfy their contracts")
+    router = APIRouter(prefix="/api/operator", tags=["control-product"])
+
+    @router.get("/product-status")
+    async def product_status() -> ProductStatus:
+        return ProductStatus(
+            procedure_state=procedure.state,
+            procedure_events=procedure.events(),
+            connectors=connectors.diagnostics(),
+            samples=connectors.poll(),
+            notification_policy=notifications.policy,
+            notification_audit=notifications.audit(),
+            availability=availability.health(),
+        )
+
+    @router.post("/procedure/commands/{command}")
+    async def procedure_command(
+        command: ProcedureCommand,
+        body: ProcedureCommandBody,
+        principal: Principal = Depends(operator_dependency),  # noqa: B008
+    ) -> ProcedureEvent:
+        try:
+            return procedure.dispatch(command, principal, body.reason)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return router

--- a/src/p1am_control_system/backend/representative_product.py
+++ b/src/p1am_control_system/backend/representative_product.py
@@ -1,0 +1,87 @@
+"""Non-confidential product demonstration composition for the operator workspace."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from availability import AvailabilityPolicy, AvailabilityService
+from connector_plugins import ConnectorDescriptor, ConnectorManager
+from notification_policy import NotificationPolicy, NotificationService
+from synthetic_procedure import SyntheticProcedure
+
+
+class _HealthyConnector:
+    descriptor = ConnectorDescriptor(
+        connector_id="SYNTHETIC.CONNECTOR.HEALTHY",
+        version="1.0.0",
+        tags=("SYNTHETIC.CONNECTOR.HEALTHY.PV",),
+        writable_tags=("SYNTHETIC.CONNECTOR.HEALTHY.SP",),
+    )
+
+    def read(self) -> dict[str, float]:
+        return {"SYNTHETIC.CONNECTOR.HEALTHY.PV": 42.0}
+
+    def write(self, tag: str, value: float) -> None:
+        if tag != "SYNTHETIC.CONNECTOR.HEALTHY.SP":
+            raise KeyError(tag)
+
+    def diagnostics(self) -> dict[str, object]:
+        return {"state": "online", "transport": "representative"}
+
+
+class _UnavailableConnector:
+    descriptor = ConnectorDescriptor(
+        connector_id="SYNTHETIC.CONNECTOR.UNAVAILABLE",
+        version="1.0.0",
+        tags=("SYNTHETIC.CONNECTOR.UNAVAILABLE.PV",),
+    )
+
+    def read(self) -> dict[str, float]:
+        raise ConnectionError("representative offline connector")
+
+    def write(self, tag: str, value: float) -> None:
+        raise ConnectionError("representative offline connector")
+
+    def diagnostics(self) -> dict[str, object]:
+        return {"state": "offline", "password": "demonstration-redaction-value"}
+
+
+class _AuditOnlyChannel:
+    def send(self, recipient: str, message: str) -> None:
+        """No external side effect; the service retains delivery audit only."""
+
+
+@dataclass(frozen=True)
+class RepresentativeProduct:
+    procedure: SyntheticProcedure
+    connectors: ConnectorManager
+    notifications: NotificationService
+    availability: AvailabilityService
+
+
+def build_representative_product(now: Callable[[], datetime]) -> RepresentativeProduct:
+    return RepresentativeProduct(
+        procedure=SyntheticProcedure(now=now),
+        connectors=ConnectorManager((_HealthyConnector(), _UnavailableConnector())),
+        notifications=NotificationService(
+            NotificationPolicy(
+                initial_delay=timedelta(minutes=1),
+                escalation_delay=timedelta(minutes=5),
+                primary_recipient="synthetic.on-call.primary",
+                escalation_recipient="synthetic.on-call.escalation",
+                max_deliveries=10,
+            ),
+            _AuditOnlyChannel(),
+            now=now,
+        ),
+        availability=AvailabilityService(
+            AvailabilityPolicy(
+                recovery_time_objective=timedelta(minutes=5),
+                recovery_point_objective=timedelta(seconds=30),
+                max_clock_skew=timedelta(seconds=2),
+                buffer_capacity=1000,
+            )
+        ),
+    )

--- a/src/p1am_control_system/backend/synthetic_procedure.py
+++ b/src/p1am_control_system/backend/synthetic_procedure.py
@@ -1,0 +1,145 @@
+"""Bounded simulator-only procedure state machine with attributable events."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Literal
+
+from identity import Principal, Role
+from pydantic import BaseModel, ConfigDict
+
+
+class ProcedureState(StrEnum):
+    IDLE = "idle"
+    STARTING = "starting"
+    RUNNING = "running"
+    HOLDING = "holding"
+    STOPPING = "stopping"
+    ABORTED = "aborted"
+    RECOVERING = "recovering"
+
+
+class ProcedureCommand(StrEnum):
+    START = "start"
+    RUN = "run"
+    HOLD = "hold"
+    RESUME = "resume"
+    STOP = "stop"
+    COMPLETE = "complete"
+    ABORT = "abort"
+    RECOVER = "recover"
+    TIMEOUT = "timeout"
+
+
+class ProcedureEvent(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    sequence: int
+    command: ProcedureCommand
+    before: ProcedureState
+    after: ProcedureState
+    actor: str
+    reason: str
+    occurred_at: datetime
+    deadline: datetime | None
+    data_classification: Literal["synthetic"] = "synthetic"
+    not_for_live_control: Literal[True] = True
+
+
+_TRANSITIONS = {
+    (ProcedureState.IDLE, ProcedureCommand.START): ProcedureState.STARTING,
+    (ProcedureState.STARTING, ProcedureCommand.RUN): ProcedureState.RUNNING,
+    (ProcedureState.RUNNING, ProcedureCommand.HOLD): ProcedureState.HOLDING,
+    (ProcedureState.HOLDING, ProcedureCommand.RESUME): ProcedureState.RUNNING,
+    (ProcedureState.RUNNING, ProcedureCommand.STOP): ProcedureState.STOPPING,
+    (ProcedureState.HOLDING, ProcedureCommand.STOP): ProcedureState.STOPPING,
+    (ProcedureState.STOPPING, ProcedureCommand.COMPLETE): ProcedureState.IDLE,
+    (ProcedureState.ABORTED, ProcedureCommand.RECOVER): ProcedureState.RECOVERING,
+    (ProcedureState.RECOVERING, ProcedureCommand.COMPLETE): ProcedureState.IDLE,
+}
+_BOUNDED_STATES = {
+    ProcedureState.STARTING,
+    ProcedureState.STOPPING,
+    ProcedureState.RECOVERING,
+}
+
+
+class SyntheticProcedure:
+    def __init__(
+        self,
+        now: Callable[[], datetime],
+        transition_timeout: timedelta = timedelta(minutes=2),
+    ) -> None:
+        if transition_timeout <= timedelta(0):
+            raise ValueError("transition_timeout must be positive")
+        self._now = now
+        self._timeout = transition_timeout
+        self._state = ProcedureState.IDLE
+        self._deadline: datetime | None = None
+        self._events: list[ProcedureEvent] = []
+
+    @property
+    def state(self) -> ProcedureState:
+        return self._state
+
+    def events(self) -> list[ProcedureEvent]:
+        return list(self._events)
+
+    def _record(
+        self,
+        command: ProcedureCommand,
+        after: ProcedureState,
+        actor: str,
+        reason: str,
+    ) -> ProcedureEvent:
+        occurred_at = self._now()
+        before = self._state
+        self._state = after
+        self._deadline = (
+            occurred_at + self._timeout if after in _BOUNDED_STATES else None
+        )
+        event = ProcedureEvent(
+            sequence=len(self._events) + 1,
+            command=command,
+            before=before,
+            after=after,
+            actor=actor,
+            reason=reason.strip(),
+            occurred_at=occurred_at,
+            deadline=self._deadline,
+        )
+        self._events.append(event)
+        return event
+
+    def dispatch(
+        self,
+        command: ProcedureCommand,
+        principal: Principal,
+        reason: str,
+    ) -> ProcedureEvent:
+        if principal.role is Role.VIEWER:
+            raise PermissionError("operator, engineer, or admin role required")
+        if not reason.strip():
+            raise ValueError("transition reason is required")
+        if command is ProcedureCommand.ABORT and self._state is not ProcedureState.IDLE:
+            after = ProcedureState.ABORTED
+        else:
+            try:
+                after = _TRANSITIONS[(self._state, command)]
+            except KeyError as exc:
+                raise ValueError(
+                    f"{command.value} is not allowed from {self._state.value}"
+                ) from exc
+        return self._record(command, after, principal.subject, reason)
+
+    def enforce_deadline(self) -> ProcedureEvent | None:
+        if self._deadline is None or self._now() <= self._deadline:
+            return None
+        return self._record(
+            ProcedureCommand.TIMEOUT,
+            ProcedureState.ABORTED,
+            "synthetic.procedure.supervisor",
+            "Bounded transition deadline exceeded",
+        )

--- a/src/p1am_control_system/backend/tests/test_availability.py
+++ b/src/p1am_control_system/backend/tests/test_availability.py
@@ -1,0 +1,73 @@
+"""F15 command authority, ordered buffering, and safe fault behavior."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from availability import AvailabilityPolicy, AvailabilityService, BufferedSample
+
+
+def _service() -> AvailabilityService:
+    return AvailabilityService(
+        AvailabilityPolicy(
+            recovery_time_objective=timedelta(minutes=5),
+            recovery_point_objective=timedelta(seconds=30),
+            max_clock_skew=timedelta(seconds=2),
+            buffer_capacity=10,
+        )
+    )
+
+
+def test_exactly_one_command_authority_is_enforced() -> None:
+    service = _service()
+
+    lease = service.acquire_authority("SYNTHETIC.CONTROLLER.PRIMARY")
+
+    with pytest.raises(PermissionError, match="already held"):
+        service.acquire_authority("SYNTHETIC.CONTROLLER.SECONDARY")
+    assert service.authority == lease
+
+
+def test_offline_buffer_reconciles_ordered_unique_samples() -> None:
+    service = _service()
+    start = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    service.set_transport_available(False)
+    service.ingest(BufferedSample(sequence=1, timestamp=start, value=10))
+    service.ingest(
+        BufferedSample(sequence=2, timestamp=start + timedelta(seconds=1), value=11)
+    )
+
+    with pytest.raises(ValueError, match="strictly increase"):
+        service.ingest(BufferedSample(sequence=3, timestamp=start, value=12))
+
+    service.set_transport_available(True)
+    reconciled = service.reconcile()
+
+    assert [sample.sequence for sample in reconciled] == [1, 2]
+    assert service.reconcile() == []
+
+
+def test_hmi_loss_rejects_energizing_but_allows_deenergizing_command() -> None:
+    service = _service()
+    service.acquire_authority("SYNTHETIC.CONTROLLER.PRIMARY")
+    service.inject_fault("hmi_unavailable")
+
+    energize = service.command("SYNTHETIC.HEATER.ENABLE", energizing=True)
+    deenergize = service.command("SYNTHETIC.HEATER.ENABLE", energizing=False)
+
+    assert energize.accepted is False
+    assert energize.fail_closed is True
+    assert deenergize.accepted is True
+
+
+def test_health_report_exposes_recovery_and_clock_contracts() -> None:
+    service = _service()
+    service.report_clock_skew(timedelta(seconds=3))
+
+    health = service.health()
+
+    assert health.recovery_time_objective_seconds == 300
+    assert health.recovery_point_objective_seconds == 30
+    assert health.clock_ordering_reliable is False
+    assert health.command_authority is None

--- a/src/p1am_control_system/backend/tests/test_connector_plugins.py
+++ b/src/p1am_control_system/backend/tests/test_connector_plugins.py
@@ -1,0 +1,88 @@
+"""F11 isolated connector/plugin and diagnostic contracts."""
+
+from __future__ import annotations
+
+from connector_plugins import (
+    CommandDisposition,
+    ConnectorDescriptor,
+    ConnectorManager,
+    ConnectorSample,
+)
+
+
+class HealthyConnector:
+    descriptor = ConnectorDescriptor(
+        connector_id="SYNTHETIC.CONNECTOR.HEALTHY",
+        version="1.0.0",
+        tags=("SYNTHETIC.HEALTHY.PV",),
+        writable_tags=("SYNTHETIC.HEALTHY.SP",),
+    )
+
+    def read(self) -> dict[str, float]:
+        return {"SYNTHETIC.HEALTHY.PV": 42.0}
+
+    def write(self, tag: str, value: float) -> None:
+        assert tag == "SYNTHETIC.HEALTHY.SP"
+        assert value == 10
+
+    def diagnostics(self) -> dict[str, object]:
+        return {"endpoint": "synthetic://healthy", "api_token": "do-not-expose"}
+
+
+class FailedConnector:
+    descriptor = ConnectorDescriptor(
+        connector_id="SYNTHETIC.CONNECTOR.FAILED",
+        version="1.0.0",
+        tags=("SYNTHETIC.FAILED.PV",),
+        writable_tags=("SYNTHETIC.FAILED.SP",),
+    )
+
+    def read(self) -> dict[str, float]:
+        raise ConnectionError("secret=field-password")
+
+    def write(self, tag: str, value: float) -> None:
+        raise ConnectionError("token=field-token")
+
+    def diagnostics(self) -> dict[str, object]:
+        return {"password": "field-password", "state": "offline"}
+
+
+def test_failed_connector_degrades_only_its_tags_without_crashing_poll() -> None:
+    manager = ConnectorManager((HealthyConnector(), FailedConnector()))
+
+    samples = manager.poll()
+
+    assert samples["SYNTHETIC.HEALTHY.PV"] == ConnectorSample(
+        value=42.0,
+        quality="good",
+        diagnostic="",
+        connector_id="SYNTHETIC.CONNECTOR.HEALTHY",
+    )
+    assert samples["SYNTHETIC.FAILED.PV"].value is None
+    assert samples["SYNTHETIC.FAILED.PV"].quality == "bad"
+    assert "SYNTHETIC.CONNECTOR.FAILED" in samples["SYNTHETIC.FAILED.PV"].diagnostic
+    assert "field-password" not in samples["SYNTHETIC.FAILED.PV"].diagnostic
+
+
+def test_failed_and_unknown_commands_fail_closed() -> None:
+    manager = ConnectorManager((HealthyConnector(), FailedConnector()))
+
+    accepted = manager.command("SYNTHETIC.HEALTHY.SP", 10)
+    failed = manager.command("SYNTHETIC.FAILED.SP", 10)
+    unknown = manager.command("SYNTHETIC.UNKNOWN.SP", 10)
+
+    assert accepted.disposition is CommandDisposition.ACCEPTED
+    assert failed.disposition is CommandDisposition.REJECTED
+    assert unknown.disposition is CommandDisposition.REJECTED
+    assert failed.fail_closed is True
+    assert "field-token" not in failed.diagnostic
+
+
+def test_diagnostics_identify_connector_and_redact_secrets() -> None:
+    manager = ConnectorManager((HealthyConnector(), FailedConnector()))
+
+    diagnostics = manager.diagnostics()
+
+    assert diagnostics[0].connector_id == "SYNTHETIC.CONNECTOR.HEALTHY"
+    assert diagnostics[0].details["api_token"] == "[REDACTED]"
+    assert diagnostics[1].details["password"] == "[REDACTED]"

--- a/src/p1am_control_system/backend/tests/test_notification_policy.py
+++ b/src/p1am_control_system/backend/tests/test_notification_policy.py
@@ -1,0 +1,111 @@
+"""F14 deterministic notification delay, suppression, and escalation contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from notification_policy import AlarmNotice, NotificationPolicy, NotificationService
+
+
+class RecordingChannel:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, str]] = []
+
+    def send(self, recipient: str, message: str) -> None:
+        self.sent.append((recipient, message))
+
+
+def _notice(
+    alarm_id: str, now: datetime, message: str = "Synthetic alarm"
+) -> AlarmNotice:
+    return AlarmNotice(
+        alarm_id=alarm_id,
+        priority="high",
+        occurred_at=now,
+        message=message,
+    )
+
+
+def test_delay_then_escalation_and_delivery_audit_are_deterministic() -> None:
+    clock = [datetime(2026, 8, 3, 20, 0, tzinfo=UTC)]
+    channel = RecordingChannel()
+    service = NotificationService(
+        NotificationPolicy(
+            initial_delay=timedelta(minutes=1),
+            escalation_delay=timedelta(minutes=3),
+            primary_recipient="synthetic.on-call.primary",
+            escalation_recipient="synthetic.on-call.escalation",
+        ),
+        channel,
+        now=lambda: clock[0],
+    )
+    service.raise_alarm(_notice("SYNTHETIC.ALARM.HIGH", clock[0]))
+
+    assert service.tick() == []
+    clock[0] += timedelta(minutes=1)
+    primary = service.tick()
+    clock[0] += timedelta(minutes=2)
+    escalated = service.tick()
+
+    assert primary[0].recipient == "synthetic.on-call.primary"
+    assert escalated[0].recipient == "synthetic.on-call.escalation"
+    assert channel.sent == [
+        ("synthetic.on-call.primary", "SYNTHETIC.ALARM.HIGH: Synthetic alarm"),
+        ("synthetic.on-call.escalation", "SYNTHETIC.ALARM.HIGH: Synthetic alarm"),
+    ]
+    assert [audit.outcome for audit in service.audit()] == ["delivered", "delivered"]
+
+
+def test_suppression_acknowledgment_cancellation_and_redaction() -> None:
+    clock = [datetime(2026, 8, 3, 20, 0, tzinfo=UTC)]
+    channel = RecordingChannel()
+    service = NotificationService(
+        NotificationPolicy(
+            initial_delay=timedelta(seconds=10),
+            escalation_delay=timedelta(minutes=1),
+            primary_recipient="synthetic.primary",
+            escalation_recipient="synthetic.escalation",
+            suppressed_alarm_ids=frozenset({"SYNTHETIC.ALARM.SUPPRESSED"}),
+        ),
+        channel,
+        now=lambda: clock[0],
+    )
+    service.raise_alarm(_notice("SYNTHETIC.ALARM.SUPPRESSED", clock[0]))
+    service.raise_alarm(
+        _notice(
+            "SYNTHETIC.ALARM.ACKED",
+            clock[0],
+            "Synthetic alarm password=do-not-expose",
+        )
+    )
+    service.acknowledge("SYNTHETIC.ALARM.ACKED", "operator.one")
+    clock[0] += timedelta(minutes=2)
+
+    assert service.tick() == []
+    assert channel.sent == []
+    assert {audit.outcome for audit in service.audit()} == {"suppressed", "cancelled"}
+    assert all("do-not-expose" not in audit.message for audit in service.audit())
+
+
+def test_rate_limit_blocks_burst_and_records_attempt() -> None:
+    clock = [datetime(2026, 8, 3, 20, 0, tzinfo=UTC)]
+    channel = RecordingChannel()
+    service = NotificationService(
+        NotificationPolicy(
+            initial_delay=timedelta(0),
+            escalation_delay=timedelta(hours=1),
+            primary_recipient="synthetic.primary",
+            escalation_recipient="synthetic.escalation",
+            max_deliveries=1,
+            rate_limit_window=timedelta(minutes=5),
+        ),
+        channel,
+        now=lambda: clock[0],
+    )
+    service.raise_alarm(_notice("SYNTHETIC.ALARM.ONE", clock[0]))
+    service.raise_alarm(_notice("SYNTHETIC.ALARM.TWO", clock[0]))
+
+    service.tick()
+
+    assert len(channel.sent) == 1
+    assert [audit.outcome for audit in service.audit()] == ["delivered", "rate_limited"]

--- a/src/p1am_control_system/backend/tests/test_product_router.py
+++ b/src/p1am_control_system/backend/tests/test_product_router.py
@@ -1,0 +1,99 @@
+"""REST surface for reusable procedure, connector, notification, and HA contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from availability import AvailabilityPolicy, AvailabilityService
+from connector_plugins import ConnectorDescriptor, ConnectorManager
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from identity import Principal, Role
+from notification_policy import NotificationPolicy, NotificationService
+from product_router import create_product_router
+from synthetic_procedure import SyntheticProcedure
+
+
+class Connector:
+    descriptor = ConnectorDescriptor(
+        connector_id="SYNTHETIC.CONNECTOR.DEMO",
+        version="1.0",
+        tags=("SYNTHETIC.DEMO.PV",),
+    )
+
+    def read(self) -> dict[str, float]:
+        return {"SYNTHETIC.DEMO.PV": 1.0}
+
+    def write(self, tag: str, value: float) -> None:
+        raise AssertionError("no writable tags")
+
+    def diagnostics(self) -> dict[str, object]:
+        return {"state": "online"}
+
+
+class Channel:
+    def send(self, recipient: str, message: str) -> None:
+        return None
+
+
+def _client() -> TestClient:
+    now = datetime(2026, 8, 3, 20, 0, tzinfo=UTC)
+    procedure = SyntheticProcedure(now=lambda: now)
+    connectors = ConnectorManager((Connector(),))
+    notifications = NotificationService(
+        NotificationPolicy(
+            initial_delay=timedelta(minutes=1),
+            escalation_delay=timedelta(minutes=5),
+            primary_recipient="synthetic.primary",
+            escalation_recipient="synthetic.escalation",
+        ),
+        Channel(),
+        now=lambda: now,
+    )
+    availability = AvailabilityService(
+        AvailabilityPolicy(
+            recovery_time_objective=timedelta(minutes=5),
+            recovery_point_objective=timedelta(seconds=30),
+            max_clock_skew=timedelta(seconds=2),
+            buffer_capacity=100,
+        )
+    )
+    app = FastAPI()
+    app.include_router(
+        create_product_router(
+            procedure,
+            connectors,
+            notifications,
+            availability,
+            operator_dependency=lambda: Principal(
+                "operator.one", "Operator One", Role.OPERATOR
+            ),
+        )
+    )
+    return TestClient(app)
+
+
+def test_product_status_exposes_all_reusable_contracts() -> None:
+    response = _client().get("/api/operator/product-status")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["procedure_state"] == "idle"
+    assert payload["connectors"][0]["connector_id"] == "SYNTHETIC.CONNECTOR.DEMO"
+    assert payload["samples"]["SYNTHETIC.DEMO.PV"]["quality"] == "good"
+    assert payload["notification_policy"]["primary_recipient"] == "synthetic.primary"
+    assert payload["availability"]["recovery_time_objective_seconds"] == 300
+    assert payload["data_classification"] == "synthetic"
+
+
+def test_procedure_commands_are_role_gated_and_attributed() -> None:
+    client = _client()
+
+    response = client.post(
+        "/api/operator/procedure/commands/start",
+        json={"reason": "Begin representative procedure"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["after"] == "starting"
+    assert response.json()["actor"] == "operator.one"

--- a/src/p1am_control_system/backend/tests/test_synthetic_procedure.py
+++ b/src/p1am_control_system/backend/tests/test_synthetic_procedure.py
@@ -1,0 +1,73 @@
+"""F09 deterministic simulator-only procedure contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from identity import Principal, Role
+from synthetic_procedure import ProcedureCommand, ProcedureState, SyntheticProcedure
+
+
+def _principal() -> Principal:
+    return Principal("operator.one", "Operator One", Role.OPERATOR)
+
+
+def test_start_run_hold_resume_stop_cycle_is_deterministic_and_attributed() -> None:
+    clock = [datetime(2026, 8, 3, 20, 0, tzinfo=UTC)]
+    procedure = SyntheticProcedure(now=lambda: clock[0])
+
+    events = [
+        procedure.dispatch(ProcedureCommand.START, _principal(), "Begin synthetic run"),
+        procedure.dispatch(ProcedureCommand.RUN, _principal(), "Start checks complete"),
+        procedure.dispatch(ProcedureCommand.HOLD, _principal(), "Synthetic hold"),
+        procedure.dispatch(
+            ProcedureCommand.RESUME, _principal(), "Resume synthetic run"
+        ),
+        procedure.dispatch(ProcedureCommand.STOP, _principal(), "Normal stop"),
+        procedure.dispatch(
+            ProcedureCommand.COMPLETE, _principal(), "Stop checks complete"
+        ),
+    ]
+
+    assert [event.after for event in events] == [
+        ProcedureState.STARTING,
+        ProcedureState.RUNNING,
+        ProcedureState.HOLDING,
+        ProcedureState.RUNNING,
+        ProcedureState.STOPPING,
+        ProcedureState.IDLE,
+    ]
+    assert all(event.actor == "operator.one" for event in events)
+    assert all(event.data_classification == "synthetic" for event in events)
+    assert procedure.state is ProcedureState.IDLE
+
+
+def test_abort_and_recovery_are_bounded() -> None:
+    clock = [datetime(2026, 8, 3, 20, 0, tzinfo=UTC)]
+    procedure = SyntheticProcedure(
+        now=lambda: clock[0],
+        transition_timeout=timedelta(seconds=30),
+    )
+    procedure.dispatch(ProcedureCommand.START, _principal(), "Begin synthetic run")
+    abort = procedure.dispatch(ProcedureCommand.ABORT, _principal(), "Synthetic fault")
+    recovery = procedure.dispatch(
+        ProcedureCommand.RECOVER, _principal(), "Recovery approved"
+    )
+
+    assert abort.after is ProcedureState.ABORTED
+    assert recovery.after is ProcedureState.RECOVERING
+    assert recovery.deadline == clock[0] + timedelta(seconds=30)
+
+    clock[0] += timedelta(seconds=31)
+    timeout = procedure.enforce_deadline()
+    assert timeout is not None
+    assert timeout.after is ProcedureState.ABORTED
+    assert timeout.command is ProcedureCommand.TIMEOUT
+
+
+def test_invalid_transition_is_fail_closed() -> None:
+    procedure = SyntheticProcedure(now=lambda: datetime(2026, 8, 3, tzinfo=UTC))
+
+    with pytest.raises(ValueError, match="not allowed"):
+        procedure.dispatch(ProcedureCommand.RUN, _principal(), "Invalid direct run")

--- a/src/p1am_control_system/frontend/src/api/endpoints.ts
+++ b/src/p1am_control_system/frontend/src/api/endpoints.ts
@@ -21,6 +21,7 @@ import {
   protectionSnapshotSchema,
   assetHealthReportSchema,
   shiftEntriesSchema,
+  productStatusSchema,
   type CaptureStatus,
   type CaptureClearResult,
   type CaptureConfig,
@@ -41,6 +42,7 @@ import {
   type ProtectionSnapshot,
   type AssetHealthReport,
   type ShiftEntry,
+  type ProductStatus,
 } from "./schemas";
 
 /**
@@ -146,6 +148,17 @@ export function getRepresentativeAssetHealth(): Promise<AssetHealthReport> {
 export function getShiftEntries(query = ""): Promise<ShiftEntry[]> {
   return apiFetch(`/operator/shift-log?query=${encodeURIComponent(query)}`, {
     schema: shiftEntriesSchema,
+  });
+}
+
+export function getProductStatus(): Promise<ProductStatus> {
+  return apiFetch("/operator/product-status", { schema: productStatusSchema });
+}
+
+export function sendProcedureCommand(command: string, reason: string): Promise<unknown> {
+  return apiFetch(`/operator/procedure/commands/${encodeURIComponent(command)}`, {
+    method: "POST",
+    json: { reason },
   });
 }
 

--- a/src/p1am_control_system/frontend/src/api/schemas.ts
+++ b/src/p1am_control_system/frontend/src/api/schemas.ts
@@ -301,6 +301,53 @@ export const shiftEntriesSchema = z.array(shiftEntrySchema);
 export type AssetHealthReport = z.infer<typeof assetHealthReportSchema>;
 export type ShiftEntry = z.infer<typeof shiftEntrySchema>;
 
+export const productStatusSchema = z.object({
+  procedure_state: z.enum([
+    "idle",
+    "starting",
+    "running",
+    "holding",
+    "stopping",
+    "aborted",
+    "recovering",
+  ]),
+  procedure_events: z.array(z.unknown()),
+  connectors: z.array(
+    z.object({
+      connector_id: z.string().startsWith("SYNTHETIC."),
+      version: z.string(),
+      details: z.record(z.string(), z.unknown()),
+    }),
+  ),
+  samples: z.record(
+    z.string(),
+    z.object({
+      value: z.number().nullable(),
+      quality: z.enum(["good", "bad"]),
+      diagnostic: z.string(),
+      connector_id: z.string().startsWith("SYNTHETIC."),
+    }),
+  ),
+  notification_policy: z.object({
+    primary_recipient: z.string(),
+    escalation_recipient: z.string(),
+  }).passthrough(),
+  notification_audit: z.array(z.unknown()),
+  availability: z.object({
+    recovery_time_objective_seconds: z.number().positive(),
+    recovery_point_objective_seconds: z.number().positive(),
+    clock_ordering_reliable: z.boolean(),
+    command_authority: z.string().nullable(),
+    transport_available: z.boolean(),
+    hmi_available: z.boolean(),
+    buffered_samples: z.number().int().nonnegative(),
+    data_classification: z.literal("synthetic"),
+  }),
+  data_classification: z.literal("synthetic"),
+  not_for_live_control: z.literal(true),
+});
+export type ProductStatus = z.infer<typeof productStatusSchema>;
+
 /**
  * Live telemetry frame pushed over the `/api/stream` WebSocket.
  *

--- a/src/p1am_control_system/frontend/src/components/OperatorWorkspace.test.tsx
+++ b/src/p1am_control_system/frontend/src/components/OperatorWorkspace.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../api/endpoints", () => ({
   getProtectionSnapshot: vi.fn(),
   getRepresentativeAssetHealth: vi.fn(),
   getShiftEntries: vi.fn(),
+  getProductStatus: vi.fn(),
 }));
 
 const overview = {
@@ -116,12 +117,50 @@ const assetHealth = {
   data_classification: "synthetic" as const,
 };
 
+const productStatus = {
+  procedure_state: "idle" as const,
+  procedure_events: [],
+  connectors: [
+    {
+      connector_id: "SYNTHETIC.CONNECTOR.DEMO",
+      version: "1.0",
+      details: { state: "online" },
+    },
+  ],
+  samples: {
+    "SYNTHETIC.DEMO.PV": {
+      value: 1,
+      quality: "good" as const,
+      diagnostic: "",
+      connector_id: "SYNTHETIC.CONNECTOR.DEMO",
+    },
+  },
+  notification_policy: {
+    primary_recipient: "synthetic.primary",
+    escalation_recipient: "synthetic.escalation",
+  },
+  notification_audit: [],
+  availability: {
+    recovery_time_objective_seconds: 300,
+    recovery_point_objective_seconds: 30,
+    clock_ordering_reliable: true,
+    command_authority: null,
+    transport_available: true,
+    hmi_available: true,
+    buffered_samples: 0,
+    data_classification: "synthetic" as const,
+  },
+  data_classification: "synthetic" as const,
+  not_for_live_control: true as const,
+};
+
 describe("OperatorWorkspace", () => {
   beforeEach(() => {
     vi.mocked(api.getOperatorOverview).mockResolvedValue(overview);
     vi.mocked(api.getProtectionSnapshot).mockResolvedValue(protections);
     vi.mocked(api.getRepresentativeAssetHealth).mockResolvedValue(assetHealth);
     vi.mocked(api.getShiftEntries).mockResolvedValue([]);
+    vi.mocked(api.getProductStatus).mockResolvedValue(productStatus);
   });
 
   it("navigates from a multi-area overview to a consistent faceplate", async () => {
@@ -153,5 +192,7 @@ describe("OperatorWorkspace", () => {
     expect(screen.getByText(/calibration due date has passed/i)).toBeInTheDocument();
     expect(screen.getByText(/Saved synthetic investigations retain/i)).toBeInTheDocument();
     expect(screen.getByText(/Signed entries are append-only/i)).toBeInTheDocument();
+    expect(screen.getByText(/Procedure state:/i)).toHaveTextContent("idle");
+    expect(screen.getByText(/RTO 300s \/ RPO 30s/i)).toBeInTheDocument();
   });
 });

--- a/src/p1am_control_system/frontend/src/components/OperatorWorkspace.tsx
+++ b/src/p1am_control_system/frontend/src/components/OperatorWorkspace.tsx
@@ -4,12 +4,14 @@ import {
   getProtectionSnapshot,
   getRepresentativeAssetHealth,
   getShiftEntries,
+  getProductStatus,
 } from "../api/endpoints";
 import type {
   AssetFaceplate,
   AssetHealthReport,
   ProcessOverview,
   ProtectionSnapshot,
+  ProductStatus,
   ShiftEntry,
 } from "../api/schemas";
 
@@ -84,6 +86,7 @@ export function OperatorWorkspace() {
   const [selected, setSelected] = useState<AssetFaceplate | null>(null);
   const [assetHealth, setAssetHealth] = useState<AssetHealthReport | null>(null);
   const [shiftEntries, setShiftEntries] = useState<ShiftEntry[]>([]);
+  const [productStatus, setProductStatus] = useState<ProductStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -93,13 +96,15 @@ export function OperatorWorkspace() {
       getProtectionSnapshot(),
       getRepresentativeAssetHealth(),
       getShiftEntries(),
+      getProductStatus(),
     ])
-      .then(([nextOverview, nextProtections, nextHealth, nextEntries]) => {
+      .then(([nextOverview, nextProtections, nextHealth, nextEntries, nextProduct]) => {
         if (active) {
           setOverview(nextOverview);
           setProtections(nextProtections);
           setAssetHealth(nextHealth);
           setShiftEntries(nextEntries);
+          setProductStatus(nextProduct);
         }
       })
       .catch((reason: unknown) => {
@@ -109,7 +114,7 @@ export function OperatorWorkspace() {
   }, []);
 
   if (error) return <div role="alert">{error}</div>;
-  if (!overview || !protections || !assetHealth) return <div>Loading representative operator workspace…</div>;
+  if (!overview || !protections || !assetHealth || !productStatus) return <div>Loading representative operator workspace…</div>;
 
   return (
     <main aria-labelledby="operator-workspace-heading">
@@ -162,6 +167,25 @@ export function OperatorWorkspace() {
           <ul>{shiftEntries.map((entry) => <li key={entry.entry_id}>{entry.summary}</li>)}</ul>
         )}
         <p>Signed entries are append-only; receiving operators acknowledge unresolved work explicitly.</p>
+      </section>
+      <section aria-labelledby="product-heading" style={{ marginTop: "1rem" }}>
+        <h3 id="product-heading">Reusable control product</h3>
+        <p>Procedure state: <strong>{productStatus.procedure_state}</strong>. Simulator-only transitions are bounded and attributable.</p>
+        <ul>
+          {productStatus.connectors.map((connector) => {
+            const samples = Object.values(productStatus.samples).filter(
+              (sample) => sample.connector_id === connector.connector_id,
+            );
+            const quality = samples.some((sample) => sample.quality === "bad") ? "bad" : "good";
+            return <li key={connector.connector_id}>{connector.connector_id}: {quality}</li>;
+          })}
+        </ul>
+        <p>
+          Notifications escalate from {productStatus.notification_policy.primary_recipient} to {productStatus.notification_policy.escalation_recipient}; deliveries are delayed, suppressed, rate-limited, redacted, and audited.
+        </p>
+        <p>
+          Recovery objectives: RTO {productStatus.availability.recovery_time_objective_seconds}s / RPO {productStatus.availability.recovery_point_objective_seconds}s. One command authority; energizing commands fail closed without the HMI.
+        </p>
       </section>
       {selected && <Faceplate asset={selected} onClose={() => setSelected(null)} />}
     </main>

--- a/src/p1am_control_system/frontend/src/help/helpContent.ts
+++ b/src/p1am_control_system/frontend/src/help/helpContent.ts
@@ -41,7 +41,16 @@ mode, alarm, interlock, and trend-drill-down context.
 - Protection cards keep control, interlock, and independent-protection
 categories distinct and show deterministic first-out consequences.
 - Any managed bypass is displayed in a persistent banner with actor, reason,
-and expiry. Items marked **Non-bypassable** cannot be bypassed through this UI.`,
+and expiry. Items marked **Non-bypassable** cannot be bypassed through this UI.
+
+### Reusable product demonstrations
+- Simulator-only procedures expose bounded start, run, hold, stop, abort, and
+recovery states with attributable transitions.
+- Connector health identifies the responsible plugin; a failed connector
+degrades only its own tags and all failed commands are rejected closed.
+- Notification and recovery summaries show escalation recipients, delivery
+controls, single command authority, clock reliability, and explicit RTO/RPO.
+These are representative contracts, not claims of redundant deployed hardware.`,
   },
 
   temperature: {


### PR DESCRIPTION
## Phase C — reusable control product

Closes #4087. Part of #4089. Stacked on Phase B.

### Delivered

- F09 simulator-only deterministic start/run/hold/resume/stop/complete/abort/recover/timeout procedure contracts with bounded transitions and attributable events
- F11 versioned connector ownership, isolated failures, owned-tag degradation, fail-closed command handling, responsible diagnostics, finite-value validation, and secret redaction
- F14 delayed/suppressed/escalated/rate-limited/redacted notifications with acknowledgement cancellation and audit-only representative delivery
- F15 one command-authority lease, ordered sequences/timestamps, bounded offline buffer, one-time reconciliation, clock reliability, explicit RTO/RPO, and energizing-command rejection without HMI availability

### Engineering evidence

RED → GREEN → REFACTOR tests cover every contract. Procedure, connector, notification, availability, composition, REST, and UI concerns are decoupled behind narrow interfaces with validated inputs and shared canonical records.

### Verification

- Backend: 1,010 passed; 6 CI-only dependency checks skipped
- Frontend: 394 passed
- Ruff, formatter, strict mypy, TypeScript, ESLint, and production bundle passed
- Connector fault, notification policy, availability ordering/reconciliation, procedure scenario, safety, and confidentiality regressions passed

### Safety boundary

All values and interfaces are representative. The UI explicitly states that these contracts do not claim deployed redundant hardware. No external notification side effect or unauthorized live-control path exists.