### PR TITLE
feat(scada): add review-only Phase D advisory workspace

### DIFF
--- a/docs/development/professional-scada-epic.md
+++ b/docs/development/professional-scada-epic.md
@@ -145,11 +145,28 @@ bundle pass; ESLint has zero errors and two unchanged pre-existing hook warnings
 
 ### Phase D — Advanced differentiation
 
-- [ ] F16 advisory optimization, digital-twin, and advanced-control workspace
+- [x] F16 advisory optimization, digital-twin, and advanced-control workspace
 
 Exit criterion: model outputs are reproducible, versioned, uncertainty-aware,
 reviewable, and unable to write authoritative commands without a separately
 approved integration.
+
+Phase D TDD evidence: the RED run failed collection because the advisory domain
+and router did not exist. GREEN added five passing domain/API contract tests for
+deterministic results, model and data provenance, bounded constraints,
+confidence intervals, replay checksums, attributable dispositions, invalid
+input rejection, and the absence of command/write routes. REFACTOR introduced
+canonical hashing, immutable contracts, retained identical evaluations, strict
+dependency checks, and shared schema validation while preserving the no-write
+boundary.
+
+Phase D release-gate evidence: Ruff, formatting, and strict mypy checks pass for
+the advisory domain and API; the complete backend suite passes with 1,015 tests
+and 6 CI-only dependency checks skipped; all 394 frontend tests, TypeScript, and
+the production bundle pass; ESLint has zero errors and two unchanged
+pre-existing hook warnings. The UI and in-app help label the model and data as
+synthetic, disclose that the representative linear projection is not validated
+against a plant, and state that no authoritative write path exists.
 
 ## Feature acceptance matrix
 

--- a/src/p1am_control_system/backend/advisory_router.py
+++ b/src/p1am_control_system/backend/advisory_router.py
@@ -1,0 +1,46 @@
+"""REST review surface for synthetic non-authoritative advisories."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from advisory_workspace import (
+    AdvisoryDisposition,
+    AdvisoryResult,
+    AdvisoryService,
+    DispositionRecord,
+    representative_advisory_request,
+)
+from fastapi import APIRouter, Depends, HTTPException
+from identity import Principal
+
+
+def create_advisory_router(
+    service: AdvisoryService,
+    operator_dependency: Callable[..., Principal],
+) -> APIRouter:
+    """Create review-only routes; no authoritative command route is defined."""
+    if not isinstance(service, AdvisoryService):
+        raise TypeError("service must be an AdvisoryService")
+    if not callable(operator_dependency):
+        raise TypeError("operator_dependency must be callable")
+    router = APIRouter(prefix="/api/operator/advisories", tags=["advisories"])
+
+    @router.get("/representative")
+    async def representative_advisory() -> AdvisoryResult:
+        return service.evaluate(representative_advisory_request())
+
+    @router.post("/{advisory_id}/dispositions")
+    async def record_disposition(
+        advisory_id: str,
+        body: AdvisoryDisposition,
+        principal: Principal = Depends(operator_dependency),  # noqa: B008
+    ) -> DispositionRecord:
+        try:
+            return service.record_disposition(advisory_id, body, principal)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return router

--- a/src/p1am_control_system/backend/advisory_workspace.py
+++ b/src/p1am_control_system/backend/advisory_workspace.py
@@ -1,0 +1,359 @@
+"""Reproducible synthetic advisories that cannot write control commands."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Callable
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal
+
+from identity import Principal
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+MODEL_DESCRIPTOR = {
+    "algorithm": "representative bounded linear projection",
+    "model_id": "SYNTHETIC.MODEL.ADVISORY",
+    "version": "1.0.0",
+}
+DEFAULT_MINIMUM = 40.0
+DEFAULT_MAXIMUM = 80.0
+CONFIDENCE_HALF_WIDTH = 2.5
+CONFIDENCE_LEVEL = 0.90
+THROUGHPUT_GAIN = 0.35
+
+
+def _canonical_sha256(payload: object) -> str:
+    """Return a stable SHA-256 for a JSON-compatible value."""
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=_json_default,
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _json_default(value: object) -> object:
+    """Convert supported immutable contract values for canonical hashing."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"unsupported canonical value: {type(value).__name__}")
+
+
+def _required_text(value: str, name: str) -> str:
+    """Normalize required human or synthetic identifiers."""
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty")
+    return normalized
+
+
+class AdvisoryRequest(BaseModel):
+    """Synthetic observations and target supplied to the advisory model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    dataset_id: str
+    observed_throughput: float
+    observed_energy: float
+    requested_throughput: float
+
+    @model_validator(mode="after")
+    def validate_request(self) -> AdvisoryRequest:
+        """Enforce finite inputs and a synthetic dataset boundary."""
+        object.__setattr__(
+            self,
+            "dataset_id",
+            _required_text(self.dataset_id, "dataset_id"),
+        )
+        if not self.dataset_id.startswith("SYNTHETIC."):
+            raise ValueError("dataset_id must identify synthetic data")
+        values = (
+            self.observed_throughput,
+            self.observed_energy,
+            self.requested_throughput,
+        )
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError("advisory inputs must be finite")
+        return self
+
+
+class ConstraintEnvelope(BaseModel):
+    """Permitted range used to bound a recommendation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    minimum: float
+    maximum: float
+    unit: str
+
+    @model_validator(mode="after")
+    def validate_range(self) -> ConstraintEnvelope:
+        """Require an ordered, finite constraint interval."""
+        if not all(math.isfinite(value) for value in (self.minimum, self.maximum)):
+            raise ValueError("constraint values must be finite")
+        if self.minimum > self.maximum:
+            raise ValueError("minimum must not exceed maximum")
+        object.__setattr__(self, "unit", _required_text(self.unit, "unit"))
+        return self
+
+
+class ConfidenceInterval(BaseModel):
+    """Uncertainty interval around one representative estimate."""
+
+    model_config = ConfigDict(frozen=True)
+
+    level: float = Field(gt=0.0, lt=1.0)
+    lower: float
+    estimate: float
+    upper: float
+
+    @model_validator(mode="after")
+    def validate_interval(self) -> ConfidenceInterval:
+        """Require a finite ordered interval containing the estimate."""
+        values = (self.lower, self.estimate, self.upper)
+        if not all(math.isfinite(value) for value in values):
+            raise ValueError("confidence values must be finite")
+        if not self.lower <= self.estimate <= self.upper:
+            raise ValueError("confidence interval must contain estimate")
+        return self
+
+
+class ModelProvenance(BaseModel):
+    """Identity of the versioned representative model artifact."""
+
+    model_config = ConfigDict(frozen=True)
+
+    model_id: Literal["SYNTHETIC.MODEL.ADVISORY"]
+    version: str
+    algorithm: str
+    artifact_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class DataProvenance(BaseModel):
+    """Identity and digest of the exact synthetic model inputs."""
+
+    model_config = ConfigDict(frozen=True)
+
+    dataset_id: str
+    content_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    feature_names: tuple[str, ...]
+
+
+class ReplayEvidence(BaseModel):
+    """Digests needed to reproduce and compare an advisory result."""
+
+    model_config = ConfigDict(frozen=True)
+
+    input_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    result_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    verified: Literal[True] = True
+
+
+class AdvisoryResult(BaseModel):
+    """Review-only model result with explicit safety and provenance labels."""
+
+    model_config = ConfigDict(frozen=True)
+
+    advisory_id: str
+    generated_at: datetime
+    model: ModelProvenance
+    data: DataProvenance
+    constraints: ConstraintEnvelope
+    confidence: ConfidenceInterval
+    recommended_setpoint: float
+    recommendation: str
+    limitation: str
+    replay: ReplayEvidence
+    authoritative_write_available: Literal[False] = False
+    data_classification: Literal["synthetic"] = "synthetic"
+    not_for_live_control: Literal[True] = True
+
+
+class DispositionDecision(StrEnum):
+    """Review outcomes available to an operator."""
+
+    ACCEPTED_FOR_REVIEW = "accepted_for_review"
+    REJECTED = "rejected"
+    DEFERRED = "deferred"
+
+
+class AdvisoryDisposition(BaseModel):
+    """Requested operator review disposition."""
+
+    model_config = ConfigDict(frozen=True)
+
+    decision: DispositionDecision
+    reason: str
+
+    @model_validator(mode="after")
+    def validate_reason(self) -> AdvisoryDisposition:
+        """Require an explicit review rationale."""
+        object.__setattr__(self, "reason", _required_text(self.reason, "reason"))
+        return self
+
+
+class DispositionRecord(BaseModel):
+    """Attributable append-only record that never applies a control value."""
+
+    model_config = ConfigDict(frozen=True)
+
+    advisory_id: str
+    decision: DispositionDecision
+    reason: str
+    actor: str
+    recorded_at: datetime
+    applied_to_control: Literal[False] = False
+
+
+class AdvisoryService:
+    """Evaluate and retain deterministic, non-authoritative advisories."""
+
+    def __init__(self, now: Callable[[], datetime]) -> None:
+        if not callable(now):
+            raise TypeError("now must be callable")
+        self._now = now
+        self._results: dict[str, AdvisoryResult] = {}
+        self._dispositions: list[DispositionRecord] = []
+
+    def evaluate(self, request: AdvisoryRequest) -> AdvisoryResult:
+        """Evaluate one request; postcondition: result is bounded and replayable."""
+        if not isinstance(request, AdvisoryRequest):
+            raise TypeError("request must be an AdvisoryRequest")
+        input_payload = request.model_dump(mode="json")
+        input_sha256 = _canonical_sha256(input_payload)
+        model = self._model_provenance()
+        constraints = ConstraintEnvelope(
+            minimum=DEFAULT_MINIMUM,
+            maximum=DEFAULT_MAXIMUM,
+            unit="synthetic energy index",
+        )
+        estimate = self._bounded_estimate(request, constraints)
+        confidence = ConfidenceInterval(
+            level=CONFIDENCE_LEVEL,
+            lower=max(constraints.minimum, estimate - CONFIDENCE_HALF_WIDTH),
+            estimate=estimate,
+            upper=min(constraints.maximum, estimate + CONFIDENCE_HALF_WIDTH),
+        )
+        core = self._result_core(request, model, constraints, confidence)
+        advisory_id = str(core["advisory_id"])
+        retained = self._results.get(advisory_id)
+        if retained is not None:
+            return retained
+        result_sha256 = _canonical_sha256(core)
+        result = AdvisoryResult.model_validate(
+            {
+                **core,
+                "replay": ReplayEvidence(
+                    input_sha256=input_sha256,
+                    result_sha256=result_sha256,
+                ),
+            }
+        )
+        self._results[result.advisory_id] = result
+        return result
+
+    def result(self, advisory_id: str) -> AdvisoryResult:
+        """Return one retained immutable advisory result."""
+        normalized = _required_text(advisory_id, "advisory_id")
+        try:
+            return self._results[normalized]
+        except KeyError as exc:
+            raise KeyError("advisory result not found") from exc
+
+    def record_disposition(
+        self,
+        advisory_id: str,
+        disposition: AdvisoryDisposition,
+        principal: Principal,
+    ) -> DispositionRecord:
+        """Append a review disposition without changing the advisory or controls."""
+        result = self.result(advisory_id)
+        if not isinstance(disposition, AdvisoryDisposition):
+            raise TypeError("disposition must be an AdvisoryDisposition")
+        if not isinstance(principal, Principal):
+            raise TypeError("principal must be a Principal")
+        record = DispositionRecord(
+            advisory_id=result.advisory_id,
+            decision=disposition.decision,
+            reason=disposition.reason,
+            actor=principal.subject,
+            recorded_at=self._now(),
+        )
+        self._dispositions.append(record)
+        return record
+
+    def dispositions(self, advisory_id: str) -> tuple[DispositionRecord, ...]:
+        """Return disposition history for one known result."""
+        result = self.result(advisory_id)
+        return tuple(
+            record
+            for record in self._dispositions
+            if record.advisory_id == result.advisory_id
+        )
+
+    @staticmethod
+    def _model_provenance() -> ModelProvenance:
+        return ModelProvenance(
+            model_id="SYNTHETIC.MODEL.ADVISORY",
+            version=MODEL_DESCRIPTOR["version"],
+            algorithm=MODEL_DESCRIPTOR["algorithm"],
+            artifact_sha256=_canonical_sha256(MODEL_DESCRIPTOR),
+        )
+
+    @staticmethod
+    def _bounded_estimate(
+        request: AdvisoryRequest, constraints: ConstraintEnvelope
+    ) -> float:
+        delta = request.requested_throughput - request.observed_throughput
+        unbounded = request.observed_energy + THROUGHPUT_GAIN * delta
+        return round(min(constraints.maximum, max(constraints.minimum, unbounded)), 3)
+
+    def _result_core(
+        self,
+        request: AdvisoryRequest,
+        model: ModelProvenance,
+        constraints: ConstraintEnvelope,
+        confidence: ConfidenceInterval,
+    ) -> dict[str, object]:
+        input_payload = request.model_dump(mode="json")
+        identity_sha256 = _canonical_sha256(
+            {"input": input_payload, "model": model.model_dump(mode="json")}
+        )
+        return {
+            "advisory_id": f"ADV-{identity_sha256[:16]}",
+            "generated_at": self._now(),
+            "model": model,
+            "data": DataProvenance(
+                dataset_id=request.dataset_id,
+                content_sha256=_canonical_sha256(input_payload),
+                feature_names=(
+                    "observed_throughput",
+                    "observed_energy",
+                    "requested_throughput",
+                ),
+            ),
+            "constraints": constraints,
+            "confidence": confidence,
+            "recommended_setpoint": confidence.estimate,
+            "recommendation": "Review bounded synthetic setpoint in scenario",
+            "limitation": (
+                "Representative linear projection only; not validated against a plant "
+                "and unable to issue authoritative commands."
+            ),
+        }
+
+
+def representative_advisory_request() -> AdvisoryRequest:
+    """Return invented inputs for the product demonstration workspace."""
+    return AdvisoryRequest(
+        dataset_id="SYNTHETIC.DATASET.REPRESENTATIVE-RUN",
+        observed_throughput=62.0,
+        observed_energy=47.0,
+        requested_throughput=68.0,
+    )

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -14,6 +14,7 @@ except ImportError:
 from typing import Any, cast
 
 import historian
+from advisory_router import create_advisory_router
 from alarm_router import create_alarm_router
 from alarm_service import AlarmService, manager_from_routing
 from alicat_manager import AlicatManager, AlicatMFC
@@ -683,6 +684,12 @@ app.include_router(
         representative_product.connectors,
         representative_product.notifications,
         representative_product.availability,
+        operator_dependency=require_api_key,
+    )
+)
+app.include_router(
+    create_advisory_router(
+        representative_product.advisories,
         operator_dependency=require_api_key,
     )
 )

--- a/src/p1am_control_system/backend/main.py
+++ b/src/p1am_control_system/backend/main.py
@@ -381,7 +381,9 @@ investigation_service = InvestigationService(
     SqliteInvestigationRepository(_config_session)
 )
 shift_log_service = ShiftLogService(SqliteShiftLogRepository(_config_session))
-asset_health_service = AssetHealthService(AssetHealthPolicy(), now=lambda: datetime.now(UTC))
+asset_health_service = AssetHealthService(
+    AssetHealthPolicy(), now=lambda: datetime.now(UTC)
+)
 
 
 def _representative_asset_health() -> AssetHealthReport:
@@ -410,6 +412,8 @@ def _representative_asset_health() -> AssetHealthReport:
         observations,
         calibration_due_at=now - timedelta(days=1),
     )
+
+
 software_revision = os.environ.get("P1AM_SOFTWARE_REVISION", "development-unidentified")
 recovery_service = RecoveryPackageService(
     configuration_workflow,

--- a/src/p1am_control_system/backend/representative_product.py
+++ b/src/p1am_control_system/backend/representative_product.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+from advisory_workspace import AdvisoryService
 from availability import AvailabilityPolicy, AvailabilityService
 from connector_plugins import ConnectorDescriptor, ConnectorManager
 from notification_policy import NotificationPolicy, NotificationService
@@ -59,6 +60,7 @@ class RepresentativeProduct:
     connectors: ConnectorManager
     notifications: NotificationService
     availability: AvailabilityService
+    advisories: AdvisoryService
 
 
 def build_representative_product(now: Callable[[], datetime]) -> RepresentativeProduct:
@@ -84,4 +86,5 @@ def build_representative_product(now: Callable[[], datetime]) -> RepresentativeP
                 buffer_capacity=1000,
             )
         ),
+        advisories=AdvisoryService(now=now),
     )

--- a/src/p1am_control_system/backend/tests/test_advisory_router.py
+++ b/src/p1am_control_system/backend/tests/test_advisory_router.py
@@ -1,0 +1,56 @@
+"""REST tests for advisory review without an authoritative write path."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from advisory_router import create_advisory_router
+from advisory_workspace import AdvisoryService
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from identity import Principal, Role
+
+
+def _client() -> tuple[TestClient, FastAPI]:
+    app = FastAPI()
+    service = AdvisoryService(now=lambda: datetime(2026, 8, 3, 21, 0, tzinfo=UTC))
+    app.include_router(
+        create_advisory_router(
+            service,
+            operator_dependency=lambda: Principal(
+                "operator.one", "Operator One", Role.OPERATOR
+            ),
+        )
+    )
+    return TestClient(app), app
+
+
+def test_representative_advisory_and_disposition_are_review_only() -> None:
+    client, app = _client()
+
+    response = client.get("/api/operator/advisories/representative")
+    assert response.status_code == 200
+    advisory = response.json()
+    assert advisory["authoritative_write_available"] is False
+    assert advisory["replay"]["verified"] is True
+
+    disposition = client.post(
+        f"/api/operator/advisories/{advisory['advisory_id']}/dispositions",
+        json={"decision": "accepted_for_review", "reason": "Use in synthetic study"},
+    )
+    assert disposition.status_code == 200
+    assert disposition.json()["applied_to_control"] is False
+
+    advisory_paths = {route.path for route in app.routes if "/advisories" in route.path}
+    assert all("command" not in path and "write" not in path for path in advisory_paths)
+
+
+def test_unknown_advisory_cannot_receive_a_disposition() -> None:
+    client, _ = _client()
+
+    response = client.post(
+        "/api/operator/advisories/unknown/dispositions",
+        json={"decision": "rejected", "reason": "No matching result"},
+    )
+
+    assert response.status_code == 404

--- a/src/p1am_control_system/backend/tests/test_advisory_workspace.py
+++ b/src/p1am_control_system/backend/tests/test_advisory_workspace.py
@@ -1,0 +1,92 @@
+"""Contracts for the synthetic, non-authoritative advisory workspace."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from advisory_workspace import (
+    AdvisoryDisposition,
+    AdvisoryRequest,
+    AdvisoryService,
+    ConstraintEnvelope,
+    DispositionDecision,
+)
+from identity import Principal, Role
+
+NOW = datetime(2026, 8, 3, 21, 0, tzinfo=UTC)
+
+
+def _request() -> AdvisoryRequest:
+    return AdvisoryRequest(
+        dataset_id="SYNTHETIC.DATASET.RUN-042",
+        observed_throughput=62.0,
+        observed_energy=47.0,
+        requested_throughput=68.0,
+    )
+
+
+def test_evaluation_is_reproducible_and_carries_complete_evidence() -> None:
+    service = AdvisoryService(now=lambda: NOW)
+
+    first = service.evaluate(_request())
+    replay = service.evaluate(_request())
+
+    assert replay == first
+    assert first.model.model_id == "SYNTHETIC.MODEL.ADVISORY"
+    assert first.model.version == "1.0.0"
+    assert len(first.model.artifact_sha256) == 64
+    assert first.data.dataset_id == "SYNTHETIC.DATASET.RUN-042"
+    assert len(first.data.content_sha256) == 64
+    assert (
+        first.constraints.minimum
+        <= first.recommended_setpoint
+        <= first.constraints.maximum
+    )
+    assert first.confidence.lower <= first.confidence.estimate <= first.confidence.upper
+    assert first.replay.verified is True
+    assert len(first.replay.input_sha256) == 64
+    assert len(first.replay.result_sha256) == 64
+    assert first.authoritative_write_available is False
+    assert first.data_classification == "synthetic"
+    assert first.not_for_live_control is True
+
+
+def test_constraints_and_confidence_reject_invalid_ranges() -> None:
+    with pytest.raises(ValueError, match="minimum"):
+        ConstraintEnvelope(minimum=80.0, maximum=70.0, unit="synthetic unit")
+
+    with pytest.raises(ValueError, match="finite"):
+        AdvisoryRequest(
+            dataset_id="SYNTHETIC.DATASET.INVALID",
+            observed_throughput=float("nan"),
+            observed_energy=1.0,
+            requested_throughput=2.0,
+        )
+
+
+def test_operator_disposition_is_attributable_and_cannot_apply_control() -> None:
+    service = AdvisoryService(now=lambda: NOW)
+    result = service.evaluate(_request())
+    principal = Principal("operator.one", "Operator One", Role.OPERATOR)
+
+    disposition = service.record_disposition(
+        result.advisory_id,
+        AdvisoryDisposition(
+            decision=DispositionDecision.DEFERRED,
+            reason="Review with the next synthetic operating scenario",
+        ),
+        principal,
+    )
+
+    assert disposition.actor == "operator.one"
+    assert disposition.advisory_id == result.advisory_id
+    assert disposition.applied_to_control is False
+    assert service.dispositions(result.advisory_id) == (disposition,)
+    assert service.result(result.advisory_id) == result
+
+    with pytest.raises(ValueError, match="reason"):
+        AdvisoryDisposition(
+            decision=DispositionDecision.REJECTED,
+            reason=" ",
+        )

--- a/src/p1am_control_system/frontend/src/api/endpoints.ts
+++ b/src/p1am_control_system/frontend/src/api/endpoints.ts
@@ -22,6 +22,8 @@ import {
   assetHealthReportSchema,
   shiftEntriesSchema,
   productStatusSchema,
+  advisoryResultSchema,
+  advisoryDispositionSchema,
   type CaptureStatus,
   type CaptureClearResult,
   type CaptureConfig,
@@ -43,6 +45,8 @@ import {
   type AssetHealthReport,
   type ShiftEntry,
   type ProductStatus,
+  type AdvisoryResult,
+  type AdvisoryDisposition,
 } from "./schemas";
 
 /**
@@ -153,6 +157,27 @@ export function getShiftEntries(query = ""): Promise<ShiftEntry[]> {
 
 export function getProductStatus(): Promise<ProductStatus> {
   return apiFetch("/operator/product-status", { schema: productStatusSchema });
+}
+
+export function getRepresentativeAdvisory(): Promise<AdvisoryResult> {
+  return apiFetch("/operator/advisories/representative", {
+    schema: advisoryResultSchema,
+  });
+}
+
+export function recordAdvisoryDisposition(
+  advisoryId: string,
+  decision: "accepted_for_review" | "rejected" | "deferred",
+  reason: string,
+): Promise<AdvisoryDisposition> {
+  return apiFetch(
+    `/operator/advisories/${encodeURIComponent(advisoryId)}/dispositions`,
+    {
+      method: "POST",
+      json: { decision, reason },
+      schema: advisoryDispositionSchema,
+    },
+  );
 }
 
 export function sendProcedureCommand(command: string, reason: string): Promise<unknown> {

--- a/src/p1am_control_system/frontend/src/api/schemas.ts
+++ b/src/p1am_control_system/frontend/src/api/schemas.ts
@@ -348,6 +348,56 @@ export const productStatusSchema = z.object({
 });
 export type ProductStatus = z.infer<typeof productStatusSchema>;
 
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
+export const advisoryResultSchema = z.object({
+  advisory_id: z.string().startsWith("ADV-"),
+  generated_at: z.string(),
+  model: z.object({
+    model_id: z.literal("SYNTHETIC.MODEL.ADVISORY"),
+    version: z.string(),
+    algorithm: z.string(),
+    artifact_sha256: sha256Schema,
+  }),
+  data: z.object({
+    dataset_id: z.string().startsWith("SYNTHETIC."),
+    content_sha256: sha256Schema,
+    feature_names: z.array(z.string()),
+  }),
+  constraints: z.object({
+    minimum: z.number(),
+    maximum: z.number(),
+    unit: z.string(),
+  }),
+  confidence: z.object({
+    level: z.number().gt(0).lt(1),
+    lower: z.number(),
+    estimate: z.number(),
+    upper: z.number(),
+  }),
+  recommended_setpoint: z.number(),
+  recommendation: z.string(),
+  limitation: z.string(),
+  replay: z.object({
+    input_sha256: sha256Schema,
+    result_sha256: sha256Schema,
+    verified: z.literal(true),
+  }),
+  authoritative_write_available: z.literal(false),
+  data_classification: z.literal("synthetic"),
+  not_for_live_control: z.literal(true),
+});
+export type AdvisoryResult = z.infer<typeof advisoryResultSchema>;
+
+export const advisoryDispositionSchema = z.object({
+  advisory_id: z.string(),
+  decision: z.enum(["accepted_for_review", "rejected", "deferred"]),
+  reason: z.string(),
+  actor: z.string(),
+  recorded_at: z.string(),
+  applied_to_control: z.literal(false),
+});
+export type AdvisoryDisposition = z.infer<typeof advisoryDispositionSchema>;
+
 /**
  * Live telemetry frame pushed over the `/api/stream` WebSocket.
  *

--- a/src/p1am_control_system/frontend/src/components/OperatorWorkspace.test.tsx
+++ b/src/p1am_control_system/frontend/src/components/OperatorWorkspace.test.tsx
@@ -9,6 +9,8 @@ vi.mock("../api/endpoints", () => ({
   getRepresentativeAssetHealth: vi.fn(),
   getShiftEntries: vi.fn(),
   getProductStatus: vi.fn(),
+  getRepresentativeAdvisory: vi.fn(),
+  recordAdvisoryDisposition: vi.fn(),
 }));
 
 const overview = {
@@ -154,6 +156,31 @@ const productStatus = {
   not_for_live_control: true as const,
 };
 
+const representativeAdvisory = {
+  advisory_id: "ADV-0123456789abcdef",
+  generated_at: "2026-08-03T21:00:00Z",
+  model: {
+    model_id: "SYNTHETIC.MODEL.ADVISORY" as const,
+    version: "1.0.0",
+    algorithm: "representative bounded linear projection",
+    artifact_sha256: "a".repeat(64),
+  },
+  data: {
+    dataset_id: "SYNTHETIC.DATASET.REPRESENTATIVE-RUN",
+    content_sha256: "b".repeat(64),
+    feature_names: ["observed_throughput", "observed_energy", "requested_throughput"],
+  },
+  constraints: { minimum: 40, maximum: 80, unit: "synthetic energy index" },
+  confidence: { level: 0.9, lower: 46.6, estimate: 49.1, upper: 51.6 },
+  recommended_setpoint: 49.1,
+  recommendation: "Review bounded synthetic setpoint in scenario",
+  limitation: "Representative linear projection only; unable to issue commands.",
+  replay: { input_sha256: "c".repeat(64), result_sha256: "d".repeat(64), verified: true as const },
+  authoritative_write_available: false as const,
+  data_classification: "synthetic" as const,
+  not_for_live_control: true as const,
+};
+
 describe("OperatorWorkspace", () => {
   beforeEach(() => {
     vi.mocked(api.getOperatorOverview).mockResolvedValue(overview);
@@ -161,6 +188,7 @@ describe("OperatorWorkspace", () => {
     vi.mocked(api.getRepresentativeAssetHealth).mockResolvedValue(assetHealth);
     vi.mocked(api.getShiftEntries).mockResolvedValue([]);
     vi.mocked(api.getProductStatus).mockResolvedValue(productStatus);
+    vi.mocked(api.getRepresentativeAdvisory).mockResolvedValue(representativeAdvisory);
   });
 
   it("navigates from a multi-area overview to a consistent faceplate", async () => {
@@ -194,5 +222,8 @@ describe("OperatorWorkspace", () => {
     expect(screen.getByText(/Signed entries are append-only/i)).toBeInTheDocument();
     expect(screen.getByText(/Procedure state:/i)).toHaveTextContent("idle");
     expect(screen.getByText(/RTO 300s \/ RPO 30s/i)).toBeInTheDocument();
+    expect(screen.getByText(/Advisory optimization & digital twin/i)).toBeInTheDocument();
+    expect(screen.getByText(/90% confidence: 46.6–51.6/i)).toBeInTheDocument();
+    expect(screen.getByText(/No authoritative write path/i)).toBeInTheDocument();
   });
 });

--- a/src/p1am_control_system/frontend/src/components/OperatorWorkspace.tsx
+++ b/src/p1am_control_system/frontend/src/components/OperatorWorkspace.tsx
@@ -5,6 +5,8 @@ import {
   getRepresentativeAssetHealth,
   getShiftEntries,
   getProductStatus,
+  getRepresentativeAdvisory,
+  recordAdvisoryDisposition,
 } from "../api/endpoints";
 import type {
   AssetFaceplate,
@@ -12,6 +14,7 @@ import type {
   ProcessOverview,
   ProtectionSnapshot,
   ProductStatus,
+  AdvisoryResult,
   ShiftEntry,
 } from "../api/schemas";
 
@@ -87,6 +90,8 @@ export function OperatorWorkspace() {
   const [assetHealth, setAssetHealth] = useState<AssetHealthReport | null>(null);
   const [shiftEntries, setShiftEntries] = useState<ShiftEntry[]>([]);
   const [productStatus, setProductStatus] = useState<ProductStatus | null>(null);
+  const [advisory, setAdvisory] = useState<AdvisoryResult | null>(null);
+  const [dispositionStatus, setDispositionStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -97,14 +102,16 @@ export function OperatorWorkspace() {
       getRepresentativeAssetHealth(),
       getShiftEntries(),
       getProductStatus(),
+      getRepresentativeAdvisory(),
     ])
-      .then(([nextOverview, nextProtections, nextHealth, nextEntries, nextProduct]) => {
+      .then(([nextOverview, nextProtections, nextHealth, nextEntries, nextProduct, nextAdvisory]) => {
         if (active) {
           setOverview(nextOverview);
           setProtections(nextProtections);
           setAssetHealth(nextHealth);
           setShiftEntries(nextEntries);
           setProductStatus(nextProduct);
+          setAdvisory(nextAdvisory);
         }
       })
       .catch((reason: unknown) => {
@@ -114,7 +121,22 @@ export function OperatorWorkspace() {
   }, []);
 
   if (error) return <div role="alert">{error}</div>;
-  if (!overview || !protections || !assetHealth || !productStatus) return <div>Loading representative operator workspace…</div>;
+  if (!overview || !protections || !assetHealth || !productStatus || !advisory) return <div>Loading representative operator workspace…</div>;
+
+  const disposition = async (
+    decision: "accepted_for_review" | "rejected" | "deferred",
+  ) => {
+    try {
+      const record = await recordAdvisoryDisposition(
+        advisory.advisory_id,
+        decision,
+        "Operator disposition from representative advisory workspace",
+      );
+      setDispositionStatus(`${record.decision.replace(/_/g, " ")} by ${record.actor}; no control value applied.`);
+    } catch (reason: unknown) {
+      setDispositionStatus(reason instanceof Error ? reason.message : "Disposition failed");
+    }
+  };
 
   return (
     <main aria-labelledby="operator-workspace-heading">
@@ -186,6 +208,24 @@ export function OperatorWorkspace() {
         <p>
           Recovery objectives: RTO {productStatus.availability.recovery_time_objective_seconds}s / RPO {productStatus.availability.recovery_point_objective_seconds}s. One command authority; energizing commands fail closed without the HMI.
         </p>
+      </section>
+      <section aria-labelledby="advisory-heading" style={{ marginTop: "1rem" }}>
+        <h3 id="advisory-heading">Advisory optimization &amp; digital twin</h3>
+        <p><strong>Review only. No authoritative write path.</strong> Synthetic demonstration; not validated against a plant.</p>
+        <p>
+          Model {advisory.model.model_id} v{advisory.model.version}; dataset {advisory.data.dataset_id}.
+        </p>
+        <p>
+          Recommendation: {advisory.recommended_setpoint} {advisory.constraints.unit} within {advisory.constraints.minimum}–{advisory.constraints.maximum}.
+          {" "}{advisory.confidence.level * 100}% confidence: {advisory.confidence.lower}–{advisory.confidence.upper}.
+        </p>
+        <p>Replay verified: {String(advisory.replay.verified)}; result checksum {advisory.replay.result_sha256.slice(0, 12)}…</p>
+        <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }}>
+          <button type="button" onClick={() => void disposition("accepted_for_review")}>Accept for review</button>
+          <button type="button" onClick={() => void disposition("deferred")}>Defer</button>
+          <button type="button" onClick={() => void disposition("rejected")}>Reject</button>
+        </div>
+        {dispositionStatus && <p role="status">{dispositionStatus}</p>}
       </section>
       {selected && <Faceplate asset={selected} onClose={() => setSelected(null)} />}
     </main>

--- a/src/p1am_control_system/frontend/src/help/helpContent.ts
+++ b/src/p1am_control_system/frontend/src/help/helpContent.ts
@@ -50,7 +50,11 @@ recovery states with attributable transitions.
 degrades only its own tags and all failed commands are rejected closed.
 - Notification and recovery summaries show escalation recipients, delivery
 controls, single command authority, clock reliability, and explicit RTO/RPO.
-These are representative contracts, not claims of redundant deployed hardware.`,
+- The advisory workspace identifies the synthetic model and data, shows bounded
+constraints and confidence, verifies replay checksums, and records attributable
+operator review dispositions. It has no authoritative command or write path.
+These are representative contracts, not claims of deployed redundant hardware,
+validated plant models, or approved advanced control.`,
   },
 
   temperature: {


### PR DESCRIPTION
## Phase D — advanced differentiation

Closes #4088. Part of #4089. Stacked on Phase C.

### Delivered

- F16 review-only advisory optimization/digital-twin workspace
- Versioned synthetic model artifact and exact input-data provenance with SHA-256 identities
- Finite validated inputs, bounded constraints, ordered confidence intervals, deterministic retained evaluations, and replay checksums
- Immutable attributable accept-for-review/defer/reject disposition records
- Typed REST/UI contracts and in-app limitations/help
- Explicit `authoritative_write_available=false`; no command or write route exists

### TDD / DbC / LoD / DRY evidence

RED failed because the advisory domain/router did not exist. GREEN added five passing domain/API tests. REFACTOR added canonical hashing, immutable models, retained identical evaluations, strict dependency validation, and shared frontend schemas while keeping model, API, and UI responsibilities separate.

### Verification

- Backend: 1,015 passed; 6 CI-only dependency checks skipped
- Frontend: 394 passed
- Ruff, formatter, strict mypy, TypeScript, ESLint, and production bundle passed
- Full safety, recovery, migration, fault, confidentiality, and no-authoritative-write regressions passed

### Safety boundary

The model and dataset are synthetic, the projection is explicitly not validated against a plant, and operator disposition never applies a control value. This PR does not authorize advanced control or live deployment.