### PR TITLE
⚡ Bolt: Replace Math.min/max spreads with single-pass loops

### DIFF
--- a/src/p1am_control_system/frontend/src/components/data_explorer/SourcePanel.tsx
+++ b/src/p1am_control_system/frontend/src/components/data_explorer/SourcePanel.tsx
@@ -68,10 +68,22 @@ export const SourcePanel: React.FC<SourcePanelProps> = ({
   const applyPreset = (seconds: number | "all") => {
     const now = Date.now();
     if (seconds === "all") {
-      const starts = signals
-        .map((s) => (s.start_time ? Date.parse(s.start_time) : NaN))
-        .filter((t) => Number.isFinite(t));
-      const start = starts.length ? Math.min(...starts) : now - 3600_000;
+      // ⚡ Bolt Optimization: Replace chained map/filter and Math.min(...spread)
+      // with a single-pass loop to avoid intermediate allocations and call stack limits.
+      let start = now - 3600_000;
+      let hasStart = false;
+      for (let i = 0; i < signals.length; i++) {
+        const startTime = signals[i].start_time;
+        if (startTime) {
+          const t = Date.parse(startTime);
+          if (Number.isFinite(t)) {
+            if (!hasStart || t < start) {
+              start = t;
+              hasStart = true;
+            }
+          }
+        }
+      }
       onHistorianChange({
         ...historian,
         start: toLocalInput(start),

--- a/src/p1am_control_system/frontend/src/lib/trendAxis.ts
+++ b/src/p1am_control_system/frontend/src/lib/trendAxis.ts
@@ -44,8 +44,14 @@ export function resolveRange(
     };
   }
   if (values.length === 0) return defaults;
-  let lo = Math.min(...values);
-  let hi = Math.max(...values);
+  // ⚡ Bolt Optimization: Use single-pass loop instead of Math.min(...)/Math.max(...)
+  // to avoid call stack limits on large arrays.
+  let lo = values[0];
+  let hi = values[0];
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] < lo) lo = values[i];
+    if (values[i] > hi) hi = values[i];
+  }
   if (hi - lo < 1e-9) {
     lo -= 1;
     hi += 1;


### PR DESCRIPTION
💡 What: Replaced `Math.min(...arr)` and `Math.max(...arr)` usages combined with array `.map().filter()` chains with single-pass `for` loops in `trendAxis.ts` and `SourcePanel.tsx`.
🎯 Why: Using the spread operator with `Math.min`/`Math.max` on large arrays can throw "Maximum call stack size exceeded" errors. Array chaining also allocates intermediate objects, adding garbage collection pressure on high-frequency paths.
📊 Impact: Eliminates the risk of stack overflows for large datasets and reduces GC overhead.
🔬 Measurement: Verified the code functions identically through existing tests while averting call stack limit issues for unbounded data streams.

---
*PR created automatically by Jules for task [18240210222541621039](https://jules.google.com/task/18240210222541621039) started by @dieterolson*