### PR TITLE
feat(swing_sim): foundation — shared swing simulation package + swing-core Rust/WASM crate (P0, #4104)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -915,11 +915,11 @@ jobs:
             if [ -z "$BASE_SHA" ]; then
               BASE_SHA="${{ github.event.pull_request.base.sha }}"
             fi
-            RUST_FILES=$(git diff --name-only "$BASE_SHA" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || true)
+            RUST_FILES=$(git diff --name-only "$BASE_SHA" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' 'src/shared/python/swing_sim/**' || true)
           elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            RUST_FILES=$(git diff --name-only "${{ github.event.before }}" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || true)
+            RUST_FILES=$(git diff --name-only "${{ github.event.before }}" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' 'src/shared/python/swing_sim/**' || true)
           else
-            RUST_FILES=$(git diff --name-only HEAD~1 HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || echo "")
+            RUST_FILES=$(git diff --name-only HEAD~1 HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' 'src/shared/python/swing_sim/**' || echo "")
           fi
 
           if [ -n "$RUST_FILES" ]; then
@@ -1029,13 +1029,24 @@ jobs:
           echo "wasm-pack build completed"
           ls pkg/
 
+      - name: Build WASM Module — swing-core (wasm-pack)
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: |
+          cd rust_core/swing-core
+          wasm-pack build --target web --features wasm --no-default-features
+          echo "wasm-pack build (swing-core) completed"
+          ls pkg/
+
       - name: Verify WASM Module
         if: steps.rust-changes.outputs.has_changes == 'true'
         run: |
-          # Verify the WASM package was produced with expected files
+          # Verify the WASM packages were produced with expected files
           test -f rust_core/tools-core/pkg/tools_core_bg.wasm && echo "✅ WASM binary exists"
           test -f rust_core/tools-core/pkg/package.json && echo "✅ package.json exists"
           test -f rust_core/tools-core/pkg/tools_core.js && echo "✅ JS glue exists"
+          test -f rust_core/swing-core/pkg/swing_core_bg.wasm && echo "✅ swing-core WASM binary exists"
+          test -f rust_core/swing-core/pkg/package.json && echo "✅ swing-core package.json exists"
+          test -f rust_core/swing-core/pkg/swing_core.js && echo "✅ swing-core JS glue exists"
 
       - name: Run Benchmarks (Criterion)
         if: steps.rust-changes.outputs.has_changes == 'true'

--- a/.github/workflows/maturin-swing-core.yml
+++ b/.github/workflows/maturin-swing-core.yml
@@ -1,0 +1,116 @@
+# Maturin CI — swing_core Python extension
+#
+# Builds the `swing-core` Rust crate (shared swing simulation kernel:
+# double-pendulum swing dynamics on an oriented swing plane, epic #4103 /
+# P0 #4104) as a maturin wheel and asserts the extension imports so
+# `from swing_core import swing` in
+# src/shared/python/swing_sim/_rust_facade.py resolves to the native backend
+# instead of raising.
+#
+# Unlike pendulum-core, swing-core IS a root Cargo workspace member, so
+# rustfmt/clippy/cargo-test coverage comes from ci-standard.yml's
+# rust-quality-gate. This workflow adds what the workspace gate cannot:
+# a per-Python-version wheel build, an import assertion, and the
+# Rust<->Python parity suite run non-skipped (it is `importorskip
+# swing_core` and so is silently skipped wherever the wheel is absent).
+#
+# Runner platforms: the d-sorg-fleet self-hosted pool spans linux, windows,
+# and macos hosts. Python versions 3.10, 3.11, and 3.12 are hard-gated here;
+# Python 3.13 coverage is deferred until all fleet runners have a 3.13
+# toolcache (same policy as maturin-pendulum-core.yml).
+
+name: Maturin — swing_core
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rust_core/swing-core/**"
+      - "src/shared/python/swing_sim/**"
+      - "rust_core/math-primitives/**"
+      - ".github/workflows/maturin-swing-core.yml"
+  pull_request:
+    paths:
+      - "rust_core/swing-core/**"
+      - "src/shared/python/swing_sim/**"
+      - "rust_core/math-primitives/**"
+      - ".github/workflows/maturin-swing-core.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: maturin-swing-core-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity-gate:
+    name: swing_core build + parity gate (Python ${{ matrix.python-version }})
+    runs-on: d-sorg-fleet
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install build + test deps
+        run: python -m pip install --upgrade pip maturin "numpy>=1.24" pytest
+
+      - name: Build swing_core wheel
+        run: python -m maturin build --release -m rust_core/swing-core/Cargo.toml --out dist
+
+      - name: Install the built wheel
+        shell: bash
+        run: |
+          WHEEL=$(ls dist/*.whl | head -1)
+          python -m pip install "$WHEEL"
+
+      - name: Assert the extension imports (hard fail — no silent fallback)
+        shell: bash
+        run: |
+          python - <<'PY'
+          # Runtime PyO3 submodule: attribute access, never `import swing_core.swing`.
+          from swing_core import swing
+          required = {
+              "PendulumParameters", "PendulumState",
+              "plane_rotation", "in_plane_gravity",
+              "mass_matrix", "step", "simulate", "total_energy",
+          }
+          missing = required - set(dir(swing))
+          assert not missing, f"swing_core.swing missing exports: {missing}"
+          print("swing_core OK:", sorted(required))
+          PY
+
+      - name: Assert the strict facade selects the Rust backend (gate)
+        shell: bash
+        env:
+          PYTHONPATH: src
+        run: |
+          python - <<'PY'
+          from shared.python.swing_sim import _rust_facade
+          assert _rust_facade.rust_available(), (
+              "swing_sim._rust_facade did not load the swing_core wheel"
+          )
+          print("swing_core backend gate OK: native loaded")
+          PY
+
+      - name: Run Rust<->Python parity suite (gate, non-skipped)
+        env:
+          PYTHONPATH: src
+        run: |
+          python -m pytest \
+            src/shared/python/swing_sim/tests/test_parity_rust.py \
+            -o addopts="" -p no:cacheprovider -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "rust_core/ai_backend",
     "rust_core/file_watcher",
     "rust_core/data-processor-core",
+    "rust_core/swing-core",
 ]
 # `src/pendulum_simulator/pendulum-core` is intentionally NOT a workspace member
 # (issue #3294). It is a PyO3 extension crate whose native dynamics are built

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,15 +26,41 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.5.3                                      |
-| **Spec Version**        | 1.5.3                                      |
-| **Last Spec Update**    | 2026-07-26                                 |
+| **Current Version**     | 1.6.0                                      |
+| **Spec Version**        | 1.6.0                                      |
+| **Last Spec Update**    | 2026-08-04                                 |
 
 ## 2. Purpose & Mission
 
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Swing simulation foundation (epic #4103, P0 #4104)
+
+- New Rust workspace member `rust_core/swing-core` (Python wheel `swing_core`
+  via maturin, WASM NPM package via wasm-pack): double-pendulum swing
+  equations of motion ported from UpstreamDrift's `double_pendulum.py`
+  (mass matrix, Coriolis/centripetal, gravity, viscous damping, RK4),
+  generalised so gravity enters as an in-plane 2-vector computed from a
+  swing-plane pose built by three sequential intrinsic tilts (yaw about
+  world-up, side tilt about the rotated axis, forward/back tilt). Feature
+  contract (`python` / `extension-module` / `wasm`, cdylib+rlib, per-crate
+  maturin pyproject, dual `#[cfg_attr]` bindings split under `py_bindings/`
+  and `wasm_bindings/`) copies `tools-core` exactly.
+- New shared Python package `src/shared/python/swing_sim/`: frozen DbC
+  dataclasses (`PlaneOrientation`, `PendulumParameters`, `PendulumState`,
+  `SwingSample` with SE(3) pose + 6-twist, `SwingTrajectory`), the
+  `SwingSource` protocol with a `DoublePendulumSwing` implementation, a
+  strict Rust façade (`_rust_facade.py`, bilateral_rust posture: raise at
+  call time when the wheel is missing for hot loops) and a pure-Python
+  reference implementation used as the Rust parity oracle and one-shot
+  fallback. In-package tests carry `unit` / `parity` / `contract` markers.
+- CI: `ci-standard.yml` rust-quality-gate change filter also watches
+  `src/shared/python/swing_sim/**` and builds/verifies the swing-core WASM
+  package; new `maturin-swing-core.yml` per-crate workflow builds the wheel
+  on Python 3.10–3.12, asserts the extension imports, and runs the parity
+  suite non-skipped. NPM publishing is deferred to epic P7.
+
 ### 2026-07-26 P1AM Control System Trend Crosshair Optimization
 
 - `src/p1am_control_system/frontend/src/components/TrendPlotOverlays.tsx` and `PlotCrosshair.tsx` reduce
@@ -1717,6 +1743,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.6.0 | feat(swing_sim, #4104): add the swing simulation foundation — new `rust_core/swing-core` workspace crate (double-pendulum EOM with plane-oriented in-plane gravity, PyO3 wheel `swing_core` + wasm-bindgen bindings) and shared `src/shared/python/swing_sim` package (DbC value types, `SwingSource` protocol, `DoublePendulumSwing`, strict Rust façade with pure-Python parity oracle); wire swing-core into the rust quality gate's wasm build and add the `maturin-swing-core.yml` build/import/parity workflow. |
 | 2026-07-26 | 1.5.3 | fix(test): create the standalone-wheel smoke environment from the real base interpreter rather than nesting it under the active CI virtualenv, keeping installed-artifact validation portable across relocated self-hosted Python 3.10 runtimes. |
 | 2026-07-26 | 1.5.3 | fix(ci): isolate both protected Python jobs in per-job virtual environments after validating the persistent setup-python runtime; repair and import-probe the matrix NumPy/SciPy stack with compatible bounds, and reinstall OpenCV without dependency resolution so it cannot replace the verified NumPy wheel. |
 | 2026-07-26 | 1.5.3 | fix(import-aliases, #3936): make canonical shared-module aliases satisfy `runpy` code lookup so packaged compatibility commands such as `python -m sidekick` execute their parent-owned `shared.python` implementation; include `contracts` in the identity-coalescing alias set and keep Sidekick agent DbC imports on the canonical shared path. |

--- a/rust_core/swing-core/Cargo.toml
+++ b/rust_core/swing-core/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "swing-core"
+description = "Swing simulation kernel: double-pendulum swing dynamics on an oriented swing plane (Rust core for Python + WASM)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "swing_core"
+# cdylib is required for PyO3 shared library output
+# rlib is required for Rust-to-Rust dependencies and tests
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+# Enable PyO3 bindings for cargo checks and local Rust tests.
+python = ["dep:pyo3", "dep:numpy", "math-primitives/python"]
+# Enable Python extension-module linkage only for maturin wheel builds.
+extension-module = ["pyo3/extension-module", "math-primitives/extension-module"]
+# Enable wasm-bindgen for WASM/NPM builds (wasm-pack)
+wasm = ["dep:wasm-bindgen", "math-primitives/wasm"]
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+numpy = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+serde = { workspace = true }
+nalgebra = "0.33"
+math-primitives = { path = "../math-primitives" }
+
+[dev-dependencies]
+proptest = { workspace = true }
+serde_json = { workspace = true }

--- a/rust_core/swing-core/pyproject.toml
+++ b/rust_core/swing-core/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "swing-core"
+version = "0.1.0"
+description = "Rust-compiled swing simulation kernel: double-pendulum swing dynamics on an oriented swing plane"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.3",
+    "numpy>=1.24",
+]
+
+[tool.maturin]
+# Build with PyO3 bindings and extension-module linkage for wheel output.
+features = ["python", "extension-module"]
+# Module name matches the #[pymodule] name in lib.rs
+module-name = "swing_core"
+# Use the Cargo manifest relative to this pyproject.toml
+manifest-path = "Cargo.toml"

--- a/rust_core/swing-core/src/lib.rs
+++ b/rust_core/swing-core/src/lib.rs
@@ -1,0 +1,45 @@
+//! # swing-core — Swing Simulation Kernel
+//!
+//! Canonical Rust implementation of the swing simulation physics shared by the
+//! PyQt6 desktop app (via PyO3 wheel `swing_core`) and the web app (via
+//! wasm-pack NPM package). Single-source physics: Python and WASM consumers
+//! call these exact functions so the two UIs cannot drift.
+//!
+//! Phase 0 (issue #4104) walking skeleton:
+//! - `swing::pendulum` — driven double-pendulum equations of motion ported
+//!   from UpstreamDrift's `double_pendulum.py` (mass matrix, Coriolis,
+//!   gravity, damping, RK4).
+//! - `swing::plane` — swing-plane orientation (three sequential tilts) and
+//!   in-plane gravity projection; the EOM consumes the projected 2-vector.
+//!
+//! # Architecture
+//! - Core physics is plain Rust (no FFI types) in `swing/`.
+//! - Python-specific glue lives in `py_bindings/` (feature `python`).
+//! - WASM-specific glue lives in `wasm_bindings/` (feature `wasm`).
+
+pub mod swing;
+
+#[cfg(feature = "python")]
+pub mod py_bindings;
+
+#[cfg(feature = "wasm")]
+pub mod wasm_bindings;
+
+// Re-export primary types at the crate root for Rust consumers.
+pub use swing::pendulum::{PendulumParameters, PendulumState};
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+/// Python module `swing_core`.
+///
+/// Registers submodules only; all classes/functions hang off runtime PyO3
+/// submodules (e.g. `swing`). Note for Python consumers: runtime submodules
+/// are attributes, not filesystem modules — use
+/// `from swing_core import swing`, never `import swing_core.swing`.
+#[cfg(feature = "python")]
+#[pymodule]
+fn swing_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    py_bindings::py_swing::register_module(m)?;
+    Ok(())
+}

--- a/rust_core/swing-core/src/py_bindings/mod.rs
+++ b/rust_core/swing-core/src/py_bindings/mod.rs
@@ -1,0 +1,7 @@
+//! Python (PyO3) bindings, split by concern.
+//!
+//! Only compiled with the `python` feature. Each submodule mirrors one
+//! domain module under `swing/` and registers a runtime PyO3 submodule on
+//! the `swing_core` extension module.
+
+pub mod py_swing;

--- a/rust_core/swing-core/src/py_bindings/py_swing.rs
+++ b/rust_core/swing-core/src/py_bindings/py_swing.rs
@@ -1,0 +1,158 @@
+//! PyO3 bindings for `swing::pendulum` and `swing::plane`.
+//!
+//! Registered as the runtime submodule `swing` on the `swing_core`
+//! extension module. Python consumers must import it via attribute access
+//! (`from swing_core import swing`), never `import swing_core.swing`.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::swing::pendulum::{self, PendulumParameters, PendulumState};
+use crate::swing::plane;
+
+#[pymethods]
+impl PendulumParameters {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn py_new(
+        m1: f64,
+        l1: f64,
+        lc1: f64,
+        i1: f64,
+        m2: f64,
+        l2: f64,
+        lc2: f64,
+        i2: f64,
+        d1: f64,
+        d2: f64,
+    ) -> PyResult<Self> {
+        let params = Self {
+            m1,
+            l1,
+            lc1,
+            i1,
+            m2,
+            l2,
+            lc2,
+            i2,
+            d1,
+            d2,
+        };
+        params.validate().map_err(PyValueError::new_err)?;
+        Ok(params)
+    }
+
+    /// Default golf-swing parameters (UpstreamDrift reference constants).
+    #[staticmethod]
+    fn golf_default_py() -> Self {
+        Self::golf_default()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PendulumParameters(m1={}, l1={}, lc1={}, i1={}, m2={}, l2={}, lc2={}, i2={}, d1={}, d2={})",
+            self.m1, self.l1, self.lc1, self.i1, self.m2, self.l2, self.lc2, self.i2, self.d1, self.d2
+        )
+    }
+}
+
+#[pymethods]
+impl PendulumState {
+    #[new]
+    fn py_new(theta1: f64, theta2: f64, omega1: f64, omega2: f64) -> Self {
+        Self {
+            theta1,
+            theta2,
+            omega1,
+            omega2,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PendulumState(theta1={}, theta2={}, omega1={}, omega2={})",
+            self.theta1, self.theta2, self.omega1, self.omega2
+        )
+    }
+}
+
+/// Plane rotation matrix as a row-major nested list `[[f64; 3]; 3]`.
+#[pyfunction]
+fn plane_rotation(yaw: f64, side_tilt: f64, fwd_tilt: f64) -> [[f64; 3]; 3] {
+    let r = plane::plane_rotation(yaw, side_tilt, fwd_tilt);
+    let mut out = [[0.0; 3]; 3];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, value) in row.iter_mut().enumerate() {
+            *value = r[(i, j)];
+        }
+    }
+    out
+}
+
+/// In-plane gravity `(g_x, g_y)` from the three tilt angles and `g` [m/s²].
+#[pyfunction]
+fn in_plane_gravity(yaw: f64, side_tilt: f64, fwd_tilt: f64, g: f64) -> (f64, f64) {
+    plane::in_plane_gravity_from_tilts(yaw, side_tilt, fwd_tilt, g)
+}
+
+/// Symmetric 2x2 mass matrix as nested list.
+#[pyfunction]
+fn mass_matrix(params: &PendulumParameters, theta2: f64) -> [[f64; 2]; 2] {
+    pendulum::mass_matrix(params, theta2)
+}
+
+/// One RK4 step of size `dt` under in-plane gravity `(gx, gy)`.
+#[pyfunction]
+fn step(
+    params: &PendulumParameters,
+    state: &PendulumState,
+    gx: f64,
+    gy: f64,
+    dt: f64,
+) -> PyResult<PendulumState> {
+    pendulum::rk4_step(params, state, (gx, gy), dt).map_err(PyValueError::new_err)
+}
+
+/// Simulate `n_steps` RK4 steps.
+///
+/// Returns a flat row-major vector of `(n_steps + 1) * 4` floats:
+/// `[theta1, theta2, omega1, omega2]` per state, initial state included.
+/// The Python façade reshapes this into an `(n+1, 4)` NumPy array.
+#[pyfunction]
+fn simulate(
+    params: &PendulumParameters,
+    initial: &PendulumState,
+    gx: f64,
+    gy: f64,
+    dt: f64,
+    n_steps: usize,
+) -> PyResult<Vec<f64>> {
+    let states = pendulum::simulate(params, initial, (gx, gy), dt, n_steps)
+        .map_err(PyValueError::new_err)?;
+    let mut out = Vec::with_capacity(states.len() * 4);
+    for s in states {
+        out.extend_from_slice(&[s.theta1, s.theta2, s.omega1, s.omega2]);
+    }
+    Ok(out)
+}
+
+/// Total mechanical energy [J] under in-plane gravity `(gx, gy)`.
+#[pyfunction]
+fn total_energy(params: &PendulumParameters, state: &PendulumState, gx: f64, gy: f64) -> f64 {
+    pendulum::total_energy(params, state, (gx, gy))
+}
+
+/// Register the `swing` runtime submodule on the parent extension module.
+pub fn register_module(parent: &Bound<'_, PyModule>) -> PyResult<()> {
+    let m = PyModule::new(parent.py(), "swing")?;
+    m.add_class::<PendulumParameters>()?;
+    m.add_class::<PendulumState>()?;
+    m.add_function(wrap_pyfunction!(plane_rotation, &m)?)?;
+    m.add_function(wrap_pyfunction!(in_plane_gravity, &m)?)?;
+    m.add_function(wrap_pyfunction!(mass_matrix, &m)?)?;
+    m.add_function(wrap_pyfunction!(step, &m)?)?;
+    m.add_function(wrap_pyfunction!(simulate, &m)?)?;
+    m.add_function(wrap_pyfunction!(total_energy, &m)?)?;
+    parent.add_submodule(&m)?;
+    Ok(())
+}

--- a/rust_core/swing-core/src/swing/mod.rs
+++ b/rust_core/swing-core/src/swing/mod.rs
@@ -1,0 +1,14 @@
+//! Swing dynamics domain module.
+//!
+//! - [`pendulum`] — double-pendulum equations of motion (mass matrix,
+//!   Coriolis/centripetal, gravity, damping) and RK4 stepping.
+//! - [`plane`] — swing-plane orientation (three sequential intrinsic tilts)
+//!   and projection of world gravity into the swing plane.
+//!
+//! The pendulum EOM is planar; plane orientation enters exclusively through
+//! the projected in-plane gravity 2-vector produced by
+//! [`plane::in_plane_gravity`]. This keeps the dynamics core independent of
+//! the world-frame convention (LoD: the EOM never sees the 3-D pose).
+
+pub mod pendulum;
+pub mod plane;

--- a/rust_core/swing-core/src/swing/pendulum.rs
+++ b/rust_core/swing-core/src/swing/pendulum.rs
@@ -1,0 +1,439 @@
+//! Double-pendulum swing dynamics.
+//!
+//! Port of UpstreamDrift's
+//! `src/engines/pendulum_models/python/double_pendulum_model/physics/double_pendulum.py`
+//! (mass matrix, Coriolis/centripetal vector, gravity vector, viscous
+//! damping, RK4 stepping), generalised so gravity enters as an **in-plane
+//! 2-vector** computed from the swing-plane pose (see [`crate::swing::plane`])
+//! instead of a projected scalar.
+//!
+//! # Angle convention
+//! - `theta1`: angle of the upper segment measured from the in-plane
+//!   downward vertical (positive counter-clockwise).
+//! - `theta2`: angle of the lower segment **relative to** the upper segment.
+//!
+//! In-plane coordinates: local x = in-plane horizontal, local y = in-plane
+//! up. A segment at angle `theta` from downward vertical points along
+//! `(sin theta, -cos theta)`.
+//!
+//! # Design by Contract
+//! - `PendulumParameters::validate` rejects non-positive masses/lengths and
+//!   non-finite values.
+//! - The mass matrix is symmetric positive-definite for valid parameters
+//!   (unit tested).
+//! - Undamped, unforced dynamics conserve total energy (unit tested:
+//!   relative drift < 1e-6 over 1000 RK4 steps).
+
+use serde::{Deserialize, Serialize};
+
+/// Numerical tolerance for detecting singular mass matrices.
+pub const MASS_MATRIX_SINGULAR_TOLERANCE: f64 = 1e-12;
+
+// Defaults ported from UpstreamDrift double_pendulum.py (documented there).
+const DEFAULT_ARM_LENGTH_M: f64 = 0.75;
+const DEFAULT_ARM_MASS_KG: f64 = 7.5;
+const DEFAULT_ARM_COM_RATIO: f64 = 0.45;
+const DEFAULT_ARM_INERTIA_SCALING: f64 = 1.0 / 12.0;
+const DEFAULT_SHAFT_LENGTH_M: f64 = 1.0;
+const DEFAULT_SHAFT_MASS_KG: f64 = 0.15;
+const DEFAULT_CLUBHEAD_MASS_KG: f64 = 0.20;
+const DEFAULT_SHAFT_COM_RATIO: f64 = 0.43;
+const DEFAULT_DAMPING_SHOULDER: f64 = 0.4;
+const DEFAULT_DAMPING_WRIST: f64 = 0.25;
+
+/// Physical parameters of the two-segment (shoulder + wrist) pendulum.
+///
+/// Inertias are about the **proximal joint** (parallel-axis already applied),
+/// matching the cached quantities in the UpstreamDrift reference.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyo3::prelude::pyclass(get_all, set_all))]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub struct PendulumParameters {
+    /// Upper segment mass [kg].
+    pub m1: f64,
+    /// Upper segment length [m].
+    pub l1: f64,
+    /// Upper segment COM distance from shoulder [m].
+    pub lc1: f64,
+    /// Upper segment inertia about the shoulder [kg·m²].
+    pub i1: f64,
+    /// Lower segment (shaft + clubhead) total mass [kg].
+    pub m2: f64,
+    /// Lower segment length [m].
+    pub l2: f64,
+    /// Lower segment COM distance from wrist [m].
+    pub lc2: f64,
+    /// Lower segment inertia about the wrist [kg·m²].
+    pub i2: f64,
+    /// Viscous damping at the shoulder [N·m·s/rad].
+    pub d1: f64,
+    /// Viscous damping at the wrist [N·m·s/rad].
+    pub d2: f64,
+}
+
+impl PendulumParameters {
+    /// Default golf-swing parameters, computed from the same segment
+    /// constants as the UpstreamDrift reference (arm rod + shaft/clubhead
+    /// composite). Kept as formulas — not hard-coded decimals — so the
+    /// Python reference and this crate agree bit-for-bit.
+    #[must_use]
+    pub fn golf_default() -> Self {
+        let m1 = DEFAULT_ARM_MASS_KG;
+        let l1 = DEFAULT_ARM_LENGTH_M;
+        let lc1 = l1 * DEFAULT_ARM_COM_RATIO;
+        let i1_com = DEFAULT_ARM_INERTIA_SCALING * m1 * l1 * l1;
+        let i1 = i1_com + m1 * lc1 * lc1;
+
+        let l2 = DEFAULT_SHAFT_LENGTH_M;
+        let ms = DEFAULT_SHAFT_MASS_KG;
+        let mh = DEFAULT_CLUBHEAD_MASS_KG;
+        let m2 = ms + mh;
+        let shaft_com = l2 * DEFAULT_SHAFT_COM_RATIO;
+        let lc2 = (shaft_com * ms + l2 * mh) / m2;
+        let shaft_inertia_com = (1.0 / 12.0) * ms * l2 * l2;
+        let parallel_axis =
+            ms * (shaft_com - lc2) * (shaft_com - lc2) + mh * (l2 - lc2) * (l2 - lc2);
+        let i2_com = shaft_inertia_com + parallel_axis;
+        let i2 = i2_com + m2 * lc2 * lc2;
+
+        Self {
+            m1,
+            l1,
+            lc1,
+            i1,
+            m2,
+            l2,
+            lc2,
+            i2,
+            d1: DEFAULT_DAMPING_SHOULDER,
+            d2: DEFAULT_DAMPING_WRIST,
+        }
+    }
+
+    /// Validate physical plausibility.
+    ///
+    /// # Errors
+    /// Returns a description of the first violated precondition.
+    pub fn validate(&self) -> Result<(), String> {
+        let fields = [
+            ("m1", self.m1),
+            ("l1", self.l1),
+            ("lc1", self.lc1),
+            ("i1", self.i1),
+            ("m2", self.m2),
+            ("l2", self.l2),
+            ("lc2", self.lc2),
+            ("i2", self.i2),
+        ];
+        for (name, value) in fields {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(format!("{name} must be finite and > 0, got {value}"));
+            }
+        }
+        for (name, value) in [("d1", self.d1), ("d2", self.d2)] {
+            if !value.is_finite() || value < 0.0 {
+                return Err(format!("{name} must be finite and >= 0, got {value}"));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Dynamic state of the pendulum (planar).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyo3::prelude::pyclass(get_all, set_all))]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub struct PendulumState {
+    /// Upper segment angle from in-plane downward vertical [rad].
+    pub theta1: f64,
+    /// Lower segment angle relative to the upper segment [rad].
+    pub theta2: f64,
+    /// Upper segment angular velocity [rad/s].
+    pub omega1: f64,
+    /// Lower segment angular velocity [rad/s].
+    pub omega2: f64,
+}
+
+/// Compute the symmetric 2x2 mass matrix `[[m11, m12], [m12, m22]]`.
+#[must_use]
+pub fn mass_matrix(p: &PendulumParameters, theta2: f64) -> [[f64; 2]; 2] {
+    debug_assert!(theta2.is_finite(), "mass_matrix: theta2 must be finite");
+    let cos_theta2 = theta2.cos();
+    let m11 = p.i1 + p.i2 + p.m2 * p.l1 * p.l1 + 2.0 * p.m2 * p.l1 * p.lc2 * cos_theta2;
+    let m12 = p.i2 + p.m2 * p.l1 * p.lc2 * cos_theta2;
+    let m22 = p.i2;
+    [[m11, m12], [m12, m22]]
+}
+
+/// Coriolis and centripetal generalized-force vector.
+#[must_use]
+pub fn coriolis_vector(p: &PendulumParameters, theta2: f64, omega1: f64, omega2: f64) -> [f64; 2] {
+    let h = -p.m2 * p.l1 * p.lc2 * theta2.sin();
+    let c1 = h * (2.0 * omega1 * omega2 + omega2 * omega2);
+    let c2 = -h * omega1 * omega1;
+    [c1, c2]
+}
+
+/// Gravitational generalized-force vector for an in-plane gravity 2-vector.
+///
+/// `g_inplane = (gx, gy)` are the gravity components along the plane's local
+/// horizontal and local up axes (see [`crate::swing::plane::in_plane_gravity`]).
+/// For the flat plane `(0, -g)` this reduces exactly to the classic scalar
+/// form `g1 = (m1·lc1 + m2·l1)·g·sin θ1 + m2·lc2·g·sin(θ1+θ2)`.
+#[must_use]
+pub fn gravity_vector(
+    p: &PendulumParameters,
+    theta1: f64,
+    theta2: f64,
+    g_inplane: (f64, f64),
+) -> [f64; 2] {
+    let (gx, gy) = g_inplane;
+    let t12 = theta1 + theta2;
+    // Segment direction derivative: d/dθ (sin θ, -cos θ) = (cos θ, sin θ).
+    // Generalized gravity torque Q_i = Σ_k m_k g_vec · ∂p_k/∂q_i; the EOM
+    // uses G = -Q (restoring convention, matching the scalar reference).
+    let a1 = p.m1 * p.lc1 + p.m2 * p.l1;
+    let a2 = p.m2 * p.lc2;
+    let g1 = -a1 * (gx * theta1.cos() + gy * theta1.sin()) - a2 * (gx * t12.cos() + gy * t12.sin());
+    let g2 = -a2 * (gx * t12.cos() + gy * t12.sin());
+    [g1, g2]
+}
+
+/// Viscous damping torques.
+#[must_use]
+pub fn damping_vector(p: &PendulumParameters, omega1: f64, omega2: f64) -> [f64; 2] {
+    [p.d1 * omega1, p.d2 * omega2]
+}
+
+fn invert_mass_matrix(p: &PendulumParameters, theta2: f64) -> Result<[[f64; 2]; 2], String> {
+    let m = mass_matrix(p, theta2);
+    let det = m[0][0] * m[1][1] - m[0][1] * m[1][0];
+    if det.abs() <= MASS_MATRIX_SINGULAR_TOLERANCE {
+        return Err("mass matrix determinant too close to zero; check pendulum parameters".into());
+    }
+    Ok([
+        [m[1][1] / det, -m[0][1] / det],
+        [-m[1][0] / det, m[0][0] / det],
+    ])
+}
+
+/// State derivatives `(dθ1, dθ2, dω1, dω2)` for unforced dynamics.
+///
+/// # Errors
+/// Returns an error if the mass matrix is numerically singular.
+pub fn derivatives(
+    p: &PendulumParameters,
+    state: &PendulumState,
+    g_inplane: (f64, f64),
+) -> Result<[f64; 4], String> {
+    let [c1, c2] = coriolis_vector(p, state.theta2, state.omega1, state.omega2);
+    let [g1, g2] = gravity_vector(p, state.theta1, state.theta2, g_inplane);
+    let [d1, d2] = damping_vector(p, state.omega1, state.omega2);
+    let inv_m = invert_mass_matrix(p, state.theta2)?;
+    let rhs1 = -(c1 + g1 + d1);
+    let rhs2 = -(c2 + g2 + d2);
+    let acc1 = inv_m[0][0] * rhs1 + inv_m[0][1] * rhs2;
+    let acc2 = inv_m[1][0] * rhs1 + inv_m[1][1] * rhs2;
+    Ok([state.omega1, state.omega2, acc1, acc2])
+}
+
+/// Advance the state by one classical RK4 step of size `dt`.
+///
+/// # Errors
+/// Returns an error if the mass matrix is numerically singular at any stage.
+pub fn rk4_step(
+    p: &PendulumParameters,
+    state: &PendulumState,
+    g_inplane: (f64, f64),
+    dt: f64,
+) -> Result<PendulumState, String> {
+    debug_assert!(
+        dt.is_finite() && dt > 0.0,
+        "rk4_step: dt must be finite and > 0"
+    );
+    let y = [state.theta1, state.theta2, state.omega1, state.omega2];
+    let f = |v: [f64; 4]| -> Result<[f64; 4], String> {
+        derivatives(
+            p,
+            &PendulumState {
+                theta1: v[0],
+                theta2: v[1],
+                omega1: v[2],
+                omega2: v[3],
+            },
+            g_inplane,
+        )
+    };
+    let add = |a: [f64; 4], s: f64, b: [f64; 4]| -> [f64; 4] {
+        [
+            a[0] + s * b[0],
+            a[1] + s * b[1],
+            a[2] + s * b[2],
+            a[3] + s * b[3],
+        ]
+    };
+    let k1 = f(y)?;
+    let k2 = f(add(y, dt / 2.0, k1))?;
+    let k3 = f(add(y, dt / 2.0, k2))?;
+    let k4 = f(add(y, dt, k3))?;
+    let mut out = [0.0; 4];
+    for i in 0..4 {
+        out[i] = y[i] + dt / 6.0 * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]);
+    }
+    Ok(PendulumState {
+        theta1: out[0],
+        theta2: out[1],
+        omega1: out[2],
+        omega2: out[3],
+    })
+}
+
+/// Total mechanical energy (kinetic + gravitational potential) [J].
+///
+/// Potential is `-Σ m_k g_vec · p_k` with COM positions measured from the
+/// shoulder pivot in in-plane coordinates. Used by conservation tests.
+#[must_use]
+pub fn total_energy(p: &PendulumParameters, state: &PendulumState, g_inplane: (f64, f64)) -> f64 {
+    let m = mass_matrix(p, state.theta2);
+    let q = [state.omega1, state.omega2];
+    let kinetic =
+        0.5 * (m[0][0] * q[0] * q[0] + 2.0 * m[0][1] * q[0] * q[1] + m[1][1] * q[1] * q[1]);
+
+    let (gx, gy) = g_inplane;
+    let dir = |theta: f64| (theta.sin(), -theta.cos());
+    let (e1x, e1y) = dir(state.theta1);
+    let (e2x, e2y) = dir(state.theta1 + state.theta2);
+    let p1 = (p.lc1 * e1x, p.lc1 * e1y);
+    let p2 = (p.l1 * e1x + p.lc2 * e2x, p.l1 * e1y + p.lc2 * e2y);
+    let potential = -(p.m1 * (gx * p1.0 + gy * p1.1) + p.m2 * (gx * p2.0 + gy * p2.1));
+    kinetic + potential
+}
+
+/// Simulate `n_steps` RK4 steps, returning `n_steps + 1` states (including
+/// the initial state).
+///
+/// # Errors
+/// Returns an error if any step encounters a singular mass matrix.
+pub fn simulate(
+    p: &PendulumParameters,
+    initial: &PendulumState,
+    g_inplane: (f64, f64),
+    dt: f64,
+    n_steps: usize,
+) -> Result<Vec<PendulumState>, String> {
+    p.validate()?;
+    let mut states = Vec::with_capacity(n_steps + 1);
+    states.push(*initial);
+    let mut current = *initial;
+    for _ in 0..n_steps {
+        current = rk4_step(p, &current, g_inplane, dt)?;
+        states.push(current);
+    }
+    Ok(states)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::swing::plane::in_plane_gravity_from_tilts;
+
+    const G: f64 = 9.80665;
+
+    fn undamped_params() -> PendulumParameters {
+        PendulumParameters {
+            d1: 0.0,
+            d2: 0.0,
+            ..PendulumParameters::golf_default()
+        }
+    }
+
+    #[test]
+    fn golf_default_is_valid() {
+        assert!(PendulumParameters::golf_default().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_nonpositive_mass() {
+        let p = PendulumParameters {
+            m1: 0.0,
+            ..PendulumParameters::golf_default()
+        };
+        assert!(p.validate().is_err());
+    }
+
+    #[test]
+    fn mass_matrix_is_symmetric_positive_definite() {
+        let p = PendulumParameters::golf_default();
+        for theta2 in [-3.0, -1.5, 0.0, 0.8, 1.6, 3.1] {
+            let m = mass_matrix(&p, theta2);
+            assert!((m[0][1] - m[1][0]).abs() < 1e-15, "asymmetric at {theta2}");
+            // Sylvester's criterion for 2x2 SPD.
+            assert!(m[0][0] > 0.0, "m11 not positive at {theta2}");
+            let det = m[0][0] * m[1][1] - m[0][1] * m[1][0];
+            assert!(det > 0.0, "determinant not positive at {theta2}: {det}");
+        }
+    }
+
+    #[test]
+    fn gravity_vector_flat_plane_matches_scalar_reference() {
+        let p = PendulumParameters::golf_default();
+        let (theta1, theta2) = (0.7, -0.4);
+        let [g1, g2] = gravity_vector(&p, theta1, theta2, (0.0, -G));
+        let expected_g1 = (p.m1 * p.lc1 + p.m2 * p.l1) * G * theta1.sin()
+            + p.m2 * p.lc2 * G * (theta1 + theta2).sin();
+        let expected_g2 = p.m2 * p.lc2 * G * (theta1 + theta2).sin();
+        assert!((g1 - expected_g1).abs() < 1e-12, "g1 {g1} != {expected_g1}");
+        assert!((g2 - expected_g2).abs() < 1e-12, "g2 {g2} != {expected_g2}");
+    }
+
+    #[test]
+    fn undamped_unforced_energy_conserved_over_1000_steps() {
+        let p = undamped_params();
+        let g = in_plane_gravity_from_tilts(0.4, 0.6, -0.2, G);
+        let initial = PendulumState {
+            theta1: 1.2,
+            theta2: -0.5,
+            omega1: 0.0,
+            omega2: 0.0,
+        };
+        let dt = 1e-4;
+        let states = simulate(&p, &initial, g, dt, 1000).expect("simulation must succeed");
+        let e0 = total_energy(&p, &initial, g);
+        let scale = e0.abs().max(1.0);
+        for (i, s) in states.iter().enumerate() {
+            let e = total_energy(&p, s, g);
+            let drift = (e - e0).abs() / scale;
+            assert!(drift < 1e-6, "energy drift {drift} at step {i}");
+        }
+    }
+
+    #[test]
+    fn damping_dissipates_energy() {
+        let p = PendulumParameters::golf_default();
+        let g = (0.0, -G);
+        let initial = PendulumState {
+            theta1: 1.0,
+            theta2: 0.3,
+            omega1: 0.5,
+            omega2: -0.2,
+        };
+        let states = simulate(&p, &initial, g, 1e-3, 2000).expect("simulation must succeed");
+        let e0 = total_energy(&p, &initial, g);
+        let e_end = total_energy(&p, states.last().expect("non-empty"), g);
+        assert!(e_end < e0, "damped energy must decrease: {e_end} >= {e0}");
+    }
+
+    #[test]
+    fn simulate_returns_n_plus_one_states() {
+        let p = PendulumParameters::golf_default();
+        let s0 = PendulumState {
+            theta1: 0.1,
+            theta2: 0.0,
+            omega1: 0.0,
+            omega2: 0.0,
+        };
+        let states = simulate(&p, &s0, (0.0, -G), 1e-3, 10).expect("simulation must succeed");
+        assert_eq!(states.len(), 11);
+        assert_eq!(states[0], s0);
+    }
+}

--- a/rust_core/swing-core/src/swing/plane.rs
+++ b/rust_core/swing-core/src/swing/plane.rs
@@ -1,0 +1,203 @@
+//! Swing-plane orientation and in-plane gravity projection.
+//!
+//! # Convention
+//! World frame: x forward (toward target line reference), y left, z up.
+//! The identity ("flat") plane pose spans world x (in-plane horizontal axis)
+//! and world z (in-plane up axis); its normal is world y. A pendulum swinging
+//! in the identity plane therefore swings in a vertical plane and feels the
+//! full gravitational acceleration in-plane.
+//!
+//! The plane pose is built from three sequential intrinsic tilts
+//! (documented order, epic #4103 P1 spec):
+//! 1. **yaw** about the world-up axis (z),
+//! 2. **side tilt** about the rotated in-plane horizontal axis,
+//! 3. **forward/back tilt** about the resulting in-plane up axis.
+//!
+//! As intrinsic rotations these compose by right-multiplication:
+//! `R = Rz(yaw) · Rx(side_tilt) · Ry(fwd_tilt)`.
+//!
+//! # Design by Contract
+//! - All angles are radians and must be finite (`debug_assert!`).
+//! - `plane_rotation` returns a proper orthonormal rotation (unit tested).
+//! - `in_plane_gravity` limits: identity pose ⇒ `(0, -g)` (full g "down"
+//!   in-plane); pure yaw is invariant (gravity is symmetric about world-up).
+
+use nalgebra::{Matrix3, Vector3};
+
+/// Build the world-from-plane rotation matrix from the three tilt angles.
+///
+/// Columns of the returned matrix are the plane's local axes expressed in
+/// world coordinates: column 0 = in-plane horizontal axis, column 1 = plane
+/// normal, column 2 = in-plane up axis (see module docs for the identity
+/// pose).
+///
+/// # Contracts (DbC)
+/// - Precondition: all angles are finite radians.
+/// - Postcondition: result is orthonormal with determinant +1.
+#[must_use]
+pub fn plane_rotation(yaw: f64, side_tilt: f64, fwd_tilt: f64) -> Matrix3<f64> {
+    debug_assert!(yaw.is_finite(), "plane_rotation: yaw must be finite");
+    debug_assert!(
+        side_tilt.is_finite(),
+        "plane_rotation: side_tilt must be finite"
+    );
+    debug_assert!(
+        fwd_tilt.is_finite(),
+        "plane_rotation: fwd_tilt must be finite"
+    );
+
+    let rz = Matrix3::new(
+        yaw.cos(),
+        -yaw.sin(),
+        0.0,
+        yaw.sin(),
+        yaw.cos(),
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    );
+    let rx = Matrix3::new(
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        side_tilt.cos(),
+        -side_tilt.sin(),
+        0.0,
+        side_tilt.sin(),
+        side_tilt.cos(),
+    );
+    let ry = Matrix3::new(
+        fwd_tilt.cos(),
+        0.0,
+        fwd_tilt.sin(),
+        0.0,
+        1.0,
+        0.0,
+        -fwd_tilt.sin(),
+        0.0,
+        fwd_tilt.cos(),
+    );
+    rz * rx * ry
+}
+
+/// Project world gravity into the swing plane.
+///
+/// Given the world-from-plane rotation `plane_r` and the gravitational
+/// acceleration magnitude `g` (m/s², non-negative), returns the in-plane
+/// gravity components `(g_x_inplane, g_y_inplane)` along the plane's local
+/// horizontal axis and local up axis respectively. The world gravity vector
+/// is `(0, 0, -g)` (z-up world).
+///
+/// The double-pendulum EOM consumes this 2-vector directly — never a scalar.
+///
+/// # Contracts (DbC)
+/// - Precondition: `g` is finite and `>= 0`.
+/// - Postcondition: `g_x² + g_y² <= g²` (projection never amplifies).
+#[must_use]
+pub fn in_plane_gravity(plane_r: &Matrix3<f64>, g: f64) -> (f64, f64) {
+    debug_assert!(
+        g.is_finite() && g >= 0.0,
+        "in_plane_gravity: g must be finite and >= 0"
+    );
+
+    let g_world = Vector3::new(0.0, 0.0, -g);
+    // Local axes in world coordinates: columns 0 (in-plane horizontal) and
+    // 2 (in-plane up) of the world-from-plane rotation.
+    let x_axis = plane_r.column(0);
+    let y_up_axis = plane_r.column(2);
+    let gx = g_world.dot(&x_axis);
+    let gy = g_world.dot(&y_up_axis);
+    debug_assert!(
+        gx * gx + gy * gy <= g * g + 1e-9,
+        "in_plane_gravity: projection must not amplify gravity"
+    );
+    (gx, gy)
+}
+
+/// Convenience: in-plane gravity straight from the three tilt angles.
+#[must_use]
+pub fn in_plane_gravity_from_tilts(yaw: f64, side_tilt: f64, fwd_tilt: f64, g: f64) -> (f64, f64) {
+    in_plane_gravity(&plane_rotation(yaw, side_tilt, fwd_tilt), g)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const G: f64 = 9.80665;
+    const TOL: f64 = 1e-12;
+
+    #[test]
+    fn plane_rotation_is_orthonormal() {
+        let cases = [
+            (0.0, 0.0, 0.0),
+            (0.3, 0.0, 0.0),
+            (0.0, 0.7, 0.0),
+            (0.0, 0.0, -0.4),
+            (1.2, -0.6, 0.35),
+            (-2.0, 1.1, 2.9),
+        ];
+        for (yaw, side, fwd) in cases {
+            let r = plane_rotation(yaw, side, fwd);
+            let should_be_identity = r.transpose() * r;
+            let err = (should_be_identity - Matrix3::identity()).norm();
+            assert!(
+                err < 1e-12,
+                "R^T R != I for ({yaw}, {side}, {fwd}): err {err}"
+            );
+            let det = r.determinant();
+            assert!((det - 1.0).abs() < 1e-12, "det != +1: {det}");
+        }
+    }
+
+    #[test]
+    fn flat_plane_gives_full_gravity_down() {
+        let r = plane_rotation(0.0, 0.0, 0.0);
+        let (gx, gy) = in_plane_gravity(&r, G);
+        assert!(
+            gx.abs() < TOL,
+            "flat plane must have zero horizontal gravity: {gx}"
+        );
+        assert!(
+            (gy + G).abs() < TOL,
+            "flat plane must feel full g down: {gy}"
+        );
+    }
+
+    #[test]
+    fn pure_yaw_leaves_gravity_projection_invariant() {
+        let (gx0, gy0) = in_plane_gravity_from_tilts(0.0, 0.0, 0.0, G);
+        for yaw in [-3.0, -1.2, 0.4, 1.7, 3.1] {
+            let (gx, gy) = in_plane_gravity_from_tilts(yaw, 0.0, 0.0, G);
+            assert!((gx - gx0).abs() < TOL, "yaw {yaw} changed gx: {gx}");
+            assert!((gy - gy0).abs() < TOL, "yaw {yaw} changed gy: {gy}");
+        }
+    }
+
+    #[test]
+    fn side_tilt_scales_in_plane_up_component_by_cosine() {
+        // Matches UpstreamDrift's scalar projected_gravity = g·cos(inclination).
+        for side in [0.0, 0.2, 0.6, 1.0, 1.5] {
+            let (_, gy) = in_plane_gravity_from_tilts(0.0, side, 0.0, G);
+            assert!(
+                (gy + G * side.cos()).abs() < 1e-12,
+                "side tilt {side}: expected {}, got {gy}",
+                -G * side.cos()
+            );
+        }
+    }
+
+    #[test]
+    fn projection_never_amplifies_gravity() {
+        for yaw in [-2.0, 0.0, 1.3] {
+            for side in [-1.4, 0.0, 0.9] {
+                for fwd in [-0.8, 0.0, 1.1] {
+                    let (gx, gy) = in_plane_gravity_from_tilts(yaw, side, fwd, G);
+                    assert!(gx * gx + gy * gy <= G * G + 1e-9);
+                }
+            }
+        }
+    }
+}

--- a/rust_core/swing-core/src/wasm_bindings/mod.rs
+++ b/rust_core/swing-core/src/wasm_bindings/mod.rs
@@ -1,0 +1,7 @@
+//! WASM (wasm-bindgen) bindings, split by concern.
+//!
+//! Only compiled with the `wasm` feature (wasm-pack builds with
+//! `--features wasm --no-default-features`). Each submodule mirrors one
+//! domain module under `swing/`.
+
+pub mod wasm_swing;

--- a/rust_core/swing-core/src/wasm_bindings/wasm_swing.rs
+++ b/rust_core/swing-core/src/wasm_bindings/wasm_swing.rs
@@ -1,0 +1,125 @@
+//! wasm-bindgen bindings for `swing::pendulum` and `swing::plane`.
+//!
+//! Flat `Vec<f64>` payloads cross the JS boundary as `Float64Array`
+//! (row-major); the web app reshapes them. Struct fields are `f64` and Copy,
+//! so wasm-bindgen auto-generates getters/setters.
+
+use wasm_bindgen::prelude::*;
+
+use crate::swing::pendulum::{self, PendulumParameters, PendulumState};
+use crate::swing::plane;
+
+#[wasm_bindgen]
+impl PendulumParameters {
+    /// Construct parameters; throws on physically invalid values.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn wasm_new(
+        m1: f64,
+        l1: f64,
+        lc1: f64,
+        i1: f64,
+        m2: f64,
+        l2: f64,
+        lc2: f64,
+        i2: f64,
+        d1: f64,
+        d2: f64,
+    ) -> Result<PendulumParameters, JsError> {
+        let params = Self {
+            m1,
+            l1,
+            lc1,
+            i1,
+            m2,
+            l2,
+            lc2,
+            i2,
+            d1,
+            d2,
+        };
+        params.validate().map_err(|e| JsError::new(&e))?;
+        Ok(params)
+    }
+
+    /// Default golf-swing parameters (UpstreamDrift reference constants).
+    #[wasm_bindgen(js_name = "golfDefault")]
+    pub fn wasm_golf_default() -> PendulumParameters {
+        Self::golf_default()
+    }
+}
+
+#[wasm_bindgen]
+impl PendulumState {
+    #[wasm_bindgen(constructor)]
+    pub fn wasm_new(theta1: f64, theta2: f64, omega1: f64, omega2: f64) -> PendulumState {
+        Self {
+            theta1,
+            theta2,
+            omega1,
+            omega2,
+        }
+    }
+}
+
+/// Plane rotation matrix as a row-major `Float64Array` of length 9.
+#[wasm_bindgen(js_name = "planeRotation")]
+pub fn wasm_plane_rotation(yaw: f64, side_tilt: f64, fwd_tilt: f64) -> Vec<f64> {
+    let r = plane::plane_rotation(yaw, side_tilt, fwd_tilt);
+    (0..3)
+        .flat_map(|i| (0..3).map(move |j| (i, j)))
+        .map(|(i, j)| r[(i, j)])
+        .collect()
+}
+
+/// In-plane gravity `[g_x, g_y]` from the three tilt angles and `g` [m/s²].
+#[wasm_bindgen(js_name = "inPlaneGravity")]
+pub fn wasm_in_plane_gravity(yaw: f64, side_tilt: f64, fwd_tilt: f64, g: f64) -> Vec<f64> {
+    let (gx, gy) = plane::in_plane_gravity_from_tilts(yaw, side_tilt, fwd_tilt, g);
+    vec![gx, gy]
+}
+
+/// One RK4 step; throws on a singular mass matrix.
+#[wasm_bindgen(js_name = "step")]
+pub fn wasm_step(
+    params: &PendulumParameters,
+    state: &PendulumState,
+    gx: f64,
+    gy: f64,
+    dt: f64,
+) -> Result<PendulumState, JsError> {
+    pendulum::rk4_step(params, state, (gx, gy), dt).map_err(|e| JsError::new(&e))
+}
+
+/// Simulate `n_steps` RK4 steps.
+///
+/// Returns a row-major `Float64Array` of `(n_steps + 1) * 4` floats:
+/// `[theta1, theta2, omega1, omega2]` per state, initial state included.
+#[wasm_bindgen(js_name = "simulate")]
+pub fn wasm_simulate(
+    params: &PendulumParameters,
+    initial: &PendulumState,
+    gx: f64,
+    gy: f64,
+    dt: f64,
+    n_steps: usize,
+) -> Result<Vec<f64>, JsError> {
+    let states =
+        pendulum::simulate(params, initial, (gx, gy), dt, n_steps).map_err(|e| JsError::new(&e))?;
+    let mut out = Vec::with_capacity(states.len() * 4);
+    for s in states {
+        out.extend_from_slice(&[s.theta1, s.theta2, s.omega1, s.omega2]);
+    }
+    Ok(out)
+}
+
+/// Total mechanical energy [J] under in-plane gravity `(gx, gy)`.
+#[wasm_bindgen(js_name = "totalEnergy")]
+pub fn wasm_total_energy(
+    params: &PendulumParameters,
+    state: &PendulumState,
+    gx: f64,
+    gy: f64,
+) -> f64 {
+    pendulum::total_energy(params, state, (gx, gy))
+}

--- a/src/shared/python/swing_sim/__init__.py
+++ b/src/shared/python/swing_sim/__init__.py
@@ -1,0 +1,37 @@
+"""Shared swing simulation package (epic #4103, P0 foundation #4104).
+
+Curated façade for the swing → impact → ball-flight platform's swing stage:
+value types, the :class:`SwingSource` protocol, the double-pendulum swing
+source, and backend discovery. Physics kernels live in the
+``rust_core/swing-core`` Rust crate (Python wheel ``swing_core``, WASM NPM
+package for the web app); :mod:`.reference` is the pure-Python parity
+oracle and one-shot fallback.
+"""
+
+from __future__ import annotations
+
+from ._rust_facade import rust_available
+from .swing_source import DoublePendulumSwing, SwingSource
+from .types import (
+    DEFAULT_GRAVITY_M_S2,
+    PendulumParameters,
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+    SwingTrajectory,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DEFAULT_GRAVITY_M_S2",
+    "DoublePendulumSwing",
+    "PendulumParameters",
+    "PendulumState",
+    "PlaneOrientation",
+    "SwingSample",
+    "SwingSource",
+    "SwingTrajectory",
+    "__version__",
+    "rust_available",
+]

--- a/src/shared/python/swing_sim/_rust_facade.py
+++ b/src/shared/python/swing_sim/_rust_facade.py
@@ -1,0 +1,161 @@
+"""Rust-accelerated swing dynamics façade (STRICT posture).
+
+Mirrors the posture of :mod:`shared.python.signal_toolkit.bilateral_rust`:
+the ``swing_core`` wheel is imported at module level; hot-loop entry points
+raise ``ImportError`` with an actionable message at call time when the wheel
+is missing. We deliberately do NOT silently substitute the ~100x slower
+pure-Python path for the integration loop — that would mask deployment
+misconfiguration. One-shot analysis calls may fall back explicitly via
+:func:`shared.python.swing_sim.reference.simulate`.
+
+PyO3 submodule import gotcha: ``swing_core`` exposes ``swing`` as a runtime
+PyO3 submodule (an attribute, not a filesystem module), so we must use
+``from swing_core import swing`` — ``import swing_core.swing`` fails.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from .types import PendulumParameters, PendulumState
+
+logger = logging.getLogger(__name__)
+
+_MISSING_WHEEL_MESSAGE = (
+    "swing_core Rust extension is not installed; the swing integration hot "
+    "loop requires it. Build/install it with "
+    "`pip install rust_core/swing-core` or "
+    "`maturin develop -m rust_core/swing-core/Cargo.toml`. For one-shot "
+    "analysis you may explicitly fall back to "
+    "shared.python.swing_sim.reference.simulate."
+)
+
+try:
+    # Runtime PyO3 submodule: attribute access on the parent, never
+    # `import swing_core.swing`.
+    from swing_core import swing as _rust_swing
+
+    _RUST_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised on machines without wheel
+    _rust_swing = None
+    _RUST_AVAILABLE = False
+    logger.warning(
+        "swing_sim._rust_facade: swing_core wheel not available; hot-loop "
+        "calls will raise ImportError. See docs/development/rust-setup.md"
+    )
+
+
+def rust_available() -> bool:
+    """Return whether the ``swing_core`` Rust wheel is importable."""
+    return _RUST_AVAILABLE
+
+
+def _require_rust() -> Any:
+    if not _RUST_AVAILABLE:
+        raise ImportError(_MISSING_WHEEL_MESSAGE)
+    return _rust_swing
+
+
+def _to_rust_params(p: PendulumParameters) -> Any:
+    rust = _require_rust()
+    return rust.PendulumParameters(
+        p.m1, p.l1, p.lc1, p.i1, p.m2, p.l2, p.lc2, p.i2, p.d1, p.d2
+    )
+
+
+def _to_rust_state(s: PendulumState) -> Any:
+    rust = _require_rust()
+    return rust.PendulumState(s.theta1, s.theta2, s.omega1, s.omega2)
+
+
+def plane_rotation_rust(yaw: float, side_tilt: float, fwd_tilt: float) -> np.ndarray:
+    """World-from-plane rotation matrix (3x3) — Rust path."""
+    rust = _require_rust()
+    return np.asarray(
+        rust.plane_rotation(float(yaw), float(side_tilt), float(fwd_tilt)),
+        dtype=np.float64,
+    )
+
+
+def in_plane_gravity_rust(
+    yaw: float, side_tilt: float, fwd_tilt: float, g: float
+) -> tuple[float, float]:
+    """In-plane gravity ``(g_x, g_y)`` from tilt angles — Rust path."""
+    rust = _require_rust()
+    gx, gy = rust.in_plane_gravity(
+        float(yaw), float(side_tilt), float(fwd_tilt), float(g)
+    )
+    return float(gx), float(gy)
+
+
+def step_rust(
+    params: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+    dt: float,
+) -> PendulumState:
+    """One RK4 step — Rust path.
+
+    Raises:
+        ImportError: If the ``swing_core`` wheel is not installed.
+        ValueError: If the mass matrix is numerically singular.
+    """
+    rust = _require_rust()
+    out = rust.step(
+        _to_rust_params(params),
+        _to_rust_state(state),
+        float(g_inplane[0]),
+        float(g_inplane[1]),
+        float(dt),
+    )
+    return PendulumState(
+        theta1=out.theta1, theta2=out.theta2, omega1=out.omega1, omega2=out.omega2
+    )
+
+
+def simulate_rust(
+    params: PendulumParameters,
+    initial: PendulumState,
+    g_inplane: tuple[float, float],
+    dt: float,
+    n_steps: int,
+) -> np.ndarray:
+    """Simulate ``n_steps`` RK4 steps — Rust path (hot loop).
+
+    Returns an ``(n_steps + 1, 4)`` array of rows
+    ``[theta1, theta2, omega1, omega2]`` including the initial state.
+
+    Raises:
+        ImportError: If the ``swing_core`` wheel is not installed.
+        ValueError: If any step encounters a singular mass matrix.
+    """
+    rust = _require_rust()
+    flat = rust.simulate(
+        _to_rust_params(params),
+        _to_rust_state(initial),
+        float(g_inplane[0]),
+        float(g_inplane[1]),
+        float(dt),
+        int(n_steps),
+    )
+    return np.asarray(flat, dtype=np.float64).reshape(int(n_steps) + 1, 4)
+
+
+def total_energy_rust(
+    params: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+) -> float:
+    """Total mechanical energy [J] — Rust path."""
+    rust = _require_rust()
+    return float(
+        rust.total_energy(
+            _to_rust_params(params),
+            _to_rust_state(state),
+            float(g_inplane[0]),
+            float(g_inplane[1]),
+        )
+    )

--- a/src/shared/python/swing_sim/reference.py
+++ b/src/shared/python/swing_sim/reference.py
@@ -1,0 +1,213 @@
+"""Pure-Python reference implementation of the swing dynamics.
+
+Mirrors ``rust_core/swing-core/src/swing`` operation-for-operation (same
+formula grouping and evaluation order) so it can serve as:
+
+1. the parity oracle for the Rust kernel (``parity``-marked tests), and
+2. the fallback backend for one-shot calls on machines without the wheel.
+
+Hot integration loops must use the Rust backend via
+:mod:`shared.python.swing_sim._rust_facade` — this module is deliberately
+unoptimised Python.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from .types import PendulumParameters, PendulumState
+
+MASS_MATRIX_SINGULAR_TOLERANCE = 1e-12
+"""Numerical tolerance for detecting singular mass matrices."""
+
+
+def plane_rotation(yaw: float, side_tilt: float, fwd_tilt: float) -> np.ndarray:
+    """World-from-plane rotation matrix ``Rz(yaw) @ Rx(side) @ Ry(fwd)``.
+
+    Columns are the plane's local axes in world coordinates: column 0 =
+    in-plane horizontal, column 1 = plane normal, column 2 = in-plane up.
+    All angles in radians.
+    """
+    for name, value in (("yaw", yaw), ("side_tilt", side_tilt), ("fwd_tilt", fwd_tilt)):
+        require(math.isfinite(value), f"{name} must be finite", value)
+    cy, sy = math.cos(yaw), math.sin(yaw)
+    cs, ss = math.cos(side_tilt), math.sin(side_tilt)
+    cf, sf = math.cos(fwd_tilt), math.sin(fwd_tilt)
+    rz = np.array([[cy, -sy, 0.0], [sy, cy, 0.0], [0.0, 0.0, 1.0]])
+    rx = np.array([[1.0, 0.0, 0.0], [0.0, cs, -ss], [0.0, ss, cs]])
+    ry = np.array([[cf, 0.0, sf], [0.0, 1.0, 0.0], [-sf, 0.0, cf]])
+    return np.asarray(rz @ rx @ ry)
+
+
+def in_plane_gravity(plane_r: np.ndarray, g: float) -> tuple[float, float]:
+    """Project world gravity ``(0, 0, -g)`` into the swing plane.
+
+    Returns ``(g_x_inplane, g_y_inplane)`` along the plane's local
+    horizontal and local up axes. The EOM consumes this 2-vector directly.
+    """
+    require(math.isfinite(g) and g >= 0.0, "g must be finite and >= 0", g)
+    r = np.asarray(plane_r, dtype=np.float64)
+    require(r.shape == (3, 3), "plane_r must be a 3x3 matrix", r.shape)
+    g_world = np.array([0.0, 0.0, -g])
+    gx = float(g_world @ r[:, 0])
+    gy = float(g_world @ r[:, 2])
+    return gx, gy
+
+
+def in_plane_gravity_from_tilts(
+    yaw: float, side_tilt: float, fwd_tilt: float, g: float
+) -> tuple[float, float]:
+    """In-plane gravity straight from the three tilt angles (radians)."""
+    return in_plane_gravity(plane_rotation(yaw, side_tilt, fwd_tilt), g)
+
+
+def mass_matrix(p: PendulumParameters, theta2: float) -> np.ndarray:
+    """Symmetric 2x2 mass matrix for the given relative angle."""
+    cos_theta2 = math.cos(theta2)
+    m11 = p.i1 + p.i2 + p.m2 * p.l1 * p.l1 + 2.0 * p.m2 * p.l1 * p.lc2 * cos_theta2
+    m12 = p.i2 + p.m2 * p.l1 * p.lc2 * cos_theta2
+    m22 = p.i2
+    return np.array([[m11, m12], [m12, m22]])
+
+
+def coriolis_vector(
+    p: PendulumParameters, theta2: float, omega1: float, omega2: float
+) -> tuple[float, float]:
+    """Coriolis and centripetal generalized-force vector."""
+    h = -p.m2 * p.l1 * p.lc2 * math.sin(theta2)
+    c1 = h * (2.0 * omega1 * omega2 + omega2 * omega2)
+    c2 = -h * omega1 * omega1
+    return c1, c2
+
+
+def gravity_vector(
+    p: PendulumParameters,
+    theta1: float,
+    theta2: float,
+    g_inplane: tuple[float, float],
+) -> tuple[float, float]:
+    """Gravity generalized-force vector for an in-plane gravity 2-vector.
+
+    For the flat plane ``(0, -g)`` this reduces exactly to the classic
+    scalar form used by the UpstreamDrift reference.
+    """
+    gx, gy = g_inplane
+    t12 = theta1 + theta2
+    a1 = p.m1 * p.lc1 + p.m2 * p.l1
+    a2 = p.m2 * p.lc2
+    g1 = -a1 * (gx * math.cos(theta1) + gy * math.sin(theta1)) - a2 * (
+        gx * math.cos(t12) + gy * math.sin(t12)
+    )
+    g2 = -a2 * (gx * math.cos(t12) + gy * math.sin(t12))
+    return g1, g2
+
+
+def damping_vector(
+    p: PendulumParameters, omega1: float, omega2: float
+) -> tuple[float, float]:
+    """Viscous damping torques."""
+    return p.d1 * omega1, p.d2 * omega2
+
+
+def _invert_mass_matrix(p: PendulumParameters, theta2: float) -> np.ndarray:
+    m = mass_matrix(p, theta2)
+    det = m[0, 0] * m[1, 1] - m[0, 1] * m[1, 0]
+    require(
+        abs(det) > MASS_MATRIX_SINGULAR_TOLERANCE,
+        "mass matrix determinant too close to zero; check pendulum parameters",
+        det,
+    )
+    return np.array([[m[1, 1] / det, -m[0, 1] / det], [-m[1, 0] / det, m[0, 0] / det]])
+
+
+def derivatives(
+    p: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+) -> tuple[float, float, float, float]:
+    """State derivatives ``(dθ1, dθ2, dω1, dω2)`` for unforced dynamics."""
+    c1, c2 = coriolis_vector(p, state.theta2, state.omega1, state.omega2)
+    g1, g2 = gravity_vector(p, state.theta1, state.theta2, g_inplane)
+    d1, d2 = damping_vector(p, state.omega1, state.omega2)
+    inv_m = _invert_mass_matrix(p, state.theta2)
+    rhs1 = -(c1 + g1 + d1)
+    rhs2 = -(c2 + g2 + d2)
+    acc1 = inv_m[0, 0] * rhs1 + inv_m[0, 1] * rhs2
+    acc2 = inv_m[1, 0] * rhs1 + inv_m[1, 1] * rhs2
+    return state.omega1, state.omega2, acc1, acc2
+
+
+def rk4_step(
+    p: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+    dt: float,
+) -> PendulumState:
+    """Advance the state by one classical RK4 step of size ``dt``."""
+    require(math.isfinite(dt) and dt > 0.0, "dt must be finite and > 0", dt)
+    y = (state.theta1, state.theta2, state.omega1, state.omega2)
+
+    def f(v: tuple[float, ...]) -> tuple[float, float, float, float]:
+        return derivatives(
+            p,
+            PendulumState(theta1=v[0], theta2=v[1], omega1=v[2], omega2=v[3]),
+            g_inplane,
+        )
+
+    def add(a: tuple[float, ...], s: float, b: tuple[float, ...]) -> tuple[float, ...]:
+        return tuple(ai + s * bi for ai, bi in zip(a, b, strict=True))
+
+    k1 = f(y)
+    k2 = f(add(y, dt / 2.0, k1))
+    k3 = f(add(y, dt / 2.0, k2))
+    k4 = f(add(y, dt, k3))
+    out = [
+        y[i] + dt / 6.0 * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]) for i in range(4)
+    ]
+    return PendulumState(theta1=out[0], theta2=out[1], omega1=out[2], omega2=out[3])
+
+
+def total_energy(
+    p: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+) -> float:
+    """Total mechanical energy (kinetic + gravitational potential) [J]."""
+    m = mass_matrix(p, state.theta2)
+    q0, q1 = state.omega1, state.omega2
+    kinetic = 0.5 * (m[0, 0] * q0 * q0 + 2.0 * m[0, 1] * q0 * q1 + m[1, 1] * q1 * q1)
+
+    gx, gy = g_inplane
+    e1x, e1y = math.sin(state.theta1), -math.cos(state.theta1)
+    t12 = state.theta1 + state.theta2
+    e2x, e2y = math.sin(t12), -math.cos(t12)
+    p1 = (p.lc1 * e1x, p.lc1 * e1y)
+    p2 = (p.l1 * e1x + p.lc2 * e2x, p.l1 * e1y + p.lc2 * e2y)
+    potential = -(p.m1 * (gx * p1[0] + gy * p1[1]) + p.m2 * (gx * p2[0] + gy * p2[1]))
+    return float(kinetic + potential)
+
+
+def simulate(
+    p: PendulumParameters,
+    initial: PendulumState,
+    g_inplane: tuple[float, float],
+    dt: float,
+    n_steps: int,
+) -> np.ndarray:
+    """Simulate ``n_steps`` RK4 steps.
+
+    Returns an ``(n_steps + 1, 4)`` array of rows
+    ``[theta1, theta2, omega1, omega2]`` including the initial state.
+    """
+    require(n_steps >= 0, "n_steps must be >= 0", n_steps)
+    out = np.empty((n_steps + 1, 4), dtype=np.float64)
+    out[0] = (initial.theta1, initial.theta2, initial.omega1, initial.omega2)
+    current = initial
+    for i in range(n_steps):
+        current = rk4_step(p, current, g_inplane, dt)
+        out[i + 1] = (current.theta1, current.theta2, current.omega1, current.omega2)
+    return out

--- a/src/shared/python/swing_sim/swing_source.py
+++ b/src/shared/python/swing_sim/swing_source.py
@@ -1,0 +1,193 @@
+"""Swing sources: ``t -> clubhead pose + twist`` abstraction (epic #4103 P1).
+
+:class:`SwingSource` is the protocol every swing generator implements —
+manual deliveries, pendulum models, and (later) the movement optimizer.
+:class:`DoublePendulumSwing` is the first concrete source: a double pendulum
+swinging on an oriented plane, integrated once at construction (one-shot,
+so backend "auto" may fall back to the pure-Python reference when the Rust
+wheel is absent) and sampled by linear interpolation afterwards.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Literal, Protocol, runtime_checkable
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from . import _rust_facade, reference
+from .types import (
+    DEFAULT_GRAVITY_M_S2,
+    PendulumParameters,
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+)
+
+Backend = Literal["auto", "rust", "python"]
+
+
+@runtime_checkable
+class SwingSource(Protocol):
+    """Anything that can be sampled for a clubhead pose + twist over time."""
+
+    @property
+    def duration(self) -> float:
+        """Total duration [s] of the swing."""
+        ...
+
+    def sample(self, t: float) -> SwingSample:
+        """Return the clubhead sample at time ``t`` in ``[0, duration]``."""
+        ...
+
+
+def _local_axis_rotation(angle: float) -> np.ndarray:
+    """Rotation about the plane-local normal axis (local y) by ``angle``."""
+    c, s = math.cos(angle), math.sin(angle)
+    return np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+
+
+class DoublePendulumSwing:
+    """Double-pendulum swing on an oriented plane, as a :class:`SwingSource`.
+
+    The trajectory is integrated once at construction on a uniform grid of
+    step ``dt`` and sampled by linear interpolation of the joint state.
+
+    Backend policy (strict-Rust posture for hot loops):
+    - ``"rust"``: require the ``swing_core`` wheel; raise ``ImportError``
+      when absent.
+    - ``"python"``: always use the pure-Python reference (parity oracle).
+    - ``"auto"`` (default): use Rust when available, else fall back — this
+      constructor is a one-shot call, so the explicit fallback is allowed.
+    """
+
+    def __init__(
+        self,
+        parameters: PendulumParameters | None = None,
+        plane: PlaneOrientation | None = None,
+        initial_state: PendulumState | None = None,
+        duration: float = 1.5,
+        dt: float = 1e-3,
+        gravity_m_s2: float = DEFAULT_GRAVITY_M_S2,
+        backend: Backend = "auto",
+    ) -> None:
+        require(
+            math.isfinite(duration) and duration > 0.0,
+            "duration must be finite and > 0",
+            duration,
+        )
+        require(math.isfinite(dt) and dt > 0.0, "dt must be finite and > 0", dt)
+        require(dt <= duration, "dt must not exceed duration", dt)
+        require(
+            math.isfinite(gravity_m_s2) and gravity_m_s2 >= 0.0,
+            "gravity_m_s2 must be finite and >= 0",
+            gravity_m_s2,
+        )
+
+        self._parameters = parameters or PendulumParameters.golf_default()
+        self._plane = plane or PlaneOrientation()
+        self._initial_state = initial_state or PendulumState(
+            theta1=math.pi / 2.0, theta2=0.0, omega1=0.0, omega2=0.0
+        )
+        self._dt = float(dt)
+        self._n_steps = int(round(duration / dt))
+        self._duration = self._n_steps * self._dt
+
+        self._plane_r = reference.plane_rotation(
+            self._plane.yaw_rad, self._plane.side_tilt_rad, self._plane.forward_tilt_rad
+        )
+        self._g_inplane = reference.in_plane_gravity(self._plane_r, gravity_m_s2)
+
+        use_rust = backend == "rust" or (
+            backend == "auto" and _rust_facade.rust_available()
+        )
+        if use_rust:
+            self._states = _rust_facade.simulate_rust(
+                self._parameters,
+                self._initial_state,
+                self._g_inplane,
+                self._dt,
+                self._n_steps,
+            )
+            self._backend: Backend = "rust"
+        else:
+            self._states = reference.simulate(
+                self._parameters,
+                self._initial_state,
+                self._g_inplane,
+                self._dt,
+                self._n_steps,
+            )
+            self._backend = "python"
+
+    @property
+    def backend(self) -> Backend:
+        """Backend that produced the trajectory (``"rust"`` or ``"python"``)."""
+        return self._backend
+
+    @property
+    def parameters(self) -> PendulumParameters:
+        """Pendulum parameters used for the integration."""
+        return self._parameters
+
+    @property
+    def plane(self) -> PlaneOrientation:
+        """Swing-plane orientation."""
+        return self._plane
+
+    @property
+    def duration(self) -> float:
+        """Total duration [s] of the integrated swing."""
+        return self._duration
+
+    def _state_at(self, t: float) -> tuple[float, float, float, float]:
+        """Linearly interpolate the joint state at time ``t``."""
+        idx = t / self._dt
+        i0 = min(int(idx), self._n_steps)
+        i1 = min(i0 + 1, self._n_steps)
+        frac = idx - i0
+        row = (1.0 - frac) * self._states[i0] + frac * self._states[i1]
+        return float(row[0]), float(row[1]), float(row[2]), float(row[3])
+
+    def sample(self, t: float) -> SwingSample:
+        """Return the clubhead :class:`SwingSample` at time ``t``.
+
+        Preconditions: ``0 <= t <= duration`` (within float tolerance).
+        """
+        require(math.isfinite(t), "t must be finite", t)
+        require(
+            -1e-9 <= t <= self._duration + 1e-9,
+            "t must be within [0, duration]",
+            t,
+        )
+        t = min(max(t, 0.0), self._duration)
+        theta1, theta2, omega1, omega2 = self._state_at(t)
+
+        p = self._parameters
+        t12 = theta1 + theta2
+        # In-plane clubhead position (local x horizontal, local y up).
+        x = p.l1 * math.sin(theta1) + p.l2 * math.sin(t12)
+        y = -(p.l1 * math.cos(theta1) + p.l2 * math.cos(t12))
+        # In-plane clubhead velocity.
+        vx = p.l1 * math.cos(theta1) * omega1 + p.l2 * math.cos(t12) * (omega1 + omega2)
+        vy = p.l1 * math.sin(theta1) * omega1 + p.l2 * math.sin(t12) * (omega1 + omega2)
+
+        r_plane = self._plane_r
+        x_axis = r_plane[:, 0]
+        normal = r_plane[:, 1]
+        up_axis = r_plane[:, 2]
+
+        position = x * x_axis + y * up_axis
+        rotation = r_plane @ _local_axis_rotation(t12)
+
+        pose = np.eye(4)
+        pose[:3, :3] = rotation
+        pose[:3, 3] = position
+
+        angular = (omega1 + omega2) * normal
+        linear = vx * x_axis + vy * up_axis
+        twist = np.concatenate([angular, linear])
+
+        return SwingSample(t=t, pose=pose, twist=twist)

--- a/src/shared/python/swing_sim/tests/__init__.py
+++ b/src/shared/python/swing_sim/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the shared swing simulation package."""

--- a/src/shared/python/swing_sim/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/tests/test_contract_api.py
@@ -1,0 +1,68 @@
+"""Contract test pinning the public API surface of swing_sim.
+
+Downstream consumers (UpstreamDrift, rate_of_closure UI, web backend)
+import from the curated façade only; this test fails loudly when the
+surface changes so removals are always deliberate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import shared.python.swing_sim as swing_sim
+
+EXPECTED_PUBLIC_API = {
+    "DEFAULT_GRAVITY_M_S2",
+    "DoublePendulumSwing",
+    "PendulumParameters",
+    "PendulumState",
+    "PlaneOrientation",
+    "SwingSample",
+    "SwingSource",
+    "SwingTrajectory",
+    "__version__",
+    "rust_available",
+}
+
+
+@pytest.mark.contract
+def test_public_api_surface_is_pinned() -> None:
+    assert set(swing_sim.__all__) == EXPECTED_PUBLIC_API
+
+
+@pytest.mark.contract
+def test_all_exports_resolve() -> None:
+    for name in swing_sim.__all__:
+        assert getattr(swing_sim, name) is not None, f"{name} did not resolve"
+
+
+@pytest.mark.contract
+def test_swing_source_protocol_shape() -> None:
+    from shared.python.swing_sim import SwingSource
+
+    assert hasattr(SwingSource, "sample")
+    assert hasattr(SwingSource, "duration")
+
+
+@pytest.mark.contract
+def test_types_are_frozen_dataclasses() -> None:
+    import dataclasses
+
+    from shared.python.swing_sim import (
+        PendulumParameters,
+        PendulumState,
+        PlaneOrientation,
+        SwingSample,
+        SwingTrajectory,
+    )
+
+    for cls in (
+        PlaneOrientation,
+        PendulumParameters,
+        PendulumState,
+        SwingSample,
+        SwingTrajectory,
+    ):
+        assert dataclasses.is_dataclass(cls), f"{cls.__name__} not a dataclass"
+        params = cls.__dataclass_params__
+        assert params.frozen, f"{cls.__name__} must be frozen"

--- a/src/shared/python/swing_sim/tests/test_parity_rust.py
+++ b/src/shared/python/swing_sim/tests/test_parity_rust.py
@@ -1,0 +1,91 @@
+"""Rust <-> Python parity tests for the swing dynamics kernel.
+
+The pure-Python :mod:`shared.python.swing_sim.reference` module is the
+oracle; the ``swing_core`` wheel must reproduce it to floating-point
+accumulation tolerance. Skipped cleanly when the wheel is absent (same
+posture as ``signal_toolkit/tests/test_bilateral_rust_parity.py``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim import reference
+from shared.python.swing_sim.types import (
+    DEFAULT_GRAVITY_M_S2 as G,
+)
+from shared.python.swing_sim.types import (
+    PendulumParameters,
+    PendulumState,
+)
+
+pytest.importorskip(
+    "swing_core",
+    reason="Rust swing_core wheel not installed on this interpreter",
+)
+# Imported after the skip so machines without the wheel can still collect.
+from shared.python.swing_sim import _rust_facade  # noqa: E402
+
+# Both sides evaluate the same formulas in the same order; differences come
+# only from double-precision accumulation across RK4 stages.
+_PARITY_TOL = 1e-9
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_plane_rotation_parity() -> None:
+    for yaw, side, fwd in ((0.0, 0.0, 0.0), (1.2, -0.6, 0.35), (-2.0, 1.1, 2.9)):
+        py_r = reference.plane_rotation(yaw, side, fwd)
+        rust_r = _rust_facade.plane_rotation_rust(yaw, side, fwd)
+        np.testing.assert_allclose(rust_r, py_r, atol=1e-14)
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_in_plane_gravity_parity() -> None:
+    for yaw, side, fwd in ((0.0, 0.0, 0.0), (0.5, 0.9, -0.3), (-2.0, 1.4, 1.1)):
+        py_g = reference.in_plane_gravity_from_tilts(yaw, side, fwd, G)
+        rust_g = _rust_facade.in_plane_gravity_rust(yaw, side, fwd, G)
+        assert rust_g[0] == pytest.approx(py_g[0], abs=1e-14)
+        assert rust_g[1] == pytest.approx(py_g[1], abs=1e-14)
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_single_step_parity() -> None:
+    p = PendulumParameters.golf_default()
+    state = PendulumState(theta1=1.2, theta2=-0.5, omega1=0.3, omega2=-0.1)
+    g = reference.in_plane_gravity_from_tilts(0.4, 0.6, -0.2, G)
+    py_next = reference.rk4_step(p, state, g, 1e-3)
+    rust_next = _rust_facade.step_rust(p, state, g, 1e-3)
+    assert rust_next.theta1 == pytest.approx(py_next.theta1, abs=_PARITY_TOL)
+    assert rust_next.theta2 == pytest.approx(py_next.theta2, abs=_PARITY_TOL)
+    assert rust_next.omega1 == pytest.approx(py_next.omega1, abs=_PARITY_TOL)
+    assert rust_next.omega2 == pytest.approx(py_next.omega2, abs=_PARITY_TOL)
+
+
+@pytest.mark.parity
+def test_trajectory_parity_500_steps() -> None:
+    p = PendulumParameters.golf_default()
+    initial = PendulumState(theta1=1.5, theta2=-0.8, omega1=0.0, omega2=0.0)
+    g = reference.in_plane_gravity_from_tilts(0.3, 0.7, 0.1, G)
+    dt, n_steps = 1e-3, 500
+
+    py_states = reference.simulate(p, initial, g, dt, n_steps)
+    rust_states = _rust_facade.simulate_rust(p, initial, g, dt, n_steps)
+
+    assert rust_states.shape == py_states.shape == (n_steps + 1, 4)
+    max_diff = float(np.abs(py_states - rust_states).max())
+    assert max_diff < _PARITY_TOL, f"trajectory diverged: max diff {max_diff}"
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_total_energy_parity() -> None:
+    p = PendulumParameters.golf_default()
+    state = PendulumState(theta1=0.9, theta2=0.4, omega1=1.1, omega2=-0.6)
+    g = (0.0, -G)
+    py_e = reference.total_energy(p, state, g)
+    rust_e = _rust_facade.total_energy_rust(p, state, g)
+    assert rust_e == pytest.approx(py_e, abs=1e-10)

--- a/src/shared/python/swing_sim/tests/test_reference.py
+++ b/src/shared/python/swing_sim/tests/test_reference.py
@@ -1,0 +1,128 @@
+"""Unit tests for the pure-Python reference dynamics (parity oracle)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim import reference
+from shared.python.swing_sim.types import (
+    DEFAULT_GRAVITY_M_S2 as G,
+)
+from shared.python.swing_sim.types import (
+    PendulumParameters,
+    PendulumState,
+)
+
+
+def _undamped() -> PendulumParameters:
+    p = PendulumParameters.golf_default()
+    return PendulumParameters(
+        m1=p.m1,
+        l1=p.l1,
+        lc1=p.lc1,
+        i1=p.i1,
+        m2=p.m2,
+        l2=p.l2,
+        lc2=p.lc2,
+        i2=p.i2,
+        d1=0.0,
+        d2=0.0,
+    )
+
+
+@pytest.mark.unit
+class TestPlaneRotation:
+    def test_identity_pose(self) -> None:
+        r = reference.plane_rotation(0.0, 0.0, 0.0)
+        np.testing.assert_allclose(r, np.eye(3), atol=1e-15)
+
+    def test_orthonormal_for_generic_tilts(self) -> None:
+        r = reference.plane_rotation(1.2, -0.6, 0.35)
+        np.testing.assert_allclose(r.T @ r, np.eye(3), atol=1e-12)
+        assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-12)
+
+    def test_flat_plane_full_gravity_down(self) -> None:
+        gx, gy = reference.in_plane_gravity_from_tilts(0.0, 0.0, 0.0, G)
+        assert gx == pytest.approx(0.0, abs=1e-12)
+        assert gy == pytest.approx(-G, abs=1e-12)
+
+    def test_pure_yaw_is_invariant(self) -> None:
+        for yaw in (-3.0, -1.2, 0.4, 1.7, 3.1):
+            gx, gy = reference.in_plane_gravity_from_tilts(yaw, 0.0, 0.0, G)
+            assert gx == pytest.approx(0.0, abs=1e-12)
+            assert gy == pytest.approx(-G, abs=1e-12)
+
+    def test_side_tilt_cosine_projection(self) -> None:
+        # Matches UpstreamDrift's scalar projected_gravity = g·cos(inclination).
+        for side in (0.2, 0.6, 1.0):
+            _, gy = reference.in_plane_gravity_from_tilts(0.0, side, 0.0, G)
+            assert gy == pytest.approx(-G * np.cos(side), abs=1e-12)
+
+    def test_projection_never_amplifies(self) -> None:
+        for yaw, side, fwd in ((0.5, 0.9, -0.3), (-2.0, 1.4, 1.1), (3.0, -0.7, 0.6)):
+            gx, gy = reference.in_plane_gravity_from_tilts(yaw, side, fwd, G)
+            assert gx * gx + gy * gy <= G * G + 1e-9
+
+
+@pytest.mark.unit
+class TestDynamics:
+    def test_mass_matrix_symmetric_positive_definite(self) -> None:
+        p = PendulumParameters.golf_default()
+        for theta2 in (-3.0, -1.5, 0.0, 0.8, 1.6, 3.1):
+            m = reference.mass_matrix(p, theta2)
+            assert m[0, 1] == pytest.approx(m[1, 0], abs=1e-15)
+            eigenvalues = np.linalg.eigvalsh(m)
+            assert np.all(eigenvalues > 0.0)
+
+    def test_gravity_vector_flat_plane_matches_scalar_reference(self) -> None:
+        p = PendulumParameters.golf_default()
+        theta1, theta2 = 0.7, -0.4
+        g1, g2 = reference.gravity_vector(p, theta1, theta2, (0.0, -G))
+        expected_g1 = (p.m1 * p.lc1 + p.m2 * p.l1) * G * np.sin(theta1) + (
+            p.m2 * p.lc2 * G * np.sin(theta1 + theta2)
+        )
+        expected_g2 = p.m2 * p.lc2 * G * np.sin(theta1 + theta2)
+        assert g1 == pytest.approx(expected_g1, abs=1e-12)
+        assert g2 == pytest.approx(expected_g2, abs=1e-12)
+
+    def test_undamped_energy_conserved_over_1000_steps(self) -> None:
+        p = _undamped()
+        g = reference.in_plane_gravity_from_tilts(0.4, 0.6, -0.2, G)
+        initial = PendulumState(theta1=1.2, theta2=-0.5, omega1=0.0, omega2=0.0)
+        states = reference.simulate(p, initial, g, 1e-4, 1000)
+        e0 = reference.total_energy(p, initial, g)
+        scale = max(abs(e0), 1.0)
+        for row in states:
+            s = PendulumState(
+                theta1=row[0], theta2=row[1], omega1=row[2], omega2=row[3]
+            )
+            assert abs(reference.total_energy(p, s, g) - e0) / scale < 1e-6
+
+    def test_damping_dissipates_energy(self) -> None:
+        p = PendulumParameters.golf_default()
+        g = (0.0, -G)
+        initial = PendulumState(theta1=1.0, theta2=0.3, omega1=0.5, omega2=-0.2)
+        states = reference.simulate(p, initial, g, 1e-3, 2000)
+        final = PendulumState(
+            theta1=states[-1, 0],
+            theta2=states[-1, 1],
+            omega1=states[-1, 2],
+            omega2=states[-1, 3],
+        )
+        assert reference.total_energy(p, final, g) < reference.total_energy(
+            p, initial, g
+        )
+
+    def test_simulate_shape_and_initial_row(self) -> None:
+        p = PendulumParameters.golf_default()
+        initial = PendulumState(theta1=0.1, theta2=0.0, omega1=0.0, omega2=0.0)
+        states = reference.simulate(p, initial, (0.0, -G), 1e-3, 10)
+        assert states.shape == (11, 4)
+        np.testing.assert_allclose(states[0], (0.1, 0.0, 0.0, 0.0))
+
+    def test_rk4_rejects_nonpositive_dt(self) -> None:
+        p = PendulumParameters.golf_default()
+        s = PendulumState(theta1=0.1, theta2=0.0, omega1=0.0, omega2=0.0)
+        with pytest.raises(ValueError, match="dt"):
+            reference.rk4_step(p, s, (0.0, -G), 0.0)

--- a/src/shared/python/swing_sim/tests/test_swing_source.py
+++ b/src/shared/python/swing_sim/tests/test_swing_source.py
@@ -1,0 +1,99 @@
+"""Unit tests for the SwingSource protocol and DoublePendulumSwing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.swing_source import DoublePendulumSwing, SwingSource
+from shared.python.swing_sim.types import (
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+)
+
+
+def _small_swing(**kwargs: object) -> DoublePendulumSwing:
+    defaults: dict[str, object] = {
+        "duration": 0.1,
+        "dt": 1e-3,
+        "backend": "python",
+    }
+    defaults.update(kwargs)
+    return DoublePendulumSwing(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestDoublePendulumSwing:
+    def test_conforms_to_swing_source_protocol(self) -> None:
+        swing = _small_swing()
+        assert isinstance(swing, SwingSource)
+
+    def test_duration_matches_grid(self) -> None:
+        swing = _small_swing(duration=0.1, dt=1e-3)
+        assert swing.duration == pytest.approx(0.1)
+
+    def test_python_backend_selected_when_forced(self) -> None:
+        assert _small_swing(backend="python").backend == "python"
+
+    def test_sample_returns_valid_swing_sample(self) -> None:
+        swing = _small_swing()
+        sample = swing.sample(0.05)
+        assert isinstance(sample, SwingSample)
+        assert sample.t == pytest.approx(0.05)
+        rotation = sample.pose[:3, :3]
+        np.testing.assert_allclose(rotation.T @ rotation, np.eye(3), atol=1e-9)
+        assert np.all(np.isfinite(sample.twist))
+
+    def test_sample_at_zero_matches_initial_geometry(self) -> None:
+        initial = PendulumState(theta1=np.pi / 2.0, theta2=0.0, omega1=0.0, omega2=0.0)
+        swing = _small_swing(initial_state=initial, plane=PlaneOrientation())
+        sample = swing.sample(0.0)
+        p = swing.parameters
+        # theta1 = pi/2, theta2 = 0: both segments horizontal along +x.
+        expected = np.array([p.l1 + p.l2, 0.0, 0.0])
+        np.testing.assert_allclose(sample.pose[:3, 3], expected, atol=1e-9)
+        # At rest: zero twist.
+        np.testing.assert_allclose(sample.twist, np.zeros(6), atol=1e-12)
+
+    def test_flat_plane_motion_stays_in_plane(self) -> None:
+        swing = _small_swing(plane=PlaneOrientation())
+        for t in (0.0, 0.03, 0.07, 0.1):
+            sample = swing.sample(t)
+            # Identity plane spans world x/z; normal is world y.
+            assert sample.pose[1, 3] == pytest.approx(0.0, abs=1e-12)
+
+    def test_yawed_plane_rotates_positions(self) -> None:
+        flat = _small_swing(plane=PlaneOrientation())
+        yawed = _small_swing(plane=PlaneOrientation(yaw_deg=90.0))
+        p_flat = flat.sample(0.05).pose[:3, 3]
+        p_yawed = yawed.sample(0.05).pose[:3, 3]
+        # Same in-plane dynamics (gravity yaw-invariant), rotated 90° about z.
+        rz90 = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        np.testing.assert_allclose(p_yawed, rz90 @ p_flat, atol=1e-9)
+
+    def test_sample_outside_duration_raises(self) -> None:
+        swing = _small_swing()
+        with pytest.raises(ValueError, match="duration"):
+            swing.sample(swing.duration + 0.1)
+        with pytest.raises(ValueError, match="duration"):
+            swing.sample(-0.1)
+
+    def test_rejects_nonpositive_duration(self) -> None:
+        with pytest.raises(ValueError, match="duration"):
+            _small_swing(duration=0.0)
+
+    def test_rejects_dt_exceeding_duration(self) -> None:
+        with pytest.raises(ValueError, match="dt"):
+            _small_swing(duration=0.01, dt=0.1)
+
+    def test_rust_backend_strict_posture(self) -> None:
+        from shared.python.swing_sim import _rust_facade
+
+        if _rust_facade.rust_available():
+            # Wheel present: rust backend must work and be reported.
+            assert _small_swing(backend="rust").backend == "rust"
+        else:
+            # Wheel absent: forcing rust must raise, never silently degrade.
+            with pytest.raises(ImportError, match="swing_core"):
+                _small_swing(backend="rust")

--- a/src/shared/python/swing_sim/tests/test_types.py
+++ b/src/shared/python/swing_sim/tests/test_types.py
@@ -1,0 +1,165 @@
+"""Unit tests for swing_sim value types (DbC validation)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.types import (
+    PendulumParameters,
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+    SwingTrajectory,
+)
+
+
+def _identity_sample(t: float) -> SwingSample:
+    return SwingSample(t=t, pose=np.eye(4), twist=np.zeros(6))
+
+
+@pytest.mark.unit
+class TestPlaneOrientation:
+    def test_default_is_zero_pose(self) -> None:
+        plane = PlaneOrientation()
+        assert plane.yaw_deg == 0.0
+        assert plane.side_tilt_deg == 0.0
+        assert plane.forward_tilt_deg == 0.0
+
+    def test_radian_conversion(self) -> None:
+        plane = PlaneOrientation(yaw_deg=180.0, side_tilt_deg=90.0)
+        assert plane.yaw_rad == pytest.approx(np.pi)
+        assert plane.side_tilt_rad == pytest.approx(np.pi / 2.0)
+        assert plane.forward_tilt_rad == 0.0
+
+    def test_rejects_non_finite(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            PlaneOrientation(yaw_deg=float("nan"))
+
+    def test_is_frozen(self) -> None:
+        plane = PlaneOrientation()
+        with pytest.raises(AttributeError):
+            plane.yaw_deg = 1.0  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestPendulumParameters:
+    def test_golf_default_is_valid_and_matches_reference_constants(self) -> None:
+        p = PendulumParameters.golf_default()
+        assert p.m1 == pytest.approx(7.5)
+        assert p.l1 == pytest.approx(0.75)
+        assert p.lc1 == pytest.approx(0.3375)
+        assert p.m2 == pytest.approx(0.35)
+        assert p.l2 == pytest.approx(1.0)
+        assert p.lc2 == pytest.approx((0.43 * 0.15 + 0.20) / 0.35)
+        assert p.d1 == pytest.approx(0.4)
+        assert p.d2 == pytest.approx(0.25)
+
+    def test_rejects_nonpositive_mass(self) -> None:
+        p = PendulumParameters.golf_default()
+        with pytest.raises(ValueError, match="m1"):
+            PendulumParameters(
+                m1=0.0,
+                l1=p.l1,
+                lc1=p.lc1,
+                i1=p.i1,
+                m2=p.m2,
+                l2=p.l2,
+                lc2=p.lc2,
+                i2=p.i2,
+            )
+
+    def test_rejects_negative_damping(self) -> None:
+        p = PendulumParameters.golf_default()
+        with pytest.raises(ValueError, match="d1"):
+            PendulumParameters(
+                m1=p.m1,
+                l1=p.l1,
+                lc1=p.lc1,
+                i1=p.i1,
+                m2=p.m2,
+                l2=p.l2,
+                lc2=p.lc2,
+                i2=p.i2,
+                d1=-0.1,
+            )
+
+    def test_rejects_com_beyond_segment(self) -> None:
+        p = PendulumParameters.golf_default()
+        with pytest.raises(ValueError, match="lc1"):
+            PendulumParameters(
+                m1=p.m1,
+                l1=p.l1,
+                lc1=2.0 * p.l1,
+                i1=p.i1,
+                m2=p.m2,
+                l2=p.l2,
+                lc2=p.lc2,
+                i2=p.i2,
+            )
+
+
+@pytest.mark.unit
+class TestPendulumState:
+    def test_valid_construction(self) -> None:
+        s = PendulumState(theta1=1.0, theta2=-0.5, omega1=0.0, omega2=2.0)
+        assert s.theta1 == 1.0
+
+    def test_rejects_non_finite(self) -> None:
+        with pytest.raises(ValueError, match="omega2"):
+            PendulumState(theta1=0.0, theta2=0.0, omega1=0.0, omega2=float("inf"))
+
+
+@pytest.mark.unit
+class TestSwingSample:
+    def test_valid_identity_sample(self) -> None:
+        sample = _identity_sample(0.5)
+        assert sample.t == 0.5
+        assert sample.pose.shape == (4, 4)
+        assert sample.twist.shape == (6,)
+
+    def test_rejects_bad_pose_shape(self) -> None:
+        with pytest.raises(ValueError, match="4x4"):
+            SwingSample(t=0.0, pose=np.eye(3), twist=np.zeros(6))
+
+    def test_rejects_bad_twist_shape(self) -> None:
+        with pytest.raises(ValueError, match="6-vector"):
+            SwingSample(t=0.0, pose=np.eye(4), twist=np.zeros(5))
+
+    def test_rejects_non_orthonormal_rotation(self) -> None:
+        pose = np.eye(4)
+        pose[0, 0] = 2.0
+        with pytest.raises(ValueError, match="orthonormal"):
+            SwingSample(t=0.0, pose=pose, twist=np.zeros(6))
+
+    def test_rejects_bad_bottom_row(self) -> None:
+        pose = np.eye(4)
+        pose[3, 0] = 1.0
+        with pytest.raises(ValueError, match="bottom row"):
+            SwingSample(t=0.0, pose=pose, twist=np.zeros(6))
+
+    def test_rejects_negative_time(self) -> None:
+        with pytest.raises(ValueError, match=">= 0"):
+            _identity_sample(-0.1)
+
+
+@pytest.mark.unit
+class TestSwingTrajectory:
+    def test_duration_and_len(self) -> None:
+        traj = SwingTrajectory(
+            samples=(
+                _identity_sample(0.0),
+                _identity_sample(0.5),
+                _identity_sample(1.0),
+            )
+        )
+        assert traj.duration == pytest.approx(1.0)
+        assert len(traj) == 3
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="samples"):
+            SwingTrajectory(samples=())
+
+    def test_rejects_non_increasing_times(self) -> None:
+        with pytest.raises(ValueError, match="increasing"):
+            SwingTrajectory(samples=(_identity_sample(0.5), _identity_sample(0.5)))

--- a/src/shared/python/swing_sim/types.py
+++ b/src/shared/python/swing_sim/types.py
@@ -1,0 +1,212 @@
+"""Core swing-simulation value types (frozen dataclasses with DbC validation).
+
+All angles on public dataclasses are degrees (UI-friendly); radians are used
+internally by the dynamics. SI units throughout (kg, m, s).
+
+Conventions (mirrors ``rust_core/swing-core/src/swing``):
+- World frame: x forward, y left, z up.
+- Plane pose: three sequential intrinsic tilts — yaw about world-up, then
+  side tilt about the rotated in-plane horizontal axis, then forward/back
+  tilt about the resulting in-plane up axis.
+- ``theta1`` measured from the in-plane downward vertical; ``theta2`` is the
+  lower segment's angle relative to the upper segment.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from shared.python.contracts import require
+
+DEFAULT_GRAVITY_M_S2 = 9.80665
+"""Standard gravitational acceleration [m/s²]."""
+
+# Defaults ported from UpstreamDrift double_pendulum.py (documented there).
+_ARM_LENGTH_M = 0.75
+_ARM_MASS_KG = 7.5
+_ARM_COM_RATIO = 0.45
+_ARM_INERTIA_SCALING = 1.0 / 12.0
+_SHAFT_LENGTH_M = 1.0
+_SHAFT_MASS_KG = 0.15
+_CLUBHEAD_MASS_KG = 0.20
+_SHAFT_COM_RATIO = 0.43
+_DAMPING_SHOULDER = 0.4
+_DAMPING_WRIST = 0.25
+
+
+def _require_finite(name: str, value: float) -> None:
+    require(math.isfinite(value), f"{name} must be finite", value)
+
+
+@dataclass(frozen=True)
+class PlaneOrientation:
+    """Swing-plane pose as three sequential intrinsic tilts (degrees).
+
+    Order (documented, epic #4103): yaw about world-up, then side tilt about
+    the rotated in-plane horizontal axis, then forward/back tilt about the
+    resulting in-plane up axis. The zero pose is a vertical plane feeling
+    full gravity in-plane.
+    """
+
+    yaw_deg: float = 0.0
+    side_tilt_deg: float = 0.0
+    forward_tilt_deg: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in ("yaw_deg", "side_tilt_deg", "forward_tilt_deg"):
+            _require_finite(name, getattr(self, name))
+
+    @property
+    def yaw_rad(self) -> float:
+        """Yaw angle in radians."""
+        return math.radians(self.yaw_deg)
+
+    @property
+    def side_tilt_rad(self) -> float:
+        """Side tilt angle in radians."""
+        return math.radians(self.side_tilt_deg)
+
+    @property
+    def forward_tilt_rad(self) -> float:
+        """Forward/back tilt angle in radians."""
+        return math.radians(self.forward_tilt_deg)
+
+
+@dataclass(frozen=True)
+class PendulumParameters:
+    """Double-pendulum physical parameters (SI units).
+
+    Inertias ``i1``/``i2`` are about the proximal joint (parallel-axis
+    already applied), matching the Rust kernel and the UpstreamDrift
+    reference implementation.
+    """
+
+    m1: float
+    l1: float
+    lc1: float
+    i1: float
+    m2: float
+    l2: float
+    lc2: float
+    i2: float
+    d1: float = _DAMPING_SHOULDER
+    d2: float = _DAMPING_WRIST
+
+    def __post_init__(self) -> None:
+        for name in ("m1", "l1", "lc1", "i1", "m2", "l2", "lc2", "i2"):
+            value = getattr(self, name)
+            _require_finite(name, value)
+            require(value > 0.0, f"{name} must be > 0", value)
+        for name in ("d1", "d2"):
+            value = getattr(self, name)
+            _require_finite(name, value)
+            require(value >= 0.0, f"{name} must be >= 0", value)
+        require(self.lc1 <= self.l1, "lc1 must not exceed l1", self.lc1)
+        require(self.lc2 <= self.l2, "lc2 must not exceed l2", self.lc2)
+
+    @classmethod
+    def golf_default(cls) -> PendulumParameters:
+        """Default golf-swing parameters (UpstreamDrift reference constants).
+
+        Computed from the same segment formulas as the Rust kernel so the
+        two backends agree bit-for-bit.
+        """
+        m1 = _ARM_MASS_KG
+        l1 = _ARM_LENGTH_M
+        lc1 = l1 * _ARM_COM_RATIO
+        i1_com = _ARM_INERTIA_SCALING * m1 * l1 * l1
+        i1 = i1_com + m1 * lc1 * lc1
+
+        l2 = _SHAFT_LENGTH_M
+        ms = _SHAFT_MASS_KG
+        mh = _CLUBHEAD_MASS_KG
+        m2 = ms + mh
+        shaft_com = l2 * _SHAFT_COM_RATIO
+        lc2 = (shaft_com * ms + l2 * mh) / m2
+        shaft_inertia_com = (1.0 / 12.0) * ms * l2 * l2
+        parallel_axis = ms * (shaft_com - lc2) * (shaft_com - lc2) + mh * (l2 - lc2) * (
+            l2 - lc2
+        )
+        i2_com = shaft_inertia_com + parallel_axis
+        i2 = i2_com + m2 * lc2 * lc2
+
+        return cls(m1=m1, l1=l1, lc1=lc1, i1=i1, m2=m2, l2=l2, lc2=lc2, i2=i2)
+
+
+@dataclass(frozen=True)
+class PendulumState:
+    """Planar dynamic state (radians, rad/s)."""
+
+    theta1: float
+    theta2: float
+    omega1: float
+    omega2: float
+
+    def __post_init__(self) -> None:
+        for name in ("theta1", "theta2", "omega1", "omega2"):
+            _require_finite(name, getattr(self, name))
+
+
+@dataclass(frozen=True)
+class SwingSample:
+    """One clubhead sample: time, SE(3) pose, and spatial twist.
+
+    - ``pose``: 4x4 homogeneous transform (world-from-clubhead), rotation in
+      the upper-left 3x3 block, position in the last column.
+    - ``twist``: 6-vector ``[wx, wy, wz, vx, vy, vz]`` — world-frame angular
+      velocity followed by clubhead linear velocity.
+    """
+
+    t: float
+    pose: np.ndarray = field(repr=False)
+    twist: np.ndarray = field(repr=False)
+
+    def __post_init__(self) -> None:
+        _require_finite("t", self.t)
+        require(self.t >= 0.0, "t must be >= 0", self.t)
+        pose = np.asarray(self.pose, dtype=np.float64)
+        twist = np.asarray(self.twist, dtype=np.float64)
+        require(pose.shape == (4, 4), "pose must be a 4x4 matrix", pose.shape)
+        require(twist.shape == (6,), "twist must be a 6-vector", twist.shape)
+        require(bool(np.all(np.isfinite(pose))), "pose must be finite", None)
+        require(bool(np.all(np.isfinite(twist))), "twist must be finite", None)
+        require(
+            bool(np.allclose(pose[3], (0.0, 0.0, 0.0, 1.0), atol=1e-12)),
+            "pose bottom row must be [0, 0, 0, 1]",
+            None,
+        )
+        rotation = pose[:3, :3]
+        require(
+            bool(np.allclose(rotation.T @ rotation, np.eye(3), atol=1e-9)),
+            "pose rotation block must be orthonormal",
+            None,
+        )
+        object.__setattr__(self, "pose", pose)
+        object.__setattr__(self, "twist", twist)
+
+
+@dataclass(frozen=True)
+class SwingTrajectory:
+    """Immutable, time-ordered sequence of :class:`SwingSample`."""
+
+    samples: tuple[SwingSample, ...]
+
+    def __post_init__(self) -> None:
+        require(len(self.samples) > 0, "trajectory must contain samples", None)
+        times = [s.t for s in self.samples]
+        require(
+            all(b > a for a, b in zip(times, times[1:], strict=False)),
+            "sample times must be strictly increasing",
+            None,
+        )
+
+    @property
+    def duration(self) -> float:
+        """Trajectory duration [s] (time of last sample minus first)."""
+        return self.samples[-1].t - self.samples[0].t
+
+    def __len__(self) -> int:
+        return len(self.samples)


### PR DESCRIPTION
Phase 0 of epic #4103, implementing the recon + architecture decision recorded on #4104.

## What this adds

### Rust: `rust_core/swing-core` (new workspace member)
- Feature contract copied exactly from `tools-core`: crate-type `["cdylib", "rlib"]`; features `python` / `extension-module` / `wasm`; per-crate maturin `pyproject.toml` with `module-name = "swing_core"`.
- `swing/pendulum.rs`: double-pendulum EOM ported from UpstreamDrift's `double_pendulum.py` (mass matrix, Coriolis/centripetal, gravity, viscous damping, RK4; θ1 from downward vertical, θ2 relative), generalised so **gravity enters as an in-plane 2-vector**, never a scalar.
- `swing/plane.rs`: plane pose from three sequential intrinsic tilts (yaw about world-up → side tilt about the rotated axis → forward/back tilt), `plane_rotation()` + `in_plane_gravity()`.
- `py_bindings/` and `wasm_bindings/` split by concern; dual `#[cfg_attr(python/wasm)]` on public structs like `tools-core/src/ball_flight.rs`.
- Rust tests: energy conservation of the undamped, unforced pendulum (< 1e-6 relative drift over 1000 RK4 steps), mass-matrix symmetry + positive-definiteness, plane-rotation orthonormality, gravity-projection limits (flat plane ⇒ full g down; yaw invariance; cosine side-tilt matching the UD scalar `projected_gravity`).

### Python: `src/shared/python/swing_sim/`
- `types.py`: frozen DbC dataclasses (`PlaneOrientation`, `PendulumParameters`, `PendulumState`, `SwingSample` with SE(3) 4x4 pose + 6-twist, `SwingTrajectory`), validated via the shared `contracts` helpers.
- `swing_source.py`: `SwingSource` protocol (`sample(t) -> SwingSample`, `duration`) + `DoublePendulumSwing`.
- `_rust_facade.py`: STRICT posture (bilateral_rust.py style) — module-level import of the wheel, actionable `ImportError` at call time for the hot integration loop; the PyO3 runtime-submodule gotcha (`from swing_core import swing`) is documented and observed.
- `reference.py`: pure-Python mirror of the Rust kernel — parity oracle and explicit one-shot fallback.
- In-package tests: `unit` per public function, `parity` (skips cleanly without the wheel, runs non-skipped in the new workflow), `contract` pinning the façade surface. All markers from the registered strict set.

### CI
- `ci-standard.yml`: rust-quality-gate change filter also watches `src/shared/python/swing_sim/**`; added a swing-core wasm-pack build + pkg-output assertions alongside the tools-core step (same pinned wasm-pack 0.13.1 + SHA256 install).
- New `maturin-swing-core.yml`: wheel build on Python 3.10–3.12, hard import assertion, strict-façade backend gate, parity suite non-skipped.
- `publish-artifacts.yml` untouched — NPM publish lands with P7 (#4111).

### SPEC.md
- Bumped to 1.6.0 with a dated section and changelog row.

## Gates (all run locally)
- `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` (workspace) ✅
- `cargo test -p swing-core` ✅ (12) · `cargo test -p swing-core --features python` ✅ (12)
- `maturin build --release -m rust_core/swing-core/Cargo.toml` ✅ → wheel installed → full swing_sim pytest **51 passed** including the 5 parity tests live against the wheel
- `ruff check` + `ruff format --check` ✅ · `mypy src/shared/python/swing_sim` ✅ (0 errors)
- `scripts/check_file_size_budget.py --changed-only` ✅ (0 violations; largest new file 439 LOC)
- `wasm-pack build --target web --features wasm --no-default-features` ✅ locally (wasm-pack 0.14.0; CI uses the pinned 0.13.1)

## Deviations from the plan (with rationale)
- `maturin-swing-core.yml` omits the standalone rust-quality-gate job that `maturin-pendulum-core.yml` carries: pendulum-core needs it because it is workspace-**excluded**; swing-core is a workspace member already covered by ci-standard's gate (DRY). Documented in the workflow header.
- The ci-standard rust change filter is a `git diff` pathspec (not a `paths:` list); new `*.rs`/`Cargo.toml` files matched already, so "extend the path filter" took the form of adding `src/shared/python/swing_sim/**` to the pathspec so façade-only changes also re-run the Rust gate + parity-relevant builds.

Refs #4103, #4104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
