### PR TITLE
feat(swing_sim): impact package — ported model with fixes, delivery front-end, physics-based gear effect (#4106)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -26,8 +26,8 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.6.0                                      |
-| **Spec Version**        | 1.6.0                                      |
+| **Current Version**     | 1.7.0                                      |
+| **Spec Version**        | 1.7.0                                      |
 | **Last Spec Update**    | 2026-08-04                                 |
 
 ## 2. Purpose & Mission
@@ -35,6 +35,44 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Swing impact package (epic #4103, #4106)
+
+- New self-façaded subpackage `src/shared/python/swing_sim/impact/`
+  (types/models/solver/utils split mirroring UpstreamDrift's
+  `physics/impact_model`, all constants vendored with citations into
+  `constants.py`): rigid-body COR impulse model with the 2/7 rolling-cap
+  friction spin derivation, spring-damper (Kelvin-Voigt) model,
+  finite-time model, energy-balance validator, and `ImpactRecorder` /
+  `ImpactSolverAPI`. The parent `swing_sim/__init__.py` façade is
+  deliberately untouched (epic integration wires it later).
+- Three defect fixes relative to the UpstreamDrift source: (a)
+  `solve_with_gear_effect` no longer drops `impact_offset` when computing
+  the base impulse — off-center hits now get the MOI effective-mass
+  reduction (regression test pins off-center ball speed < center); (b)
+  opt-in full 3-D inertia treatment via a 3x3 `clubhead_moi_tensor`
+  (`1/m_eff = 1/m + (r x n)^T I^-1 (r x n)`; a diagonal tensor matching
+  the scalar MOI reproduces the scalar path exactly); (c) friction-spin
+  axis sign corrected to `t x n` (the ported `n x t` spun lofted strikes
+  toward topspin and contradicted its own slip-reduction cap logic).
+- New `delivery.py` front-end: launch-monitor delivery numbers (club
+  path/face/attack/dynamic loft/lie deg, clubhead speed, toe/high offsets
+  in mm) → impact-model vectors in the AffineDrift frame (x target,
+  y up, z right; path + = in-to-out, face + = open), with spin-loft and
+  D-plane diagnostics (`spin_axis = unit(v x n)`, signed tilt; + = fade).
+- New physics-based `gear_effect.py` replacing the old three-empirical-
+  constants version: head rotation recoil `I^-1 (r x (-J n))` with the
+  CG-depth lever arm (`DRIVER_CG_DEPTH_M`), time-averaged tangential
+  face-surface sweep, and the same 2/7-capped friction impulse converting
+  it to ball spin. Bulge/roll enters through an app-agnostic
+  `face_normal_at_offset(toe_m, high_m)` callable seam (club package, PR
+  #4112). Signature tests: toe hit → draw-side spin, high hit → reduced
+  backspin, bulge partially offsetting toe-hit pull.
+- In-package tests (`unit` / `physics` / `regression` / `contract`
+  markers): hand-computed impulse pins, COR monotonicity, spin cap,
+  energy balance vs `1/2 mu v^2 (1-e^2)`, both bug-fix regressions,
+  delivery round-trips, gear-effect signatures, and a contract test
+  pinning the `swing_sim.impact` public API.
+
 ### 2026-08-04 Swing simulation foundation (epic #4103, P0 #4104)
 
 - New Rust workspace member `rust_core/swing-core` (Python wheel `swing_core`
@@ -1743,6 +1781,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.7.0 | feat(swing_sim, #4106): add the impact physics subpackage `src/shared/python/swing_sim/impact/` — rigid-body COR impulse model (2/7 rolling-cap friction spin) + spring-damper + finite-time models, energy-balance validator, and recorder ported self-contained from UpstreamDrift's `physics/impact_model` with three fixes (off-center base impulse no longer drops `impact_offset`; opt-in 3x3 club MOI tensor effective mass `1/m_eff = 1/m + (r x n)^T I^-1 (r x n)`; friction-spin axis sign corrected to `t x n`); new launch-monitor delivery front-end (`delivery.py`, AffineDrift frame, spin-loft + D-plane diagnostics) and physics-based gear effect (`gear_effect.py`, head recoil × CG-depth lever arm, bulge/roll via `face_normal_at_offset` callable seam) replacing the empirical three-constant version. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4104): add the swing simulation foundation — new `rust_core/swing-core` workspace crate (double-pendulum EOM with plane-oriented in-plane gravity, PyO3 wheel `swing_core` + wasm-bindgen bindings) and shared `src/shared/python/swing_sim` package (DbC value types, `SwingSource` protocol, `DoublePendulumSwing`, strict Rust façade with pure-Python parity oracle); wire swing-core into the rust quality gate's wasm build and add the `maturin-swing-core.yml` build/import/parity workflow. |
 | 2026-07-26 | 1.5.3 | fix(test): create the standalone-wheel smoke environment from the real base interpreter rather than nesting it under the active CI virtualenv, keeping installed-artifact validation portable across relocated self-hosted Python 3.10 runtimes. |
 | 2026-07-26 | 1.5.3 | fix(ci): isolate both protected Python jobs in per-job virtual environments after validating the persistent setup-python runtime; repair and import-probe the matrix NumPy/SciPy stack with compatible bounds, and reinstall OpenCV without dependency resolution so it cannot replace the verified NumPy wheel. |

--- a/src/shared/python/swing_sim/impact/__init__.py
+++ b/src/shared/python/swing_sim/impact/__init__.py
@@ -1,0 +1,92 @@
+"""Impact physics subpackage for swing_sim (epic #4103, issue #4106).
+
+Self-façaded: downstream code imports from
+``shared.python.swing_sim.impact`` only. The rigid-body COR impulse model
+(with the 2/7 rolling-cap friction spin derivation), spring-damper model,
+energy-balance validator, and recorder are ported from UpstreamDrift's
+``src/shared/python/physics/impact_model`` package; the delivery
+front-end (:mod:`.delivery`) and the physics-based gear effect
+(:mod:`.gear_effect`) are new in Tools.
+
+The parent ``swing_sim/__init__.py`` façade is wired up during epic
+integration; do not add impact exports there from this subpackage.
+"""
+
+from __future__ import annotations
+
+from .constants import (
+    DRIVER_CG_DEPTH_M,
+    DRIVER_COR,
+    DRIVER_MASS_KG,
+    DRIVER_MOI_KG_M2,
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_MOMENT_OF_INERTIA_KG_M2,
+    GOLF_BALL_RADIUS_M,
+    TYPICAL_CONTACT_DURATION_S,
+)
+from .delivery import (
+    DeliveryDerived,
+    DeliveryParameters,
+    derive_delivery,
+    to_pre_impact_state,
+)
+from .gear_effect import (
+    FaceNormalAtOffset,
+    GearEffectResult,
+    compute_gear_effect,
+    resolve_contact_normal,
+)
+from .models import (
+    SPHERE_ROLLING_CAP_FACTOR,
+    FiniteTimeImpactModel,
+    ImpactModel,
+    RigidBodyImpactModel,
+    SpringDamperImpactModel,
+    create_impact_model,
+    face_basis,
+    offset_to_face_vector,
+)
+from .solver import ImpactRecorder, ImpactSolverAPI
+from .types import (
+    ImpactEvent,
+    ImpactModelType,
+    ImpactParameters,
+    PostImpactState,
+    PreImpactState,
+)
+from .utils import validate_energy_balance
+
+__all__ = [
+    "DRIVER_CG_DEPTH_M",
+    "DRIVER_COR",
+    "DRIVER_MASS_KG",
+    "DRIVER_MOI_KG_M2",
+    "GOLF_BALL_MASS_KG",
+    "GOLF_BALL_MOMENT_OF_INERTIA_KG_M2",
+    "GOLF_BALL_RADIUS_M",
+    "SPHERE_ROLLING_CAP_FACTOR",
+    "TYPICAL_CONTACT_DURATION_S",
+    "DeliveryDerived",
+    "DeliveryParameters",
+    "FaceNormalAtOffset",
+    "FiniteTimeImpactModel",
+    "GearEffectResult",
+    "ImpactEvent",
+    "ImpactModel",
+    "ImpactModelType",
+    "ImpactParameters",
+    "ImpactRecorder",
+    "ImpactSolverAPI",
+    "PostImpactState",
+    "PreImpactState",
+    "RigidBodyImpactModel",
+    "SpringDamperImpactModel",
+    "compute_gear_effect",
+    "create_impact_model",
+    "derive_delivery",
+    "face_basis",
+    "offset_to_face_vector",
+    "resolve_contact_normal",
+    "to_pre_impact_state",
+    "validate_energy_balance",
+]

--- a/src/shared/python/swing_sim/impact/constants.py
+++ b/src/shared/python/swing_sim/impact/constants.py
@@ -1,0 +1,69 @@
+"""Vendored physical constants for the impact package (SI units).
+
+Vendored from UpstreamDrift ``src/shared/python/core/physics_constants.py``
+so that swing_sim stays self-contained (Tools must NOT import
+upstream-drift; the dependency arrow points the other way — UD vendors
+Tools). Each constant carries its original citation.
+
+Epic #4103 / issue #4106.
+"""
+
+from __future__ import annotations
+
+# --- Golf ball (USGA equipment rules) ------------------------------------
+GOLF_BALL_MASS_KG = 0.04593
+"""Maximum golf ball mass (1.620 oz). Source: USGA Rule 5-1."""
+
+GOLF_BALL_DIAMETER_M = 0.04267
+"""Minimum golf ball diameter (1.680 in). Source: USGA Rule 5-2."""
+
+GOLF_BALL_RADIUS_M = GOLF_BALL_DIAMETER_M / 2.0
+"""Minimum golf ball radius (derived from USGA Rule 5-2)."""
+
+GOLF_BALL_MOMENT_OF_INERTIA_KG_M2 = (
+    (2.0 / 5.0) * GOLF_BALL_MASS_KG * GOLF_BALL_RADIUS_M**2
+)
+"""Golf ball MOI, uniform solid-sphere approximation (2/5 m r^2)."""
+
+# --- Driver clubhead ------------------------------------------------------
+DRIVER_COR = 0.83
+"""Driver coefficient of restitution. Source: USGA/R&A CT limit
+(~0.83 equivalent COR)."""
+
+DRIVER_MOI_KG_M2 = 4.5e-4
+"""Driver clubhead MOI about CG (perpendicular to face).
+Source: typical driver specs."""
+
+DRIVER_MASS_KG = 0.200
+"""Typical driver clubhead mass. Source: industry standard specs."""
+
+DRIVER_LOFT_RAD = 0.18325957145940461  # math.radians(10.5)
+"""Typical driver loft (10.5 deg). Source: modern trade average."""
+
+DRIVER_LIE_RAD = 1.0471975511965976  # math.radians(60.0)
+"""Typical driver lie angle (60 deg). Source: industry standard specs."""
+
+DRIVER_CG_DEPTH_M = 0.035
+"""Typical driver CG depth behind the face plane [m]. Modern drivers place
+the CG 30-40 mm rearward of the face; the front-to-back lever arm is what
+produces gear-effect spin on off-center hits. Source: published driver CG
+measurements (e.g. Golf Laboratories / manufacturer spec sheets, ~1.2-1.6
+in). New in Tools; not present in the UpstreamDrift constant set."""
+
+# --- Contact --------------------------------------------------------------
+TYPICAL_CONTACT_DURATION_S = 0.0005
+"""Typical ball-clubface contact time. Source: high-speed video studies."""
+
+__all__ = [
+    "DRIVER_CG_DEPTH_M",
+    "DRIVER_COR",
+    "DRIVER_LIE_RAD",
+    "DRIVER_LOFT_RAD",
+    "DRIVER_MASS_KG",
+    "DRIVER_MOI_KG_M2",
+    "GOLF_BALL_DIAMETER_M",
+    "GOLF_BALL_MASS_KG",
+    "GOLF_BALL_MOMENT_OF_INERTIA_KG_M2",
+    "GOLF_BALL_RADIUS_M",
+    "TYPICAL_CONTACT_DURATION_S",
+]

--- a/src/shared/python/swing_sim/impact/delivery.py
+++ b/src/shared/python/swing_sim/impact/delivery.py
@@ -1,0 +1,278 @@
+"""Delivery front-end: launch-monitor parameters -> impact-model inputs.
+
+New in Tools (epic #4103 / issue #4106); no upstream equivalent exists in
+UpstreamDrift.
+
+Frame and sign conventions (AffineDrift frame)
+----------------------------------------------
+All vectors are expressed in the AffineDrift frame:
+
+- ``x`` = target line, ``y`` = up, ``z`` = right (right-handed).
+- Club path (+) = in-to-out: the clubhead travels right of the target
+  line at impact (+z velocity component, right-handed player).
+- Face angle (+) = open: the face normal points right of the target
+  (+z component).
+- Attack angle (+) = hitting up (+y velocity component).
+- Dynamic loft (+) tilts the face normal upward (+y component).
+- Impact offset: toe (+) and high (+) in millimetres, converted to the
+  impact model's ``[horizontal, vertical]`` metre offsets. For a
+  right-handed player the toe axis is +z (see
+  :func:`.models.face_basis`).
+
+The impact model itself (:mod:`.models`) is frame-agnostic — it consumes
+whatever consistent right-handed SI frame the vectors are given in — so
+the vectors built here feed it directly with no further mapping. (For
+reference, UpstreamDrift's physics stack uses x forward / y left / z up;
+that adapter concern lives at the UD boundary, not here.)
+
+Angle composition:
+
+    v_hat = [cos(AoA) cos(path), sin(AoA), cos(AoA) sin(path)]
+    n_hat = [cos(loft) cos(face), sin(loft), cos(loft) sin(face)]
+
+Dynamic loft and face angle are launch-monitor MEASUREMENTS of the
+delivered normal, so delivered lie is already reflected in them;
+``lie_deg`` here is the residual toe-up(+)/toe-down(-) rotation of the
+face about its own normal, used only to orient the toe/high offset axes
+(``[h, v] = R(lie) [toe, high]``).
+
+Spin loft and D-plane diagnostics
+---------------------------------
+Spin loft is the 3-D angle between the delivered face normal and the club
+path vector: ``spin_loft = arccos(v_hat . n_hat)``. The D-plane is the
+plane spanned by ``v_hat`` and ``n_hat``; in the classic approximation
+(Jorgensen, *The Physics of Golf*; TrackMan D-plane literature) the ball
+launches close to the face normal and spins about the D-plane's normal:
+
+    spin_axis = unit(v_hat x n_hat)
+
+For a square face this axis is horizontal (+z, pure backspin). A
+face-minus-path difference tilts it; the reported tilt angle is
+
+    tilt = atan2(-axis_y_component, in-plane horizontal component)
+
+signed so positive tilt = fade/slice-side spin (curves right for a
+right-handed player) and negative = draw/hook-side.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from .constants import DRIVER_MASS_KG, DRIVER_MOI_KG_M2
+from .models import _norm
+from .types import PreImpactState
+
+_MM_TO_M = 1e-3
+_MAX_ANGLE_DEG = 89.0
+
+
+@dataclass(frozen=True)
+class DeliveryParameters:
+    """Launch-monitor-style delivery numbers (degrees, m/s, mm).
+
+    Attributes:
+        clubhead_speed_mps: Clubhead speed at impact [m/s] (> 0)
+        club_path_deg: Club path [deg]; + = in-to-out
+        face_angle_deg: Face angle [deg]; + = open (right of target)
+        attack_angle_deg: Attack angle [deg]; + = hitting up
+        dynamic_loft_deg: Delivered (dynamic) loft [deg]
+        lie_deg: Residual delivered lie rotation about the face normal
+            [deg]; + = toe up. Orients the offset axes only (see module
+            docstring).
+        impact_offset_toe_mm: Impact offset toward the toe [mm]
+        impact_offset_high_mm: Impact offset up the face [mm]
+    """
+
+    clubhead_speed_mps: float
+    club_path_deg: float = 0.0
+    face_angle_deg: float = 0.0
+    attack_angle_deg: float = 0.0
+    dynamic_loft_deg: float = 10.5
+    lie_deg: float = 0.0
+    impact_offset_toe_mm: float = 0.0
+    impact_offset_high_mm: float = 0.0
+
+    def __post_init__(self) -> None:
+        require(
+            math.isfinite(self.clubhead_speed_mps) and self.clubhead_speed_mps > 0,
+            "clubhead_speed_mps must be positive and finite",
+            self.clubhead_speed_mps,
+        )
+        for name in (
+            "club_path_deg",
+            "face_angle_deg",
+            "attack_angle_deg",
+            "dynamic_loft_deg",
+            "lie_deg",
+        ):
+            value = getattr(self, name)
+            require(
+                math.isfinite(value) and abs(value) <= _MAX_ANGLE_DEG,
+                f"{name} must be finite and within +/-{_MAX_ANGLE_DEG} deg",
+                value,
+            )
+        for name in ("impact_offset_toe_mm", "impact_offset_high_mm"):
+            require(
+                math.isfinite(getattr(self, name)),
+                f"{name} must be finite",
+                getattr(self, name),
+            )
+
+
+@dataclass(frozen=True)
+class DeliveryDerived:
+    """Impact-model inputs plus D-plane diagnostics (AffineDrift frame).
+
+    Attributes:
+        clubhead_velocity: Clubhead velocity vector [m/s] (3,)
+        face_normal: Unit delivered face normal (3,)
+        impact_offset: (2,) [horizontal, vertical] offset [m] in the
+            impact model's convention (lie-rotated toe/high offsets)
+        clubhead_angular_velocity: Head angular velocity [rad/s] (3,);
+            zeros unless supplied by a richer swing source
+        spin_loft_deg: 3-D angle between face normal and club path [deg]
+        face_to_path_deg: Face angle minus club path [deg] (horizontal)
+        spin_axis: Unit D-plane spin axis (3,); +z = pure backspin
+        spin_axis_tilt_deg: Signed spin-axis tilt [deg]; + = fade side
+    """
+
+    clubhead_velocity: np.ndarray
+    face_normal: np.ndarray
+    impact_offset: np.ndarray
+    clubhead_angular_velocity: np.ndarray
+    spin_loft_deg: float
+    face_to_path_deg: float
+    spin_axis: np.ndarray
+    spin_axis_tilt_deg: float
+
+
+def derive_delivery(
+    params: DeliveryParameters,
+    clubhead_angular_velocity: np.ndarray | None = None,
+) -> DeliveryDerived:
+    """Convert delivery parameters into impact-model inputs + diagnostics.
+
+    Args:
+        params: Launch-monitor-style delivery parameters.
+        clubhead_angular_velocity: Optional head angular velocity [rad/s]
+            (3,) from a richer swing source; defaults to zeros.
+
+    Returns:
+        :class:`DeliveryDerived` in the AffineDrift frame.
+    """
+    path = math.radians(params.club_path_deg)
+    face = math.radians(params.face_angle_deg)
+    aoa = math.radians(params.attack_angle_deg)
+    loft = math.radians(params.dynamic_loft_deg)
+    lie = math.radians(params.lie_deg)
+
+    v_hat = np.array(
+        [
+            math.cos(aoa) * math.cos(path),
+            math.sin(aoa),
+            math.cos(aoa) * math.sin(path),
+        ]
+    )
+    n_hat = np.array(
+        [
+            math.cos(loft) * math.cos(face),
+            math.sin(loft),
+            math.cos(loft) * math.sin(face),
+        ]
+    )
+    clubhead_velocity = params.clubhead_speed_mps * v_hat
+
+    # Lie rotates the toe/high axes about the face normal (+ = toe up):
+    # [h, v] = R(lie) [toe, high].
+    toe_m = params.impact_offset_toe_mm * _MM_TO_M
+    high_m = params.impact_offset_high_mm * _MM_TO_M
+    cos_l, sin_l = math.cos(lie), math.sin(lie)
+    impact_offset = np.array(
+        [toe_m * cos_l - high_m * sin_l, toe_m * sin_l + high_m * cos_l]
+    )
+
+    # D-plane diagnostics (see module docstring for the derivation).
+    cos_spin_loft = float(np.clip(np.dot(v_hat, n_hat), -1.0, 1.0))
+    spin_loft_deg = math.degrees(math.acos(cos_spin_loft))
+
+    axis_raw = np.cross(v_hat, n_hat)
+    axis_mag = _norm(axis_raw)
+    if axis_mag > 1e-12:
+        spin_axis = axis_raw / axis_mag
+    else:  # Zero spin loft: degenerate D-plane, report pure-backspin axis.
+        spin_axis = np.array([0.0, 0.0, 1.0])
+    horizontal = math.hypot(float(spin_axis[0]), float(spin_axis[2]))
+    spin_axis_tilt_deg = math.degrees(math.atan2(-float(spin_axis[1]), horizontal))
+
+    omega = (
+        np.asarray(clubhead_angular_velocity, dtype=float)
+        if clubhead_angular_velocity is not None
+        else np.zeros(3)
+    )
+
+    return DeliveryDerived(
+        clubhead_velocity=clubhead_velocity,
+        face_normal=n_hat,
+        impact_offset=impact_offset,
+        clubhead_angular_velocity=omega,
+        spin_loft_deg=spin_loft_deg,
+        face_to_path_deg=params.face_angle_deg - params.club_path_deg,
+        spin_axis=spin_axis,
+        spin_axis_tilt_deg=spin_axis_tilt_deg,
+    )
+
+
+def to_pre_impact_state(
+    params: DeliveryParameters,
+    clubhead_mass: float = DRIVER_MASS_KG,
+    clubhead_moi: float = DRIVER_MOI_KG_M2,
+    clubhead_moi_tensor: np.ndarray | None = None,
+    ball_velocity: np.ndarray | None = None,
+    ball_angular_velocity: np.ndarray | None = None,
+    clubhead_angular_velocity: np.ndarray | None = None,
+) -> PreImpactState:
+    """Build a :class:`.types.PreImpactState` from delivery parameters.
+
+    Args:
+        params: Launch-monitor-style delivery parameters.
+        clubhead_mass: Clubhead mass [kg]
+        clubhead_moi: Scalar clubhead MOI about CG [kg.m^2]
+        clubhead_moi_tensor: Optional 3x3 clubhead MOI tensor (enables the
+            full 3-D effective-mass treatment in :mod:`.models`)
+        ball_velocity: Ball velocity [m/s] (default: at rest)
+        ball_angular_velocity: Ball spin [rad/s] (default: none)
+        clubhead_angular_velocity: Head angular velocity [rad/s]
+            (default: zeros)
+
+    Returns:
+        A pre-impact state carrying the delivered vectors AND the impact
+        offset, so off-center hits get the MOI effective-mass reduction.
+    """
+    derived = derive_delivery(params, clubhead_angular_velocity)
+    return PreImpactState(
+        clubhead_velocity=derived.clubhead_velocity,
+        clubhead_angular_velocity=derived.clubhead_angular_velocity,
+        clubhead_orientation=derived.face_normal,
+        ball_position=np.zeros(3),
+        ball_velocity=(
+            np.asarray(ball_velocity, dtype=float)
+            if ball_velocity is not None
+            else np.zeros(3)
+        ),
+        ball_angular_velocity=(
+            np.asarray(ball_angular_velocity, dtype=float)
+            if ball_angular_velocity is not None
+            else np.zeros(3)
+        ),
+        clubhead_mass=clubhead_mass,
+        clubhead_loft=math.radians(params.dynamic_loft_deg),
+        clubhead_moi=clubhead_moi,
+        impact_offset=derived.impact_offset,
+        clubhead_moi_tensor=clubhead_moi_tensor,
+    )

--- a/src/shared/python/swing_sim/impact/gear_effect.py
+++ b/src/shared/python/swing_sim/impact/gear_effect.py
@@ -1,0 +1,203 @@
+"""Physics-based gear-effect spin from off-center impact.
+
+New in Tools (epic #4103 / issue #4106). Replaces the empirical
+three-constant model from UpstreamDrift
+``physics/impact_model/utils.py::compute_gear_effect_spin`` with a
+first-principles derivation.
+
+Mechanism
+---------
+An off-center normal impulse ``J n`` applied at CG-to-contact offset ``r``
+exerts a torque impulse ``r x (-J n)`` on the clubhead, so the head picks
+up a rotation recoil ``d_omega = I^-1 (r x (-J n))`` during contact
+(``I`` scalar or full 3x3 tensor). Because the head CG sits a depth ``d``
+BEHIND the face plane, the contact point is ``r = r_plane + d n`` and the
+rotating face sweeps the contact point tangentially:
+
+    v_surface = ramp * (d_omega x r)
+
+(``ramp = 1/2``: the recoil builds roughly linearly from zero over the
+contact, so the time-averaged surface velocity is half the final value).
+The ball "gears" against this moving surface — friction drags the ball
+surface with the face, producing spin opposite the head's recoil, via the
+same Coulomb friction impulse capped at the rolling-without-slip limit
+(``J_f = min(mu J, m_ball v_t 2/7)``, see
+:data:`.models.SPHERE_ROLLING_CAP_FACTOR`) used for loft-driven spin.
+
+Qualitative signatures reproduced (right-handed player, AffineDrift frame
+x target / y up / z right, toe axis +z):
+
+- Toe hit (+toe): head recoils about -y (toe twists open/back), face
+  surface sweeps toe-ward under the ball, friction drags the ball toward
+  +z at the back of the ball => +y ball spin = draw-side spin.
+- High hit (+high): head recoils about +z (loft increases), face sweeps
+  upward under the ball => -z spin component = reduced backspin.
+
+Bulge/roll seam
+---------------
+Face curvature is club data, not impact physics, so it enters through the
+optional ``face_normal_at_offset(toe_m, high_m) -> normal`` callable
+(provided by the app's club package): the local normal at the offset
+replaces the nominal face normal for the impulse direction, starting a
+toe hit further right (open) so the gear-effect draw spin curves it back —
+keeping swing_sim app-agnostic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from .constants import (
+    DRIVER_CG_DEPTH_M,
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_MOMENT_OF_INERTIA_KG_M2,
+    GOLF_BALL_RADIUS_M,
+)
+from .models import SPHERE_ROLLING_CAP_FACTOR, _norm, offset_to_face_vector
+
+FaceNormalAtOffset = Callable[[float, float], np.ndarray]
+"""Callable seam for bulge/roll: ``(toe_m, high_m) -> local face normal``."""
+
+_CONTACT_RAMP_FACTOR = 0.5
+"""Time-average factor for the head recoil built up during contact."""
+
+
+@dataclass(frozen=True)
+class GearEffectResult:
+    """Result of the physics-based gear-effect computation.
+
+    Attributes:
+        ball_spin_delta: Additional ball spin from gear effect [rad/s] (3,)
+        head_angular_velocity_delta: Head rotation recoil acquired during
+            contact [rad/s] (3,)
+        contact_normal: Unit face normal actually used at the contact point
+            (local bulge/roll normal when a curvature callable was
+            supplied) (3,)
+        tangential_surface_speed: Time-averaged tangential face-surface
+            speed at the contact point [m/s]
+    """
+
+    ball_spin_delta: np.ndarray
+    head_angular_velocity_delta: np.ndarray
+    contact_normal: np.ndarray
+    tangential_surface_speed: float
+
+
+def resolve_contact_normal(
+    impact_offset: np.ndarray,
+    face_normal: np.ndarray,
+    face_normal_at_offset: FaceNormalAtOffset | None = None,
+) -> np.ndarray:
+    """Unit contact normal: local bulge/roll normal if supplied, else nominal.
+
+    Args:
+        impact_offset: (2,) offset [m] [toe (+), high (+)]
+        face_normal: Nominal face normal (3,)
+        face_normal_at_offset: Optional club-package callable returning the
+            local face normal at ``(toe_m, high_m)`` (bulge/roll curvature).
+
+    Returns:
+        Unit normal (3,) used for the impulse direction.
+    """
+    offset = np.asarray(impact_offset, dtype=float).reshape(-1)
+    require(offset.size == 2, "impact_offset must have exactly 2 components")
+    if face_normal_at_offset is not None:
+        n = np.asarray(face_normal_at_offset(float(offset[0]), float(offset[1])))
+    else:
+        n = np.asarray(face_normal, dtype=float)
+    n_mag = _norm(n)
+    require(n_mag > 1e-10, "contact normal must be non-zero")
+    return n / n_mag
+
+
+def compute_gear_effect(
+    impact_offset: np.ndarray,
+    face_normal: np.ndarray,
+    normal_impulse: float,
+    clubhead_moi: float | np.ndarray,
+    cg_depth_m: float = DRIVER_CG_DEPTH_M,
+    friction_coefficient: float = 0.4,
+    reference_up: np.ndarray | None = None,
+    face_normal_at_offset: FaceNormalAtOffset | None = None,
+) -> GearEffectResult:
+    """Compute gear-effect spin from the head's rotation recoil.
+
+    Args:
+        impact_offset: (2,) offset from head CG in the face plane [m]
+            [horizontal (+ = toe), vertical (+ = high)]
+        face_normal: Nominal clubface normal (3,), need not be unit length
+        normal_impulse: Normal impulse magnitude J from the base COR
+            solve [N.s] (non-negative)
+        clubhead_moi: Scalar clubhead MOI about the CG [kg.m^2], or a full
+            3x3 MOI tensor in the same frame as the vectors
+        cg_depth_m: CG distance behind the face plane [m] (front-to-back
+            lever arm; zero depth means no tangential sweep and no gear
+            spin from in-plane offsets)
+        friction_coefficient: Ball-face Coulomb friction coefficient
+        reference_up: Optional world-up hint for the face basis
+        face_normal_at_offset: Optional bulge/roll callable (see module
+            docstring)
+
+    Returns:
+        :class:`GearEffectResult` with the ball spin delta, head recoil,
+        contact normal, and tangential surface speed.
+    """
+    require(normal_impulse >= 0.0, "normal_impulse must be non-negative")
+    require(cg_depth_m >= 0.0, "cg_depth_m must be non-negative")
+    require(friction_coefficient >= 0.0, "friction_coefficient non-negative")
+
+    n = resolve_contact_normal(impact_offset, face_normal, face_normal_at_offset)
+    offset = np.asarray(impact_offset, dtype=float).reshape(-1)
+
+    # CG-to-contact vector: in-plane offset (built on the NOMINAL normal's
+    # face basis so curvature does not skew the geometry) plus CG depth.
+    nominal = np.asarray(face_normal, dtype=float)
+    nominal = nominal / _norm(nominal)
+    r_plane = offset_to_face_vector(offset, nominal, reference_up)
+    r_contact = r_plane + cg_depth_m * nominal
+
+    # Head rotation recoil from the torque impulse of the reaction -J n.
+    torque_impulse = np.cross(r_contact, -normal_impulse * n)
+    if isinstance(clubhead_moi, np.ndarray) and clubhead_moi.shape == (3, 3):
+        d_omega = np.linalg.solve(np.asarray(clubhead_moi, dtype=float), torque_impulse)
+    else:
+        moi_scalar = float(np.asarray(clubhead_moi, dtype=float).reshape(-1)[0])
+        require(moi_scalar > 0.0, "clubhead_moi must be positive")
+        d_omega = torque_impulse / moi_scalar
+
+    # Time-averaged tangential surface velocity of the face at the contact.
+    v_surface = _CONTACT_RAMP_FACTOR * np.cross(d_omega, r_contact)
+    v_tangent = v_surface - float(np.dot(v_surface, n)) * n
+    v_t = _norm(v_tangent)
+
+    if v_t <= 1e-9 or normal_impulse <= 0.0:
+        return GearEffectResult(
+            ball_spin_delta=np.zeros(3),
+            head_angular_velocity_delta=d_omega,
+            contact_normal=n,
+            tangential_surface_speed=0.0,
+        )
+
+    # Friction drags the ball surface WITH the moving face (the ball gears
+    # against the face), capped at the rolling-without-slip limit.
+    t_dir = v_tangent / v_t
+    j_friction = min(
+        friction_coefficient * normal_impulse,
+        GOLF_BALL_MASS_KG * v_t * SPHERE_ROLLING_CAP_FACTOR,
+    )
+    # Friction impulse J_f t_dir acts at the ball contact point -R n:
+    # torque = (-R n) x (J_f t_dir) => spin axis = (t_dir x n).
+    spin_axis = np.cross(t_dir, n)
+    spin_magnitude = j_friction * GOLF_BALL_RADIUS_M / GOLF_BALL_MOMENT_OF_INERTIA_KG_M2
+
+    return GearEffectResult(
+        ball_spin_delta=spin_magnitude * spin_axis,
+        head_angular_velocity_delta=d_omega,
+        contact_normal=n,
+        tangential_surface_speed=v_t,
+    )

--- a/src/shared/python/swing_sim/impact/models.py
+++ b/src/shared/python/swing_sim/impact/models.py
@@ -1,0 +1,454 @@
+"""Impact models (rigid-body COR impulse, spring-damper, finite-time).
+
+Ported from UpstreamDrift ``src/shared/python/physics/impact_model/models.py``
+(epic #4103 / issue #4106), rewritten self-contained against the vendored
+:mod:`.constants` and the Tools shared :mod:`shared.python.contracts`.
+
+Changes from the UpstreamDrift source:
+
+- Full 3-D inertia treatment (opt-in): when ``PreImpactState`` carries a
+  3x3 ``clubhead_moi_tensor``, the effective club mass for an off-center
+  hit is computed from the exact rigid-body impulse denominator
+
+      1 / m_eff = 1/m_club + (r x n)^T I^-1 (r x n)
+
+  where ``r`` is the CG-to-contact vector and ``n`` the face normal. This
+  is the club-side term of
+  ``J = (1/m_ball + 1/m_club + n . ((I^-1 (r x n)) x r))^-1 (1+e) v_rel``
+  (the triple product identity gives
+  ``n . ((I^-1 (r x n)) x r) = (r x n)^T I^-1 (r x n)``).
+  The scalar-MOI fallback ``1/m + |r|^2 / I`` is preserved and is exactly
+  reproduced by a diagonal tensor ``I * eye(3)`` because ``r`` lies in the
+  face plane (``r`` perpendicular to ``n`` implies ``|r x n| = |r|``).
+  Any CG-depth component of ``r`` along ``n`` drops out of ``r x n`` and
+  therefore never affects the normal-impulse effective mass.
+- Friction-spin axis sign fix (found during the port): the source used
+  ``n x t`` which spins a lofted strike toward topspin and contradicts
+  its own pre-existing-spin slip reduction; the physical torque axis is
+  ``t x n`` (see the inline derivation in ``_compute_friction_spin``).
+"""
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from shared.python.contracts import precondition, require, require_finite
+
+from .constants import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_MOMENT_OF_INERTIA_KG_M2,
+    GOLF_BALL_RADIUS_M,
+)
+from .types import ImpactModelType, ImpactParameters, PostImpactState, PreImpactState
+
+# Rolling-without-slip tangential-impulse factor for a uniform solid sphere.
+#
+# Derivation (UpstreamDrift #7054). A tangential friction impulse ``J_f``
+# applied at the ball surface (lever arm = radius R) changes the
+# contact-point tangential velocity by both a linear and an angular
+# contribution:
+#   * CoM tangential velocity change:        dV     = J_f / m
+#   * surface speed from spin-up:            R*dOmega = J_f*R^2 / I
+# Rolling without slip is reached when the contact point stops sliding,
+# i.e. when dV + R*dOmega equals the effective tangential approach speed:
+#   J_f*(1/m + R^2/I) = v_t   =>   J_f = v_t / (1/m + R^2/I).
+# For a uniform solid sphere I = (2/5) m R^2, so R^2/I = 5/(2m) and
+#   J_f = v_t / (1/m + 5/(2m)) = m*v_t * (2/7).
+# Ref: Cross, "Grip-slip behavior of a bouncing ball",
+# Am. J. Phys. 70, 1093 (2002).
+SPHERE_ROLLING_CAP_FACTOR = 2.0 / 7.0
+
+_DEFAULT_REFERENCE_UP = np.array([0.0, 1.0, 0.0])
+_FALLBACK_REFERENCE_UP = np.array([0.0, 0.0, 1.0])
+
+
+def _norm(vector: np.ndarray) -> float:
+    """Euclidean norm of a small vector."""
+    flat = np.asarray(vector, dtype=float).reshape(-1)
+    return 0.0 if flat.size == 0 else float(math.sqrt(float(np.dot(flat, flat))))
+
+
+def face_basis(
+    face_normal: np.ndarray,
+    reference_up: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return the (toe_axis, up_axis) face-plane basis for a face normal.
+
+    ``up_axis`` is the projection of ``reference_up`` (default world up,
+    AffineDrift +y) onto the face plane; ``toe_axis = n x up_axis`` so that
+    for a target-facing normal ``n = +x`` in the AffineDrift frame
+    (x target, y up, z right) the toe axis is ``+z`` — the toe of a
+    right-handed player's club points right of the target line.
+
+    Args:
+        face_normal: Face normal vector (3,), need not be unit length.
+        reference_up: World-up hint (3,); defaults to [0, 1, 0]. If the
+            normal is (near-)parallel to it, [0, 0, 1] is used instead.
+
+    Returns:
+        Tuple ``(toe_axis, up_axis)`` of orthonormal vectors in the face
+        plane (both perpendicular to the normal).
+    """
+    n = np.asarray(face_normal, dtype=float)
+    n_mag = _norm(n)
+    require(n_mag > 1e-10, "face_normal must be non-zero")
+    n = n / n_mag
+    up = (
+        np.asarray(reference_up, dtype=float)
+        if reference_up is not None
+        else _DEFAULT_REFERENCE_UP
+    )
+    up_axis = up - float(np.dot(up, n)) * n
+    if _norm(up_axis) < 1e-8:
+        up_axis = _FALLBACK_REFERENCE_UP - float(np.dot(_FALLBACK_REFERENCE_UP, n)) * n
+    up_axis = up_axis / _norm(up_axis)
+    toe_axis = np.cross(n, up_axis)
+    return toe_axis, up_axis
+
+
+def offset_to_face_vector(
+    impact_offset: np.ndarray,
+    face_normal: np.ndarray,
+    reference_up: np.ndarray | None = None,
+) -> np.ndarray:
+    """Lift a 2-D face offset [horizontal, vertical] to a 3-D vector.
+
+    The result lies in the face plane:
+    ``r = horizontal * toe_axis + vertical * up_axis``.
+
+    Args:
+        impact_offset: (2,) offset [m] [horizontal (+ toe), vertical (+ high)]
+        face_normal: Face normal (3,)
+        reference_up: Optional world-up hint for the face basis.
+
+    Returns:
+        (3,) CG-to-contact offset within the face plane [m].
+    """
+    offset = np.asarray(impact_offset, dtype=float).reshape(-1)
+    require(offset.size == 2, "impact_offset must have exactly 2 components")
+    toe_axis, up_axis = face_basis(face_normal, reference_up)
+    lifted: np.ndarray = offset[0] * toe_axis + offset[1] * up_axis
+    return lifted
+
+
+class ImpactModel(ABC):
+    """Abstract base class for impact models."""
+
+    @abstractmethod
+    def solve(
+        self,
+        pre_state: PreImpactState,
+        params: ImpactParameters,
+    ) -> PostImpactState:
+        """Solve the impact and return post-impact state."""
+        ...
+
+
+class RigidBodyImpactModel(ImpactModel):
+    """Rigid body collision with coefficient of restitution.
+
+    Uses instantaneous impulse-momentum equations with COR to compute
+    post-impact velocities. Off-center hits reduce the effective club mass
+    via the clubhead MOI (scalar or full 3x3 tensor, see module docstring).
+    """
+
+    def _compute_effective_club_mass(self, pre_state: PreImpactState) -> float:
+        """Effective club mass along the contact normal.
+
+        Scalar path: ``1 / (1/m + |r|^2 / I)`` with ``|r|`` the in-plane
+        offset magnitude. Tensor path (opt-in via ``clubhead_moi_tensor``):
+        ``1 / (1/m + (r x n)^T I^-1 (r x n))``.
+        """
+        if pre_state is None:
+            raise ValueError("pre_state must be provided")
+        m_club = pre_state.clubhead_mass
+        if pre_state.impact_offset is None:
+            return m_club
+
+        offset = np.asarray(pre_state.impact_offset, dtype=float).reshape(-1)
+        r_offset = _norm(offset)
+        if r_offset <= 1e-6:
+            return m_club
+
+        if pre_state.clubhead_moi_tensor is not None:
+            tensor = np.asarray(pre_state.clubhead_moi_tensor, dtype=float)
+            require(tensor.shape == (3, 3), "clubhead_moi_tensor must be 3x3")
+            n = pre_state.clubhead_orientation / _norm(pre_state.clubhead_orientation)
+            r_vec = offset_to_face_vector(offset, n)
+            r_cross_n = np.cross(r_vec, n)
+            angular_term = float(r_cross_n @ np.linalg.solve(tensor, r_cross_n))
+            return 1.0 / (1.0 / m_club + angular_term)
+
+        if pre_state.clubhead_moi > 0:
+            return 1.0 / (1.0 / m_club + r_offset**2 / pre_state.clubhead_moi)
+        return m_club
+
+    def _compute_impulse(
+        self,
+        v_rel: np.ndarray,
+        n: np.ndarray,
+        m_club_effective: float,
+        cor: float,
+    ) -> tuple[float, float]:
+        """Normal impulse magnitude and approach speed along ``n``."""
+        if v_rel is None:
+            raise ValueError("v_rel must be provided")
+        v_approach = float(np.dot(v_rel, n))
+        m_eff = (GOLF_BALL_MASS_KG * m_club_effective) / (
+            GOLF_BALL_MASS_KG + m_club_effective
+        )
+        j = (1 + cor) * m_eff * v_approach
+        return j, v_approach
+
+    def _compute_friction_spin(
+        self,
+        pre_state: PreImpactState,
+        v_rel: np.ndarray,
+        v_approach: float,
+        n: np.ndarray,
+        j: float,
+        friction_coefficient: float,
+    ) -> np.ndarray:
+        """Ball spin after the Coulomb friction impulse (2/7 rolling cap)."""
+        if pre_state is None:
+            raise ValueError("pre_state must be provided")
+        v_tangent = v_rel - v_approach * n
+        tangent_mag = _norm(v_tangent)
+        if tangent_mag <= 1e-6:
+            return pre_state.ball_angular_velocity.copy()
+
+        tangent_dir = v_tangent / tangent_mag
+        # Spin axis: friction drags the ball's contact surface along the
+        # face's relative tangential motion t; the impulse J_f*t acts at
+        # the ball contact point -R*n, so torque = (-R n) x (J_f t) and the
+        # axis is t x n. (Sign fix vs the UpstreamDrift source, which used
+        # n x t and therefore spun a lofted strike toward TOPSPIN — also
+        # inconsistent with its own pre-existing-spin slip reduction
+        # below. For a lofted, target-bound strike in the AffineDrift
+        # frame this axis is +z: backspin points right of the target.)
+        spin_axis = np.cross(tangent_dir, n)
+        # Rolling cap relative to contact-point speed (pre-existing spin
+        # reduces sliding).
+        omega_contact = float(np.dot(pre_state.ball_angular_velocity, spin_axis))
+        v_t_eff = max(0.0, tangent_mag - omega_contact * GOLF_BALL_RADIUS_M)
+        # Coulomb friction impulse, capped at the rolling-without-slip
+        # impulse for a uniform solid sphere (J_f = m*v_t*2/7, see
+        # SPHERE_ROLLING_CAP_FACTOR derivation above).
+        j_friction = min(
+            float(friction_coefficient * j),
+            GOLF_BALL_MASS_KG * v_t_eff * SPHERE_ROLLING_CAP_FACTOR,
+        )
+        spin_magnitude = j_friction / (
+            GOLF_BALL_MOMENT_OF_INERTIA_KG_M2 / GOLF_BALL_RADIUS_M
+        )
+        return pre_state.ball_angular_velocity + spin_magnitude * spin_axis
+
+    def _compute_energy_transfer(
+        self,
+        pre_ball_velocity: np.ndarray,
+        post_ball_velocity: np.ndarray,
+    ) -> float:
+        """Ball kinetic-energy change across the impact [J]."""
+        if pre_ball_velocity is None:
+            raise ValueError("pre_ball_velocity must be provided")
+        ke_pre = (
+            0.5
+            * GOLF_BALL_MASS_KG
+            * float(np.dot(pre_ball_velocity, pre_ball_velocity))
+        )
+        ke_post = (
+            0.5
+            * GOLF_BALL_MASS_KG
+            * float(np.dot(post_ball_velocity, post_ball_velocity))
+        )
+        return ke_post - ke_pre
+
+    @precondition(
+        lambda self, pre_state, params: pre_state.clubhead_mass > 0,
+        "Clubhead mass must be positive",
+    )
+    @precondition(
+        lambda self, pre_state, params: 0 <= params.cor <= 1,
+        "Coefficient of restitution must be between 0 and 1",
+    )
+    @precondition(
+        lambda self, pre_state, params: params.friction_coefficient >= 0,
+        "Friction coefficient must be non-negative",
+    )
+    def solve(
+        self,
+        pre_state: PreImpactState,
+        params: ImpactParameters,
+    ) -> PostImpactState:
+        """Solve impact using rigid body collision model with MOI."""
+        require_finite(pre_state.clubhead_velocity, "clubhead_velocity")
+        require_finite(pre_state.ball_velocity, "ball_velocity")
+        require_finite(pre_state.clubhead_orientation, "clubhead_orientation")
+        n_mag = _norm(pre_state.clubhead_orientation)
+        require(n_mag > 1e-10, "clubhead_orientation must be non-zero")
+
+        m_club_effective = self._compute_effective_club_mass(pre_state)
+        n = pre_state.clubhead_orientation / n_mag
+        v_rel = pre_state.clubhead_velocity - pre_state.ball_velocity
+
+        j, v_approach = self._compute_impulse(v_rel, n, m_club_effective, params.cor)
+
+        v_ball_post = pre_state.ball_velocity + (j / GOLF_BALL_MASS_KG) * n
+        v_club_post = pre_state.clubhead_velocity - (j / pre_state.clubhead_mass) * n
+
+        ball_spin = self._compute_friction_spin(
+            pre_state, v_rel, v_approach, n, j, params.friction_coefficient
+        )
+        energy_transfer = self._compute_energy_transfer(
+            pre_state.ball_velocity, v_ball_post
+        )
+        impact_loc = (
+            np.asarray(pre_state.impact_offset, dtype=float).copy()
+            if pre_state.impact_offset is not None
+            else np.zeros(2)
+        )
+
+        return PostImpactState(
+            ball_velocity=v_ball_post,
+            ball_angular_velocity=ball_spin,
+            clubhead_velocity=v_club_post,
+            clubhead_angular_velocity=pre_state.clubhead_angular_velocity.copy(),
+            contact_duration=0.0,
+            energy_transfer=energy_transfer,
+            impact_location=impact_loc,
+        )
+
+
+class SpringDamperImpactModel(ImpactModel):
+    """Spring-damper (Kelvin-Voigt) compliant contact model.
+
+    Uses semi-implicit integration of spring-damper contact to compute
+    force and velocity evolution during impact.
+    """
+
+    @precondition(lambda self, dt=1e-7: dt > 0, "Time step must be positive")
+    def __init__(self, dt: float = 1e-7) -> None:
+        """Initialize spring-damper model.
+
+        Args:
+            dt: Integration time step [s]. Default: 0.1 us (1e-7 s).
+        """
+        if dt is None:
+            raise ValueError("dt must be provided")
+        self.dt = dt
+
+    @precondition(
+        lambda self, pre_state, params: pre_state.clubhead_mass > 0,
+        "Clubhead mass must be positive",
+    )
+    @precondition(
+        lambda self, pre_state, params: params.contact_stiffness > 0,
+        "Contact stiffness must be positive",
+    )
+    def solve(
+        self,
+        pre_state: PreImpactState,
+        params: ImpactParameters,
+    ) -> PostImpactState:
+        """Solve impact using spring-damper contact model."""
+        if pre_state is None:
+            raise ValueError("pre_state must be provided")
+        m_ball = GOLF_BALL_MASS_KG
+        m_club = pre_state.clubhead_mass
+        n = pre_state.clubhead_orientation / _norm(pre_state.clubhead_orientation)
+
+        # Tiny clearance avoids dt-dependent overshoot at contact onset.
+        initial_gap = GOLF_BALL_RADIUS_M * 1e-4
+        x_ball: np.ndarray = (GOLF_BALL_RADIUS_M + initial_gap) * n
+        v_ball: np.ndarray = pre_state.ball_velocity.copy()
+        x_club: np.ndarray = np.zeros(3)
+        v_club: np.ndarray = pre_state.clubhead_velocity.copy()
+
+        contact_time = 0.0
+        max_time = 0.005  # 5 ms max contact time [s]
+        max_steps = int(max_time / self.dt)
+        max_force = 1e5  # [N] limit to prevent numerical blow-up
+
+        for _ in range(max_steps):
+            gap = float(np.dot(x_ball - x_club, n)) - GOLF_BALL_RADIUS_M
+
+            if gap < 0:  # In contact (penetration)
+                penetration = -gap
+                v_rel_normal = float(np.dot(v_ball - v_club, n))
+                f_spring = params.contact_stiffness * penetration
+                f_damper = -params.contact_damping * v_rel_normal
+                f_magnitude = max(0.0, min(f_spring + f_damper, max_force))
+                f_contact = f_magnitude * n
+
+                # Semi-implicit Euler: velocities first, then positions.
+                v_ball = v_ball + (f_contact / m_ball) * self.dt
+                v_club = v_club - (f_contact / m_club) * self.dt
+                x_ball = x_ball + v_ball * self.dt
+                x_club = x_club + v_club * self.dt
+                contact_time += self.dt
+            elif contact_time > 0:
+                break  # Was in contact but now separated.
+            else:
+                # Pre-contact: advance positions only.
+                x_ball = x_ball + v_ball * self.dt
+                x_club = x_club + v_club * self.dt
+
+        ke_pre = (
+            0.5
+            * m_ball
+            * float(np.dot(pre_state.ball_velocity, pre_state.ball_velocity))
+        )
+        ke_post = 0.5 * m_ball * float(np.dot(v_ball, v_ball))
+
+        return PostImpactState(
+            ball_velocity=v_ball,
+            ball_angular_velocity=pre_state.ball_angular_velocity.copy(),
+            clubhead_velocity=v_club,
+            clubhead_angular_velocity=pre_state.clubhead_angular_velocity.copy(),
+            contact_duration=contact_time,
+            energy_transfer=ke_post - ke_pre,
+            impact_location=np.zeros(2),
+        )
+
+
+class FiniteTimeImpactModel(ImpactModel):
+    """Finite-time impulse-momentum model.
+
+    Uses the rigid-body result but reports the specified contact duration.
+    """
+
+    def solve(
+        self,
+        pre_state: PreImpactState,
+        params: ImpactParameters,
+    ) -> PostImpactState:
+        """Solve impact using finite-time model."""
+        if pre_state is None:
+            raise ValueError("pre_state must be provided")
+        result = RigidBodyImpactModel().solve(pre_state, params)
+        return PostImpactState(
+            ball_velocity=result.ball_velocity,
+            ball_angular_velocity=result.ball_angular_velocity,
+            clubhead_velocity=result.clubhead_velocity,
+            clubhead_angular_velocity=result.clubhead_angular_velocity,
+            contact_duration=params.contact_duration,
+            energy_transfer=result.energy_transfer,
+            impact_location=result.impact_location,
+        )
+
+
+def create_impact_model(model_type: ImpactModelType) -> ImpactModel:
+    """Factory function to create an impact model instance."""
+    if model_type == ImpactModelType.RIGID_BODY:
+        return RigidBodyImpactModel()
+    if model_type == ImpactModelType.SPRING_DAMPER:
+        # Annotated local: the contract-decorated __init__ obscures the
+        # constructor's return type from mypy.
+        spring_model: ImpactModel = SpringDamperImpactModel()
+        return spring_model
+    if model_type == ImpactModelType.FINITE_TIME:
+        return FiniteTimeImpactModel()
+    raise ValueError(f"Unknown impact model type: {model_type}")

--- a/src/shared/python/swing_sim/impact/solver.py
+++ b/src/shared/python/swing_sim/impact/solver.py
@@ -1,0 +1,471 @@
+"""Impact recorder and engine-agnostic solver API.
+
+Ported from UpstreamDrift ``src/shared/python/physics/impact_model/solver.py``
+(epic #4103 / issue #4106), rewritten self-contained.
+
+Changes from the UpstreamDrift source:
+
+- BUG FIX (recon #4104, defect a): ``solve_with_gear_effect`` previously
+  computed the base impulse WITHOUT the impact offset — the
+  ``PreImpactState`` it built silently dropped ``impact_offset``, so
+  off-center hits skipped the MOI effective-mass reduction and launched
+  at full center-strike ball speed. The offset is now carried into the
+  pre-impact state (and the recorded event), so off-center ball speed is
+  correctly lower than a center strike.
+- Gear effect is now the physics-derived head-recoil model from
+  :mod:`.gear_effect` (the three empirical scaling constants are gone),
+  with an optional ``face_normal_at_offset`` bulge/roll callable supplied
+  by the app's club package.
+- ``solve_impact`` accepts optional ``impact_offset`` /
+  ``clubhead_moi`` / ``clubhead_moi_tensor`` passthroughs.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import numpy as np
+
+from shared.python.contracts import precondition
+
+from .constants import DRIVER_MASS_KG, DRIVER_MOI_KG_M2, GOLF_BALL_MASS_KG
+from .gear_effect import FaceNormalAtOffset, compute_gear_effect, resolve_contact_normal
+from .models import _norm, create_impact_model
+from .types import (
+    ImpactEvent,
+    ImpactModelType,
+    ImpactParameters,
+    PostImpactState,
+    PreImpactState,
+)
+from .utils import validate_energy_balance
+
+logger = logging.getLogger(__name__)
+
+
+class ImpactRecorder:
+    """Records impact events during simulation.
+
+    Surfaces pre-impact and post-impact states in recorder outputs and
+    provides energy-balance checks for each impact.
+    """
+
+    def __init__(self) -> None:
+        """Initialize impact recorder."""
+        self.events: list[ImpactEvent] = []
+        self._impact_counter = 0
+
+    def record_impact(
+        self,
+        timestamp: float,
+        pre_state: PreImpactState,
+        post_state: PostImpactState,
+        params: ImpactParameters,
+        model_type: ImpactModelType = ImpactModelType.RIGID_BODY,
+    ) -> ImpactEvent:
+        """Record an impact event.
+
+        Args:
+            timestamp: Simulation time [s]
+            pre_state: Pre-impact state
+            post_state: Post-impact state
+            params: Impact parameters used
+            model_type: Type of impact model used
+
+        Returns:
+            Recorded ImpactEvent
+        """
+        if timestamp is None:
+            raise ValueError("timestamp must be provided")
+        energy_balance = validate_energy_balance(pre_state, post_state, params)
+
+        event = ImpactEvent(
+            timestamp=timestamp,
+            pre_state=pre_state,
+            post_state=post_state,
+            energy_balance=energy_balance,
+            impact_id=self._impact_counter,
+            model_type=model_type,
+        )
+        self.events.append(event)
+        self._impact_counter += 1
+
+        logger.info(
+            "Impact #%d recorded at t=%.4fs, ball speed: %.1f m/s, energy loss: %.1f%%",
+            event.impact_id,
+            timestamp,
+            energy_balance["ball_launch_speed"],
+            100.0 * energy_balance["energy_loss_ratio"],
+        )
+        return event
+
+    def get_all_events(self) -> list[ImpactEvent]:
+        """Get all recorded impact events."""
+        return self.events.copy()
+
+    def export_to_dict(self) -> dict:
+        """Export all events as dictionary for JSON serialization."""
+        events_data = [
+            {
+                "impact_id": event.impact_id,
+                "timestamp": event.timestamp,
+                "model_type": event.model_type.name,
+                "pre_impact": {
+                    "clubhead_velocity": event.pre_state.clubhead_velocity.tolist(),
+                    "ball_velocity": event.pre_state.ball_velocity.tolist(),
+                    "ball_spin": event.pre_state.ball_angular_velocity.tolist(),
+                },
+                "post_impact": {
+                    "ball_velocity": event.post_state.ball_velocity.tolist(),
+                    "ball_spin": event.post_state.ball_angular_velocity.tolist(),
+                    "clubhead_velocity": event.post_state.clubhead_velocity.tolist(),
+                    "contact_duration": event.post_state.contact_duration,
+                    "energy_transfer": event.post_state.energy_transfer,
+                },
+                "energy_balance": event.energy_balance,
+            }
+            for event in self.events
+        ]
+        return {
+            "num_impacts": len(self.events),
+            "events": events_data,
+            "summary": self.get_summary(),
+        }
+
+    def get_summary(self) -> dict[str, float]:
+        """Get summary statistics for all impacts."""
+        if not self.events:
+            return {"num_impacts": 0}
+        speeds = [e.energy_balance["ball_launch_speed"] for e in self.events]
+        losses = [e.energy_balance["energy_loss_ratio"] for e in self.events]
+        return {
+            "num_impacts": len(self.events),
+            "mean_ball_speed": float(np.mean(speeds)),
+            "max_ball_speed": float(np.max(speeds)),
+            "mean_energy_loss_ratio": float(np.mean(losses)),
+        }
+
+    def reset(self) -> None:
+        """Clear all recorded events."""
+        self.events.clear()
+        self._impact_counter = 0
+
+
+class ImpactSolverAPI:
+    """Engine-agnostic API for impact solving.
+
+    Provides a unified interface for different physics engines, with
+    optional recording and energy/COR/spin validation.
+    """
+
+    def __init__(
+        self,
+        model_type: ImpactModelType = ImpactModelType.RIGID_BODY,
+        params: ImpactParameters | None = None,
+    ) -> None:
+        """Initialize impact solver.
+
+        Args:
+            model_type: Type of impact model to use
+            params: Impact parameters (uses defaults if None)
+        """
+        if model_type is None:
+            raise ValueError("model_type must be provided")
+        self.model_type = model_type
+        self.model = create_impact_model(model_type)
+        self.params = params or ImpactParameters()
+        self.recorder = ImpactRecorder()
+
+    def _build_pre_state(
+        self,
+        clubhead_velocity: np.ndarray,
+        clubhead_orientation: np.ndarray,
+        ball_velocity: np.ndarray | None,
+        ball_angular_velocity: np.ndarray | None,
+        clubhead_mass: float,
+        impact_offset: np.ndarray | None,
+        clubhead_moi: float,
+        clubhead_moi_tensor: np.ndarray | None,
+    ) -> PreImpactState:
+        """Assemble a PreImpactState, defaulting the ball to rest."""
+        return PreImpactState(
+            clubhead_velocity=np.asarray(clubhead_velocity, dtype=float),
+            clubhead_angular_velocity=np.zeros(3),
+            clubhead_orientation=np.asarray(clubhead_orientation, dtype=float),
+            ball_position=np.zeros(3),
+            ball_velocity=(
+                np.asarray(ball_velocity, dtype=float)
+                if ball_velocity is not None
+                else np.zeros(3)
+            ),
+            ball_angular_velocity=(
+                np.asarray(ball_angular_velocity, dtype=float)
+                if ball_angular_velocity is not None
+                else np.zeros(3)
+            ),
+            clubhead_mass=clubhead_mass,
+            clubhead_moi=clubhead_moi,
+            impact_offset=(
+                np.asarray(impact_offset, dtype=float)
+                if impact_offset is not None
+                else None
+            ),
+            clubhead_moi_tensor=clubhead_moi_tensor,
+        )
+
+    @precondition(
+        lambda self, timestamp, *args, **kwargs: timestamp >= 0,
+        "Timestamp must be non-negative",
+    )
+    def solve_impact(
+        self,
+        timestamp: float,
+        clubhead_velocity: np.ndarray,
+        clubhead_orientation: np.ndarray,
+        ball_velocity: np.ndarray | None = None,
+        ball_angular_velocity: np.ndarray | None = None,
+        clubhead_mass: float = DRIVER_MASS_KG,
+        impact_offset: np.ndarray | None = None,
+        clubhead_moi: float = DRIVER_MOI_KG_M2,
+        clubhead_moi_tensor: np.ndarray | None = None,
+        record: bool = True,
+    ) -> PostImpactState:
+        """Solve impact and optionally record the event.
+
+        Args:
+            timestamp: Current simulation time [s]
+            clubhead_velocity: Clubhead velocity [m/s] (3,)
+            clubhead_orientation: Clubface normal [unitless] (3,)
+            ball_velocity: Ball velocity (default: stationary) [m/s] (3,)
+            ball_angular_velocity: Ball spin (default: zero) [rad/s] (3,)
+            clubhead_mass: Clubhead mass [kg] (must be positive)
+            impact_offset: Optional face offset from CG [m] (2,)
+                [horizontal, vertical] — enables the MOI effective-mass
+                reduction for off-center strikes
+            clubhead_moi: Scalar clubhead MOI about CG [kg.m^2]
+            clubhead_moi_tensor: Optional 3x3 MOI tensor (full 3-D
+                effective-mass treatment)
+            record: Whether to record this impact
+
+        Returns:
+            Post-impact state
+        """
+        if timestamp is None:
+            raise ValueError("timestamp must be provided")
+        if clubhead_mass <= 0:
+            raise ValueError("Clubhead mass must be positive")
+        pre_state = self._build_pre_state(
+            clubhead_velocity,
+            clubhead_orientation,
+            ball_velocity,
+            ball_angular_velocity,
+            clubhead_mass,
+            impact_offset,
+            clubhead_moi,
+            clubhead_moi_tensor,
+        )
+        post_state = self.model.solve(pre_state, self.params)
+        if record:
+            self.recorder.record_impact(
+                timestamp, pre_state, post_state, self.params, self.model_type
+            )
+        return post_state
+
+    def solve_with_gear_effect(
+        self,
+        timestamp: float,
+        clubhead_velocity: np.ndarray,
+        clubhead_orientation: np.ndarray,
+        impact_offset: np.ndarray,
+        ball_velocity: np.ndarray | None = None,
+        clubhead_mass: float = DRIVER_MASS_KG,
+        clubhead_moi: float = DRIVER_MOI_KG_M2,
+        clubhead_moi_tensor: np.ndarray | None = None,
+        face_normal_at_offset: FaceNormalAtOffset | None = None,
+        record: bool = True,
+    ) -> PostImpactState:
+        """Solve an off-center impact with physics-based gear-effect spin.
+
+        The impact offset is carried into the base solve (bug fix, see
+        module docstring), the local bulge/roll normal (if a curvature
+        callable is given) sets the impulse direction, and the head's
+        rotation recoil adds gear-effect spin via :mod:`.gear_effect`.
+
+        Args:
+            timestamp: Current simulation time [s]
+            clubhead_velocity: Clubhead velocity [m/s] (3,)
+            clubhead_orientation: Nominal clubface normal (3,)
+            impact_offset: Offset from face center [m] (2,)
+                [horizontal (+ toe), vertical (+ high)]
+            ball_velocity: Ball velocity [m/s] (3,)
+            clubhead_mass: Clubhead mass [kg]
+            clubhead_moi: Scalar clubhead MOI about CG [kg.m^2]
+            clubhead_moi_tensor: Optional 3x3 MOI tensor
+            face_normal_at_offset: Optional bulge/roll callable
+                ``(toe_m, high_m) -> local normal`` from the club package
+            record: Whether to record this impact
+
+        Returns:
+            Post-impact state with gear-effect spin and head recoil.
+        """
+        if timestamp is None:
+            raise ValueError("timestamp must be provided")
+        offset = np.asarray(impact_offset, dtype=float)
+        contact_normal = resolve_contact_normal(
+            offset, clubhead_orientation, face_normal_at_offset
+        )
+
+        # Base solve WITH the offset so the MOI effective-mass reduction
+        # applies (previously the offset was silently dropped here).
+        pre_state = self._build_pre_state(
+            clubhead_velocity,
+            contact_normal,
+            ball_velocity,
+            None,
+            clubhead_mass,
+            offset,
+            clubhead_moi,
+            clubhead_moi_tensor,
+        )
+        post_state = self.model.solve(pre_state, self.params)
+
+        # Recover the normal impulse from the ball's velocity change.
+        delta_v = post_state.ball_velocity - pre_state.ball_velocity
+        normal_impulse = max(
+            0.0, GOLF_BALL_MASS_KG * float(np.dot(delta_v, contact_normal))
+        )
+
+        gear = compute_gear_effect(
+            impact_offset=offset,
+            face_normal=np.asarray(clubhead_orientation, dtype=float),
+            normal_impulse=normal_impulse,
+            clubhead_moi=(
+                clubhead_moi_tensor if clubhead_moi_tensor is not None else clubhead_moi
+            ),
+            cg_depth_m=self.params.cg_depth,
+            friction_coefficient=self.params.friction_coefficient,
+            face_normal_at_offset=face_normal_at_offset,
+        )
+
+        modified_post = PostImpactState(
+            ball_velocity=post_state.ball_velocity,
+            ball_angular_velocity=(
+                post_state.ball_angular_velocity + gear.ball_spin_delta
+            ),
+            clubhead_velocity=post_state.clubhead_velocity,
+            clubhead_angular_velocity=(
+                post_state.clubhead_angular_velocity + gear.head_angular_velocity_delta
+            ),
+            contact_duration=post_state.contact_duration,
+            energy_transfer=post_state.energy_transfer,
+            impact_location=offset,
+        )
+        if record:
+            self.recorder.record_impact(
+                timestamp, pre_state, modified_post, self.params, self.model_type
+            )
+        return modified_post
+
+    def get_energy_report(self) -> dict:
+        """Get energy balance report for all recorded impacts."""
+        if not self.recorder.events:
+            raise RuntimeError("No impacts recorded")
+        reports = [
+            {
+                "impact_id": event.impact_id,
+                "timestamp": event.timestamp,
+                "ke_pre": event.energy_balance["total_ke_pre"],
+                "ke_post": event.energy_balance["total_ke_post"],
+                "energy_lost": event.energy_balance["energy_lost"],
+                "loss_ratio": event.energy_balance["energy_loss_ratio"],
+                "ball_speed": event.energy_balance["ball_launch_speed"],
+            }
+            for event in self.recorder.events
+        ]
+        total_ke_pre = sum(r["ke_pre"] for r in reports)
+        total_ke_post = sum(r["ke_post"] for r in reports)
+        return {
+            "impacts": reports,
+            "total_ke_pre": total_ke_pre,
+            "total_ke_post": total_ke_post,
+            "total_energy_lost": total_ke_pre - total_ke_post,
+            "overall_loss_ratio": (
+                (total_ke_pre - total_ke_post) / total_ke_pre if total_ke_pre > 0 else 0
+            ),
+        }
+
+    def validate_cor_behavior(
+        self, tolerance: float = 0.05
+    ) -> dict[str, bool | float | str | int]:
+        """Validate COR behavior across recorded impacts.
+
+        Args:
+            tolerance: Acceptable deviation from expected COR
+
+        Returns:
+            Validation result with pass/fail and details
+        """
+        if tolerance is None:
+            raise ValueError("tolerance must be provided")
+        if not self.recorder.events:
+            raise RuntimeError("No impacts recorded")
+
+        expected_cor = self.params.cor
+        measured_cors = []
+        for event in self.recorder.events:
+            v_club_pre = _norm(event.pre_state.clubhead_velocity)
+            v_ball_pre = _norm(event.pre_state.ball_velocity)
+            v_club_post = _norm(event.post_state.clubhead_velocity)
+            v_ball_post = _norm(event.post_state.ball_velocity)
+            # COR = (v_ball_post - v_club_post) / (v_club_pre - v_ball_pre)
+            approach = v_club_pre - v_ball_pre
+            if approach > 0.1:  # Avoid division by small number
+                measured_cors.append((v_ball_post - v_club_post) / approach)
+
+        if not measured_cors:
+            raise RuntimeError("Could not compute COR")
+
+        mean_cor = float(np.mean(measured_cors))
+        deviation = abs(mean_cor - expected_cor)
+        return {
+            "valid": deviation <= tolerance,
+            "expected_cor": expected_cor,
+            "measured_cor_mean": mean_cor,
+            "deviation": deviation,
+            "tolerance": tolerance,
+            "num_samples": len(measured_cors),
+        }
+
+    def validate_spin_behavior(
+        self, max_spin_rpm: float = 10000
+    ) -> dict[str, bool | float | str | int]:
+        """Validate spin behavior is within physical limits.
+
+        Args:
+            max_spin_rpm: Maximum acceptable spin rate [RPM]
+
+        Returns:
+            Validation result with pass/fail and details
+        """
+        if max_spin_rpm is None:
+            raise ValueError("max_spin_rpm must be provided")
+        if not self.recorder.events:
+            raise RuntimeError("No impacts recorded")
+
+        max_spin_rad = max_spin_rpm * 2 * math.pi / 60  # Convert to rad/s
+        spins = [
+            _norm(event.post_state.ball_angular_velocity)
+            for event in self.recorder.events
+        ]
+        max_observed = float(np.max(spins))
+        return {
+            "valid": max_observed <= max_spin_rad,
+            "max_observed_rpm": max_observed * 60 / (2 * math.pi),
+            "max_allowed_rpm": max_spin_rpm,
+            "num_samples": len(spins),
+        }
+
+    def reset(self) -> None:
+        """Reset solver state and clear recorded impacts."""
+        self.recorder.reset()

--- a/src/shared/python/swing_sim/impact/tests/__init__.py
+++ b/src/shared/python/swing_sim/impact/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the swing_sim impact subpackage (epic #4103, issue #4106)."""

--- a/src/shared/python/swing_sim/impact/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/impact/tests/test_contract_api.py
@@ -1,0 +1,84 @@
+"""Contract test pinning the public API surface of swing_sim.impact.
+
+Downstream consumers (UpstreamDrift, the app's club package, web backend)
+import from this self-façaded subpackage only; this test fails loudly
+when the surface changes so removals are always deliberate. The parent
+``swing_sim`` façade is wired during epic integration and intentionally
+does NOT re-export impact symbols yet.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import shared.python.swing_sim.impact as impact
+
+EXPECTED_PUBLIC_API = {
+    "DRIVER_CG_DEPTH_M",
+    "DRIVER_COR",
+    "DRIVER_MASS_KG",
+    "DRIVER_MOI_KG_M2",
+    "GOLF_BALL_MASS_KG",
+    "GOLF_BALL_MOMENT_OF_INERTIA_KG_M2",
+    "GOLF_BALL_RADIUS_M",
+    "SPHERE_ROLLING_CAP_FACTOR",
+    "TYPICAL_CONTACT_DURATION_S",
+    "DeliveryDerived",
+    "DeliveryParameters",
+    "FaceNormalAtOffset",
+    "FiniteTimeImpactModel",
+    "GearEffectResult",
+    "ImpactEvent",
+    "ImpactModel",
+    "ImpactModelType",
+    "ImpactParameters",
+    "ImpactRecorder",
+    "ImpactSolverAPI",
+    "PostImpactState",
+    "PreImpactState",
+    "RigidBodyImpactModel",
+    "SpringDamperImpactModel",
+    "compute_gear_effect",
+    "create_impact_model",
+    "derive_delivery",
+    "face_basis",
+    "offset_to_face_vector",
+    "resolve_contact_normal",
+    "to_pre_impact_state",
+    "validate_energy_balance",
+}
+
+
+@pytest.mark.contract
+def test_public_api_surface_is_pinned() -> None:
+    assert set(impact.__all__) == EXPECTED_PUBLIC_API
+
+
+@pytest.mark.contract
+def test_all_exports_resolve() -> None:
+    for name in impact.__all__:
+        assert getattr(impact, name) is not None, f"{name} did not resolve"
+
+
+@pytest.mark.contract
+def test_parent_facade_untouched() -> None:
+    """Integration wires the parent façade later (epic #4103)."""
+    import shared.python.swing_sim as swing_sim
+
+    assert "ImpactSolverAPI" not in swing_sim.__all__
+
+
+@pytest.mark.contract
+def test_delivery_types_are_frozen_dataclasses() -> None:
+    for cls in (impact.DeliveryParameters, impact.DeliveryDerived):
+        assert dataclasses.is_dataclass(cls)
+        assert cls.__dataclass_params__.frozen  # type: ignore[attr-defined]
+
+
+@pytest.mark.contract
+def test_pre_impact_state_has_tensor_field() -> None:
+    fields = {f.name for f in dataclasses.fields(impact.PreImpactState)}
+    assert "impact_offset" in fields
+    assert "clubhead_moi_tensor" in fields

--- a/src/shared/python/swing_sim/impact/tests/test_delivery.py
+++ b/src/shared/python/swing_sim/impact/tests/test_delivery.py
@@ -1,0 +1,137 @@
+"""Delivery front-end tests: angle mapping, offsets, D-plane diagnostics."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.impact.delivery import (
+    DeliveryParameters,
+    derive_delivery,
+    to_pre_impact_state,
+)
+from shared.python.swing_sim.impact.models import RigidBodyImpactModel
+from shared.python.swing_sim.impact.types import ImpactParameters
+
+
+def _params(**kwargs: float) -> DeliveryParameters:
+    defaults: dict[str, float] = {"clubhead_speed_mps": 50.0}
+    defaults.update(kwargs)
+    return DeliveryParameters(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestDeliveryValidation:
+    def test_rejects_non_positive_speed(self) -> None:
+        with pytest.raises(ValueError, match="clubhead_speed_mps"):
+            DeliveryParameters(clubhead_speed_mps=0.0)
+
+    def test_rejects_non_finite_angle(self) -> None:
+        with pytest.raises(ValueError, match="face_angle_deg"):
+            _params(face_angle_deg=float("nan"))
+
+    def test_rejects_out_of_range_angle(self) -> None:
+        with pytest.raises(ValueError, match="club_path_deg"):
+            _params(club_path_deg=120.0)
+
+    def test_is_frozen(self) -> None:
+        params = _params()
+        with pytest.raises(AttributeError):
+            params.club_path_deg = 1.0  # type: ignore[misc]
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestDeliveryVectors:
+    def test_neutral_delivery_is_straight_normal(self) -> None:
+        """Zero path/face/AoA: velocity along +x, normal lofted in x-y."""
+        derived = derive_delivery(_params(dynamic_loft_deg=10.5))
+        loft = math.radians(10.5)
+        np.testing.assert_allclose(
+            derived.clubhead_velocity, [50.0, 0.0, 0.0], atol=1e-12
+        )
+        np.testing.assert_allclose(
+            derived.face_normal, [math.cos(loft), math.sin(loft), 0.0], atol=1e-12
+        )
+        np.testing.assert_allclose(derived.impact_offset, [0.0, 0.0], atol=1e-15)
+        assert derived.spin_loft_deg == pytest.approx(10.5)
+        assert derived.face_to_path_deg == pytest.approx(0.0)
+        np.testing.assert_allclose(derived.spin_axis, [0.0, 0.0, 1.0], atol=1e-9)
+        assert derived.spin_axis_tilt_deg == pytest.approx(0.0, abs=1e-9)
+
+    def test_in_to_out_path_moves_right(self) -> None:
+        derived = derive_delivery(_params(club_path_deg=4.0))
+        assert derived.clubhead_velocity[2] > 0.0  # +z = right
+
+    def test_open_face_points_right(self) -> None:
+        derived = derive_delivery(_params(face_angle_deg=3.0))
+        assert derived.face_normal[2] > 0.0
+
+    def test_positive_attack_angle_moves_up(self) -> None:
+        derived = derive_delivery(_params(attack_angle_deg=5.0))
+        assert derived.clubhead_velocity[1] > 0.0
+        assert float(np.linalg.norm(derived.clubhead_velocity)) == pytest.approx(50.0)
+
+    def test_spin_loft_is_loft_minus_attack_for_square_face(self) -> None:
+        derived = derive_delivery(_params(dynamic_loft_deg=12.0, attack_angle_deg=-3.0))
+        assert derived.spin_loft_deg == pytest.approx(15.0, abs=1e-9)
+
+    def test_open_face_tilts_spin_axis_fade_side(self) -> None:
+        """Face open of path (D-plane): positive tilt = fade/slice spin."""
+        fade = derive_delivery(_params(dynamic_loft_deg=10.5, face_angle_deg=4.0))
+        draw = derive_delivery(_params(dynamic_loft_deg=10.5, face_angle_deg=-4.0))
+        assert fade.spin_axis_tilt_deg > 0.0
+        assert draw.spin_axis_tilt_deg < 0.0
+        assert fade.spin_axis_tilt_deg == pytest.approx(
+            -draw.spin_axis_tilt_deg, rel=1e-9
+        )
+
+    def test_offset_millimetre_conversion(self) -> None:
+        derived = derive_delivery(
+            _params(impact_offset_toe_mm=12.0, impact_offset_high_mm=-5.0)
+        )
+        np.testing.assert_allclose(derived.impact_offset, [0.012, -0.005])
+
+    def test_lie_rotates_offset_axes(self) -> None:
+        """+90 deg toe-up lie maps a pure toe offset onto the vertical axis."""
+        derived = derive_delivery(_params(lie_deg=89.0, impact_offset_toe_mm=10.0))
+        assert derived.impact_offset[1] == pytest.approx(
+            0.010 * math.sin(math.radians(89.0))
+        )
+
+    def test_angular_velocity_passthrough(self) -> None:
+        omega = np.array([0.0, 1.0, 2.0])
+        derived = derive_delivery(_params(), clubhead_angular_velocity=omega)
+        np.testing.assert_allclose(derived.clubhead_angular_velocity, omega)
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestToPreImpactState:
+    def test_round_trip_neutral_delivery_launches_near_normal(self) -> None:
+        """End-to-end: neutral delivery -> impact solve -> straight launch."""
+        pre = to_pre_impact_state(_params(dynamic_loft_deg=10.5))
+        post = RigidBodyImpactModel().solve(pre, ImpactParameters())
+        v = post.ball_velocity / np.linalg.norm(post.ball_velocity)
+        # Ball launches along the face normal (rigid-body normal impulse).
+        np.testing.assert_allclose(v, pre.clubhead_orientation, atol=1e-12)
+        assert abs(v[2]) < 1e-12  # no sideways component
+        # Backspin about +z (sign-fixed friction spin axis).
+        assert post.ball_angular_velocity[2] > 0.0
+
+    def test_offset_carried_into_state(self) -> None:
+        pre = to_pre_impact_state(_params(impact_offset_toe_mm=20.0))
+        assert pre.impact_offset is not None
+        assert pre.impact_offset[0] == pytest.approx(0.020)
+
+    def test_tensor_passthrough(self) -> None:
+        tensor = 4.5e-4 * np.eye(3)
+        pre = to_pre_impact_state(_params(), clubhead_moi_tensor=tensor)
+        assert pre.clubhead_moi_tensor is tensor
+
+    def test_ball_defaults_to_rest(self) -> None:
+        pre = to_pre_impact_state(_params())
+        np.testing.assert_allclose(pre.ball_velocity, 0.0)
+        np.testing.assert_allclose(pre.ball_angular_velocity, 0.0)

--- a/src/shared/python/swing_sim/impact/tests/test_gear_effect.py
+++ b/src/shared/python/swing_sim/impact/tests/test_gear_effect.py
@@ -1,0 +1,201 @@
+"""Physics-based gear-effect tests: qualitative signatures + bulge seam.
+
+Signatures validated (right-handed player, AffineDrift frame
+x target / y up / z right; backspin axis = +z, draw-side spin = +y):
+
+- toe hit -> draw-side spin (+y)
+- heel hit -> fade-side spin (-y)
+- high hit -> reduced backspin (-z delta)
+- low hit -> added backspin (+z delta)
+- bulge partially offsets the toe-hit pull (starts the ball further right)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.impact.constants import (
+    DRIVER_MOI_KG_M2,
+    GOLF_BALL_MASS_KG,
+)
+from shared.python.swing_sim.impact.gear_effect import (
+    GearEffectResult,
+    compute_gear_effect,
+    resolve_contact_normal,
+)
+from shared.python.swing_sim.impact.models import SPHERE_ROLLING_CAP_FACTOR
+from shared.python.swing_sim.impact.solver import ImpactSolverAPI
+
+_N_SQUARE = np.array([1.0, 0.0, 0.0])
+_V_CLUB = np.array([50.0, 0.0, 0.0])
+_J_TYPICAL = 3.0  # [N.s] ~ (1+e) mu v for a 50 m/s driver strike
+
+
+def _gear(offset: np.ndarray, cg_depth_m: float | None = None) -> GearEffectResult:
+    if cg_depth_m is None:
+        return compute_gear_effect(
+            impact_offset=offset,
+            face_normal=_N_SQUARE,
+            normal_impulse=_J_TYPICAL,
+            clubhead_moi=DRIVER_MOI_KG_M2,
+        )
+    return compute_gear_effect(
+        impact_offset=offset,
+        face_normal=_N_SQUARE,
+        normal_impulse=_J_TYPICAL,
+        clubhead_moi=DRIVER_MOI_KG_M2,
+        cg_depth_m=cg_depth_m,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestGearEffectSignatures:
+    def test_toe_hit_gives_draw_side_spin(self) -> None:
+        result = _gear(np.array([0.02, 0.0]))
+        assert result.ball_spin_delta[1] > 0.0  # +y = draw (RH)
+        assert abs(result.ball_spin_delta[1]) > abs(result.ball_spin_delta[2])
+
+    def test_heel_hit_gives_fade_side_spin(self) -> None:
+        result = _gear(np.array([-0.02, 0.0]))
+        assert result.ball_spin_delta[1] < 0.0  # -y = fade (RH)
+
+    def test_high_hit_reduces_backspin(self) -> None:
+        result = _gear(np.array([0.0, 0.015]))
+        assert result.ball_spin_delta[2] < 0.0  # opposes +z backspin
+
+    def test_low_hit_adds_backspin(self) -> None:
+        result = _gear(np.array([0.0, -0.015]))
+        assert result.ball_spin_delta[2] > 0.0
+
+    def test_toe_and_heel_are_antisymmetric(self) -> None:
+        toe = _gear(np.array([0.02, 0.0]))
+        heel = _gear(np.array([-0.02, 0.0]))
+        np.testing.assert_allclose(
+            toe.ball_spin_delta, -heel.ball_spin_delta, atol=1e-12
+        )
+
+    def test_center_hit_produces_no_gear_spin(self) -> None:
+        result = _gear(np.zeros(2))
+        np.testing.assert_allclose(result.ball_spin_delta, 0.0)
+        assert result.tangential_surface_speed == 0.0
+
+    def test_zero_cg_depth_produces_no_gear_spin(self) -> None:
+        """No front-to-back lever arm -> no tangential sweep -> no spin."""
+        result = _gear(np.array([0.02, 0.0]), cg_depth_m=0.0)
+        np.testing.assert_allclose(result.ball_spin_delta, 0.0, atol=1e-12)
+
+    def test_toe_hit_head_recoil_opens_face(self) -> None:
+        """Toe hit twists the head about -y: the toe rotates backward."""
+        result = _gear(np.array([0.02, 0.0]))
+        assert result.head_angular_velocity_delta[1] < 0.0
+
+    def test_spin_scales_with_offset(self) -> None:
+        small = _gear(np.array([0.005, 0.0]))
+        large = _gear(np.array([0.02, 0.0]))
+        assert abs(large.ball_spin_delta[1]) > abs(small.ball_spin_delta[1])
+
+    def test_higher_moi_reduces_gear_spin(self) -> None:
+        """Forgiving (high-MOI) heads twist less and gear less."""
+        low = _gear(np.array([0.02, 0.0]))
+        high = compute_gear_effect(
+            impact_offset=np.array([0.02, 0.0]),
+            face_normal=_N_SQUARE,
+            normal_impulse=_J_TYPICAL,
+            clubhead_moi=4.0 * DRIVER_MOI_KG_M2,
+        )
+        assert abs(high.ball_spin_delta[1]) < abs(low.ball_spin_delta[1])
+
+    def test_tensor_moi_matches_matching_scalar(self) -> None:
+        scalar = _gear(np.array([0.02, 0.01]))
+        tensor = compute_gear_effect(
+            impact_offset=np.array([0.02, 0.01]),
+            face_normal=_N_SQUARE,
+            normal_impulse=_J_TYPICAL,
+            clubhead_moi=DRIVER_MOI_KG_M2 * np.eye(3),
+        )
+        np.testing.assert_allclose(
+            tensor.ball_spin_delta, scalar.ball_spin_delta, rtol=1e-12
+        )
+
+    def test_friction_cap_bounds_spin(self) -> None:
+        """The friction impulse never exceeds the 2/7 rolling cap."""
+        result = _gear(np.array([0.03, 0.0]))
+        i_ball_over_r = GOLF_BALL_MASS_KG * (2.0 / 5.0) * 0.021335
+        cap = (
+            GOLF_BALL_MASS_KG
+            * result.tangential_surface_speed
+            * SPHERE_ROLLING_CAP_FACTOR
+        ) / i_ball_over_r
+        assert float(np.linalg.norm(result.ball_spin_delta)) <= cap * (1.0 + 1e-9)
+
+    def test_negative_impulse_rejected(self) -> None:
+        with pytest.raises(ValueError, match="normal_impulse"):
+            compute_gear_effect(
+                impact_offset=np.array([0.02, 0.0]),
+                face_normal=_N_SQUARE,
+                normal_impulse=-1.0,
+                clubhead_moi=DRIVER_MOI_KG_M2,
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestBulgeRollSeam:
+    @staticmethod
+    def _bulge_normal(toe_m: float, high_m: float) -> np.ndarray:
+        """Toy bulge/roll: convex face with 0.25 m radius of curvature."""
+        radius = 0.25
+        n = np.array([1.0, high_m / radius, toe_m / radius])
+        return n / np.linalg.norm(n)
+
+    def test_local_normal_resolution(self) -> None:
+        n = resolve_contact_normal(np.array([0.02, 0.0]), _N_SQUARE, self._bulge_normal)
+        assert n[2] > 0.0  # toe-side bulge normal points right (open)
+        assert float(np.linalg.norm(n)) == pytest.approx(1.0)
+
+    def test_bulge_partially_offsets_toe_hit_pull(self) -> None:
+        """Toe hit with bulge launches further right than with a flat face,
+        so the gear-effect draw spin curves it back toward the target."""
+        api_flat = ImpactSolverAPI()
+        flat = api_flat.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _N_SQUARE,
+            impact_offset=np.array([0.02, 0.0]),
+            record=False,
+        )
+        api_bulge = ImpactSolverAPI()
+        bulged = api_bulge.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _N_SQUARE,
+            impact_offset=np.array([0.02, 0.0]),
+            face_normal_at_offset=self._bulge_normal,
+            record=False,
+        )
+        # Launch direction gains a rightward (+z) component from bulge...
+        assert bulged.ball_velocity[2] > flat.ball_velocity[2]
+        # ...while the gear effect still adds draw-side spin on top of the
+        # open-local-normal friction spin (compare against the same local
+        # normal solved WITHOUT gear effect).
+        no_gear = ImpactSolverAPI().solve_impact(
+            0.0,
+            _V_CLUB,
+            self._bulge_normal(0.02, 0.0),
+            impact_offset=np.array([0.02, 0.0]),
+            record=False,
+        )
+        assert bulged.ball_angular_velocity[1] > no_gear.ball_angular_velocity[1]
+
+    def test_gear_solver_adds_head_recoil(self) -> None:
+        api = ImpactSolverAPI()
+        post = api.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _N_SQUARE,
+            impact_offset=np.array([0.02, 0.0]),
+            record=False,
+        )
+        assert post.clubhead_angular_velocity[1] < 0.0  # toe twists open

--- a/src/shared/python/swing_sim/impact/tests/test_models.py
+++ b/src/shared/python/swing_sim/impact/tests/test_models.py
@@ -1,0 +1,254 @@
+"""Impact model tests: port-parity pins, COR, spin cap, MOI effective mass.
+
+Includes the regression tests for both defects fixed relative to the
+UpstreamDrift source (recon #4104): (a) off-center hits must see the MOI
+effective-mass reduction; (b) opt-in full 3-D inertia tensor treatment.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.impact.constants import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+)
+from shared.python.swing_sim.impact.models import (
+    SPHERE_ROLLING_CAP_FACTOR,
+    FiniteTimeImpactModel,
+    RigidBodyImpactModel,
+    SpringDamperImpactModel,
+    create_impact_model,
+    face_basis,
+    offset_to_face_vector,
+)
+from shared.python.swing_sim.impact.types import (
+    ImpactModelType,
+    ImpactParameters,
+    PreImpactState,
+)
+
+
+def _pre_state(
+    club_speed: float = 50.0,
+    normal: np.ndarray | None = None,
+    impact_offset: np.ndarray | None = None,
+    clubhead_mass: float = 0.200,
+    clubhead_moi: float = 4.5e-4,
+    clubhead_moi_tensor: np.ndarray | None = None,
+) -> PreImpactState:
+    n = normal if normal is not None else np.array([1.0, 0.0, 0.0])
+    return PreImpactState(
+        clubhead_velocity=club_speed * np.array([1.0, 0.0, 0.0]),
+        clubhead_angular_velocity=np.zeros(3),
+        clubhead_orientation=n,
+        ball_position=np.zeros(3),
+        ball_velocity=np.zeros(3),
+        ball_angular_velocity=np.zeros(3),
+        clubhead_mass=clubhead_mass,
+        clubhead_moi=clubhead_moi,
+        impact_offset=impact_offset,
+        clubhead_moi_tensor=clubhead_moi_tensor,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestRigidBodyPins:
+    """Port-parity pins against hand-computed impulse cases."""
+
+    def test_center_strike_hand_computed_ball_speed(self) -> None:
+        """j = (1+e) mu v; v_ball = j / m_ball, for a square center hit."""
+        params = ImpactParameters(cor=0.83)
+        m_club, v_club = 0.200, 50.0
+        pre = _pre_state(club_speed=v_club, clubhead_mass=m_club)
+        post = RigidBodyImpactModel().solve(pre, params)
+
+        mu = (GOLF_BALL_MASS_KG * m_club) / (GOLF_BALL_MASS_KG + m_club)
+        j = (1 + 0.83) * mu * v_club
+        assert post.ball_velocity[0] == pytest.approx(j / GOLF_BALL_MASS_KG)
+        assert post.ball_velocity[1] == pytest.approx(0.0)
+        assert post.ball_velocity[2] == pytest.approx(0.0)
+        # Club slows by j / m_club along the normal.
+        assert post.clubhead_velocity[0] == pytest.approx(v_club - j / m_club)
+
+    def test_center_strike_smash_factor_plausible(self) -> None:
+        """Driver-like smash factor ~1.4-1.5 for a square center strike."""
+        pre = _pre_state(club_speed=50.0)
+        post = RigidBodyImpactModel().solve(pre, ImpactParameters(cor=0.83))
+        smash = float(np.linalg.norm(post.ball_velocity)) / 50.0
+        assert 1.35 < smash < 1.55
+
+    def test_cor_monotonicity_and_bounds(self) -> None:
+        """Higher COR launches the ball faster; e=0 vs e=1 pin."""
+        speeds = []
+        for cor in (0.0, 0.5, 0.83, 1.0):
+            post = RigidBodyImpactModel().solve(_pre_state(), ImpactParameters(cor=cor))
+            speeds.append(float(np.linalg.norm(post.ball_velocity)))
+        assert speeds == sorted(speeds)
+        # e=1 transfers exactly twice the impulse of e=0.
+        assert speeds[-1] == pytest.approx(2.0 * speeds[0])
+
+    def test_cor_out_of_range_rejected(self) -> None:
+        with pytest.raises(Exception, match="restitution"):
+            RigidBodyImpactModel().solve(_pre_state(), ImpactParameters(cor=1.5))
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestFrictionSpin:
+    def test_oblique_impact_spin_axis_and_cap(self) -> None:
+        """Lofted (oblique) strike: backspin about +z, capped at 2/7 limit."""
+        loft = np.radians(10.5)
+        n = np.array([np.cos(loft), np.sin(loft), 0.0])
+        pre = _pre_state(normal=n)
+        params = ImpactParameters(cor=0.83, friction_coefficient=10.0)
+        post = RigidBodyImpactModel().solve(pre, params)
+
+        # AffineDrift frame: backspin axis is +z for a target-bound shot.
+        assert post.ball_angular_velocity[2] > 0.0
+
+        # With absurd friction the cap must bind: J_f = m v_t (2/7).
+        v_rel = pre.clubhead_velocity
+        v_t = float(np.linalg.norm(v_rel - np.dot(v_rel, n) * n))
+        i_ball = (2.0 / 5.0) * GOLF_BALL_MASS_KG * GOLF_BALL_RADIUS_M**2
+        cap_spin = (
+            (GOLF_BALL_MASS_KG * v_t * SPHERE_ROLLING_CAP_FACTOR)
+            * GOLF_BALL_RADIUS_M
+            / i_ball
+        )
+        assert float(np.linalg.norm(post.ball_angular_velocity)) == pytest.approx(
+            cap_spin, rel=1e-9
+        )
+
+    def test_square_strike_produces_no_spin(self) -> None:
+        post = RigidBodyImpactModel().solve(_pre_state(), ImpactParameters())
+        assert np.allclose(post.ball_angular_velocity, 0.0)
+
+    def test_rolling_cap_factor_is_two_sevenths(self) -> None:
+        assert SPHERE_ROLLING_CAP_FACTOR == pytest.approx(2.0 / 7.0)
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestEffectiveMass:
+    """Regression tests for defect (a) and the 3-D tensor opt-in (b)."""
+
+    def test_off_center_ball_speed_below_center(self) -> None:
+        """Regression (a): off-center hits must launch slower than center."""
+        params = ImpactParameters(cor=0.83)
+        model = RigidBodyImpactModel()
+        center = model.solve(_pre_state(), params)
+        toe = model.solve(_pre_state(impact_offset=np.array([0.02, 0.0])), params)
+        v_center = float(np.linalg.norm(center.ball_velocity))
+        v_toe = float(np.linalg.norm(toe.ball_velocity))
+        assert v_toe < v_center
+
+    def test_off_center_effective_mass_hand_computed(self) -> None:
+        """m_eff = 1/(1/m + r^2/I) drives the reduced impulse."""
+        params = ImpactParameters(cor=0.83)
+        m_club, moi, r = 0.200, 4.5e-4, 0.02
+        pre = _pre_state(
+            impact_offset=np.array([r, 0.0]),
+            clubhead_mass=m_club,
+            clubhead_moi=moi,
+        )
+        post = RigidBodyImpactModel().solve(pre, params)
+        m_eff_club = 1.0 / (1.0 / m_club + r**2 / moi)
+        mu = (GOLF_BALL_MASS_KG * m_eff_club) / (GOLF_BALL_MASS_KG + m_eff_club)
+        j = (1 + 0.83) * mu * 50.0
+        assert post.ball_velocity[0] == pytest.approx(j / GOLF_BALL_MASS_KG)
+
+    def test_diagonal_tensor_reproduces_scalar(self) -> None:
+        """Regression (b): I*eye(3) tensor must match the scalar path."""
+        params = ImpactParameters(cor=0.83)
+        moi = 4.5e-4
+        offset = np.array([0.015, 0.01])
+        scalar_post = RigidBodyImpactModel().solve(
+            _pre_state(impact_offset=offset, clubhead_moi=moi), params
+        )
+        tensor_post = RigidBodyImpactModel().solve(
+            _pre_state(
+                impact_offset=offset,
+                clubhead_moi=0.0,  # must be ignored when tensor present
+                clubhead_moi_tensor=moi * np.eye(3),
+            ),
+            params,
+        )
+        np.testing.assert_allclose(
+            tensor_post.ball_velocity, scalar_post.ball_velocity, rtol=1e-12
+        )
+
+    def test_anisotropic_tensor_differs_from_scalar(self) -> None:
+        """A non-spherical tensor must change the off-center result."""
+        params = ImpactParameters(cor=0.83)
+        moi = 4.5e-4
+        offset = np.array([0.02, 0.0])
+        scalar_post = RigidBodyImpactModel().solve(
+            _pre_state(impact_offset=offset, clubhead_moi=moi), params
+        )
+        tensor = np.diag([moi, 5.0 * moi, moi])  # stiffer about the y axis
+        tensor_post = RigidBodyImpactModel().solve(
+            _pre_state(impact_offset=offset, clubhead_moi_tensor=tensor), params
+        )
+        # Toe offset twists about y: larger I_yy -> less mass loss -> faster.
+        assert float(np.linalg.norm(tensor_post.ball_velocity)) > float(
+            np.linalg.norm(scalar_post.ball_velocity)
+        )
+
+    def test_bad_tensor_shape_rejected(self) -> None:
+        pre = _pre_state(
+            impact_offset=np.array([0.02, 0.0]),
+            clubhead_moi_tensor=np.eye(2),
+        )
+        with pytest.raises(Exception, match="3x3"):
+            RigidBodyImpactModel().solve(pre, ImpactParameters())
+
+
+@pytest.mark.unit
+class TestFaceBasis:
+    def test_target_facing_normal_gives_rh_toe_axis(self) -> None:
+        """AffineDrift n=+x: toe axis is +z (right), up axis is +y."""
+        toe, up = face_basis(np.array([1.0, 0.0, 0.0]))
+        np.testing.assert_allclose(toe, [0.0, 0.0, 1.0], atol=1e-12)
+        np.testing.assert_allclose(up, [0.0, 1.0, 0.0], atol=1e-12)
+
+    def test_offset_lift_is_in_face_plane(self) -> None:
+        loft = np.radians(30.0)
+        n = np.array([np.cos(loft), np.sin(loft), 0.0])
+        r = offset_to_face_vector(np.array([0.01, 0.02]), n)
+        assert abs(float(np.dot(r, n))) < 1e-12
+        assert float(np.linalg.norm(r)) == pytest.approx(
+            np.hypot(0.01, 0.02), rel=1e-12
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestOtherModels:
+    def test_spring_damper_transfers_momentum(self) -> None:
+        model = SpringDamperImpactModel(dt=1e-6)
+        post = model.solve(_pre_state(), ImpactParameters())
+        assert post.ball_velocity[0] > 40.0
+        assert post.contact_duration > 0.0
+        assert post.clubhead_velocity[0] < 50.0
+
+    def test_finite_time_reports_configured_duration(self) -> None:
+        params = ImpactParameters(contact_duration=4.2e-4)
+        post = FiniteTimeImpactModel().solve(_pre_state(), params)
+        assert post.contact_duration == pytest.approx(4.2e-4)
+        rigid = RigidBodyImpactModel().solve(_pre_state(), params)
+        np.testing.assert_allclose(post.ball_velocity, rigid.ball_velocity)
+
+    def test_factory_covers_all_types(self) -> None:
+        assert isinstance(
+            create_impact_model(ImpactModelType.RIGID_BODY), RigidBodyImpactModel
+        )
+        assert isinstance(
+            create_impact_model(ImpactModelType.SPRING_DAMPER),
+            SpringDamperImpactModel,
+        )
+        assert isinstance(
+            create_impact_model(ImpactModelType.FINITE_TIME), FiniteTimeImpactModel
+        )

--- a/src/shared/python/swing_sim/impact/tests/test_solver.py
+++ b/src/shared/python/swing_sim/impact/tests/test_solver.py
@@ -1,0 +1,213 @@
+"""Solver API, recorder, and energy-balance tests.
+
+Includes the solver-level regression test for defect (a): the base
+impulse of ``solve_with_gear_effect`` must include the impact offset.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.impact.models import RigidBodyImpactModel
+from shared.python.swing_sim.impact.solver import ImpactRecorder, ImpactSolverAPI
+from shared.python.swing_sim.impact.types import (
+    ImpactModelType,
+    ImpactParameters,
+    PreImpactState,
+)
+from shared.python.swing_sim.impact.utils import validate_energy_balance
+
+_V_CLUB = np.array([50.0, 0.0, 0.0])
+_N_SQUARE = np.array([1.0, 0.0, 0.0])
+
+
+def _lofted_normal(loft_deg: float = 10.5) -> np.ndarray:
+    loft = np.radians(loft_deg)
+    return np.array([np.cos(loft), np.sin(loft), 0.0])
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestSolveImpact:
+    def test_solve_and_record(self) -> None:
+        api = ImpactSolverAPI()
+        post = api.solve_impact(0.0, _V_CLUB, _N_SQUARE)
+        assert post.ball_velocity[0] > 60.0
+        assert len(api.recorder.events) == 1
+
+    def test_record_flag_false_skips_recording(self) -> None:
+        api = ImpactSolverAPI()
+        api.solve_impact(0.0, _V_CLUB, _N_SQUARE, record=False)
+        assert api.recorder.events == []
+
+    def test_offset_passthrough_reduces_ball_speed(self) -> None:
+        api = ImpactSolverAPI()
+        center = api.solve_impact(0.0, _V_CLUB, _N_SQUARE, record=False)
+        toe = api.solve_impact(
+            0.0,
+            _V_CLUB,
+            _N_SQUARE,
+            impact_offset=np.array([0.02, 0.0]),
+            record=False,
+        )
+        assert float(np.linalg.norm(toe.ball_velocity)) < float(
+            np.linalg.norm(center.ball_velocity)
+        )
+
+    def test_negative_timestamp_rejected(self) -> None:
+        api = ImpactSolverAPI()
+        with pytest.raises(Exception, match="[Tt]imestamp"):
+            api.solve_impact(-1.0, _V_CLUB, _N_SQUARE)
+
+    def test_non_positive_mass_rejected(self) -> None:
+        api = ImpactSolverAPI()
+        with pytest.raises(ValueError, match="mass"):
+            api.solve_impact(0.0, _V_CLUB, _N_SQUARE, clubhead_mass=0.0)
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+@pytest.mark.regression
+class TestGearEffectSolveRegression:
+    """Defect (a): the offset must reach the base-impulse computation."""
+
+    def test_off_center_gear_solve_slower_than_center(self) -> None:
+        api = ImpactSolverAPI()
+        center = api.solve_impact(0.0, _V_CLUB, _lofted_normal(), record=False)
+        toe = api.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _lofted_normal(),
+            impact_offset=np.array([0.025, 0.0]),
+            record=False,
+        )
+        assert float(np.linalg.norm(toe.ball_velocity)) < float(
+            np.linalg.norm(center.ball_velocity)
+        )
+
+    def test_recorded_pre_state_carries_offset(self) -> None:
+        """The recorded event must expose the offset it was solved with."""
+        api = ImpactSolverAPI()
+        offset = np.array([0.015, -0.005])
+        api.solve_with_gear_effect(0.0, _V_CLUB, _lofted_normal(), impact_offset=offset)
+        (event,) = api.recorder.events
+        assert event.pre_state.impact_offset is not None
+        np.testing.assert_allclose(event.pre_state.impact_offset, offset)
+
+    def test_zero_offset_matches_plain_solve(self) -> None:
+        api = ImpactSolverAPI()
+        plain = api.solve_impact(0.0, _V_CLUB, _lofted_normal(), record=False)
+        geared = api.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _lofted_normal(),
+            impact_offset=np.zeros(2),
+            record=False,
+        )
+        np.testing.assert_allclose(geared.ball_velocity, plain.ball_velocity)
+        np.testing.assert_allclose(
+            geared.ball_angular_velocity, plain.ball_angular_velocity, atol=1e-9
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestValidationAndReporting:
+    def _api_with_impacts(self) -> ImpactSolverAPI:
+        api = ImpactSolverAPI()
+        for i, speed in enumerate((45.0, 50.0, 55.0)):
+            api.solve_impact(float(i), speed * _N_SQUARE, _N_SQUARE)
+        return api
+
+    def test_cor_validation_within_tolerance(self) -> None:
+        result = self._api_with_impacts().validate_cor_behavior(tolerance=0.05)
+        assert result["valid"] is True
+        assert result["num_samples"] == 3
+
+    def test_spin_validation_square_strikes(self) -> None:
+        result = self._api_with_impacts().validate_spin_behavior()
+        assert result["valid"] is True
+
+    def test_energy_report_totals(self) -> None:
+        report = self._api_with_impacts().get_energy_report()
+        assert len(report["impacts"]) == 3
+        assert report["total_energy_lost"] > 0.0
+        assert 0.0 < report["overall_loss_ratio"] < 1.0
+
+    def test_reports_require_recorded_impacts(self) -> None:
+        api = ImpactSolverAPI()
+        with pytest.raises(RuntimeError, match="No impacts"):
+            api.get_energy_report()
+        with pytest.raises(RuntimeError, match="No impacts"):
+            api.validate_cor_behavior()
+
+    def test_reset_clears_recorder(self) -> None:
+        api = self._api_with_impacts()
+        api.reset()
+        assert api.recorder.events == []
+
+    def test_recorder_export_and_summary(self) -> None:
+        api = self._api_with_impacts()
+        exported = api.recorder.export_to_dict()
+        assert exported["num_impacts"] == 3
+        assert (
+            exported["summary"]["max_ball_speed"]
+            >= (exported["summary"]["mean_ball_speed"])
+        )
+        assert len(api.recorder.get_all_events()) == 3
+
+    def test_model_type_selection(self) -> None:
+        api = ImpactSolverAPI(model_type=ImpactModelType.FINITE_TIME)
+        post = api.solve_impact(0.0, _V_CLUB, _N_SQUARE, record=False)
+        assert post.contact_duration == pytest.approx(api.params.contact_duration)
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestEnergyBalance:
+    def test_energy_loss_matches_cor_expectation(self) -> None:
+        """For a center strike the COM-frame loss is 1/2 mu v^2 (1-e^2)."""
+        params = ImpactParameters(cor=0.83)
+        pre = PreImpactState(
+            clubhead_velocity=_V_CLUB.copy(),
+            clubhead_angular_velocity=np.zeros(3),
+            clubhead_orientation=_N_SQUARE.copy(),
+            ball_position=np.zeros(3),
+            ball_velocity=np.zeros(3),
+            ball_angular_velocity=np.zeros(3),
+        )
+        post = RigidBodyImpactModel().solve(pre, params)
+        balance = validate_energy_balance(pre, post, params)
+        assert balance["energy_lost"] == pytest.approx(
+            balance["expected_loss_j"], rel=1e-9
+        )
+        assert 0.0 < balance["energy_loss_ratio"] < 1.0
+
+    def test_elastic_impact_conserves_energy(self) -> None:
+        params = ImpactParameters(cor=1.0, friction_coefficient=0.0)
+        pre = PreImpactState(
+            clubhead_velocity=_V_CLUB.copy(),
+            clubhead_angular_velocity=np.zeros(3),
+            clubhead_orientation=_N_SQUARE.copy(),
+            ball_position=np.zeros(3),
+            ball_velocity=np.zeros(3),
+            ball_angular_velocity=np.zeros(3),
+        )
+        post = RigidBodyImpactModel().solve(pre, params)
+        balance = validate_energy_balance(pre, post, params)
+        assert balance["energy_lost"] == pytest.approx(0.0, abs=1e-9)
+
+
+@pytest.mark.unit
+class TestRecorder:
+    def test_ids_increment_and_reset(self) -> None:
+        recorder = ImpactRecorder()
+        assert recorder.get_summary() == {"num_impacts": 0}
+        api = ImpactSolverAPI()
+        api.solve_impact(0.0, _V_CLUB, _N_SQUARE)
+        api.solve_impact(1.0, _V_CLUB, _N_SQUARE)
+        ids = [e.impact_id for e in api.recorder.events]
+        assert ids == [0, 1]
+        api.recorder.reset()
+        assert api.recorder.events == []

--- a/src/shared/python/swing_sim/impact/types.py
+++ b/src/shared/python/swing_sim/impact/types.py
@@ -1,0 +1,151 @@
+"""Impact model value types.
+
+Ported from UpstreamDrift ``src/shared/python/physics/impact_model/types.py``
+(epic #4103 / issue #4106), rewritten self-contained against the vendored
+:mod:`.constants`.
+
+Changes from the UpstreamDrift source:
+
+- ``PreImpactState`` gains ``clubhead_moi_tensor`` — an optional 3x3 club
+  MOI tensor enabling the full 3-D effective-mass treatment
+  ``J = (1/m_ball + 1/m_club + (r x n) . I^-1 (r x n))^-1`` in
+  :mod:`.models` (scalar ``clubhead_moi`` fallback preserved).
+- ``ImpactParameters`` drops the three empirical gear-effect scaling
+  constants (``gear_effect_factor`` / ``h_scale`` / ``v_scale``); gear
+  effect is now derived from first principles in :mod:`.gear_effect` and
+  needs only ``cg_depth`` (CG distance behind the face plane).
+
+Frame note: the impact model itself is frame-agnostic — all vectors must
+simply share one right-handed Cartesian frame. The delivery front-end
+(:mod:`.delivery`) produces vectors in the AffineDrift frame
+(x = target line, y = up, z = right).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+import numpy as np
+
+from .constants import (
+    DRIVER_CG_DEPTH_M,
+    DRIVER_COR,
+    DRIVER_LIE_RAD,
+    DRIVER_LOFT_RAD,
+    DRIVER_MASS_KG,
+    DRIVER_MOI_KG_M2,
+    TYPICAL_CONTACT_DURATION_S,
+)
+
+
+class ImpactModelType(Enum):
+    """Types of impact physics models."""
+
+    RIGID_BODY = auto()  # Instantaneous impulse with COR
+    SPRING_DAMPER = auto()  # Kelvin-Voigt viscoelastic
+    FINITE_TIME = auto()  # Impulse-momentum with duration
+
+
+@dataclass
+class PreImpactState:
+    """State of ball and clubhead immediately before impact.
+
+    Attributes:
+        clubhead_velocity: Clubhead velocity [m/s] (3,)
+        clubhead_angular_velocity: Clubhead angular velocity [rad/s] (3,)
+        clubhead_orientation: Clubface normal vector [unitless] (3,)
+        ball_position: Ball center position [m] (3,)
+        ball_velocity: Ball velocity [m/s] (3,)
+        ball_angular_velocity: Ball spin [rad/s] (3,)
+        clubhead_mass: Effective clubhead mass [kg]
+        clubhead_loft: Clubface loft angle [rad]
+        clubhead_lie: Clubface lie angle [rad]
+        clubhead_moi: Clubhead scalar moment of inertia about CG [kg.m^2]
+        impact_offset: Impact location offset from CG on clubface [m] (2,)
+            [horizontal (+ = toe side), vertical (+ = high on face)]
+        clubhead_moi_tensor: Optional full 3x3 clubhead MOI tensor about the
+            CG [kg.m^2], expressed in the same frame as the vectors. When
+            provided it replaces the scalar ``clubhead_moi`` in the
+            effective-mass computation for off-center hits.
+    """
+
+    clubhead_velocity: np.ndarray
+    clubhead_angular_velocity: np.ndarray
+    clubhead_orientation: np.ndarray
+    ball_position: np.ndarray
+    ball_velocity: np.ndarray
+    ball_angular_velocity: np.ndarray
+    clubhead_mass: float = DRIVER_MASS_KG
+    clubhead_loft: float = DRIVER_LOFT_RAD
+    clubhead_lie: float = DRIVER_LIE_RAD
+    clubhead_moi: float = DRIVER_MOI_KG_M2
+    impact_offset: np.ndarray | None = None
+    clubhead_moi_tensor: np.ndarray | None = None
+
+
+@dataclass
+class PostImpactState:
+    """State of ball and clubhead immediately after impact.
+
+    Attributes:
+        ball_velocity: Ball launch velocity [m/s] (3,)
+        ball_angular_velocity: Ball spin [rad/s] (3,)
+        clubhead_velocity: Clubhead velocity after impact [m/s] (3,)
+        clubhead_angular_velocity: Clubhead angular velocity after [rad/s] (3,)
+        contact_duration: Duration of contact [s]
+        energy_transfer: Kinetic energy transferred to ball [J]
+        impact_location: Location of impact on clubface [m] (2,) [x, y]
+    """
+
+    ball_velocity: np.ndarray
+    ball_angular_velocity: np.ndarray
+    clubhead_velocity: np.ndarray
+    clubhead_angular_velocity: np.ndarray
+    contact_duration: float
+    energy_transfer: float
+    impact_location: np.ndarray
+
+
+@dataclass
+class ImpactParameters:
+    """Parameters for impact model.
+
+    Attributes:
+        cor: Coefficient of restitution (0-1)
+        contact_duration: Contact time [s]
+        contact_stiffness: Spring stiffness for compliant model [N/m]
+        contact_damping: Damping for compliant model [N.s/m]
+        friction_coefficient: Ball-face friction
+        cg_depth: Clubhead CG distance behind the face plane [m]; the
+            front-to-back lever arm driving physics-based gear effect
+            (:mod:`.gear_effect`).
+    """
+
+    cor: float = DRIVER_COR
+    contact_duration: float = TYPICAL_CONTACT_DURATION_S
+    contact_stiffness: float = 1e6  # [N/m]
+    contact_damping: float = 1e3  # [N.s/m]
+    friction_coefficient: float = 0.4
+    cg_depth: float = DRIVER_CG_DEPTH_M
+
+
+@dataclass
+class ImpactEvent:
+    """Complete record of a single impact event.
+
+    Attributes:
+        timestamp: Simulation time when impact occurred [s]
+        pre_state: State before impact
+        post_state: State after impact
+        energy_balance: Energy analysis results
+        impact_id: Unique identifier for this impact
+        model_type: Type of impact model used
+    """
+
+    timestamp: float
+    pre_state: PreImpactState
+    post_state: PostImpactState
+    energy_balance: dict[str, float]
+    impact_id: int
+    model_type: ImpactModelType

--- a/src/shared/python/swing_sim/impact/utils.py
+++ b/src/shared/python/swing_sim/impact/utils.py
@@ -1,0 +1,109 @@
+"""Impact energy-balance validation.
+
+Ported from UpstreamDrift ``src/shared/python/physics/impact_model/utils.py``
+(epic #4103 / issue #4106), rewritten self-contained against the vendored
+:mod:`.constants`.
+
+The empirical ``compute_gear_effect_spin`` (three tuned constants with a
+hard-coded world-up axis) present in the UpstreamDrift source is
+intentionally NOT ported; it is replaced by the physics-derived treatment
+in :mod:`.gear_effect`.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from .constants import GOLF_BALL_MASS_KG, GOLF_BALL_MOMENT_OF_INERTIA_KG_M2
+from .types import ImpactParameters, PostImpactState, PreImpactState
+
+
+def validate_energy_balance(
+    pre_state: PreImpactState,
+    post_state: PostImpactState,
+    params: ImpactParameters,
+) -> dict[str, float]:
+    """Validate energy balance before and after impact.
+
+    Total mechanical energy should be conserved up to COR losses:
+    the expected loss in the relative (COM) frame is
+    ``dKE = 1/2 * mu * v_rel_n^2 * (1 - e^2)``.
+
+    Args:
+        pre_state: Pre-impact state
+        post_state: Post-impact state
+        params: Impact parameters
+
+    Returns:
+        Dictionary with energy analysis results.
+    """
+    if pre_state is None:
+        raise ValueError("pre_state must be provided")
+    m_ball = GOLF_BALL_MASS_KG
+    m_club = pre_state.clubhead_mass
+    i_ball = GOLF_BALL_MOMENT_OF_INERTIA_KG_M2
+
+    n_raw = np.asarray(pre_state.clubhead_orientation, dtype=float).reshape(-1)
+    n_norm = math.sqrt(float(np.dot(n_raw, n_raw))) if n_raw.size > 0 else 0.0
+    n_unit = n_raw / n_norm if n_norm > 1e-12 else np.array([1.0, 0.0, 0.0])
+    v_rel = np.asarray(pre_state.clubhead_velocity, dtype=float) - np.asarray(
+        pre_state.ball_velocity, dtype=float
+    )
+    mu = (m_ball * m_club) / (m_ball + m_club)
+    expected_loss_j = (
+        0.5 * mu * float(np.dot(v_rel, n_unit)) ** 2 * (1.0 - params.cor**2)
+    )
+
+    ke_ball_pre = (
+        0.5 * m_ball * float(np.dot(pre_state.ball_velocity, pre_state.ball_velocity))
+    )
+    ke_ball_rot_pre = (
+        0.5
+        * i_ball
+        * float(
+            np.dot(pre_state.ball_angular_velocity, pre_state.ball_angular_velocity)
+        )
+    )
+    ke_club_pre = (
+        0.5
+        * m_club
+        * float(np.dot(pre_state.clubhead_velocity, pre_state.clubhead_velocity))
+    )
+    total_ke_pre = ke_ball_pre + ke_ball_rot_pre + ke_club_pre
+
+    ke_ball_post = (
+        0.5 * m_ball * float(np.dot(post_state.ball_velocity, post_state.ball_velocity))
+    )
+    ke_ball_rot_post = (
+        0.5
+        * i_ball
+        * float(
+            np.dot(post_state.ball_angular_velocity, post_state.ball_angular_velocity)
+        )
+    )
+    ke_club_post = (
+        0.5
+        * m_club
+        * float(np.dot(post_state.clubhead_velocity, post_state.clubhead_velocity))
+    )
+    total_ke_post = ke_ball_post + ke_ball_rot_post + ke_club_post
+
+    energy_lost = total_ke_pre - total_ke_post
+    expected_loss_factor = 1 - params.cor**2  # COR relates velocities, not energy
+
+    return {
+        "total_ke_pre": float(total_ke_pre),
+        "total_ke_post": float(total_ke_post),
+        "energy_lost": float(energy_lost),
+        "energy_loss_ratio": (
+            float(energy_lost / total_ke_pre) if total_ke_pre > 0 else 0.0
+        ),
+        "expected_loss_factor": expected_loss_factor,
+        "expected_loss_j": float(expected_loss_j),
+        "ball_ke_post": float(ke_ball_post),
+        "ball_launch_speed": float(
+            math.sqrt(float(np.dot(post_state.ball_velocity, post_state.ball_velocity)))
+        ),
+    }


### PR DESCRIPTION
## Summary

Second wave of epic #4103 (recon #4104, issue #4106): the impact-physics package for `swing_sim`, stacked on `feat/swing-sim-foundation` (PR #4113).

Ports UpstreamDrift's `src/shared/python/physics/impact_model/` ({types,models,solver,utils}.py) into a **self-façaded** `src/shared/python/swing_sim/impact/` subpackage — rigid-body COR impulse model with the 2/7 rolling-cap friction spin derivation, spring-damper (Kelvin-Voigt) model, finite-time model, energy-balance validator, and `ImpactRecorder`/`ImpactSolverAPI` — rewritten self-contained (constants vendored with citations into `impact/constants.py`; Tools must not import upstream-drift). `swing_sim/__init__.py` is untouched; epic integration wires the parent façade later.

## Bug fixes vs the UpstreamDrift source

1. **Offset dropped from the base impulse (recon defect a):** `solve_with_gear_effect` built its `PreImpactState` without `impact_offset`, so off-center hits skipped the MOI effective-mass reduction and launched at full center-strike speed. The offset now flows into the base solve and the recorded event. Regression test pins off-center ball speed < center ball speed.
2. **Scalar-MOI-only effective mass (recon defect b):** opt-in full 3-D inertia treatment via a 3x3 `clubhead_moi_tensor` — `1/m_eff = 1/m_club + (r x n)^T I^-1 (r x n)` (the club-side term of `J = (1/m_ball + 1/m_club + n.((I^-1(r x n)) x r))^-1 (1+e) v_rel`). Scalar fallback preserved; test proves a diagonal tensor matching the scalar reproduces scalar results exactly, and an anisotropic tensor diverges.
3. **(Found during port) friction-spin axis sign:** the source used `n x t`, which spins a lofted strike toward *topspin* and contradicts its own pre-existing-spin slip-reduction cap; corrected to the physical torque axis `t x n` (friction impulse at the ball contact point `-R n`), with the derivation inline and a test pinning backspin about +z for a lofted target-bound strike.

## New components

- **`delivery.py` (launch-monitor front-end, no upstream equivalent):** club path / face angle / attack angle / dynamic loft / lie [deg], clubhead speed, toe/high offsets [mm] → clubhead velocity vector, unit face normal, and model-convention offsets in the **AffineDrift frame** (x target, y up, z right; path + = in-to-out, face + = open; the impact model itself is frame-agnostic, so these vectors feed it directly). Derived diagnostics: spin loft (`arccos(v.n)`) and D-plane spin axis (`unit(v x n)`, signed tilt with + = fade side), derivations in docstrings.
- **`gear_effect.py` (physics-based, replaces the 3-empirical-constants version):** head rotation recoil `d_omega = I^-1 (r x (-J n))` (scalar or tensor MOI) with the CG-depth lever arm `r = r_plane + d n` (`DRIVER_CG_DEPTH_M = 35 mm`, cited), time-averaged tangential face-surface sweep (`1/2 d_omega x r`), converted to ball spin through the same 2/7-capped Coulomb friction impulse. Bulge/roll enters via the app-agnostic `face_normal_at_offset(toe_m, high_m)` callable seam (club package, PR #4112). Signature tests: toe hit → draw-side spin (RH), heel → fade-side (antisymmetric), high hit → reduced backspin, low → added backspin, zero CG depth → zero gear spin, bulge starts a toe hit further right while gear draw spin remains to bring it back.

## Tests & gates

73 new tests (`unit` / `physics` / `regression` / `contract` markers): hand-computed impulse pins, COR monotonicity + e=0 vs e=1 pin, spin cap binding, energy balance vs `1/2 mu v_n^2 (1-e^2)` (exact for center strike; zero loss at e=1, mu=0), both recon bug-fix regressions, delivery round-trips (zero path/face/AoA → straight launch along the lofted normal), gear-effect signatures, and a contract test pinning the `swing_sim.impact` public API (plus one asserting the parent façade stays untouched).

- pytest `src/shared/python/swing_sim` (full tree): **124 passed** (51 foundation + 73 new)
- ruff check + format: clean
- mypy on the package: clean (8 files)
- `scripts/check_file_size_budget.py --max-loc 500`: 0 violations (largest file: solver.py, 471 LOC)
- SPEC.md: dated subsection + 1.7.0 changelog row

Closes #4106. Part of #4103 (recon: #4104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
