### PR TITLE
feat(swing_sim): ball-flight package — 7 literature models, launch deriver, Rust facade (#4107)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,43 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Swing simulation ball-flight package (epic #4103, #4107)
+
+- New self-facaded subpackage `src/shared/python/swing_sim/flight/` porting
+  UpstreamDrift's pure-Python flight stack (`physics/flight_models.py`):
+  `FlightModelRegistry` with all 7 literature models (Waterloo/Penner
+  quadratic-Cd + power-law-Cl, MacDonald-Hanzely spin decay, and the five
+  constant-coefficient presets — Nathan, Ballantyne, J. Cole, Rospie DL,
+  Charry L3 — keeping their `ConstantCoefficientSpec`
+  name/description/reference citation metadata), scipy `solve_ivp` RK45
+  integration with a terminal ground event, and `FlightResult` metrics
+  (carry, max height, flight time, landing angle, lateral deviation).
+  Constants are vendored with citations into `flight/_constants.py`.
+- Public launch deriver `derive_launch_conditions` (port of the pipeline
+  `_LaunchConditionsDeriver` in UpstreamDrift's
+  `swing_ball_flight_pipeline.py`): post-impact ball velocity/spin vectors
+  → speed, launch angle, azimuth, spin rate [RPM], unit spin axis; the
+  optional `LaunchConditions.spin_axis` override makes the derivation
+  round-trip exactly through `get_initial_velocity`/`get_spin_vector`.
+- Frame adapters `to_flight_frame`/`from_flight_frame` between the app
+  frame (x target, y up, z right) and the UpstreamDrift flight frame
+  (x forward, y left, z up), tested for round-trip and handedness.
+- Graceful Rust fast path (`flight/_rust_facade.py`, aerodynamics-facade
+  posture — scipy is a fully supported fallback, unlike the strict swing
+  facade): `is_rust_available()` + `simulate_trajectory_rust()` over the
+  canonical `rust_core/tools-core/src/ball_flight.rs` RK4 kernel, which now
+  exposes `simulate_trajectory`/`analyze_trajectory` pyfunctions plus
+  property setters (ball/environment scalars, spin axis, wind) and
+  trajectory velocity getters; results are converted into the flight frame.
+  Parity tests compare Rust vs the Python Penner model (tight for zero-spin
+  drag, banded for spinning shots whose lift laws differ) and skip cleanly
+  when the wheel is absent or predates the new bindings.
+- Pipeline seam `flight/pipeline.py`: runtime-checkable
+  `FlightSimulatorProtocol` (satisfied by every registry model) and a
+  `simulate(launch, model_name="waterloo_penner")` convenience mirroring
+  UpstreamDrift's DI design so the impact stage (#4106) plugs in directly.
+  The parent `swing_sim` facade is unchanged.
+
 ### 2026-08-04 Swing simulation foundation (epic #4103, P0 #4104)
 
 - New Rust workspace member `rust_core/swing-core` (Python wheel `swing_core`
@@ -1743,6 +1780,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.6.0 | feat(swing_sim, #4107): add the ball-flight package `src/shared/python/swing_sim/flight/` — 7 literature flight models (Waterloo/Penner, MacDonald-Hanzely, and five cited constant-coefficient presets) behind `FlightModelRegistry` with scipy RK45 + terminal ground event; public `derive_launch_conditions` (post-impact velocity/spin → launch conditions with exact round-trip); app↔flight frame adapters; graceful Rust fast path over `tools-core`'s canonical `ball_flight.rs` kernel (new `simulate_trajectory`/`analyze_trajectory` pyfunctions, property setters, velocity getters) with parity tests; `FlightSimulatorProtocol` + `simulate()` pipeline seam for the impact stage. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4104): add the swing simulation foundation — new `rust_core/swing-core` workspace crate (double-pendulum EOM with plane-oriented in-plane gravity, PyO3 wheel `swing_core` + wasm-bindgen bindings) and shared `src/shared/python/swing_sim` package (DbC value types, `SwingSource` protocol, `DoublePendulumSwing`, strict Rust façade with pure-Python parity oracle); wire swing-core into the rust quality gate's wasm build and add the `maturin-swing-core.yml` build/import/parity workflow. |
 | 2026-07-26 | 1.5.3 | fix(test): create the standalone-wheel smoke environment from the real base interpreter rather than nesting it under the active CI virtualenv, keeping installed-artifact validation portable across relocated self-hosted Python 3.10 runtimes. |
 | 2026-07-26 | 1.5.3 | fix(ci): isolate both protected Python jobs in per-job virtual environments after validating the persistent setup-python runtime; repair and import-probe the matrix NumPy/SciPy stack with compatible bounds, and reinstall OpenCV without dependency resolution so it cannot replace the verified NumPy wheel. |

--- a/rust_core/tools-core/src/ball_flight.rs
+++ b/rust_core/tools-core/src/ball_flight.rs
@@ -593,6 +593,71 @@ impl BallProperties {
             self.mass, self.diameter
         )
     }
+
+    #[getter]
+    fn get_mass(&self) -> f64 {
+        self.mass
+    }
+    #[setter]
+    fn set_mass(&mut self, value: f64) {
+        self.mass = value;
+    }
+    #[getter]
+    fn get_diameter(&self) -> f64 {
+        self.diameter
+    }
+    #[setter]
+    fn set_diameter(&mut self, value: f64) {
+        self.diameter = value;
+    }
+    #[getter]
+    fn get_cd0(&self) -> f64 {
+        self.cd0
+    }
+    #[setter]
+    fn set_cd0(&mut self, value: f64) {
+        self.cd0 = value;
+    }
+    #[getter]
+    fn get_cd1(&self) -> f64 {
+        self.cd1
+    }
+    #[setter]
+    fn set_cd1(&mut self, value: f64) {
+        self.cd1 = value;
+    }
+    #[getter]
+    fn get_cd2(&self) -> f64 {
+        self.cd2
+    }
+    #[setter]
+    fn set_cd2(&mut self, value: f64) {
+        self.cd2 = value;
+    }
+    #[getter]
+    fn get_cl0(&self) -> f64 {
+        self.cl0
+    }
+    #[setter]
+    fn set_cl0(&mut self, value: f64) {
+        self.cl0 = value;
+    }
+    #[getter]
+    fn get_cl1(&self) -> f64 {
+        self.cl1
+    }
+    #[setter]
+    fn set_cl1(&mut self, value: f64) {
+        self.cl1 = value;
+    }
+    #[getter]
+    fn get_cl2(&self) -> f64 {
+        self.cl2
+    }
+    #[setter]
+    fn set_cl2(&mut self, value: f64) {
+        self.cl2 = value;
+    }
 }
 
 #[cfg(feature = "python")]
@@ -620,6 +685,20 @@ impl LaunchConditions {
             self.velocity, self.launch_angle, self.spin_rate
         )
     }
+
+    /// Set the spin axis as a (not necessarily normalized) 3-vector.
+    ///
+    /// The default constructor pins pure backspin (`[0, -1, 0]`); this
+    /// setter lets Python callers (swing_sim flight facade, #4107) pass
+    /// tilted spin axes derived from impact solvers.
+    fn set_spin_axis(&mut self, x: f64, y: f64, z: f64) {
+        self.spin_axis = Vector3::new(x, y, z);
+    }
+
+    /// Return the spin axis as an `(x, y, z)` tuple.
+    fn get_spin_axis(&self) -> (f64, f64, f64) {
+        (self.spin_axis.x, self.spin_axis.y, self.spin_axis.z)
+    }
 }
 
 #[cfg(feature = "python")]
@@ -630,6 +709,37 @@ impl EnvironmentalConditions {
     #[pyo3(text_signature = "()")]
     fn py_new() -> Self {
         Self::default()
+    }
+
+    /// Set the wind velocity vector [m/s].
+    fn set_wind(&mut self, x: f64, y: f64, z: f64) {
+        self.wind_velocity = Vector3::new(x, y, z);
+    }
+
+    /// Return the wind velocity as an `(x, y, z)` tuple.
+    fn get_wind(&self) -> (f64, f64, f64) {
+        (
+            self.wind_velocity.x,
+            self.wind_velocity.y,
+            self.wind_velocity.z,
+        )
+    }
+
+    #[getter]
+    fn get_air_density(&self) -> f64 {
+        self.air_density
+    }
+    #[setter]
+    fn set_air_density(&mut self, value: f64) {
+        self.air_density = value;
+    }
+    #[getter]
+    fn get_gravity(&self) -> f64 {
+        self.gravity
+    }
+    #[setter]
+    fn set_gravity(&mut self, value: f64) {
+        self.gravity = value;
     }
 }
 
@@ -655,6 +765,18 @@ impl TrajectoryPoint {
     #[getter]
     fn spin_rate(&self) -> f64 {
         self.spin
+    }
+    #[getter]
+    fn vx(&self) -> f64 {
+        self.velocity.x
+    }
+    #[getter]
+    fn vy(&self) -> f64 {
+        self.velocity.y
+    }
+    #[getter]
+    fn vz(&self) -> f64 {
+        self.velocity.z
     }
 
     fn __repr__(&self) -> String {
@@ -691,6 +813,50 @@ impl TrajectoryAnalysis {
             self.carry_distance, self.max_height, self.flight_time
         )
     }
+}
+
+/// Simulate a complete ball flight trajectory (Python entry point).
+///
+/// Thin wrapper over [`simulate_trajectory`] that converts the release-mode
+/// precondition `assert!`s into `ValueError`s so invalid Python input never
+/// panics across the FFI boundary. Consumed by
+/// `src/shared/python/swing_sim/flight/_rust_facade.py` (#4107).
+#[cfg(feature = "python")]
+#[pyo3::prelude::pyfunction]
+#[pyo3(name = "simulate_trajectory")]
+pub fn py_simulate_trajectory(
+    ball: BallProperties,
+    env: EnvironmentalConditions,
+    launch: LaunchConditions,
+    max_time: f64,
+    dt: f64,
+) -> pyo3::PyResult<Vec<TrajectoryPoint>> {
+    use pyo3::exceptions::PyValueError;
+    if !(launch.velocity.is_finite() && launch.velocity > 0.0) {
+        return Err(PyValueError::new_err(format!(
+            "Launch velocity must be finite and positive, got {}",
+            launch.velocity
+        )));
+    }
+    if !(dt.is_finite() && dt > 0.0) {
+        return Err(PyValueError::new_err(format!(
+            "Time step must be finite and positive, got {dt}"
+        )));
+    }
+    if !(max_time.is_finite() && max_time > 0.0) {
+        return Err(PyValueError::new_err(format!(
+            "Max time must be finite and positive, got {max_time}"
+        )));
+    }
+    Ok(simulate_trajectory(&ball, &env, &launch, max_time, dt))
+}
+
+/// Analyze a completed trajectory (Python entry point).
+#[cfg(feature = "python")]
+#[pyo3::prelude::pyfunction]
+#[pyo3(name = "analyze_trajectory")]
+pub fn py_analyze_trajectory(trajectory: Vec<TrajectoryPoint>) -> TrajectoryAnalysis {
+    analyze_trajectory(&trajectory)
 }
 
 // ── WASM bindings ────────────────────────────────────────────────────────────

--- a/rust_core/tools-core/src/lib.rs
+++ b/rust_core/tools-core/src/lib.rs
@@ -42,6 +42,8 @@ fn tools_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<atmosphere::AtmosphereProperties>()?;
     m.add_class::<rrt::Obstacle>()?;
     m.add_class::<rrt::RRTPlanner>()?;
+    m.add_function(wrap_pyfunction!(ball_flight::py_simulate_trajectory, m)?)?;
+    m.add_function(wrap_pyfunction!(ball_flight::py_analyze_trajectory, m)?)?;
     m.add_function(wrap_pyfunction!(math::py_lerp, m)?)?;
     m.add_function(wrap_pyfunction!(math::py_clamp, m)?)?;
     m.add_function(wrap_pyfunction!(math::py_deg_to_rad, m)?)?;

--- a/src/shared/python/swing_sim/flight/__init__.py
+++ b/src/shared/python/swing_sim/flight/__init__.py
@@ -1,0 +1,58 @@
+"""Ball-flight subpackage of :mod:`shared.python.swing_sim` (epic #4103, #4107).
+
+Self-facaded port of UpstreamDrift's pure-Python flight stack
+(``physics/flight_models.py`` and the launch-derivation seam of
+``physics/swing_ball_flight_pipeline.py``): seven literature flight models
+behind :class:`FlightModelRegistry`, scipy ``solve_ivp`` RK45 integration
+with a terminal ground event, a public launch-conditions deriver, frame
+adapters between the app frame (x target / y up / z right) and the flight
+frame (x forward / y left / z up), and a graceful Rust fast path backed by
+the canonical ``rust_core/tools-core/src/ball_flight.rs`` kernel.
+
+Import from this facade only; module layout underneath is private.
+"""
+
+from __future__ import annotations
+
+from ._rust_facade import is_rust_available, simulate_trajectory_rust
+from .frames import from_flight_frame, to_flight_frame
+from .launch import derive_launch_conditions
+from .models import (
+    BallFlightModel,
+    ConstantCoefficientModel,
+    ConstantCoefficientSpec,
+    MacDonaldHanzelyModel,
+    WaterlooPennerModel,
+)
+from .pipeline import FlightSimulatorProtocol, simulate
+from .registry import FlightModelRegistry, FlightModelType, compare_models
+from .types import (
+    DEFAULT_BACKSPIN_AXIS,
+    FlightResult,
+    LaunchConditions,
+    TrajectoryPoint,
+    compute_flight_metrics,
+)
+
+__all__ = [
+    "DEFAULT_BACKSPIN_AXIS",
+    "BallFlightModel",
+    "ConstantCoefficientModel",
+    "ConstantCoefficientSpec",
+    "FlightModelRegistry",
+    "FlightModelType",
+    "FlightResult",
+    "FlightSimulatorProtocol",
+    "LaunchConditions",
+    "MacDonaldHanzelyModel",
+    "TrajectoryPoint",
+    "WaterlooPennerModel",
+    "compare_models",
+    "compute_flight_metrics",
+    "derive_launch_conditions",
+    "from_flight_frame",
+    "is_rust_available",
+    "simulate",
+    "simulate_trajectory_rust",
+    "to_flight_frame",
+]

--- a/src/shared/python/swing_sim/flight/_constants.py
+++ b/src/shared/python/swing_sim/flight/_constants.py
@@ -1,0 +1,59 @@
+"""Vendored physical constants for the ball-flight package (with citations).
+
+Vendored from UpstreamDrift ``src/shared/python/core/physics_constants.py``
+so :mod:`shared.python.swing_sim.flight` stays self-contained (epic #4103,
+flight port #4107). Kept in a flight-private module (rather than a shared
+``swing_sim/constants.py``) so parallel domain ports (impact, #4106) cannot
+conflict on one shared file; promote to a shared module when a second
+subpackage needs the same values.
+
+Every constant records units and source in its docstring.
+"""
+
+from __future__ import annotations
+
+import math
+
+GRAVITY_M_S2 = 9.80665
+"""Standard gravity [m/s^2] — NIST CODATA 2018."""
+
+AIR_DENSITY_SEA_LEVEL_KG_M3 = 1.225
+"""Air density at sea level, 15 C [kg/m^3] — ISA Standard Atmosphere."""
+
+GOLF_BALL_MASS_KG = 0.04593
+"""Maximum golf ball mass (1.620 oz) [kg] — USGA Rule 5-1."""
+
+GOLF_BALL_DIAMETER_M = 0.04267
+"""Minimum golf ball diameter (1.680 in) [m] — USGA Rule 5-2."""
+
+GOLF_BALL_RADIUS_M = GOLF_BALL_DIAMETER_M / 2.0
+"""Minimum golf ball radius [m] — derived from USGA Rule 5-2."""
+
+MAX_GOLF_BALL_LIFT_COEFFICIENT = 0.155
+"""Physical cap on the golf-ball lift coefficient [-] — Penner (2003) fit
+ceiling used by the UpstreamDrift flight models."""
+
+MIN_SPEED_THRESHOLD_M_S = 0.1
+"""Minimum speed for aerodynamic force evaluation [m/s] — numerical guard."""
+
+NUMERICAL_EPSILON = 1e-10
+"""Epsilon for vector normalisation [-] — numerical guard."""
+
+MPH_TO_MPS = 0.44704
+"""Miles per hour to metres per second [(m/s)/mph] — NIST (exact)."""
+
+RPM_TO_RAD_S = 2.0 * math.pi / 60.0
+"""Revolutions per minute to radians per second [(rad/s)/RPM] — exact."""
+
+__all__ = [
+    "AIR_DENSITY_SEA_LEVEL_KG_M3",
+    "GOLF_BALL_DIAMETER_M",
+    "GOLF_BALL_MASS_KG",
+    "GOLF_BALL_RADIUS_M",
+    "GRAVITY_M_S2",
+    "MAX_GOLF_BALL_LIFT_COEFFICIENT",
+    "MIN_SPEED_THRESHOLD_M_S",
+    "MPH_TO_MPS",
+    "NUMERICAL_EPSILON",
+    "RPM_TO_RAD_S",
+]

--- a/src/shared/python/swing_sim/flight/_rust_facade.py
+++ b/src/shared/python/swing_sim/flight/_rust_facade.py
@@ -1,0 +1,165 @@
+"""Rust-accelerated ball-flight facade (GRACEFUL dual-path posture).
+
+Mirrors UpstreamDrift ``physics/aerodynamics/_rust_facade.py``: the
+``tools_core`` wheel is probed at import time and callers choose the fast
+path via :func:`is_rust_available`. Unlike the swing-dynamics facade
+(strict, bilateral_rust posture), flight is perfectly serviceable in
+scipy, so absence of the wheel never raises at import — the scipy models
+in :mod:`shared.python.swing_sim.flight.models` are the fallback.
+
+The canonical Rust implementation is
+``rust_core/tools-core/src/ball_flight.rs`` (its header notes it replaces
+the UpstreamDrift Numba version). Its native frame is the app frame
+(x downrange, y up, z lateral/right); this facade converts results into
+the flight frame (x forward, y left, z up) used across this package.
+
+Requires a ``tools_core`` wheel that exposes ``simulate_trajectory``
+(added alongside this package); older wheels that only ship the classes
+report unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import numpy as np
+
+from .frames import from_flight_frame, to_flight_frame
+from .types import (
+    FlightResult,
+    LaunchConditions,
+    TrajectoryPoint,
+    compute_flight_metrics,
+)
+
+logger = logging.getLogger(__name__)
+
+RUST_MODEL_NAME = "tools-core Rust RK4"
+
+_RUST_AVAILABLE = False
+_rust: Any = None
+
+try:
+    import tools_core
+
+    _rust = tools_core
+    _RUST_AVAILABLE = bool(
+        hasattr(_rust, "simulate_trajectory")
+        and hasattr(_rust, "BallProperties")
+        and hasattr(_rust, "EnvironmentalConditions")
+        and hasattr(_rust, "LaunchConditions")
+    )
+    if _RUST_AVAILABLE:
+        logger.info("tools_core ball_flight kernel loaded (Rust fast path)")
+    else:
+        logger.info(
+            "tools_core installed but simulate_trajectory missing (older wheel) "
+            "— using pure-Python scipy flight models."
+        )
+except ImportError:  # pragma: no cover - exercised on machines without wheel
+    logger.info(
+        "tools_core not installed — using pure-Python scipy flight models. "
+        "Install with `pip install rust_core/tools-core`."
+    )
+
+
+def is_rust_available() -> bool:
+    """Return True when the Rust ball-flight kernel is loaded."""
+    return _RUST_AVAILABLE
+
+
+def _build_rust_inputs(
+    launch: LaunchConditions,
+) -> tuple[Any, Any, Any]:
+    """Construct ``tools_core`` ball/env/launch objects from a launch spec."""
+    ball = _rust.BallProperties()
+    ball.mass = float(launch.ball_mass)
+    ball.diameter = 2.0 * float(launch.ball_radius)
+
+    env = _rust.EnvironmentalConditions()
+    env.air_density = float(launch.air_density)
+    env.gravity = float(launch.gravity)
+    wind_flight = launch.get_wind_vector()
+    if float(np.linalg.norm(wind_flight)) > 0.0:
+        wind_app = from_flight_frame(wind_flight)
+        env.set_wind(float(wind_app[0]), float(wind_app[1]), float(wind_app[2]))
+
+    rust_launch = _rust.LaunchConditions(
+        float(launch.ball_speed),
+        math.degrees(launch.launch_angle),
+        math.degrees(launch.azimuth_angle),
+        float(launch.spin_rate),
+    )
+    spin_vec_flight = launch.get_spin_vector()
+    spin_mag = float(np.linalg.norm(spin_vec_flight))
+    if spin_mag > 0.0:
+        axis_app = from_flight_frame(spin_vec_flight / spin_mag)
+        rust_launch.set_spin_axis(
+            float(axis_app[0]), float(axis_app[1]), float(axis_app[2])
+        )
+    return ball, env, rust_launch
+
+
+def simulate_trajectory_rust(
+    launch: LaunchConditions,
+    max_time: float = 10.0,
+    dt: float = 0.01,
+) -> FlightResult:
+    """Simulate a trajectory with the ``tools_core`` Rust RK4 kernel.
+
+    Args:
+        launch: Flight-frame launch conditions (radians / RPM / SI).
+        max_time: Maximum simulated time [s], > 0.
+        dt: Fixed RK4 step [s], > 0.
+
+    Returns:
+        :class:`FlightResult` with the trajectory converted to the flight
+        frame (x forward, y left, z up).
+
+    Raises:
+        ImportError: If the Rust kernel is unavailable (use
+            :func:`is_rust_available` and fall back to the scipy models).
+        ValueError: If ``launch.ball_speed``, ``max_time``, or ``dt`` is
+            not positive (validated here so the Rust precondition
+            ``assert!`` never panics across the FFI boundary).
+    """
+    if not _RUST_AVAILABLE:
+        raise ImportError(
+            "tools_core ball-flight kernel is not available; fall back to "
+            "shared.python.swing_sim.flight.models (scipy). Build the wheel "
+            "with `pip install rust_core/tools-core`."
+        )
+    if launch is None:
+        raise ValueError("launch must be provided")
+    if launch.ball_speed <= 0.0:
+        raise ValueError(f"ball_speed must be > 0; got {launch.ball_speed!r}")
+    if not (math.isfinite(max_time) and max_time > 0.0):
+        raise ValueError(f"max_time must be finite and > 0; got {max_time!r}")
+    if not (math.isfinite(dt) and dt > 0.0):
+        raise ValueError(f"dt must be finite and > 0; got {dt!r}")
+
+    ball, env, rust_launch = _build_rust_inputs(launch)
+    raw_points = _rust.simulate_trajectory(ball, env, rust_launch, max_time, dt)
+
+    points: list[TrajectoryPoint] = []
+    for p in raw_points:
+        pos_app = np.array([p.x, p.y, p.z])
+        vel_app = np.array([p.vx, p.vy, p.vz])
+        points.append(
+            TrajectoryPoint(
+                time=float(p.time),
+                position=to_flight_frame(pos_app),
+                velocity=to_flight_frame(vel_app),
+            )
+        )
+
+    return compute_flight_metrics(points, RUST_MODEL_NAME)
+
+
+__all__ = [
+    "RUST_MODEL_NAME",
+    "is_rust_available",
+    "simulate_trajectory_rust",
+]

--- a/src/shared/python/swing_sim/flight/frames.py
+++ b/src/shared/python/swing_sim/flight/frames.py
@@ -1,0 +1,65 @@
+"""Frame adapters between the app frame and the UpstreamDrift flight frame.
+
+- Flight frame (UpstreamDrift physics stack, and everything inside
+  :mod:`shared.python.swing_sim.flight`): x forward, y left, z up.
+- App frame (Tools AffineDrift / ``tools_core.ball_flight`` Rust kernel):
+  x target (downrange), y up, z right.
+
+Both are right-handed, related by a pure rotation, so the same adapter
+applies to positions, velocities, angular velocities, and spin axes.
+
+Mapping: app x = flight x; app y = flight z; app z = -flight y.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _validated(vec: np.ndarray, name: str) -> np.ndarray:
+    """Return ``vec`` as a float array of shape (3,) or (N, 3)."""
+    arr = np.asarray(vec, dtype=float)
+    if arr.shape != (3,) and not (arr.ndim == 2 and arr.shape[1] == 3):
+        raise ValueError(f"{name} must have shape (3,) or (N, 3); got {arr.shape}")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} must be finite")
+    return arr
+
+
+def to_flight_frame(vec_app: np.ndarray) -> np.ndarray:
+    """Convert vector(s) from the app frame to the flight frame.
+
+    Args:
+        vec_app: Vector(s) in the app frame (x target, y up, z right),
+            shape (3,) or (N, 3).
+
+    Returns:
+        Vector(s) in the flight frame (x forward, y left, z up), same shape.
+    """
+    arr = _validated(vec_app, "vec_app")
+    out = np.empty_like(arr)
+    out[..., 0] = arr[..., 0]
+    out[..., 1] = -arr[..., 2]
+    out[..., 2] = arr[..., 1]
+    return out
+
+
+def from_flight_frame(vec_flight: np.ndarray) -> np.ndarray:
+    """Convert vector(s) from the flight frame to the app frame.
+
+    Args:
+        vec_flight: Vector(s) in the flight frame (x forward, y left, z up),
+            shape (3,) or (N, 3).
+
+    Returns:
+        Vector(s) in the app frame (x target, y up, z right), same shape.
+    """
+    arr = _validated(vec_flight, "vec_flight")
+    out = np.empty_like(arr)
+    out[..., 0] = arr[..., 0]
+    out[..., 1] = arr[..., 2]
+    out[..., 2] = -arr[..., 1]
+    return out
+
+
+__all__ = ["from_flight_frame", "to_flight_frame"]

--- a/src/shared/python/swing_sim/flight/launch.py
+++ b/src/shared/python/swing_sim/flight/launch.py
@@ -1,0 +1,84 @@
+"""Launch-condition derivation from post-impact ball kinematics.
+
+Public, tested port of ``_LaunchConditionsDeriver`` from UpstreamDrift
+``src/shared/python/physics/swing_ball_flight_pipeline.py`` (epic #4103,
+flight port #4107): post-impact ball velocity/spin vectors in the flight
+frame (x forward / y left / z up) → speed, launch angle, azimuth, spin
+rate [RPM], and unit spin axis, packed as
+:class:`~shared.python.swing_sim.flight.types.LaunchConditions`.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from ._constants import RPM_TO_RAD_S
+from .types import DEFAULT_BACKSPIN_AXIS, LaunchConditions
+
+_EPS = 1e-12
+
+
+def derive_launch_conditions(
+    ball_velocity: np.ndarray,
+    ball_angular_velocity: np.ndarray,
+) -> LaunchConditions:
+    """Return :class:`LaunchConditions` from post-impact ball kinematics.
+
+    Args:
+        ball_velocity: Post-impact ball velocity [m/s], shape (3,), flight
+            frame (x forward, y left, z up).
+        ball_angular_velocity: Post-impact ball angular velocity [rad/s],
+            shape (3,), flight frame.
+
+    Returns:
+        LaunchConditions ready for any :class:`BallFlightModel` — speed,
+        launch angle from the horizontal plane [rad], azimuth (bearing from
+        +x, positive toward +y) [rad], spin rate [RPM], and unit spin axis.
+
+    Raises:
+        ValueError: If either vector is not a finite 3-vector.
+    """
+    vel = np.asarray(ball_velocity, dtype=float)
+    spin_w = np.asarray(ball_angular_velocity, dtype=float)
+    for name, vec in (
+        ("ball_velocity", vel),
+        ("ball_angular_velocity", spin_w),
+    ):
+        if vec.shape != (3,):
+            raise ValueError(f"{name} must be shape (3,); got {vec.shape}")
+        if not np.all(np.isfinite(vec)):
+            raise ValueError(f"{name} must be finite; got {vec!r}")
+
+    speed = float(math.hypot(vel[0], vel[1], vel[2]))
+
+    # Launch angle from the horizontal plane, radians.
+    horiz_speed = float(math.hypot(vel[0], vel[1]))
+    if horiz_speed < _EPS:
+        launch_angle_rad = math.pi / 2.0
+    else:
+        launch_angle_rad = float(math.atan2(vel[2], horiz_speed))
+
+    # Azimuth angle (compass bearing, 0 = forward = +x), radians.
+    azimuth_rad = 0.0
+    if horiz_speed > _EPS:
+        azimuth_rad = float(math.atan2(vel[1], vel[0]))
+
+    spin_rate_rad_s = float(math.hypot(spin_w[0], spin_w[1], spin_w[2]))
+    spin_rate_rpm = spin_rate_rad_s / RPM_TO_RAD_S
+    if spin_rate_rad_s > _EPS:
+        spin_axis = spin_w / spin_rate_rad_s
+    else:
+        spin_axis = np.array(DEFAULT_BACKSPIN_AXIS)
+
+    return LaunchConditions(
+        ball_speed=speed,
+        launch_angle=launch_angle_rad,
+        azimuth_angle=azimuth_rad,
+        spin_rate=spin_rate_rpm,
+        spin_axis=(float(spin_axis[0]), float(spin_axis[1]), float(spin_axis[2])),
+    )
+
+
+__all__ = ["derive_launch_conditions"]

--- a/src/shared/python/swing_sim/flight/models.py
+++ b/src/shared/python/swing_sim/flight/models.py
@@ -1,0 +1,391 @@
+"""Literature ball-flight models (scipy ``solve_ivp`` RK45 integration).
+
+Ported from UpstreamDrift ``src/shared/python/physics/flight_models.py``
+(epic #4103, flight port #4107), rewritten self-contained: the
+:class:`BallFlightModel` base with the unified ODE loop and terminal ground
+event, the Waterloo/Penner quadratic-coefficient model, the
+MacDonald-Hanzely spin-decay model, and the constant-coefficient model
+family parameterised by :class:`ConstantCoefficientSpec` (name /
+description / reference metadata preserved as the citation trail).
+"""
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import cast
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+from ._constants import (
+    MAX_GOLF_BALL_LIFT_COEFFICIENT,
+    MIN_SPEED_THRESHOLD_M_S,
+    NUMERICAL_EPSILON,
+    RPM_TO_RAD_S,
+)
+from .types import (
+    FlightResult,
+    LaunchConditions,
+    TrajectoryPoint,
+    compute_flight_metrics,
+)
+
+
+def _capped_lift_coefficient(value: float) -> float:
+    """Return a physically bounded golf-ball lift coefficient."""
+    if value <= 0.0:
+        return 0.0
+    return min(MAX_GOLF_BALL_LIFT_COEFFICIENT, value)
+
+
+def _spin_ratio_lift_coefficient(spin_ratio: float, max_coefficient: float) -> float:
+    """Calibrate low-spin lift without letting high-spin shots balloon."""
+    if spin_ratio <= 0.0 or max_coefficient <= 0.0:
+        return 0.0
+    return _capped_lift_coefficient(min(max_coefficient, 1.7 * spin_ratio))
+
+
+class BallFlightModel(ABC):
+    """Base class for flight models (shared ODE loop and metrics)."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the display name of the flight model."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Return a short description of the model approach."""
+        ...
+
+    @property
+    @abstractmethod
+    def reference(self) -> str:
+        """Return the citation or reference for the model."""
+        ...
+
+    @abstractmethod
+    def simulate(
+        self, launch: LaunchConditions, max_time: float = 10.0, dt: float = 0.01
+    ) -> FlightResult:
+        """Simulate ball flight and return the trajectory result."""
+        ...
+
+    def _compute_metrics(self, trajectory: list[TrajectoryPoint]) -> FlightResult:
+        """Delegate to the shared module-level metrics computation."""
+        return compute_flight_metrics(trajectory, self.name)
+
+    def _run_ode_simulation(
+        self,
+        launch: LaunchConditions,
+        deriv_func: Callable[[float, np.ndarray], np.ndarray],
+        max_time: float,
+        dt: float,
+    ) -> FlightResult:
+        """Unified ODE integration loop with a terminal ground event.
+
+        Preconditions: ``launch`` provided, ``max_time > 0``, ``0 < dt``.
+        """
+        if launch is None:
+            raise ValueError("launch must be provided")
+        if not (math.isfinite(max_time) and max_time > 0.0):
+            raise ValueError(f"max_time must be finite and > 0; got {max_time!r}")
+        if not (math.isfinite(dt) and dt > 0.0):
+            raise ValueError(f"dt must be finite and > 0; got {dt!r}")
+        v0 = launch.get_initial_velocity()
+        y0 = np.array([0.0, 0.0, 0.0, v0[0], v0[1], v0[2]])
+
+        def ground_ev(t: float, y: np.ndarray) -> float:
+            """Return the ball height for ground-contact event detection."""
+            return float(y[2])
+
+        # Type-safe attribute assignment for solve_ivp
+        setattr(ground_ev, "terminal", True)  # noqa: B010
+        setattr(ground_ev, "direction", -1)  # noqa: B010
+
+        sol = solve_ivp(
+            deriv_func,
+            (0, max_time),
+            y0,
+            method="RK45",
+            events=ground_ev,
+            dense_output=True,
+            max_step=0.1,
+        )
+
+        t_eval = np.arange(0, sol.t[-1], dt)
+        points = [
+            TrajectoryPoint(float(t), sol.sol(t)[:3], sol.sol(t)[3:]) for t in t_eval
+        ]
+        if sol.t[-1] not in t_eval:
+            points.append(
+                TrajectoryPoint(float(sol.t[-1]), sol.y[:3, -1], sol.y[3:, -1])
+            )
+
+        return self._compute_metrics(points)
+
+
+class WaterlooPennerModel(BallFlightModel):
+    """Waterloo/Penner model implementation."""
+
+    def __init__(
+        self,
+        cd0: float = 0.21,
+        cd1: float = 0.05,
+        cd2: float = 0.02,
+        cl0: float = 0.00,
+        cl1: float = 0.70,
+        cl2: float = 0.645,
+        cl_max: float = MAX_GOLF_BALL_LIFT_COEFFICIENT,
+    ) -> None:
+        self.params = (cd0, cd1, cd2, cl0, cl1, cl2, cl_max)
+
+    @property
+    def name(self) -> str:
+        """Return the Waterloo/Penner model name."""
+        return "Waterloo/Penner"
+
+    @property
+    def description(self) -> str:
+        """Return the Waterloo/Penner model description."""
+        return "Waterloo quadratic Cd with Penner spin-ratio lift fit"
+
+    @property
+    def reference(self) -> str:
+        """Return the Waterloo/Penner model citation."""
+        return "Penner (2003); McPhee et al. (Waterloo)"
+
+    def simulate(
+        self, launch: LaunchConditions, max_time: float = 10.0, dt: float = 0.01
+    ) -> FlightResult:
+        """Simulate flight using the quadratic-Cd / power-law-Cl model."""
+        if launch is None:
+            raise ValueError("launch must be provided")
+        cd0, cd1, cd2, cl0, cl1, cl2, cl_max = self.params
+        omega_v = launch.get_spin_vector()
+        omega_m = math.hypot(omega_v[0], omega_v[1], omega_v[2])
+        wind_v = launch.get_wind_vector()
+        area = math.pi * launch.ball_radius**2
+
+        def derivatives(t: float, y: np.ndarray) -> np.ndarray:
+            """Compute state derivatives using quadratic Cd/Cl aerodynamics."""
+            if t is None:
+                raise ValueError("t must be provided")
+            v_val = cast(np.ndarray, y[3:])
+            v_rel = v_val - wind_v
+            speed = math.hypot(v_rel[0], v_rel[1], v_rel[2])
+            if speed < MIN_SPEED_THRESHOLD_M_S:
+                return np.array(
+                    [v_val[0], v_val[1], v_val[2], 0.0, 0.0, -launch.gravity]
+                )
+
+            vu = v_rel / speed
+            s = (omega_m * launch.ball_radius) / speed
+            cd = cd0 + cd1 * s + cd2 * s**2
+            cl_val = cl0 + cl1 * s**cl2 if s > 0.0 else cl0
+            cl = min(cl_max, _capped_lift_coefficient(cl_val))
+
+            acc = (
+                -(0.5 * launch.air_density * speed**2 * cd * area / launch.ball_mass)
+                * vu
+            )
+            if omega_m > 0:
+                cross = np.cross(omega_v / omega_m, vu)
+                cross_norm = math.hypot(cross[0], cross[1], cross[2])
+                if cross_norm > NUMERICAL_EPSILON:
+                    acc += (
+                        0.5
+                        * launch.air_density
+                        * speed**2
+                        * cl
+                        * area
+                        / launch.ball_mass
+                    ) * (cross / cross_norm)
+
+            acc[2] -= launch.gravity
+            return np.array([v_val[0], v_val[1], v_val[2], acc[0], acc[1], acc[2]])
+
+        return self._run_ode_simulation(launch, derivatives, max_time, dt)
+
+
+class MacDonaldHanzelyModel(BallFlightModel):
+    """MacDonald-Hanzely model implementation."""
+
+    def __init__(
+        self, cd: float = 0.225, cl: float = 0.20, decay: float = 0.05
+    ) -> None:
+        self.cd, self.cl, self.decay = cd, cl, decay
+
+    @property
+    def name(self) -> str:
+        """Return the MacDonald-Hanzely model name."""
+        return "MacDonald-Hanzely"
+
+    @property
+    def description(self) -> str:
+        """Return the MacDonald-Hanzely model description."""
+        return "ODE model with exponential spin decay"
+
+    @property
+    def reference(self) -> str:
+        """Return the MacDonald-Hanzely model citation."""
+        return "MacDonald & Hanzely (1991)"
+
+    def simulate(
+        self, launch: LaunchConditions, max_time: float = 10.0, dt: float = 0.01
+    ) -> FlightResult:
+        """Simulate flight using the MacDonald-Hanzely spin-decay model."""
+        if launch is None:
+            raise ValueError("launch must be provided")
+        omega_0 = launch.spin_rate * RPM_TO_RAD_S
+        spin_axis = launch.get_spin_vector()
+        spin_norm = math.hypot(spin_axis[0], spin_axis[1], spin_axis[2])
+        if spin_norm > 0:
+            spin_axis = spin_axis / spin_norm
+        wind_v = launch.get_wind_vector()
+        area = math.pi * launch.ball_radius**2
+        k_drag = 0.5 * launch.air_density * area * self.cd / launch.ball_mass
+
+        def derivatives(t: float, y: np.ndarray) -> np.ndarray:
+            """Compute state derivatives with exponential spin decay."""
+            if t is None:
+                raise ValueError("t must be provided")
+            v_val = cast(np.ndarray, y[3:])
+            v_rel = v_val - wind_v
+            speed = math.hypot(v_rel[0], v_rel[1], v_rel[2])
+            if speed < MIN_SPEED_THRESHOLD_M_S:
+                return np.array(
+                    [v_val[0], v_val[1], v_val[2], 0.0, 0.0, -launch.gravity]
+                )
+
+            omega = omega_0 * math.exp(-self.decay * t)
+            vu = v_rel / speed
+            acc = -k_drag * speed**2 * vu
+
+            if omega > 0:
+                spin_ratio = omega * launch.ball_radius / speed
+                cl_eff = _spin_ratio_lift_coefficient(spin_ratio, self.cl)
+                cross = np.cross(spin_axis, vu)
+                cross_norm = math.hypot(cross[0], cross[1], cross[2])
+                if cross_norm > NUMERICAL_EPSILON:
+                    acc += (
+                        0.5
+                        * launch.air_density
+                        * area
+                        * cl_eff
+                        * speed**2
+                        / launch.ball_mass
+                    ) * (cross / cross_norm)
+
+            acc[2] -= launch.gravity
+            return np.array([v_val[0], v_val[1], v_val[2], acc[0], acc[1], acc[2]])
+
+        return self._run_ode_simulation(launch, derivatives, max_time, dt)
+
+
+@dataclass(frozen=True)
+class ConstantCoefficientSpec:
+    """Specification for constant coefficient flight models.
+
+    Attributes:
+        name: Display name for the model.
+        description: Short description of the model.
+        reference: Citation or reference for the model.
+        cd: Drag coefficient [unitless].
+        cl: Lift coefficient [unitless].
+        spin_decay: Spin decay rate [1/s]. Use 0.0 to disable decay.
+    """
+
+    name: str
+    description: str
+    reference: str
+    cd: float
+    cl: float
+    spin_decay: float
+
+
+class ConstantCoefficientModel(BallFlightModel):
+    """Flight model using constant Cd/Cl with optional spin decay."""
+
+    def __init__(self, spec: ConstantCoefficientSpec) -> None:
+        self._spec = spec
+
+    @property
+    def name(self) -> str:
+        """Return the model name from the specification."""
+        return self._spec.name
+
+    @property
+    def description(self) -> str:
+        """Return the model description from the specification."""
+        return self._spec.description
+
+    @property
+    def reference(self) -> str:
+        """Return the model citation from the specification."""
+        return self._spec.reference
+
+    def simulate(
+        self, launch: LaunchConditions, max_time: float = 10.0, dt: float = 0.01
+    ) -> FlightResult:
+        """Simulate flight using constant drag and lift coefficients."""
+        if launch is None:
+            raise ValueError("launch must be provided")
+        omega_0 = launch.spin_rate * RPM_TO_RAD_S
+        spin_axis = launch.get_spin_vector()
+        spin_norm = math.hypot(spin_axis[0], spin_axis[1], spin_axis[2])
+        if spin_norm > 0:
+            spin_axis = spin_axis / spin_norm
+        wind_v = launch.get_wind_vector()
+        area = math.pi * launch.ball_radius**2
+        k_drag = 0.5 * launch.air_density * area * self._spec.cd / launch.ball_mass
+
+        def derivatives(t: float, y: np.ndarray) -> np.ndarray:
+            """Compute state derivatives with constant coefficients and decay."""
+            if t is None:
+                raise ValueError("t must be provided")
+            v_val = cast(np.ndarray, y[3:])
+            v_rel = v_val - wind_v
+            speed = math.hypot(v_rel[0], v_rel[1], v_rel[2])
+            if speed < MIN_SPEED_THRESHOLD_M_S:
+                return np.array(
+                    [v_val[0], v_val[1], v_val[2], 0.0, 0.0, -launch.gravity]
+                )
+
+            omega = omega_0 * math.exp(-self._spec.spin_decay * t)
+            vu = v_rel / speed
+            acc = -k_drag * speed**2 * vu
+
+            if omega > 0:
+                spin_ratio = omega * launch.ball_radius / speed
+                cl_eff = _spin_ratio_lift_coefficient(spin_ratio, self._spec.cl)
+                cross = np.cross(spin_axis, vu)
+                cross_norm = math.hypot(cross[0], cross[1], cross[2])
+                if cross_norm > NUMERICAL_EPSILON:
+                    acc += (
+                        0.5
+                        * launch.air_density
+                        * area
+                        * cl_eff
+                        * speed**2
+                        / launch.ball_mass
+                    ) * (cross / cross_norm)
+
+            acc[2] -= launch.gravity
+            return np.array([v_val[0], v_val[1], v_val[2], acc[0], acc[1], acc[2]])
+
+        return self._run_ode_simulation(launch, derivatives, max_time, dt)
+
+
+__all__ = [
+    "BallFlightModel",
+    "ConstantCoefficientModel",
+    "ConstantCoefficientSpec",
+    "MacDonaldHanzelyModel",
+    "WaterlooPennerModel",
+]

--- a/src/shared/python/swing_sim/flight/pipeline.py
+++ b/src/shared/python/swing_sim/flight/pipeline.py
@@ -1,0 +1,75 @@
+"""Flight-pipeline seam: DI protocol + one-call convenience simulate.
+
+Mirrors the DI design of UpstreamDrift
+``src/shared/python/physics/swing_ball_flight_pipeline.py``
+(``FlightSimulatorProtocol``): the impact stage (#4106) derives
+:class:`LaunchConditions` via
+:func:`shared.python.swing_sim.flight.launch.derive_launch_conditions`
+and plugs them straight into any :class:`FlightSimulatorProtocol`
+implementation — every :class:`BallFlightModel` already satisfies it,
+and tests inject mocks.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .registry import FlightModelRegistry, FlightModelType
+from .types import FlightResult, LaunchConditions
+
+
+@runtime_checkable
+class FlightSimulatorProtocol(Protocol):
+    """Minimal protocol for any ball-flight simulator.
+
+    Satisfied by every :class:`BallFlightModel` in this package; the Rust
+    facade's :func:`simulate_trajectory_rust` can be adapted trivially.
+    Tests inject mocks.
+    """
+
+    def simulate(
+        self,
+        launch: LaunchConditions,
+        max_time: float = 10.0,
+        dt: float = 0.01,
+    ) -> FlightResult:
+        """Return a :class:`FlightResult` for the given launch conditions."""
+        ...
+
+
+def simulate(
+    launch: LaunchConditions,
+    model_name: str = "waterloo_penner",
+    max_time: float = 10.0,
+    dt: float = 0.01,
+) -> FlightResult:
+    """Simulate a ball flight with a registry model selected by name.
+
+    Args:
+        launch: Flight-frame launch conditions (radians / RPM / SI).
+        model_name: A :class:`FlightModelType` value string, e.g.
+            ``"waterloo_penner"`` or ``"macdonald_hanzely"``.
+        max_time: Maximum simulated time [s], > 0.
+        dt: Trajectory sampling interval [s], > 0.
+
+    Returns:
+        The :class:`FlightResult` from the selected model.
+
+    Raises:
+        ValueError: If ``launch`` is missing or ``model_name`` is not a
+            known :class:`FlightModelType` value.
+    """
+    if launch is None:
+        raise ValueError("launch must be provided")
+    try:
+        model_type = FlightModelType(model_name)
+    except ValueError as exc:
+        valid = ", ".join(m.value for m in FlightModelType)
+        raise ValueError(
+            f"unknown flight model {model_name!r}; valid names: {valid}"
+        ) from exc
+    model = FlightModelRegistry.get_model(model_type)
+    return model.simulate(launch, max_time=max_time, dt=dt)
+
+
+__all__ = ["FlightSimulatorProtocol", "simulate"]

--- a/src/shared/python/swing_sim/flight/registry.py
+++ b/src/shared/python/swing_sim/flight/registry.py
@@ -1,0 +1,134 @@
+"""Flight model registry — all 7 literature models with citation metadata.
+
+Ported from UpstreamDrift ``src/shared/python/physics/flight_models.py``
+(``FlightModelType``, ``FlightModelRegistry``, ``compare_models``) for
+epic #4103 / flight port #4107. The five constant-coefficient presets keep
+their ``ConstantCoefficientSpec`` name/description/reference metadata —
+that is the citation trail.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from .models import (
+    BallFlightModel,
+    ConstantCoefficientModel,
+    ConstantCoefficientSpec,
+    MacDonaldHanzelyModel,
+    WaterlooPennerModel,
+)
+from .types import FlightResult, LaunchConditions
+
+
+class FlightModelType(Enum):
+    """Available ball flight physics models."""
+
+    WATERLOO_PENNER = "waterloo_penner"
+    MACDONALD_HANZELY = "macdonald_hanzely"
+    NATHAN = "nathan"
+    BALLANTYNE = "ballantyne"
+    JCOLE = "jcole"
+    ROSPIE_DL = "rospie_dl"
+    CHARRY_L3 = "charry_l3"
+
+
+_CONSTANT_COEFFICIENT_SPECS: dict[FlightModelType, ConstantCoefficientSpec] = {
+    FlightModelType.NATHAN: ConstantCoefficientSpec(
+        name="Nathan",
+        description="Constant Cd/Cl model with spin decay",
+        reference="Nathan et al. (2018)",
+        cd=0.22,
+        cl=0.24,
+        spin_decay=0.03,
+    ),
+    FlightModelType.BALLANTYNE: ConstantCoefficientSpec(
+        name="Ballantyne",
+        description="Constant Cd/Cl model for steady spin",
+        reference="Ballantyne et al. (2012)",
+        cd=0.20,
+        cl=0.18,
+        spin_decay=0.02,
+    ),
+    FlightModelType.JCOLE: ConstantCoefficientSpec(
+        name="J. Cole",
+        description="Constant Cd/Cl model with moderate decay",
+        reference="Cole (2016)",
+        cd=0.23,
+        cl=0.22,
+        spin_decay=0.04,
+    ),
+    FlightModelType.ROSPIE_DL: ConstantCoefficientSpec(
+        name="Rospie DL",
+        description="Constant Cd/Cl model tuned for driver launch",
+        reference="Rospie & Layton (2014)",
+        cd=0.21,
+        cl=0.19,
+        spin_decay=0.03,
+    ),
+    FlightModelType.CHARRY_L3: ConstantCoefficientSpec(
+        name="Charry L3",
+        description="Constant Cd/Cl model with higher drag",
+        reference="Charry et al. (2017)",
+        cd=0.24,
+        cl=0.21,
+        spin_decay=0.05,
+    ),
+}
+
+
+class FlightModelRegistry:
+    """Registry for managing flight models."""
+
+    _models: dict[FlightModelType, BallFlightModel] = {}
+
+    @classmethod
+    def get_model(cls, model_type: FlightModelType) -> BallFlightModel:
+        """Return the flight model instance for the given model type."""
+        if model_type is None:
+            raise ValueError("model_type must be provided")
+        if not cls._models:
+            cls._initialize()
+        return cls._models[model_type]
+
+    @classmethod
+    def get_all_models(cls) -> list[BallFlightModel]:
+        """Return all registered flight model instances."""
+        if not cls._models:
+            cls._initialize()
+        return list(cls._models.values())
+
+    @classmethod
+    def reset(cls) -> None:
+        """Clear the registry, forcing re-initialization on next access.
+
+        Use in test teardown to prevent cross-test pollution from the shared
+        class-level ``_models`` dict (UpstreamDrift issue #1775).
+        """
+        cls._models.clear()
+
+    @classmethod
+    def _initialize(cls) -> None:
+        cls._models[FlightModelType.WATERLOO_PENNER] = WaterlooPennerModel()
+        cls._models[FlightModelType.MACDONALD_HANZELY] = MacDonaldHanzelyModel()
+        for model_type, spec in _CONSTANT_COEFFICIENT_SPECS.items():
+            cls._models[model_type] = ConstantCoefficientModel(spec)
+
+
+def compare_models(
+    launch: LaunchConditions, models: list[BallFlightModel]
+) -> dict[str, FlightResult]:
+    """Compare multiple models for the same launch conditions."""
+    if launch is None:
+        raise ValueError("launch must be provided")
+    results = {}
+    for model in models:
+        results[model.name] = model.simulate(launch)
+    return results
+
+
+__all__ = [
+    "FlightModelRegistry",
+    "FlightModelType",
+    "compare_models",
+]

--- a/src/shared/python/swing_sim/flight/tests/__init__.py
+++ b/src/shared/python/swing_sim/flight/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for :mod:`shared.python.swing_sim.flight` (epic #4103, #4107)."""

--- a/src/shared/python/swing_sim/flight/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/flight/tests/test_contract_api.py
@@ -1,0 +1,81 @@
+"""Contract test pinning the public API surface of swing_sim.flight.
+
+Downstream consumers (impact stage #4106, UpstreamDrift, web backend)
+import from the subpackage facade only; this test fails loudly when the
+surface changes so removals are always deliberate.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import shared.python.swing_sim.flight as flight
+
+EXPECTED_PUBLIC_API = {
+    "DEFAULT_BACKSPIN_AXIS",
+    "BallFlightModel",
+    "ConstantCoefficientModel",
+    "ConstantCoefficientSpec",
+    "FlightModelRegistry",
+    "FlightModelType",
+    "FlightResult",
+    "FlightSimulatorProtocol",
+    "LaunchConditions",
+    "MacDonaldHanzelyModel",
+    "TrajectoryPoint",
+    "WaterlooPennerModel",
+    "compare_models",
+    "compute_flight_metrics",
+    "derive_launch_conditions",
+    "from_flight_frame",
+    "is_rust_available",
+    "simulate",
+    "simulate_trajectory_rust",
+    "to_flight_frame",
+}
+
+
+@pytest.mark.contract
+def test_public_api_surface_is_pinned() -> None:
+    assert set(flight.__all__) == EXPECTED_PUBLIC_API
+
+
+@pytest.mark.contract
+def test_all_exports_resolve() -> None:
+    for name in flight.__all__:
+        assert getattr(flight, name) is not None, f"{name} did not resolve"
+
+
+@pytest.mark.contract
+def test_swing_sim_top_level_facade_unchanged() -> None:
+    """The flight port must not widen the parent swing_sim facade (#4104)."""
+    import shared.python.swing_sim as swing_sim
+
+    assert "flight" not in swing_sim.__all__
+
+
+@pytest.mark.contract
+def test_value_types_are_frozen_dataclasses() -> None:
+    for cls in (
+        flight.LaunchConditions,
+        flight.TrajectoryPoint,
+        flight.FlightResult,
+        flight.ConstantCoefficientSpec,
+    ):
+        assert dataclasses.is_dataclass(cls), f"{cls.__name__} not a dataclass"
+        assert cls.__dataclass_params__.frozen, f"{cls.__name__} must be frozen"
+
+
+@pytest.mark.contract
+def test_model_type_values_are_pinned() -> None:
+    assert {m.value for m in flight.FlightModelType} == {
+        "waterloo_penner",
+        "macdonald_hanzely",
+        "nathan",
+        "ballantyne",
+        "jcole",
+        "rospie_dl",
+        "charry_l3",
+    }

--- a/src/shared/python/swing_sim/flight/tests/test_frames.py
+++ b/src/shared/python/swing_sim/flight/tests/test_frames.py
@@ -1,0 +1,52 @@
+"""Frame-adapter tests: app frame <-> flight frame, both directions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.flight import from_flight_frame, to_flight_frame
+
+
+@pytest.mark.unit
+def test_basis_vectors_map_correctly() -> None:
+    # App frame: x target, y up, z right. Flight frame: x fwd, y left, z up.
+    np.testing.assert_allclose(
+        to_flight_frame(np.array([1.0, 0.0, 0.0])), [1.0, 0.0, 0.0]
+    )
+    np.testing.assert_allclose(
+        to_flight_frame(np.array([0.0, 1.0, 0.0])), [0.0, 0.0, 1.0]
+    )  # app up -> flight up
+    np.testing.assert_allclose(
+        to_flight_frame(np.array([0.0, 0.0, 1.0])), [0.0, -1.0, 0.0]
+    )  # app right -> flight -left
+
+
+@pytest.mark.unit
+def test_round_trip_is_identity_both_directions() -> None:
+    rng = np.random.default_rng(42)
+    vecs = rng.normal(size=(64, 3))
+    np.testing.assert_allclose(from_flight_frame(to_flight_frame(vecs)), vecs)
+    np.testing.assert_allclose(to_flight_frame(from_flight_frame(vecs)), vecs)
+    single = np.array([1.5, -2.0, 0.25])
+    np.testing.assert_allclose(from_flight_frame(to_flight_frame(single)), single)
+
+
+@pytest.mark.unit
+def test_adapters_are_proper_rotations() -> None:
+    """Norms and handedness (cross products) are preserved."""
+    rng = np.random.default_rng(7)
+    a, b = rng.normal(size=3), rng.normal(size=3)
+    fa, fb = to_flight_frame(a), to_flight_frame(b)
+    assert np.linalg.norm(fa) == pytest.approx(np.linalg.norm(a))
+    np.testing.assert_allclose(
+        np.cross(fa, fb), to_flight_frame(np.cross(a, b)), atol=1e-12
+    )
+
+
+@pytest.mark.unit
+def test_rejects_bad_shapes_and_nonfinite() -> None:
+    with pytest.raises(ValueError, match="shape"):
+        to_flight_frame(np.zeros(4))
+    with pytest.raises(ValueError, match="finite"):
+        from_flight_frame(np.array([np.inf, 0.0, 0.0]))

--- a/src/shared/python/swing_sim/flight/tests/test_launch_deriver.py
+++ b/src/shared/python/swing_sim/flight/tests/test_launch_deriver.py
@@ -1,0 +1,63 @@
+"""Launch-deriver round-trip tests (post-impact vectors -> LaunchConditions)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.flight import (
+    DEFAULT_BACKSPIN_AXIS,
+    derive_launch_conditions,
+)
+from shared.python.swing_sim.flight._constants import RPM_TO_RAD_S
+
+
+@pytest.mark.unit
+def test_derive_recovers_speed_angles_and_spin() -> None:
+    vel = np.array([60.0, 5.0, 15.0])
+    spin = 300.0 * np.array([0.0, -1.0, 0.0])  # pure backspin, 300 rad/s
+
+    launch = derive_launch_conditions(vel, spin)
+
+    assert launch.ball_speed == pytest.approx(float(np.linalg.norm(vel)))
+    horiz = math.hypot(vel[0], vel[1])
+    assert launch.launch_angle == pytest.approx(math.atan2(vel[2], horiz))
+    assert launch.azimuth_angle == pytest.approx(math.atan2(vel[1], vel[0]))
+    assert launch.spin_rate == pytest.approx(300.0 / RPM_TO_RAD_S)
+    assert launch.spin_axis == pytest.approx((0.0, -1.0, 0.0))
+
+
+@pytest.mark.unit
+def test_derived_conditions_round_trip_through_launch_vectors() -> None:
+    """get_initial_velocity / get_spin_vector reproduce the input vectors."""
+    vel = np.array([55.0, -8.0, 12.0])
+    spin = np.array([30.0, -280.0, 45.0])
+
+    launch = derive_launch_conditions(vel, spin)
+
+    np.testing.assert_allclose(launch.get_initial_velocity(), vel, atol=1e-9)
+    np.testing.assert_allclose(launch.get_spin_vector(), spin, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_vertical_launch_pins_angle_to_pi_over_two() -> None:
+    launch = derive_launch_conditions(np.array([0.0, 0.0, 30.0]), np.zeros(3))
+    assert launch.launch_angle == pytest.approx(math.pi / 2.0)
+    assert launch.azimuth_angle == 0.0
+
+
+@pytest.mark.unit
+def test_zero_spin_defaults_to_backspin_axis() -> None:
+    launch = derive_launch_conditions(np.array([50.0, 0.0, 10.0]), np.zeros(3))
+    assert launch.spin_rate == 0.0
+    assert launch.spin_axis == pytest.approx(DEFAULT_BACKSPIN_AXIS)
+
+
+@pytest.mark.unit
+def test_rejects_malformed_vectors() -> None:
+    with pytest.raises(ValueError, match="ball_velocity"):
+        derive_launch_conditions(np.array([1.0, 2.0]), np.zeros(3))
+    with pytest.raises(ValueError, match="ball_angular_velocity"):
+        derive_launch_conditions(np.zeros(3), np.array([np.nan, 0.0, 0.0]))

--- a/src/shared/python/swing_sim/flight/tests/test_models_physics.py
+++ b/src/shared/python/swing_sim/flight/tests/test_models_physics.py
@@ -1,0 +1,134 @@
+"""Physics sanity tests for the ported flight models.
+
+Ballistic limit, carry monotonicity, ground-event termination, and
+cross-model carry spread for a standard driver launch.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.flight import (
+    FlightModelRegistry,
+    LaunchConditions,
+    WaterlooPennerModel,
+)
+
+# Standard driver launch: ~74 m/s (165 mph) ball speed, 12 deg, 2600 RPM.
+DRIVER_LAUNCH = LaunchConditions(
+    ball_speed=74.0,
+    launch_angle=math.radians(12.0),
+    spin_rate=2600.0,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Iterator[None]:
+    """Prevent cross-test pollution of the class-level model dict."""
+    FlightModelRegistry.reset()
+    yield
+    FlightModelRegistry.reset()
+
+
+def _vacuum_range(speed: float, angle: float, g: float) -> float:
+    """Analytic drag-free projectile range for a ground-level launch."""
+    return speed * speed * math.sin(2.0 * angle) / g
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_no_spin_low_speed_approaches_vacuum_projectile() -> None:
+    """A slow spinless launch stays within a small drag margin of vacuum."""
+    speed, angle = 10.0, math.radians(30.0)
+    launch = LaunchConditions(ball_speed=speed, launch_angle=angle, spin_rate=0.0)
+    result = WaterlooPennerModel().simulate(launch)
+
+    expected = _vacuum_range(speed, angle, launch.gravity)
+    assert result.carry_distance <= expected  # drag only removes range
+    assert result.carry_distance > 0.90 * expected  # small drag margin
+    expected_h = (speed * math.sin(angle)) ** 2 / (2.0 * launch.gravity)
+    assert result.max_height == pytest.approx(expected_h, rel=0.10)
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_carry_is_monotonic_in_ball_speed() -> None:
+    model = WaterlooPennerModel()
+    carries = []
+    for speed in (40.0, 50.0, 60.0, 70.0, 80.0):
+        launch = LaunchConditions(
+            ball_speed=speed, launch_angle=math.radians(12.0), spin_rate=2600.0
+        )
+        carries.append(model.simulate(launch).carry_distance)
+    assert all(b > a for a, b in zip(carries, carries[1:], strict=False))
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_ground_event_terminates_trajectory() -> None:
+    result = WaterlooPennerModel().simulate(DRIVER_LAUNCH, max_time=60.0)
+    final = result.trajectory[-1]
+    # Terminal event: final height at the ground, not at max_time.
+    assert final.position[2] == pytest.approx(0.0, abs=1e-6)
+    assert result.flight_time < 60.0
+    assert result.landing_angle > 0.0  # descending at landing
+    # Interior of the trajectory is strictly above ground.
+    heights = result.to_position_array()[1:-1, 2]
+    assert np.all(heights > -1e-9)
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_backspin_increases_peak_height() -> None:
+    model = WaterlooPennerModel()
+    no_spin = LaunchConditions(
+        ball_speed=74.0, launch_angle=math.radians(12.0), spin_rate=0.0
+    )
+    assert model.simulate(DRIVER_LAUNCH).max_height > model.simulate(no_spin).max_height
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_cross_model_carry_spread_for_driver_launch() -> None:
+    """All 7 models land a standard driver launch in a plausible carry band."""
+    carries: dict[str, float] = {}
+    for model in FlightModelRegistry.get_all_models():
+        result = model.simulate(DRIVER_LAUNCH, max_time=20.0)
+        carries[model.name] = result.carry_distance
+    assert len(carries) == 7
+    for name, carry in carries.items():
+        assert 150.0 <= carry <= 320.0, f"{name} carry {carry:.1f} m out of band"
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_pure_backspin_launch_stays_on_target_line() -> None:
+    """Zero azimuth + pure backspin gives no lateral deviation."""
+    result = WaterlooPennerModel().simulate(DRIVER_LAUNCH)
+    assert abs(result.lateral_deviation) < 1e-6
+
+
+@pytest.mark.unit
+def test_launch_conditions_validation() -> None:
+    with pytest.raises(ValueError, match="ball_speed"):
+        LaunchConditions(ball_speed=-1.0, launch_angle=0.2)
+    with pytest.raises(ValueError, match="launch_angle"):
+        LaunchConditions(ball_speed=70.0, launch_angle=12.0)  # degrees passed
+    with pytest.raises(ValueError, match="spin_rate"):
+        LaunchConditions(ball_speed=70.0, launch_angle=0.2, spin_rate=-5.0)
+    with pytest.raises(ValueError, match="unit vector"):
+        LaunchConditions(ball_speed=70.0, launch_angle=0.2, spin_axis=(0.0, -2.0, 0.0))
+
+
+@pytest.mark.unit
+def test_from_imperial_converts_units() -> None:
+    launch = LaunchConditions.from_imperial(
+        ball_speed_mph=165.0, launch_angle_deg=12.0, spin_rate_rpm=2600.0
+    )
+    assert launch.ball_speed == pytest.approx(165.0 * 0.44704)
+    assert launch.launch_angle == pytest.approx(math.radians(12.0))
+    assert launch.spin_rate == 2600.0

--- a/src/shared/python/swing_sim/flight/tests/test_parity_rust_flight.py
+++ b/src/shared/python/swing_sim/flight/tests/test_parity_rust_flight.py
@@ -1,0 +1,99 @@
+"""Rust <-> Python ball-flight parity (graceful skip without the wheel).
+
+The ``tools_core`` Rust kernel and the Python Waterloo/Penner model share
+the same quadratic drag law and defaults (cd0=0.21, cd1=0.05, cd2=0.02),
+so a zero-spin trajectory must agree to integrator tolerance (fixed-step
+RK4 vs adaptive RK45 + dt-quantised ground stop). Lift laws differ
+(quadratic-polynomial vs Penner power fit), so spinning shots are only
+compared coarsely.
+
+Skips cleanly when ``tools_core`` is absent or is an older wheel that
+does not expose ``simulate_trajectory``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from shared.python.swing_sim.flight import (
+    LaunchConditions,
+    WaterlooPennerModel,
+    is_rust_available,
+    simulate_trajectory_rust,
+)
+
+pytestmark = pytest.mark.skipif(
+    not is_rust_available(),
+    reason=(
+        "tools_core wheel absent or too old (no simulate_trajectory); "
+        "Rust ball-flight fast path unavailable on this interpreter"
+    ),
+)
+
+
+@pytest.mark.parity
+@pytest.mark.physics
+def test_zero_spin_trajectory_matches_penner_within_tolerance() -> None:
+    launch = LaunchConditions(
+        ball_speed=70.0, launch_angle=math.radians(12.0), spin_rate=0.0
+    )
+    rust = simulate_trajectory_rust(launch, max_time=20.0, dt=0.005)
+    python = WaterlooPennerModel().simulate(launch, max_time=20.0, dt=0.005)
+
+    assert rust.carry_distance == pytest.approx(python.carry_distance, rel=0.02)
+    assert rust.max_height == pytest.approx(python.max_height, rel=0.02)
+    assert rust.flight_time == pytest.approx(python.flight_time, rel=0.02)
+    assert rust.landing_angle == pytest.approx(python.landing_angle, abs=2.0)
+
+
+@pytest.mark.parity
+@pytest.mark.physics
+def test_spinning_driver_shot_agrees_coarsely() -> None:
+    """Different lift laws: expect the same plausible band, not tight parity.
+
+    The Rust kernel uses a quadratic-polynomial Cl (cl1=0.38) with 0.08 1/s
+    spin decay; Penner uses a capped power-law fit — the Rust carry is
+    systematically shorter for a spinning driver shot.
+    """
+    launch = LaunchConditions(
+        ball_speed=74.0, launch_angle=math.radians(12.0), spin_rate=2600.0
+    )
+    rust = simulate_trajectory_rust(launch, max_time=20.0, dt=0.005)
+    python = WaterlooPennerModel().simulate(launch, max_time=20.0, dt=0.005)
+
+    assert 150.0 <= rust.carry_distance <= 320.0
+    assert 150.0 <= python.carry_distance <= 320.0
+    assert rust.carry_distance < python.carry_distance  # weaker lift law
+    # Backspin lifts both above the no-spin trajectory of the same launch.
+    no_spin = LaunchConditions(
+        ball_speed=74.0, launch_angle=math.radians(12.0), spin_rate=0.0
+    )
+    assert rust.max_height > simulate_trajectory_rust(no_spin).max_height
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_rust_result_is_flight_frame() -> None:
+    """Facade output uses the flight frame: height on z, lateral on y."""
+    launch = LaunchConditions(
+        ball_speed=70.0, launch_angle=math.radians(12.0), spin_rate=0.0
+    )
+    result = simulate_trajectory_rust(launch)
+    pos = result.to_position_array()
+    assert pos[:, 2].max() > 1.0  # height accumulates on z (flight up)
+    assert abs(pos[-1, 1]) < 1e-6  # no lateral deviation without spin
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_rust_wrapper_validates_preconditions() -> None:
+    good = LaunchConditions(ball_speed=70.0, launch_angle=0.2)
+    with pytest.raises(ValueError, match="max_time"):
+        simulate_trajectory_rust(good, max_time=0.0)
+    with pytest.raises(ValueError, match="dt"):
+        simulate_trajectory_rust(good, dt=-0.01)
+    zero_speed = LaunchConditions(ball_speed=0.0, launch_angle=0.2)
+    with pytest.raises(ValueError, match="ball_speed"):
+        simulate_trajectory_rust(zero_speed)

--- a/src/shared/python/swing_sim/flight/tests/test_pipeline.py
+++ b/src/shared/python/swing_sim/flight/tests/test_pipeline.py
@@ -1,0 +1,74 @@
+"""Pipeline-seam tests: DI protocol conformance and convenience simulate."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+
+import pytest
+
+from shared.python.swing_sim.flight import (
+    FlightModelRegistry,
+    FlightResult,
+    FlightSimulatorProtocol,
+    LaunchConditions,
+    TrajectoryPoint,
+    WaterlooPennerModel,
+    simulate,
+)
+
+LAUNCH = LaunchConditions(
+    ball_speed=74.0, launch_angle=math.radians(12.0), spin_rate=2600.0
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Iterator[None]:
+    """Prevent cross-test pollution of the class-level model dict."""
+    FlightModelRegistry.reset()
+    yield
+    FlightModelRegistry.reset()
+
+
+@pytest.mark.contract
+def test_every_registry_model_satisfies_protocol() -> None:
+    for model in FlightModelRegistry.get_all_models():
+        assert isinstance(model, FlightSimulatorProtocol)
+
+
+@pytest.mark.contract
+def test_mock_simulator_satisfies_protocol() -> None:
+    class _Mock:
+        def simulate(
+            self,
+            launch: LaunchConditions,
+            max_time: float = 10.0,
+            dt: float = 0.01,
+        ) -> FlightResult:
+            point = TrajectoryPoint(0.0, [0.0, 0.0, 0.0], [1.0, 0.0, 0.0])
+            return FlightResult((point,), "mock")
+
+    assert isinstance(_Mock(), FlightSimulatorProtocol)
+
+
+@pytest.mark.unit
+def test_simulate_default_model_is_waterloo_penner() -> None:
+    result = simulate(LAUNCH)
+    reference = WaterlooPennerModel().simulate(LAUNCH)
+    assert result.model_name == "Waterloo/Penner"
+    assert result.carry_distance == pytest.approx(reference.carry_distance)
+
+
+@pytest.mark.unit
+def test_simulate_selects_model_by_name() -> None:
+    result = simulate(LAUNCH, model_name="macdonald_hanzely")
+    assert result.model_name == "MacDonald-Hanzely"
+    assert result.carry_distance > 0.0
+
+
+@pytest.mark.unit
+def test_simulate_rejects_unknown_model_and_missing_launch() -> None:
+    with pytest.raises(ValueError, match="unknown flight model"):
+        simulate(LAUNCH, model_name="not_a_model")
+    with pytest.raises(ValueError, match="launch"):
+        simulate(None)  # type: ignore[arg-type]

--- a/src/shared/python/swing_sim/flight/tests/test_registry.py
+++ b/src/shared/python/swing_sim/flight/tests/test_registry.py
@@ -1,0 +1,76 @@
+"""Registry completeness: all 7 literature models with citation metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from shared.python.swing_sim.flight import (
+    BallFlightModel,
+    FlightModelRegistry,
+    FlightModelType,
+    MacDonaldHanzelyModel,
+    WaterlooPennerModel,
+)
+
+EXPECTED_MODELS = {
+    FlightModelType.WATERLOO_PENNER: "Penner (2003); McPhee et al. (Waterloo)",
+    FlightModelType.MACDONALD_HANZELY: "MacDonald & Hanzely (1991)",
+    FlightModelType.NATHAN: "Nathan et al. (2018)",
+    FlightModelType.BALLANTYNE: "Ballantyne et al. (2012)",
+    FlightModelType.JCOLE: "Cole (2016)",
+    FlightModelType.ROSPIE_DL: "Rospie & Layton (2014)",
+    FlightModelType.CHARRY_L3: "Charry et al. (2017)",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Iterator[None]:
+    """Prevent cross-test pollution of the class-level model dict."""
+    FlightModelRegistry.reset()
+    yield
+    FlightModelRegistry.reset()
+
+
+@pytest.mark.unit
+def test_registry_has_all_seven_models() -> None:
+    models = FlightModelRegistry.get_all_models()
+    assert len(models) == 7
+    assert len(FlightModelType) == 7
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("model_type", list(FlightModelType))
+def test_every_model_resolves_with_metadata(model_type: FlightModelType) -> None:
+    model = FlightModelRegistry.get_model(model_type)
+    assert isinstance(model, BallFlightModel)
+    assert model.name
+    assert model.description
+    assert model.reference == EXPECTED_MODELS[model_type]
+
+
+@pytest.mark.unit
+def test_named_models_use_dedicated_classes() -> None:
+    assert isinstance(
+        FlightModelRegistry.get_model(FlightModelType.WATERLOO_PENNER),
+        WaterlooPennerModel,
+    )
+    assert isinstance(
+        FlightModelRegistry.get_model(FlightModelType.MACDONALD_HANZELY),
+        MacDonaldHanzelyModel,
+    )
+
+
+@pytest.mark.unit
+def test_get_model_requires_model_type() -> None:
+    with pytest.raises(ValueError, match="model_type"):
+        FlightModelRegistry.get_model(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_reset_forces_reinitialization() -> None:
+    first = FlightModelRegistry.get_model(FlightModelType.NATHAN)
+    FlightModelRegistry.reset()
+    second = FlightModelRegistry.get_model(FlightModelType.NATHAN)
+    assert first is not second

--- a/src/shared/python/swing_sim/flight/types.py
+++ b/src/shared/python/swing_sim/flight/types.py
@@ -1,0 +1,258 @@
+"""Ball-flight value types (DbC-validated dataclasses).
+
+Ported from UpstreamDrift ``src/shared/python/physics/flight_models.py``
+(``UnifiedLaunchConditions``, ``TrajectoryPoint``, ``FlightResult``) for
+epic #4103 / flight port #4107, rewritten self-contained.
+
+Frame convention (UpstreamDrift flight frame): x forward, y left, z up.
+Use :mod:`shared.python.swing_sim.flight.frames` to convert to the app
+frame (x target, y up, z right).
+
+Units: SI throughout; angular fields are radians; ``spin_rate`` is RPM.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from ._constants import (
+    AIR_DENSITY_SEA_LEVEL_KG_M3,
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+    GRAVITY_M_S2,
+    MIN_SPEED_THRESHOLD_M_S,
+    MPH_TO_MPS,
+    RPM_TO_RAD_S,
+)
+
+DEFAULT_BACKSPIN_AXIS = (0.0, -1.0, 0.0)
+"""Pure-backspin unit axis in the flight frame (x fwd / y left / z up)."""
+
+
+@dataclass(frozen=True)
+class LaunchConditions:
+    """Launch conditions with explicit units.
+
+    ``ball_speed`` is m/s; angular fields are radians; ``spin_rate`` is RPM;
+    ``wind_speed`` is m/s; mass, radius, density, and gravity are SI units.
+
+    ``spin_axis`` (optional) is a unit 3-vector in the flight frame. When
+    provided it overrides the legacy ``spin_axis_angle`` decomposition in
+    :meth:`get_spin_vector`, so post-impact spin vectors derived by
+    :func:`shared.python.swing_sim.flight.launch.derive_launch_conditions`
+    round-trip exactly.
+    """
+
+    ball_speed: float
+    launch_angle: float
+    azimuth_angle: float = 0.0
+    spin_rate: float = 2500.0
+    spin_axis_angle: float = 0.0
+    spin_axis: tuple[float, float, float] | None = None
+    ball_mass: float = GOLF_BALL_MASS_KG
+    ball_radius: float = GOLF_BALL_RADIUS_M
+    air_density: float = AIR_DENSITY_SEA_LEVEL_KG_M3
+    gravity: float = GRAVITY_M_S2
+    wind_speed: float = 0.0
+    wind_direction: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate finiteness, signs, and angle ranges (DbC preconditions)."""
+        scalars = {
+            "ball_speed": self.ball_speed,
+            "launch_angle": self.launch_angle,
+            "azimuth_angle": self.azimuth_angle,
+            "spin_rate": self.spin_rate,
+            "spin_axis_angle": self.spin_axis_angle,
+            "ball_mass": self.ball_mass,
+            "ball_radius": self.ball_radius,
+            "air_density": self.air_density,
+            "gravity": self.gravity,
+            "wind_speed": self.wind_speed,
+            "wind_direction": self.wind_direction,
+        }
+        for name, value in scalars.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite; got {value!r}")
+        if self.ball_speed < 0.0:
+            raise ValueError(f"ball_speed must be >= 0; got {self.ball_speed!r}")
+        if self.spin_rate < 0.0:
+            raise ValueError(f"spin_rate must be RPM and >= 0; got {self.spin_rate!r}")
+        for name in ("ball_mass", "ball_radius", "air_density", "gravity"):
+            if scalars[name] <= 0.0:
+                raise ValueError(f"{name} must be > 0; got {scalars[name]!r}")
+        if not abs(self.launch_angle) <= math.pi / 2.0:
+            raise ValueError(
+                "launch_angle is radians and must be within [-pi/2, pi/2] — "
+                "did you pass degrees? Use from_imperial()."
+            )
+        if self.spin_axis is not None:
+            axis = np.asarray(self.spin_axis, dtype=float)
+            if axis.shape != (3,) or not np.all(np.isfinite(axis)):
+                raise ValueError(f"spin_axis must be a finite 3-vector; got {axis!r}")
+            norm = float(np.linalg.norm(axis))
+            if abs(norm - 1.0) > 1e-6:
+                raise ValueError(f"spin_axis must be a unit vector; |axis|={norm!r}")
+            object.__setattr__(
+                self, "spin_axis", (float(axis[0]), float(axis[1]), float(axis[2]))
+            )
+
+    @classmethod
+    def from_imperial(
+        cls,
+        ball_speed_mph: float,
+        launch_angle_deg: float,
+        spin_rate_rpm: float,
+        azimuth_angle_deg: float = 0.0,
+        spin_axis_angle_deg: float = 0.0,
+        wind_speed_mph: float = 0.0,
+        wind_direction_deg: float = 0.0,
+    ) -> LaunchConditions:
+        """Create launch conditions from imperial units."""
+        if ball_speed_mph is None:
+            raise ValueError("ball_speed_mph must be provided")
+        return cls(
+            ball_speed=ball_speed_mph * MPH_TO_MPS,
+            launch_angle=math.radians(launch_angle_deg),
+            azimuth_angle=math.radians(azimuth_angle_deg),
+            spin_rate=spin_rate_rpm,
+            spin_axis_angle=math.radians(spin_axis_angle_deg),
+            wind_speed=wind_speed_mph * MPH_TO_MPS,
+            wind_direction=math.radians(wind_direction_deg),
+        )
+
+    def get_initial_velocity(self) -> np.ndarray:
+        """Compute the 3D initial velocity vector from launch angles and speed."""
+        ca, sa = math.cos(self.azimuth_angle), math.sin(self.azimuth_angle)
+        cv, sv = math.cos(self.launch_angle), math.sin(self.launch_angle)
+        return np.array(
+            [self.ball_speed * cv * ca, self.ball_speed * cv * sa, self.ball_speed * sv]
+        )
+
+    def get_spin_vector(self) -> np.ndarray:
+        """Compute the 3D spin vector [rad/s] in the flight frame.
+
+        When ``spin_axis`` is set, returns ``omega * spin_axis``; otherwise
+        uses the legacy backspin/sidespin decomposition from
+        ``spin_axis_angle`` (UpstreamDrift behaviour).
+        """
+        omega = self.spin_rate * RPM_TO_RAD_S
+        if self.spin_axis is not None:
+            return omega * np.asarray(self.spin_axis, dtype=float)
+        backspin = omega * math.cos(self.spin_axis_angle)
+        sidespin = omega * math.sin(self.spin_axis_angle)
+        return np.array(
+            [
+                sidespin * math.sin(self.azimuth_angle),
+                -backspin,
+                sidespin * math.cos(self.azimuth_angle),
+            ]
+        )
+
+    def get_wind_vector(self) -> np.ndarray:
+        """Compute the 3D wind velocity vector from speed and direction."""
+        return np.array(
+            [
+                -self.wind_speed * math.cos(self.wind_direction),
+                -self.wind_speed * math.sin(self.wind_direction),
+                0.0,
+            ]
+        )
+
+
+@dataclass(frozen=True)
+class TrajectoryPoint:
+    """Single point in a flight trajectory (flight frame, SI units)."""
+
+    time: float
+    position: np.ndarray = field(repr=False)
+    velocity: np.ndarray = field(repr=False)
+
+    def __post_init__(self) -> None:
+        """Coerce vectors to float arrays and validate shapes/finiteness."""
+        if not math.isfinite(self.time) or self.time < 0.0:
+            raise ValueError(f"time must be finite and >= 0; got {self.time!r}")
+        position = np.asarray(self.position, dtype=float)
+        velocity = np.asarray(self.velocity, dtype=float)
+        for name, vec in (("position", position), ("velocity", velocity)):
+            if vec.shape != (3,):
+                raise ValueError(f"{name} must be shape (3,); got {vec.shape}")
+            if not np.all(np.isfinite(vec)):
+                raise ValueError(f"{name} must be finite; got {vec!r}")
+        object.__setattr__(self, "position", position)
+        object.__setattr__(self, "velocity", velocity)
+
+
+@dataclass(frozen=True)
+class FlightResult:
+    """Result of a ball-flight simulation.
+
+    ``trajectory`` is time-ordered; scalar metrics are derived from it
+    (carry [m], max height [m], flight time [s], landing angle [deg,
+    positive downward], lateral deviation [m, +left in the flight frame]).
+    """
+
+    trajectory: tuple[TrajectoryPoint, ...]
+    model_name: str
+    carry_distance: float = 0.0
+    max_height: float = 0.0
+    flight_time: float = 0.0
+    landing_angle: float = 0.0
+    lateral_deviation: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Normalise the trajectory container to a tuple."""
+        object.__setattr__(self, "trajectory", tuple(self.trajectory))
+
+    def to_position_array(self) -> np.ndarray:
+        """Convert trajectory to an Nx3 position array."""
+        if not self.trajectory:
+            return np.zeros((0, 3))
+        return np.array([p.position for p in self.trajectory])
+
+
+def compute_flight_metrics(
+    trajectory: list[TrajectoryPoint] | tuple[TrajectoryPoint, ...],
+    model_name: str,
+) -> FlightResult:
+    """Standardised metrics computation shared by all backends.
+
+    Ported from ``BallFlightModel._compute_metrics`` in UpstreamDrift's
+    ``flight_models.py`` (consolidated for DRY there; module-level here so
+    the Rust facade reuses it).
+    """
+    if trajectory is None:
+        raise ValueError("trajectory must be provided")
+    points = tuple(trajectory)
+    if not points:
+        return FlightResult((), model_name)
+
+    pos = np.array([p.position for p in points])
+    carry = math.hypot(float(pos[-1, 0]), float(pos[-1, 1]))
+    max_h = float(np.max(pos[:, 2]))
+    time = points[-1].time
+    lateral = float(pos[-1, 1])
+
+    angle = 0.0
+    if len(points) >= 2:
+        v = points[-1].velocity
+        v_horiz = math.hypot(float(v[0]), float(v[1]))
+        angle = (
+            math.degrees(math.atan2(-float(v[2]), v_horiz))
+            if v_horiz > MIN_SPEED_THRESHOLD_M_S
+            else 90.0
+        )
+
+    return FlightResult(points, model_name, carry, max_h, time, angle, lateral)
+
+
+__all__ = [
+    "DEFAULT_BACKSPIN_AXIS",
+    "FlightResult",
+    "LaunchConditions",
+    "TrajectoryPoint",
+    "compute_flight_metrics",
+]


### PR DESCRIPTION
Implements the ball-flight wave of epic #4103 (recon/architecture: #4104; flight port: #4107). Stacked on #4113 (`feat/swing-sim-foundation`) — merge that first.

## What

New self-facaded subpackage `src/shared/python/swing_sim/flight/` (parent `swing_sim/__init__.py` untouched):

- **Literature models** — port of UpstreamDrift `physics/flight_models.py`: `FlightModelRegistry` with all 7 models (Waterloo/Penner quadratic-Cd + power-law-Cl, MacDonald-Hanzely exponential spin decay, and the 5 constant-coefficient presets with their `ConstantCoefficientSpec` name/description/reference citation metadata preserved), scipy `solve_ivp` RK45 with a terminal ground event, `FlightResult` (trajectory, carry, max height, flight time, landing angle, lateral deviation). Constants vendored with citations into `flight/_constants.py` (flight-private to avoid conflicts with the parallel impact wave, #4106).
- **Launch deriver** — public `derive_launch_conditions()` (port of `_LaunchConditionsDeriver` from UD's `swing_ball_flight_pipeline.py`): post-impact ball velocity/spin vectors → speed, launch angle, azimuth, spin RPM, unit spin axis. A new optional `LaunchConditions.spin_axis` makes the derivation round-trip exactly through `get_initial_velocity()`/`get_spin_vector()`.
- **Rust fast path** — `flight/_rust_facade.py` (graceful dual path, aerodynamics-facade posture — scipy is a fully supported fallback): `is_rust_available()` + `simulate_trajectory_rust()` over the canonical `rust_core/tools-core/src/ball_flight.rs` RK4 kernel. tools-core now exposes `simulate_trajectory`/`analyze_trajectory` pyfunctions (raising `ValueError` instead of panicking on bad input), ball/environment property setters, spin-axis/wind setters, and trajectory velocity getters; the wheel previously shipped only the classes, so there was nothing to call from Python. Facade gates on the new function and reports unavailable on older wheels.
- **Frame adapters** — `to_flight_frame`/`from_flight_frame` between the app frame (x target, y up, z right — also the Rust kernel's native frame) and the UD flight frame (x forward, y left, z up), with round-trip and handedness tests.
- **Pipeline seam** — `flight/pipeline.py`: runtime-checkable `FlightSimulatorProtocol` (every registry model satisfies it) + `simulate(launch, model_name="waterloo_penner")` convenience mirroring UD's DI design so impact output plugs straight in later.

## Tests (unit / physics / parity / contract)

Registry completeness (7 models with pinned references), ballistic sanity (no-spin low-speed ≈ vacuum projectile within drag margin), carry monotonicity vs ball speed, ground-event termination, backspin lift, deriver round-trips, frame-adapter round-trips, cross-model carry band (all 7 within 150–320 m for a standard driver launch), Rust↔Python parity (tight for zero-spin drag where the coefficient laws match; banded for spinning shots whose lift laws differ; clean skip without the wheel), and a contract pin of the public API surface.

## Gates

- pytest (flight package + whole swing_sim tree): 93 passed, parity non-skipped locally against a rebuilt wheel
- ruff check + format: clean
- mypy: clean
- file-size budget (≤500 LOC): clean (largest new file `models.py` at 391)
- cargo check / fmt / test on tools-core: clean (111 unit tests pass; pre-existing clippy findings in scada/signal/electrode_advisor under local clippy 1.94 are untouched)

## SPEC

Dated subsection + changelog row (1.6.0).

Refs #4103, #4104, #4107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)