### PR TITLE
feat(rate_of_closure): simulation session — swing sources, impact scrubber, flight, screw axis, playback, export (#4105 #4107 #4108 #4110)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -915,11 +915,11 @@ jobs:
             if [ -z "$BASE_SHA" ]; then
               BASE_SHA="${{ github.event.pull_request.base.sha }}"
             fi
-            RUST_FILES=$(git diff --name-only "$BASE_SHA" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || true)
+            RUST_FILES=$(git diff --name-only "$BASE_SHA" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' 'src/shared/python/swing_sim/**' || true)
           elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-            RUST_FILES=$(git diff --name-only "${{ github.event.before }}" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || true)
+            RUST_FILES=$(git diff --name-only "${{ github.event.before }}" HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' 'src/shared/python/swing_sim/**' || true)
           else
-            RUST_FILES=$(git diff --name-only HEAD~1 HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' || echo "")
+            RUST_FILES=$(git diff --name-only HEAD~1 HEAD -- '*.rs' 'Cargo.toml' '*/Cargo.toml' 'rust-toolchain.toml' 'src/shared/python/swing_sim/**' || echo "")
           fi
 
           if [ -n "$RUST_FILES" ]; then
@@ -1029,13 +1029,24 @@ jobs:
           echo "wasm-pack build completed"
           ls pkg/
 
+      - name: Build WASM Module — swing-core (wasm-pack)
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: |
+          cd rust_core/swing-core
+          wasm-pack build --target web --features wasm --no-default-features
+          echo "wasm-pack build (swing-core) completed"
+          ls pkg/
+
       - name: Verify WASM Module
         if: steps.rust-changes.outputs.has_changes == 'true'
         run: |
-          # Verify the WASM package was produced with expected files
+          # Verify the WASM packages were produced with expected files
           test -f rust_core/tools-core/pkg/tools_core_bg.wasm && echo "✅ WASM binary exists"
           test -f rust_core/tools-core/pkg/package.json && echo "✅ package.json exists"
           test -f rust_core/tools-core/pkg/tools_core.js && echo "✅ JS glue exists"
+          test -f rust_core/swing-core/pkg/swing_core_bg.wasm && echo "✅ swing-core WASM binary exists"
+          test -f rust_core/swing-core/pkg/package.json && echo "✅ swing-core package.json exists"
+          test -f rust_core/swing-core/pkg/swing_core.js && echo "✅ swing-core JS glue exists"
 
       - name: Run Benchmarks (Criterion)
         if: steps.rust-changes.outputs.has_changes == 'true'

--- a/.github/workflows/maturin-swing-core.yml
+++ b/.github/workflows/maturin-swing-core.yml
@@ -1,0 +1,116 @@
+# Maturin CI — swing_core Python extension
+#
+# Builds the `swing-core` Rust crate (shared swing simulation kernel:
+# double-pendulum swing dynamics on an oriented swing plane, epic #4103 /
+# P0 #4104) as a maturin wheel and asserts the extension imports so
+# `from swing_core import swing` in
+# src/shared/python/swing_sim/_rust_facade.py resolves to the native backend
+# instead of raising.
+#
+# Unlike pendulum-core, swing-core IS a root Cargo workspace member, so
+# rustfmt/clippy/cargo-test coverage comes from ci-standard.yml's
+# rust-quality-gate. This workflow adds what the workspace gate cannot:
+# a per-Python-version wheel build, an import assertion, and the
+# Rust<->Python parity suite run non-skipped (it is `importorskip
+# swing_core` and so is silently skipped wherever the wheel is absent).
+#
+# Runner platforms: the d-sorg-fleet self-hosted pool spans linux, windows,
+# and macos hosts. Python versions 3.10, 3.11, and 3.12 are hard-gated here;
+# Python 3.13 coverage is deferred until all fleet runners have a 3.13
+# toolcache (same policy as maturin-pendulum-core.yml).
+
+name: Maturin — swing_core
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rust_core/swing-core/**"
+      - "src/shared/python/swing_sim/**"
+      - "rust_core/math-primitives/**"
+      - ".github/workflows/maturin-swing-core.yml"
+  pull_request:
+    paths:
+      - "rust_core/swing-core/**"
+      - "src/shared/python/swing_sim/**"
+      - "rust_core/math-primitives/**"
+      - ".github/workflows/maturin-swing-core.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: maturin-swing-core-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  parity-gate:
+    name: swing_core build + parity gate (Python ${{ matrix.python-version }})
+    runs-on: d-sorg-fleet
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install build + test deps
+        run: python -m pip install --upgrade pip maturin "numpy>=1.24" pytest
+
+      - name: Build swing_core wheel
+        run: python -m maturin build --release -m rust_core/swing-core/Cargo.toml --out dist
+
+      - name: Install the built wheel
+        shell: bash
+        run: |
+          WHEEL=$(ls dist/*.whl | head -1)
+          python -m pip install "$WHEEL"
+
+      - name: Assert the extension imports (hard fail — no silent fallback)
+        shell: bash
+        run: |
+          python - <<'PY'
+          # Runtime PyO3 submodule: attribute access, never `import swing_core.swing`.
+          from swing_core import swing
+          required = {
+              "PendulumParameters", "PendulumState",
+              "plane_rotation", "in_plane_gravity",
+              "mass_matrix", "step", "simulate", "total_energy",
+          }
+          missing = required - set(dir(swing))
+          assert not missing, f"swing_core.swing missing exports: {missing}"
+          print("swing_core OK:", sorted(required))
+          PY
+
+      - name: Assert the strict facade selects the Rust backend (gate)
+        shell: bash
+        env:
+          PYTHONPATH: src
+        run: |
+          python - <<'PY'
+          from shared.python.swing_sim import _rust_facade
+          assert _rust_facade.rust_available(), (
+              "swing_sim._rust_facade did not load the swing_core wheel"
+          )
+          print("swing_core backend gate OK: native loaded")
+          PY
+
+      - name: Run Rust<->Python parity suite (gate, non-skipped)
+        env:
+          PYTHONPATH: src
+        run: |
+          python -m pytest \
+            src/shared/python/swing_sim/tests/test_parity_rust.py \
+            -o addopts="" -p no:cacheprovider -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "rust_core/ai_backend",
     "rust_core/file_watcher",
     "rust_core/data-processor-core",
+    "rust_core/swing-core",
 ]
 # `src/pendulum_simulator/pendulum-core` is intentionally NOT a workspace member
 # (issue #3294). It is a PyO3 extension crate whose native dynamics are built

--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,43 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Swing simulation ball-flight package (epic #4103, #4107)
+
+- New self-facaded subpackage `src/shared/python/swing_sim/flight/` porting
+  UpstreamDrift's pure-Python flight stack (`physics/flight_models.py`):
+  `FlightModelRegistry` with all 7 literature models (Waterloo/Penner
+  quadratic-Cd + power-law-Cl, MacDonald-Hanzely spin decay, and the five
+  constant-coefficient presets — Nathan, Ballantyne, J. Cole, Rospie DL,
+  Charry L3 — keeping their `ConstantCoefficientSpec`
+  name/description/reference citation metadata), scipy `solve_ivp` RK45
+  integration with a terminal ground event, and `FlightResult` metrics
+  (carry, max height, flight time, landing angle, lateral deviation).
+  Constants are vendored with citations into `flight/_constants.py`.
+- Public launch deriver `derive_launch_conditions` (port of the pipeline
+  `_LaunchConditionsDeriver` in UpstreamDrift's
+  `swing_ball_flight_pipeline.py`): post-impact ball velocity/spin vectors
+  → speed, launch angle, azimuth, spin rate [RPM], unit spin axis; the
+  optional `LaunchConditions.spin_axis` override makes the derivation
+  round-trip exactly through `get_initial_velocity`/`get_spin_vector`.
+- Frame adapters `to_flight_frame`/`from_flight_frame` between the app
+  frame (x target, y up, z right) and the UpstreamDrift flight frame
+  (x forward, y left, z up), tested for round-trip and handedness.
+- Graceful Rust fast path (`flight/_rust_facade.py`, aerodynamics-facade
+  posture — scipy is a fully supported fallback, unlike the strict swing
+  facade): `is_rust_available()` + `simulate_trajectory_rust()` over the
+  canonical `rust_core/tools-core/src/ball_flight.rs` RK4 kernel, which now
+  exposes `simulate_trajectory`/`analyze_trajectory` pyfunctions plus
+  property setters (ball/environment scalars, spin axis, wind) and
+  trajectory velocity getters; results are converted into the flight frame.
+  Parity tests compare Rust vs the Python Penner model (tight for zero-spin
+  drag, banded for spinning shots whose lift laws differ) and skip cleanly
+  when the wheel is absent or predates the new bindings.
+- Pipeline seam `flight/pipeline.py`: runtime-checkable
+  `FlightSimulatorProtocol` (satisfied by every registry model) and a
+  `simulate(launch, model_name="waterloo_penner")` convenience mirroring
+  UpstreamDrift's DI design so the impact stage (#4106) plugs in directly.
+  The parent `swing_sim` facade is unchanged.
+
 ### 2026-08-04 Swing simulation foundation (epic #4103, P0 #4104)
 
 - New Rust workspace member `rust_core/swing-core` (Python wheel `swing_core`
@@ -1743,6 +1780,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.6.0 | feat(swing_sim, #4107): add the ball-flight package `src/shared/python/swing_sim/flight/` — 7 literature flight models (Waterloo/Penner, MacDonald-Hanzely, and five cited constant-coefficient presets) behind `FlightModelRegistry` with scipy RK45 + terminal ground event; public `derive_launch_conditions` (post-impact velocity/spin → launch conditions with exact round-trip); app↔flight frame adapters; graceful Rust fast path over `tools-core`'s canonical `ball_flight.rs` kernel (new `simulate_trajectory`/`analyze_trajectory` pyfunctions, property setters, velocity getters) with parity tests; `FlightSimulatorProtocol` + `simulate()` pipeline seam for the impact stage. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4104): add the swing simulation foundation — new `rust_core/swing-core` workspace crate (double-pendulum EOM with plane-oriented in-plane gravity, PyO3 wheel `swing_core` + wasm-bindgen bindings) and shared `src/shared/python/swing_sim` package (DbC value types, `SwingSource` protocol, `DoublePendulumSwing`, strict Rust façade with pure-Python parity oracle); wire swing-core into the rust quality gate's wasm build and add the `maturin-swing-core.yml` build/import/parity workflow. |
 | 2026-07-26 | 1.5.3 | fix(test): create the standalone-wheel smoke environment from the real base interpreter rather than nesting it under the active CI virtualenv, keeping installed-artifact validation portable across relocated self-hosted Python 3.10 runtimes. |
 | 2026-07-26 | 1.5.3 | fix(ci): isolate both protected Python jobs in per-job virtual environments after validating the persistent setup-python runtime; repair and import-probe the matrix NumPy/SciPy stack with compatible bounds, and reinstall OpenCV without dependency resolution so it cannot replace the verified NumPy wheel. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,57 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Rate of Closure Simulation Session (epic #4103 — #4105 #4107 #4108 #4110)
+
+- `src/rate_of_closure/simulation/` integrates the swing_sim packages
+  into the app: app-frame swing sources (`sources.py` — a manual
+  constant-twist source wrapping the explorer's `ImpactScenario`, the
+  shared `DoublePendulumSwing` behind an `AppFrameSwing` frame adapter,
+  and a NEW planar triple pendulum with an absolute-angle n-link EOM,
+  RK4, energy-conservation-tested); `session.py` orchestrating swing →
+  delivery → `swing_sim.impact` rigid-body solve with gear effect (the
+  club package's `face_normal_at_offset` bulge/roll callable wired in)
+  → `swing_sim.flight` launch derivation + literature flight model,
+  producing one exportable `SimulationRun` (time-stamped swing samples
+  with SE(3) poses + twists, impact instant + delivery diagnostics,
+  launch summary, flight trajectory). The impact-time scrubber keeps
+  the ball at a FIXED world position and translates the swing so the
+  clubhead at τ meets it, with delivery numbers updating live;
+  `isa.py` is the single thin adapter over
+  `rotation_converter.screw_visualization.extract_screw_axes_from_trajectory`
+  (DeprecationWarning confined, per-step θ divided by dt into deg/s,
+  R_ISA from the midpoint-to-axis distance); `export.py` writes the
+  phase-tagged CSV time series and a JSON summary/params document.
+- The PyQt6 app grows a Simulation tab: source/plane-tilt/club/flight
+  pickers (sourced hover guidance on every new input), scrub slider
+  with auto (max-clubhead-speed) reset, launch result rows
+  (ball speed, launch angle/azimuth, spin, carry, apex, flight time,
+  landing angle) with click-through explanations added to
+  `derivation.LAUNCH_EXPLANATIONS`, a 3D scene (ball and ground behind
+  independent checkboxes, flight trajectory polyline, toggleable
+  screw-axis overlay annotated with rate/pitch/R_ISA) with full video
+  playback — play/pause, whole-timeline scrub, frame step ±, loop, and
+  rate presets (0.1×/0.25×/0.5×/1× real-time/2×) — plus a sortable
+  run-data inspector with CSV/JSON export. Scene colors come from the
+  shared theme palette (`get_chart_color`) only. The clickable result
+  row is extracted to `ui/pyqt6/result_row.py` and shared with the
+  main window.
+- Web parity (practical degree): `web/src/model/simulation.ts` +
+  `flight.ts` port the minimal physics (double-pendulum RK4 from
+  `reference.py`, scalar-MOI rigid-body impact with the 2/7 friction
+  cap, launch derivation, Waterloo/Penner flight on fixed-step RK4)
+  with vitest parity pins against the pytest numbers (tight for the
+  formula-for-formula ports, banded for RK45-vs-RK4 flight); a
+  Simulation tab hosts source/tilt inputs, the τ scrubber, ball/ground
+  toggles, a canvas scene with the trajectory polyline, video playback
+  with the same rate presets, and JSON export as a download. The WASM
+  kernels replace the hand port in P7, which also brings gear effect,
+  the triple pendulum, and the screw-axis overlay to the web (noted in
+  code). Tests: `tests/rate_of_closure/test_simulation.py` (sources,
+  session bands, scrubber coincidence, ISA vs `twist_to_screw`, export
+  round-trips) and `test_simulation_gui.py` (tab smoke, playback,
+  toggles, guidance, inspector).
+
 ### 2026-08-04 Rate of Closure Club Library, Inertial Model & Parametric Head (P2, #4106)
 
 - `src/rate_of_closure/club/` adds the club-modeling package: a frozen
@@ -1900,6 +1951,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 | Date | Version | Changes |
 | ---- | ------- | ------- |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4107): add the ball-flight package `src/shared/python/swing_sim/flight/` — 7 literature flight models (Waterloo/Penner, MacDonald-Hanzely, and five cited constant-coefficient presets) behind `FlightModelRegistry` with scipy RK45 + terminal ground event; public `derive_launch_conditions` (post-impact velocity/spin → launch conditions with exact round-trip); app↔flight frame adapters; graceful Rust fast path over `tools-core`'s canonical `ball_flight.rs` kernel (new `simulate_trajectory`/`analyze_trajectory` pyfunctions, property setters, velocity getters) with parity tests; `FlightSimulatorProtocol` + `simulate()` pipeline seam for the impact stage. |
+| 2026-08-04 | 1.8.0 | feat(rate_of_closure, epic #4103): simulation session integrating swing_sim into the app — app-frame swing sources (manual constant twist, shared double pendulum, new triple pendulum), swing → impact (gear effect + bulge/roll callable) → flight orchestration into one exportable SimulationRun, fixed-ball impact-time scrubber, thin ISA adapter over the rotation converter with a toggleable screw-axis overlay, PyQt6 Simulation tab (sourced-guidance inputs, launch rows with explanations, ball/ground toggles, flight polyline, full video playback with 1×-real-time rate presets, sortable inspector, CSV/JSON export) and a parity-pinned web Simulation tab (pendulum/impact/flight TS port, scrubber, playback, JSON download; WASM supersedes in P7). |
 | 2026-08-04 | 1.7.0 | feat(swing_sim, #4106): add the impact physics subpackage `src/shared/python/swing_sim/impact/` — rigid-body COR impulse model (2/7 rolling-cap friction spin) + spring-damper + finite-time models, energy-balance validator, and recorder ported self-contained from UpstreamDrift's `physics/impact_model` with three fixes (off-center base impulse no longer drops `impact_offset`; opt-in 3x3 club MOI tensor effective mass `1/m_eff = 1/m + (r x n)^T I^-1 (r x n)`; friction-spin axis sign corrected to `t x n`); new launch-monitor delivery front-end (`delivery.py`, AffineDrift frame, spin-loft + D-plane diagnostics) and physics-based gear effect (`gear_effect.py`, head recoil × CG-depth lever arm, bulge/roll via `face_normal_at_offset` callable seam) replacing the empirical three-constant version. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4104): add the swing simulation foundation — new `rust_core/swing-core` workspace crate (double-pendulum EOM with plane-oriented in-plane gravity, PyO3 wheel `swing_core` + wasm-bindgen bindings) and shared `src/shared/python/swing_sim` package (DbC value types, `SwingSource` protocol, `DoublePendulumSwing`, strict Rust façade with pure-Python parity oracle); wire swing-core into the rust quality gate's wasm build and add the `maturin-swing-core.yml` build/import/parity workflow. |
 | 2026-08-04 | 1.5.6 | feat(rate_of_closure): club library, inertial model, and parametric head with bulge & roll (P2, #4106) — frozen SI ClubSpec with DbC bounds, 15-club library normalized from typical published specs (UpstreamDrift club_configurations.py source), head+shaft+grip composite inertia (balance point, grip-axis and shaft-axis MOI), deterministic superellipse-loft parametric head whose face honors bulge/roll sagitta and loft tilt with mass-scaled envelope, face_normal_at_offset exposed for the future impact package in Python and TypeScript with pinned parity tests, PyQt6 Club group (picker drives GC-to-face/lie with overrides preserved; sourced tooltips) and web ClubPanel generating heads client-side into the existing mesh render paths. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,8 +26,8 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.6.0                                      |
-| **Spec Version**        | 1.6.0                                      |
+| **Current Version**     | 1.7.0                                      |
+| **Spec Version**        | 1.7.0                                      |
 | **Last Spec Update**    | 2026-08-04                                 |
 
 ## 2. Purpose & Mission
@@ -35,6 +35,44 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Swing impact package (epic #4103, #4106)
+
+- New self-façaded subpackage `src/shared/python/swing_sim/impact/`
+  (types/models/solver/utils split mirroring UpstreamDrift's
+  `physics/impact_model`, all constants vendored with citations into
+  `constants.py`): rigid-body COR impulse model with the 2/7 rolling-cap
+  friction spin derivation, spring-damper (Kelvin-Voigt) model,
+  finite-time model, energy-balance validator, and `ImpactRecorder` /
+  `ImpactSolverAPI`. The parent `swing_sim/__init__.py` façade is
+  deliberately untouched (epic integration wires it later).
+- Three defect fixes relative to the UpstreamDrift source: (a)
+  `solve_with_gear_effect` no longer drops `impact_offset` when computing
+  the base impulse — off-center hits now get the MOI effective-mass
+  reduction (regression test pins off-center ball speed < center); (b)
+  opt-in full 3-D inertia treatment via a 3x3 `clubhead_moi_tensor`
+  (`1/m_eff = 1/m + (r x n)^T I^-1 (r x n)`; a diagonal tensor matching
+  the scalar MOI reproduces the scalar path exactly); (c) friction-spin
+  axis sign corrected to `t x n` (the ported `n x t` spun lofted strikes
+  toward topspin and contradicted its own slip-reduction cap logic).
+- New `delivery.py` front-end: launch-monitor delivery numbers (club
+  path/face/attack/dynamic loft/lie deg, clubhead speed, toe/high offsets
+  in mm) → impact-model vectors in the AffineDrift frame (x target,
+  y up, z right; path + = in-to-out, face + = open), with spin-loft and
+  D-plane diagnostics (`spin_axis = unit(v x n)`, signed tilt; + = fade).
+- New physics-based `gear_effect.py` replacing the old three-empirical-
+  constants version: head rotation recoil `I^-1 (r x (-J n))` with the
+  CG-depth lever arm (`DRIVER_CG_DEPTH_M`), time-averaged tangential
+  face-surface sweep, and the same 2/7-capped friction impulse converting
+  it to ball spin. Bulge/roll enters through an app-agnostic
+  `face_normal_at_offset(toe_m, high_m)` callable seam (club package, PR
+  #4112). Signature tests: toe hit → draw-side spin, high hit → reduced
+  backspin, bulge partially offsetting toe-hit pull.
+- In-package tests (`unit` / `physics` / `regression` / `contract`
+  markers): hand-computed impulse pins, COR monotonicity, spin cap,
+  energy balance vs `1/2 mu v^2 (1-e^2)`, both bug-fix regressions,
+  delivery round-trips, gear-effect signatures, and a contract test
+  pinning the `swing_sim.impact` public API.
+
 ### 2026-08-04 Swing simulation foundation (epic #4103, P0 #4104)
 
 - New Rust workspace member `rust_core/swing-core` (Python wheel `swing_core`
@@ -1743,6 +1781,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.7.0 | feat(swing_sim, #4106): add the impact physics subpackage `src/shared/python/swing_sim/impact/` — rigid-body COR impulse model (2/7 rolling-cap friction spin) + spring-damper + finite-time models, energy-balance validator, and recorder ported self-contained from UpstreamDrift's `physics/impact_model` with three fixes (off-center base impulse no longer drops `impact_offset`; opt-in 3x3 club MOI tensor effective mass `1/m_eff = 1/m + (r x n)^T I^-1 (r x n)`; friction-spin axis sign corrected to `t x n`); new launch-monitor delivery front-end (`delivery.py`, AffineDrift frame, spin-loft + D-plane diagnostics) and physics-based gear effect (`gear_effect.py`, head recoil × CG-depth lever arm, bulge/roll via `face_normal_at_offset` callable seam) replacing the empirical three-constant version. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4104): add the swing simulation foundation — new `rust_core/swing-core` workspace crate (double-pendulum EOM with plane-oriented in-plane gravity, PyO3 wheel `swing_core` + wasm-bindgen bindings) and shared `src/shared/python/swing_sim` package (DbC value types, `SwingSource` protocol, `DoublePendulumSwing`, strict Rust façade with pure-Python parity oracle); wire swing-core into the rust quality gate's wasm build and add the `maturin-swing-core.yml` build/import/parity workflow. |
 | 2026-07-26 | 1.5.3 | fix(test): create the standalone-wheel smoke environment from the real base interpreter rather than nesting it under the active CI virtualenv, keeping installed-artifact validation portable across relocated self-hosted Python 3.10 runtimes. |
 | 2026-07-26 | 1.5.3 | fix(ci): isolate both protected Python jobs in per-job virtual environments after validating the persistent setup-python runtime; repair and import-probe the matrix NumPy/SciPy stack with compatible bounds, and reinstall OpenCV without dependency resolution so it cannot replace the verified NumPy wheel. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -26,15 +26,41 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.5.3                                      |
-| **Spec Version**        | 1.5.3                                      |
-| **Last Spec Update**    | 2026-07-26                                 |
+| **Current Version**     | 1.6.0                                      |
+| **Spec Version**        | 1.6.0                                      |
+| **Last Spec Update**    | 2026-08-04                                 |
 
 ## 2. Purpose & Mission
 
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Swing simulation foundation (epic #4103, P0 #4104)
+
+- New Rust workspace member `rust_core/swing-core` (Python wheel `swing_core`
+  via maturin, WASM NPM package via wasm-pack): double-pendulum swing
+  equations of motion ported from UpstreamDrift's `double_pendulum.py`
+  (mass matrix, Coriolis/centripetal, gravity, viscous damping, RK4),
+  generalised so gravity enters as an in-plane 2-vector computed from a
+  swing-plane pose built by three sequential intrinsic tilts (yaw about
+  world-up, side tilt about the rotated axis, forward/back tilt). Feature
+  contract (`python` / `extension-module` / `wasm`, cdylib+rlib, per-crate
+  maturin pyproject, dual `#[cfg_attr]` bindings split under `py_bindings/`
+  and `wasm_bindings/`) copies `tools-core` exactly.
+- New shared Python package `src/shared/python/swing_sim/`: frozen DbC
+  dataclasses (`PlaneOrientation`, `PendulumParameters`, `PendulumState`,
+  `SwingSample` with SE(3) pose + 6-twist, `SwingTrajectory`), the
+  `SwingSource` protocol with a `DoublePendulumSwing` implementation, a
+  strict Rust façade (`_rust_facade.py`, bilateral_rust posture: raise at
+  call time when the wheel is missing for hot loops) and a pure-Python
+  reference implementation used as the Rust parity oracle and one-shot
+  fallback. In-package tests carry `unit` / `parity` / `contract` markers.
+- CI: `ci-standard.yml` rust-quality-gate change filter also watches
+  `src/shared/python/swing_sim/**` and builds/verifies the swing-core WASM
+  package; new `maturin-swing-core.yml` per-crate workflow builds the wheel
+  on Python 3.10–3.12, asserts the extension imports, and runs the parity
+  suite non-skipped. NPM publishing is deferred to epic P7.
+
 ### 2026-07-26 P1AM Control System Trend Crosshair Optimization
 
 - `src/p1am_control_system/frontend/src/components/TrendPlotOverlays.tsx` and `PlotCrosshair.tsx` reduce
@@ -1717,6 +1743,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.6.0 | feat(swing_sim, #4104): add the swing simulation foundation — new `rust_core/swing-core` workspace crate (double-pendulum EOM with plane-oriented in-plane gravity, PyO3 wheel `swing_core` + wasm-bindgen bindings) and shared `src/shared/python/swing_sim` package (DbC value types, `SwingSource` protocol, `DoublePendulumSwing`, strict Rust façade with pure-Python parity oracle); wire swing-core into the rust quality gate's wasm build and add the `maturin-swing-core.yml` build/import/parity workflow. |
 | 2026-07-26 | 1.5.3 | fix(test): create the standalone-wheel smoke environment from the real base interpreter rather than nesting it under the active CI virtualenv, keeping installed-artifact validation portable across relocated self-hosted Python 3.10 runtimes. |
 | 2026-07-26 | 1.5.3 | fix(ci): isolate both protected Python jobs in per-job virtual environments after validating the persistent setup-python runtime; repair and import-probe the matrix NumPy/SciPy stack with compatible bounds, and reinstall OpenCV without dependency resolution so it cannot replace the verified NumPy wheel. |
 | 2026-07-26 | 1.5.3 | fix(import-aliases, #3936): make canonical shared-module aliases satisfy `runpy` code lookup so packaged compatibility commands such as `python -m sidekick` execute their parent-owned `shared.python` implementation; include `contracts` in the identity-coalescing alias set and keep Sidekick agent DbC imports on the canonical shared path. |

--- a/rust_core/swing-core/Cargo.toml
+++ b/rust_core/swing-core/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "swing-core"
+description = "Swing simulation kernel: double-pendulum swing dynamics on an oriented swing plane (Rust core for Python + WASM)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "swing_core"
+# cdylib is required for PyO3 shared library output
+# rlib is required for Rust-to-Rust dependencies and tests
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = []
+# Enable PyO3 bindings for cargo checks and local Rust tests.
+python = ["dep:pyo3", "dep:numpy", "math-primitives/python"]
+# Enable Python extension-module linkage only for maturin wheel builds.
+extension-module = ["pyo3/extension-module", "math-primitives/extension-module"]
+# Enable wasm-bindgen for WASM/NPM builds (wasm-pack)
+wasm = ["dep:wasm-bindgen", "math-primitives/wasm"]
+
+[dependencies]
+pyo3 = { workspace = true, optional = true }
+numpy = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+serde = { workspace = true }
+nalgebra = "0.33"
+math-primitives = { path = "../math-primitives" }
+
+[dev-dependencies]
+proptest = { workspace = true }
+serde_json = { workspace = true }

--- a/rust_core/swing-core/pyproject.toml
+++ b/rust_core/swing-core/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "swing-core"
+version = "0.1.0"
+description = "Rust-compiled swing simulation kernel: double-pendulum swing dynamics on an oriented swing plane"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.3",
+    "numpy>=1.24",
+]
+
+[tool.maturin]
+# Build with PyO3 bindings and extension-module linkage for wheel output.
+features = ["python", "extension-module"]
+# Module name matches the #[pymodule] name in lib.rs
+module-name = "swing_core"
+# Use the Cargo manifest relative to this pyproject.toml
+manifest-path = "Cargo.toml"

--- a/rust_core/swing-core/src/lib.rs
+++ b/rust_core/swing-core/src/lib.rs
@@ -1,0 +1,45 @@
+//! # swing-core — Swing Simulation Kernel
+//!
+//! Canonical Rust implementation of the swing simulation physics shared by the
+//! PyQt6 desktop app (via PyO3 wheel `swing_core`) and the web app (via
+//! wasm-pack NPM package). Single-source physics: Python and WASM consumers
+//! call these exact functions so the two UIs cannot drift.
+//!
+//! Phase 0 (issue #4104) walking skeleton:
+//! - `swing::pendulum` — driven double-pendulum equations of motion ported
+//!   from UpstreamDrift's `double_pendulum.py` (mass matrix, Coriolis,
+//!   gravity, damping, RK4).
+//! - `swing::plane` — swing-plane orientation (three sequential tilts) and
+//!   in-plane gravity projection; the EOM consumes the projected 2-vector.
+//!
+//! # Architecture
+//! - Core physics is plain Rust (no FFI types) in `swing/`.
+//! - Python-specific glue lives in `py_bindings/` (feature `python`).
+//! - WASM-specific glue lives in `wasm_bindings/` (feature `wasm`).
+
+pub mod swing;
+
+#[cfg(feature = "python")]
+pub mod py_bindings;
+
+#[cfg(feature = "wasm")]
+pub mod wasm_bindings;
+
+// Re-export primary types at the crate root for Rust consumers.
+pub use swing::pendulum::{PendulumParameters, PendulumState};
+
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
+
+/// Python module `swing_core`.
+///
+/// Registers submodules only; all classes/functions hang off runtime PyO3
+/// submodules (e.g. `swing`). Note for Python consumers: runtime submodules
+/// are attributes, not filesystem modules — use
+/// `from swing_core import swing`, never `import swing_core.swing`.
+#[cfg(feature = "python")]
+#[pymodule]
+fn swing_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    py_bindings::py_swing::register_module(m)?;
+    Ok(())
+}

--- a/rust_core/swing-core/src/py_bindings/mod.rs
+++ b/rust_core/swing-core/src/py_bindings/mod.rs
@@ -1,0 +1,7 @@
+//! Python (PyO3) bindings, split by concern.
+//!
+//! Only compiled with the `python` feature. Each submodule mirrors one
+//! domain module under `swing/` and registers a runtime PyO3 submodule on
+//! the `swing_core` extension module.
+
+pub mod py_swing;

--- a/rust_core/swing-core/src/py_bindings/py_swing.rs
+++ b/rust_core/swing-core/src/py_bindings/py_swing.rs
@@ -1,0 +1,158 @@
+//! PyO3 bindings for `swing::pendulum` and `swing::plane`.
+//!
+//! Registered as the runtime submodule `swing` on the `swing_core`
+//! extension module. Python consumers must import it via attribute access
+//! (`from swing_core import swing`), never `import swing_core.swing`.
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+use crate::swing::pendulum::{self, PendulumParameters, PendulumState};
+use crate::swing::plane;
+
+#[pymethods]
+impl PendulumParameters {
+    #[new]
+    #[allow(clippy::too_many_arguments)]
+    fn py_new(
+        m1: f64,
+        l1: f64,
+        lc1: f64,
+        i1: f64,
+        m2: f64,
+        l2: f64,
+        lc2: f64,
+        i2: f64,
+        d1: f64,
+        d2: f64,
+    ) -> PyResult<Self> {
+        let params = Self {
+            m1,
+            l1,
+            lc1,
+            i1,
+            m2,
+            l2,
+            lc2,
+            i2,
+            d1,
+            d2,
+        };
+        params.validate().map_err(PyValueError::new_err)?;
+        Ok(params)
+    }
+
+    /// Default golf-swing parameters (UpstreamDrift reference constants).
+    #[staticmethod]
+    fn golf_default_py() -> Self {
+        Self::golf_default()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PendulumParameters(m1={}, l1={}, lc1={}, i1={}, m2={}, l2={}, lc2={}, i2={}, d1={}, d2={})",
+            self.m1, self.l1, self.lc1, self.i1, self.m2, self.l2, self.lc2, self.i2, self.d1, self.d2
+        )
+    }
+}
+
+#[pymethods]
+impl PendulumState {
+    #[new]
+    fn py_new(theta1: f64, theta2: f64, omega1: f64, omega2: f64) -> Self {
+        Self {
+            theta1,
+            theta2,
+            omega1,
+            omega2,
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "PendulumState(theta1={}, theta2={}, omega1={}, omega2={})",
+            self.theta1, self.theta2, self.omega1, self.omega2
+        )
+    }
+}
+
+/// Plane rotation matrix as a row-major nested list `[[f64; 3]; 3]`.
+#[pyfunction]
+fn plane_rotation(yaw: f64, side_tilt: f64, fwd_tilt: f64) -> [[f64; 3]; 3] {
+    let r = plane::plane_rotation(yaw, side_tilt, fwd_tilt);
+    let mut out = [[0.0; 3]; 3];
+    for (i, row) in out.iter_mut().enumerate() {
+        for (j, value) in row.iter_mut().enumerate() {
+            *value = r[(i, j)];
+        }
+    }
+    out
+}
+
+/// In-plane gravity `(g_x, g_y)` from the three tilt angles and `g` [m/s²].
+#[pyfunction]
+fn in_plane_gravity(yaw: f64, side_tilt: f64, fwd_tilt: f64, g: f64) -> (f64, f64) {
+    plane::in_plane_gravity_from_tilts(yaw, side_tilt, fwd_tilt, g)
+}
+
+/// Symmetric 2x2 mass matrix as nested list.
+#[pyfunction]
+fn mass_matrix(params: &PendulumParameters, theta2: f64) -> [[f64; 2]; 2] {
+    pendulum::mass_matrix(params, theta2)
+}
+
+/// One RK4 step of size `dt` under in-plane gravity `(gx, gy)`.
+#[pyfunction]
+fn step(
+    params: &PendulumParameters,
+    state: &PendulumState,
+    gx: f64,
+    gy: f64,
+    dt: f64,
+) -> PyResult<PendulumState> {
+    pendulum::rk4_step(params, state, (gx, gy), dt).map_err(PyValueError::new_err)
+}
+
+/// Simulate `n_steps` RK4 steps.
+///
+/// Returns a flat row-major vector of `(n_steps + 1) * 4` floats:
+/// `[theta1, theta2, omega1, omega2]` per state, initial state included.
+/// The Python façade reshapes this into an `(n+1, 4)` NumPy array.
+#[pyfunction]
+fn simulate(
+    params: &PendulumParameters,
+    initial: &PendulumState,
+    gx: f64,
+    gy: f64,
+    dt: f64,
+    n_steps: usize,
+) -> PyResult<Vec<f64>> {
+    let states = pendulum::simulate(params, initial, (gx, gy), dt, n_steps)
+        .map_err(PyValueError::new_err)?;
+    let mut out = Vec::with_capacity(states.len() * 4);
+    for s in states {
+        out.extend_from_slice(&[s.theta1, s.theta2, s.omega1, s.omega2]);
+    }
+    Ok(out)
+}
+
+/// Total mechanical energy [J] under in-plane gravity `(gx, gy)`.
+#[pyfunction]
+fn total_energy(params: &PendulumParameters, state: &PendulumState, gx: f64, gy: f64) -> f64 {
+    pendulum::total_energy(params, state, (gx, gy))
+}
+
+/// Register the `swing` runtime submodule on the parent extension module.
+pub fn register_module(parent: &Bound<'_, PyModule>) -> PyResult<()> {
+    let m = PyModule::new(parent.py(), "swing")?;
+    m.add_class::<PendulumParameters>()?;
+    m.add_class::<PendulumState>()?;
+    m.add_function(wrap_pyfunction!(plane_rotation, &m)?)?;
+    m.add_function(wrap_pyfunction!(in_plane_gravity, &m)?)?;
+    m.add_function(wrap_pyfunction!(mass_matrix, &m)?)?;
+    m.add_function(wrap_pyfunction!(step, &m)?)?;
+    m.add_function(wrap_pyfunction!(simulate, &m)?)?;
+    m.add_function(wrap_pyfunction!(total_energy, &m)?)?;
+    parent.add_submodule(&m)?;
+    Ok(())
+}

--- a/rust_core/swing-core/src/swing/mod.rs
+++ b/rust_core/swing-core/src/swing/mod.rs
@@ -1,0 +1,14 @@
+//! Swing dynamics domain module.
+//!
+//! - [`pendulum`] — double-pendulum equations of motion (mass matrix,
+//!   Coriolis/centripetal, gravity, damping) and RK4 stepping.
+//! - [`plane`] — swing-plane orientation (three sequential intrinsic tilts)
+//!   and projection of world gravity into the swing plane.
+//!
+//! The pendulum EOM is planar; plane orientation enters exclusively through
+//! the projected in-plane gravity 2-vector produced by
+//! [`plane::in_plane_gravity`]. This keeps the dynamics core independent of
+//! the world-frame convention (LoD: the EOM never sees the 3-D pose).
+
+pub mod pendulum;
+pub mod plane;

--- a/rust_core/swing-core/src/swing/pendulum.rs
+++ b/rust_core/swing-core/src/swing/pendulum.rs
@@ -1,0 +1,439 @@
+//! Double-pendulum swing dynamics.
+//!
+//! Port of UpstreamDrift's
+//! `src/engines/pendulum_models/python/double_pendulum_model/physics/double_pendulum.py`
+//! (mass matrix, Coriolis/centripetal vector, gravity vector, viscous
+//! damping, RK4 stepping), generalised so gravity enters as an **in-plane
+//! 2-vector** computed from the swing-plane pose (see [`crate::swing::plane`])
+//! instead of a projected scalar.
+//!
+//! # Angle convention
+//! - `theta1`: angle of the upper segment measured from the in-plane
+//!   downward vertical (positive counter-clockwise).
+//! - `theta2`: angle of the lower segment **relative to** the upper segment.
+//!
+//! In-plane coordinates: local x = in-plane horizontal, local y = in-plane
+//! up. A segment at angle `theta` from downward vertical points along
+//! `(sin theta, -cos theta)`.
+//!
+//! # Design by Contract
+//! - `PendulumParameters::validate` rejects non-positive masses/lengths and
+//!   non-finite values.
+//! - The mass matrix is symmetric positive-definite for valid parameters
+//!   (unit tested).
+//! - Undamped, unforced dynamics conserve total energy (unit tested:
+//!   relative drift < 1e-6 over 1000 RK4 steps).
+
+use serde::{Deserialize, Serialize};
+
+/// Numerical tolerance for detecting singular mass matrices.
+pub const MASS_MATRIX_SINGULAR_TOLERANCE: f64 = 1e-12;
+
+// Defaults ported from UpstreamDrift double_pendulum.py (documented there).
+const DEFAULT_ARM_LENGTH_M: f64 = 0.75;
+const DEFAULT_ARM_MASS_KG: f64 = 7.5;
+const DEFAULT_ARM_COM_RATIO: f64 = 0.45;
+const DEFAULT_ARM_INERTIA_SCALING: f64 = 1.0 / 12.0;
+const DEFAULT_SHAFT_LENGTH_M: f64 = 1.0;
+const DEFAULT_SHAFT_MASS_KG: f64 = 0.15;
+const DEFAULT_CLUBHEAD_MASS_KG: f64 = 0.20;
+const DEFAULT_SHAFT_COM_RATIO: f64 = 0.43;
+const DEFAULT_DAMPING_SHOULDER: f64 = 0.4;
+const DEFAULT_DAMPING_WRIST: f64 = 0.25;
+
+/// Physical parameters of the two-segment (shoulder + wrist) pendulum.
+///
+/// Inertias are about the **proximal joint** (parallel-axis already applied),
+/// matching the cached quantities in the UpstreamDrift reference.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyo3::prelude::pyclass(get_all, set_all))]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub struct PendulumParameters {
+    /// Upper segment mass [kg].
+    pub m1: f64,
+    /// Upper segment length [m].
+    pub l1: f64,
+    /// Upper segment COM distance from shoulder [m].
+    pub lc1: f64,
+    /// Upper segment inertia about the shoulder [kg·m²].
+    pub i1: f64,
+    /// Lower segment (shaft + clubhead) total mass [kg].
+    pub m2: f64,
+    /// Lower segment length [m].
+    pub l2: f64,
+    /// Lower segment COM distance from wrist [m].
+    pub lc2: f64,
+    /// Lower segment inertia about the wrist [kg·m²].
+    pub i2: f64,
+    /// Viscous damping at the shoulder [N·m·s/rad].
+    pub d1: f64,
+    /// Viscous damping at the wrist [N·m·s/rad].
+    pub d2: f64,
+}
+
+impl PendulumParameters {
+    /// Default golf-swing parameters, computed from the same segment
+    /// constants as the UpstreamDrift reference (arm rod + shaft/clubhead
+    /// composite). Kept as formulas — not hard-coded decimals — so the
+    /// Python reference and this crate agree bit-for-bit.
+    #[must_use]
+    pub fn golf_default() -> Self {
+        let m1 = DEFAULT_ARM_MASS_KG;
+        let l1 = DEFAULT_ARM_LENGTH_M;
+        let lc1 = l1 * DEFAULT_ARM_COM_RATIO;
+        let i1_com = DEFAULT_ARM_INERTIA_SCALING * m1 * l1 * l1;
+        let i1 = i1_com + m1 * lc1 * lc1;
+
+        let l2 = DEFAULT_SHAFT_LENGTH_M;
+        let ms = DEFAULT_SHAFT_MASS_KG;
+        let mh = DEFAULT_CLUBHEAD_MASS_KG;
+        let m2 = ms + mh;
+        let shaft_com = l2 * DEFAULT_SHAFT_COM_RATIO;
+        let lc2 = (shaft_com * ms + l2 * mh) / m2;
+        let shaft_inertia_com = (1.0 / 12.0) * ms * l2 * l2;
+        let parallel_axis =
+            ms * (shaft_com - lc2) * (shaft_com - lc2) + mh * (l2 - lc2) * (l2 - lc2);
+        let i2_com = shaft_inertia_com + parallel_axis;
+        let i2 = i2_com + m2 * lc2 * lc2;
+
+        Self {
+            m1,
+            l1,
+            lc1,
+            i1,
+            m2,
+            l2,
+            lc2,
+            i2,
+            d1: DEFAULT_DAMPING_SHOULDER,
+            d2: DEFAULT_DAMPING_WRIST,
+        }
+    }
+
+    /// Validate physical plausibility.
+    ///
+    /// # Errors
+    /// Returns a description of the first violated precondition.
+    pub fn validate(&self) -> Result<(), String> {
+        let fields = [
+            ("m1", self.m1),
+            ("l1", self.l1),
+            ("lc1", self.lc1),
+            ("i1", self.i1),
+            ("m2", self.m2),
+            ("l2", self.l2),
+            ("lc2", self.lc2),
+            ("i2", self.i2),
+        ];
+        for (name, value) in fields {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(format!("{name} must be finite and > 0, got {value}"));
+            }
+        }
+        for (name, value) in [("d1", self.d1), ("d2", self.d2)] {
+            if !value.is_finite() || value < 0.0 {
+                return Err(format!("{name} must be finite and >= 0, got {value}"));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Dynamic state of the pendulum (planar).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "python", pyo3::prelude::pyclass(get_all, set_all))]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub struct PendulumState {
+    /// Upper segment angle from in-plane downward vertical [rad].
+    pub theta1: f64,
+    /// Lower segment angle relative to the upper segment [rad].
+    pub theta2: f64,
+    /// Upper segment angular velocity [rad/s].
+    pub omega1: f64,
+    /// Lower segment angular velocity [rad/s].
+    pub omega2: f64,
+}
+
+/// Compute the symmetric 2x2 mass matrix `[[m11, m12], [m12, m22]]`.
+#[must_use]
+pub fn mass_matrix(p: &PendulumParameters, theta2: f64) -> [[f64; 2]; 2] {
+    debug_assert!(theta2.is_finite(), "mass_matrix: theta2 must be finite");
+    let cos_theta2 = theta2.cos();
+    let m11 = p.i1 + p.i2 + p.m2 * p.l1 * p.l1 + 2.0 * p.m2 * p.l1 * p.lc2 * cos_theta2;
+    let m12 = p.i2 + p.m2 * p.l1 * p.lc2 * cos_theta2;
+    let m22 = p.i2;
+    [[m11, m12], [m12, m22]]
+}
+
+/// Coriolis and centripetal generalized-force vector.
+#[must_use]
+pub fn coriolis_vector(p: &PendulumParameters, theta2: f64, omega1: f64, omega2: f64) -> [f64; 2] {
+    let h = -p.m2 * p.l1 * p.lc2 * theta2.sin();
+    let c1 = h * (2.0 * omega1 * omega2 + omega2 * omega2);
+    let c2 = -h * omega1 * omega1;
+    [c1, c2]
+}
+
+/// Gravitational generalized-force vector for an in-plane gravity 2-vector.
+///
+/// `g_inplane = (gx, gy)` are the gravity components along the plane's local
+/// horizontal and local up axes (see [`crate::swing::plane::in_plane_gravity`]).
+/// For the flat plane `(0, -g)` this reduces exactly to the classic scalar
+/// form `g1 = (m1·lc1 + m2·l1)·g·sin θ1 + m2·lc2·g·sin(θ1+θ2)`.
+#[must_use]
+pub fn gravity_vector(
+    p: &PendulumParameters,
+    theta1: f64,
+    theta2: f64,
+    g_inplane: (f64, f64),
+) -> [f64; 2] {
+    let (gx, gy) = g_inplane;
+    let t12 = theta1 + theta2;
+    // Segment direction derivative: d/dθ (sin θ, -cos θ) = (cos θ, sin θ).
+    // Generalized gravity torque Q_i = Σ_k m_k g_vec · ∂p_k/∂q_i; the EOM
+    // uses G = -Q (restoring convention, matching the scalar reference).
+    let a1 = p.m1 * p.lc1 + p.m2 * p.l1;
+    let a2 = p.m2 * p.lc2;
+    let g1 = -a1 * (gx * theta1.cos() + gy * theta1.sin()) - a2 * (gx * t12.cos() + gy * t12.sin());
+    let g2 = -a2 * (gx * t12.cos() + gy * t12.sin());
+    [g1, g2]
+}
+
+/// Viscous damping torques.
+#[must_use]
+pub fn damping_vector(p: &PendulumParameters, omega1: f64, omega2: f64) -> [f64; 2] {
+    [p.d1 * omega1, p.d2 * omega2]
+}
+
+fn invert_mass_matrix(p: &PendulumParameters, theta2: f64) -> Result<[[f64; 2]; 2], String> {
+    let m = mass_matrix(p, theta2);
+    let det = m[0][0] * m[1][1] - m[0][1] * m[1][0];
+    if det.abs() <= MASS_MATRIX_SINGULAR_TOLERANCE {
+        return Err("mass matrix determinant too close to zero; check pendulum parameters".into());
+    }
+    Ok([
+        [m[1][1] / det, -m[0][1] / det],
+        [-m[1][0] / det, m[0][0] / det],
+    ])
+}
+
+/// State derivatives `(dθ1, dθ2, dω1, dω2)` for unforced dynamics.
+///
+/// # Errors
+/// Returns an error if the mass matrix is numerically singular.
+pub fn derivatives(
+    p: &PendulumParameters,
+    state: &PendulumState,
+    g_inplane: (f64, f64),
+) -> Result<[f64; 4], String> {
+    let [c1, c2] = coriolis_vector(p, state.theta2, state.omega1, state.omega2);
+    let [g1, g2] = gravity_vector(p, state.theta1, state.theta2, g_inplane);
+    let [d1, d2] = damping_vector(p, state.omega1, state.omega2);
+    let inv_m = invert_mass_matrix(p, state.theta2)?;
+    let rhs1 = -(c1 + g1 + d1);
+    let rhs2 = -(c2 + g2 + d2);
+    let acc1 = inv_m[0][0] * rhs1 + inv_m[0][1] * rhs2;
+    let acc2 = inv_m[1][0] * rhs1 + inv_m[1][1] * rhs2;
+    Ok([state.omega1, state.omega2, acc1, acc2])
+}
+
+/// Advance the state by one classical RK4 step of size `dt`.
+///
+/// # Errors
+/// Returns an error if the mass matrix is numerically singular at any stage.
+pub fn rk4_step(
+    p: &PendulumParameters,
+    state: &PendulumState,
+    g_inplane: (f64, f64),
+    dt: f64,
+) -> Result<PendulumState, String> {
+    debug_assert!(
+        dt.is_finite() && dt > 0.0,
+        "rk4_step: dt must be finite and > 0"
+    );
+    let y = [state.theta1, state.theta2, state.omega1, state.omega2];
+    let f = |v: [f64; 4]| -> Result<[f64; 4], String> {
+        derivatives(
+            p,
+            &PendulumState {
+                theta1: v[0],
+                theta2: v[1],
+                omega1: v[2],
+                omega2: v[3],
+            },
+            g_inplane,
+        )
+    };
+    let add = |a: [f64; 4], s: f64, b: [f64; 4]| -> [f64; 4] {
+        [
+            a[0] + s * b[0],
+            a[1] + s * b[1],
+            a[2] + s * b[2],
+            a[3] + s * b[3],
+        ]
+    };
+    let k1 = f(y)?;
+    let k2 = f(add(y, dt / 2.0, k1))?;
+    let k3 = f(add(y, dt / 2.0, k2))?;
+    let k4 = f(add(y, dt, k3))?;
+    let mut out = [0.0; 4];
+    for i in 0..4 {
+        out[i] = y[i] + dt / 6.0 * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]);
+    }
+    Ok(PendulumState {
+        theta1: out[0],
+        theta2: out[1],
+        omega1: out[2],
+        omega2: out[3],
+    })
+}
+
+/// Total mechanical energy (kinetic + gravitational potential) [J].
+///
+/// Potential is `-Σ m_k g_vec · p_k` with COM positions measured from the
+/// shoulder pivot in in-plane coordinates. Used by conservation tests.
+#[must_use]
+pub fn total_energy(p: &PendulumParameters, state: &PendulumState, g_inplane: (f64, f64)) -> f64 {
+    let m = mass_matrix(p, state.theta2);
+    let q = [state.omega1, state.omega2];
+    let kinetic =
+        0.5 * (m[0][0] * q[0] * q[0] + 2.0 * m[0][1] * q[0] * q[1] + m[1][1] * q[1] * q[1]);
+
+    let (gx, gy) = g_inplane;
+    let dir = |theta: f64| (theta.sin(), -theta.cos());
+    let (e1x, e1y) = dir(state.theta1);
+    let (e2x, e2y) = dir(state.theta1 + state.theta2);
+    let p1 = (p.lc1 * e1x, p.lc1 * e1y);
+    let p2 = (p.l1 * e1x + p.lc2 * e2x, p.l1 * e1y + p.lc2 * e2y);
+    let potential = -(p.m1 * (gx * p1.0 + gy * p1.1) + p.m2 * (gx * p2.0 + gy * p2.1));
+    kinetic + potential
+}
+
+/// Simulate `n_steps` RK4 steps, returning `n_steps + 1` states (including
+/// the initial state).
+///
+/// # Errors
+/// Returns an error if any step encounters a singular mass matrix.
+pub fn simulate(
+    p: &PendulumParameters,
+    initial: &PendulumState,
+    g_inplane: (f64, f64),
+    dt: f64,
+    n_steps: usize,
+) -> Result<Vec<PendulumState>, String> {
+    p.validate()?;
+    let mut states = Vec::with_capacity(n_steps + 1);
+    states.push(*initial);
+    let mut current = *initial;
+    for _ in 0..n_steps {
+        current = rk4_step(p, &current, g_inplane, dt)?;
+        states.push(current);
+    }
+    Ok(states)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::swing::plane::in_plane_gravity_from_tilts;
+
+    const G: f64 = 9.80665;
+
+    fn undamped_params() -> PendulumParameters {
+        PendulumParameters {
+            d1: 0.0,
+            d2: 0.0,
+            ..PendulumParameters::golf_default()
+        }
+    }
+
+    #[test]
+    fn golf_default_is_valid() {
+        assert!(PendulumParameters::golf_default().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_nonpositive_mass() {
+        let p = PendulumParameters {
+            m1: 0.0,
+            ..PendulumParameters::golf_default()
+        };
+        assert!(p.validate().is_err());
+    }
+
+    #[test]
+    fn mass_matrix_is_symmetric_positive_definite() {
+        let p = PendulumParameters::golf_default();
+        for theta2 in [-3.0, -1.5, 0.0, 0.8, 1.6, 3.1] {
+            let m = mass_matrix(&p, theta2);
+            assert!((m[0][1] - m[1][0]).abs() < 1e-15, "asymmetric at {theta2}");
+            // Sylvester's criterion for 2x2 SPD.
+            assert!(m[0][0] > 0.0, "m11 not positive at {theta2}");
+            let det = m[0][0] * m[1][1] - m[0][1] * m[1][0];
+            assert!(det > 0.0, "determinant not positive at {theta2}: {det}");
+        }
+    }
+
+    #[test]
+    fn gravity_vector_flat_plane_matches_scalar_reference() {
+        let p = PendulumParameters::golf_default();
+        let (theta1, theta2) = (0.7, -0.4);
+        let [g1, g2] = gravity_vector(&p, theta1, theta2, (0.0, -G));
+        let expected_g1 = (p.m1 * p.lc1 + p.m2 * p.l1) * G * theta1.sin()
+            + p.m2 * p.lc2 * G * (theta1 + theta2).sin();
+        let expected_g2 = p.m2 * p.lc2 * G * (theta1 + theta2).sin();
+        assert!((g1 - expected_g1).abs() < 1e-12, "g1 {g1} != {expected_g1}");
+        assert!((g2 - expected_g2).abs() < 1e-12, "g2 {g2} != {expected_g2}");
+    }
+
+    #[test]
+    fn undamped_unforced_energy_conserved_over_1000_steps() {
+        let p = undamped_params();
+        let g = in_plane_gravity_from_tilts(0.4, 0.6, -0.2, G);
+        let initial = PendulumState {
+            theta1: 1.2,
+            theta2: -0.5,
+            omega1: 0.0,
+            omega2: 0.0,
+        };
+        let dt = 1e-4;
+        let states = simulate(&p, &initial, g, dt, 1000).expect("simulation must succeed");
+        let e0 = total_energy(&p, &initial, g);
+        let scale = e0.abs().max(1.0);
+        for (i, s) in states.iter().enumerate() {
+            let e = total_energy(&p, s, g);
+            let drift = (e - e0).abs() / scale;
+            assert!(drift < 1e-6, "energy drift {drift} at step {i}");
+        }
+    }
+
+    #[test]
+    fn damping_dissipates_energy() {
+        let p = PendulumParameters::golf_default();
+        let g = (0.0, -G);
+        let initial = PendulumState {
+            theta1: 1.0,
+            theta2: 0.3,
+            omega1: 0.5,
+            omega2: -0.2,
+        };
+        let states = simulate(&p, &initial, g, 1e-3, 2000).expect("simulation must succeed");
+        let e0 = total_energy(&p, &initial, g);
+        let e_end = total_energy(&p, states.last().expect("non-empty"), g);
+        assert!(e_end < e0, "damped energy must decrease: {e_end} >= {e0}");
+    }
+
+    #[test]
+    fn simulate_returns_n_plus_one_states() {
+        let p = PendulumParameters::golf_default();
+        let s0 = PendulumState {
+            theta1: 0.1,
+            theta2: 0.0,
+            omega1: 0.0,
+            omega2: 0.0,
+        };
+        let states = simulate(&p, &s0, (0.0, -G), 1e-3, 10).expect("simulation must succeed");
+        assert_eq!(states.len(), 11);
+        assert_eq!(states[0], s0);
+    }
+}

--- a/rust_core/swing-core/src/swing/plane.rs
+++ b/rust_core/swing-core/src/swing/plane.rs
@@ -1,0 +1,203 @@
+//! Swing-plane orientation and in-plane gravity projection.
+//!
+//! # Convention
+//! World frame: x forward (toward target line reference), y left, z up.
+//! The identity ("flat") plane pose spans world x (in-plane horizontal axis)
+//! and world z (in-plane up axis); its normal is world y. A pendulum swinging
+//! in the identity plane therefore swings in a vertical plane and feels the
+//! full gravitational acceleration in-plane.
+//!
+//! The plane pose is built from three sequential intrinsic tilts
+//! (documented order, epic #4103 P1 spec):
+//! 1. **yaw** about the world-up axis (z),
+//! 2. **side tilt** about the rotated in-plane horizontal axis,
+//! 3. **forward/back tilt** about the resulting in-plane up axis.
+//!
+//! As intrinsic rotations these compose by right-multiplication:
+//! `R = Rz(yaw) · Rx(side_tilt) · Ry(fwd_tilt)`.
+//!
+//! # Design by Contract
+//! - All angles are radians and must be finite (`debug_assert!`).
+//! - `plane_rotation` returns a proper orthonormal rotation (unit tested).
+//! - `in_plane_gravity` limits: identity pose ⇒ `(0, -g)` (full g "down"
+//!   in-plane); pure yaw is invariant (gravity is symmetric about world-up).
+
+use nalgebra::{Matrix3, Vector3};
+
+/// Build the world-from-plane rotation matrix from the three tilt angles.
+///
+/// Columns of the returned matrix are the plane's local axes expressed in
+/// world coordinates: column 0 = in-plane horizontal axis, column 1 = plane
+/// normal, column 2 = in-plane up axis (see module docs for the identity
+/// pose).
+///
+/// # Contracts (DbC)
+/// - Precondition: all angles are finite radians.
+/// - Postcondition: result is orthonormal with determinant +1.
+#[must_use]
+pub fn plane_rotation(yaw: f64, side_tilt: f64, fwd_tilt: f64) -> Matrix3<f64> {
+    debug_assert!(yaw.is_finite(), "plane_rotation: yaw must be finite");
+    debug_assert!(
+        side_tilt.is_finite(),
+        "plane_rotation: side_tilt must be finite"
+    );
+    debug_assert!(
+        fwd_tilt.is_finite(),
+        "plane_rotation: fwd_tilt must be finite"
+    );
+
+    let rz = Matrix3::new(
+        yaw.cos(),
+        -yaw.sin(),
+        0.0,
+        yaw.sin(),
+        yaw.cos(),
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+    );
+    let rx = Matrix3::new(
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        side_tilt.cos(),
+        -side_tilt.sin(),
+        0.0,
+        side_tilt.sin(),
+        side_tilt.cos(),
+    );
+    let ry = Matrix3::new(
+        fwd_tilt.cos(),
+        0.0,
+        fwd_tilt.sin(),
+        0.0,
+        1.0,
+        0.0,
+        -fwd_tilt.sin(),
+        0.0,
+        fwd_tilt.cos(),
+    );
+    rz * rx * ry
+}
+
+/// Project world gravity into the swing plane.
+///
+/// Given the world-from-plane rotation `plane_r` and the gravitational
+/// acceleration magnitude `g` (m/s², non-negative), returns the in-plane
+/// gravity components `(g_x_inplane, g_y_inplane)` along the plane's local
+/// horizontal axis and local up axis respectively. The world gravity vector
+/// is `(0, 0, -g)` (z-up world).
+///
+/// The double-pendulum EOM consumes this 2-vector directly — never a scalar.
+///
+/// # Contracts (DbC)
+/// - Precondition: `g` is finite and `>= 0`.
+/// - Postcondition: `g_x² + g_y² <= g²` (projection never amplifies).
+#[must_use]
+pub fn in_plane_gravity(plane_r: &Matrix3<f64>, g: f64) -> (f64, f64) {
+    debug_assert!(
+        g.is_finite() && g >= 0.0,
+        "in_plane_gravity: g must be finite and >= 0"
+    );
+
+    let g_world = Vector3::new(0.0, 0.0, -g);
+    // Local axes in world coordinates: columns 0 (in-plane horizontal) and
+    // 2 (in-plane up) of the world-from-plane rotation.
+    let x_axis = plane_r.column(0);
+    let y_up_axis = plane_r.column(2);
+    let gx = g_world.dot(&x_axis);
+    let gy = g_world.dot(&y_up_axis);
+    debug_assert!(
+        gx * gx + gy * gy <= g * g + 1e-9,
+        "in_plane_gravity: projection must not amplify gravity"
+    );
+    (gx, gy)
+}
+
+/// Convenience: in-plane gravity straight from the three tilt angles.
+#[must_use]
+pub fn in_plane_gravity_from_tilts(yaw: f64, side_tilt: f64, fwd_tilt: f64, g: f64) -> (f64, f64) {
+    in_plane_gravity(&plane_rotation(yaw, side_tilt, fwd_tilt), g)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const G: f64 = 9.80665;
+    const TOL: f64 = 1e-12;
+
+    #[test]
+    fn plane_rotation_is_orthonormal() {
+        let cases = [
+            (0.0, 0.0, 0.0),
+            (0.3, 0.0, 0.0),
+            (0.0, 0.7, 0.0),
+            (0.0, 0.0, -0.4),
+            (1.2, -0.6, 0.35),
+            (-2.0, 1.1, 2.9),
+        ];
+        for (yaw, side, fwd) in cases {
+            let r = plane_rotation(yaw, side, fwd);
+            let should_be_identity = r.transpose() * r;
+            let err = (should_be_identity - Matrix3::identity()).norm();
+            assert!(
+                err < 1e-12,
+                "R^T R != I for ({yaw}, {side}, {fwd}): err {err}"
+            );
+            let det = r.determinant();
+            assert!((det - 1.0).abs() < 1e-12, "det != +1: {det}");
+        }
+    }
+
+    #[test]
+    fn flat_plane_gives_full_gravity_down() {
+        let r = plane_rotation(0.0, 0.0, 0.0);
+        let (gx, gy) = in_plane_gravity(&r, G);
+        assert!(
+            gx.abs() < TOL,
+            "flat plane must have zero horizontal gravity: {gx}"
+        );
+        assert!(
+            (gy + G).abs() < TOL,
+            "flat plane must feel full g down: {gy}"
+        );
+    }
+
+    #[test]
+    fn pure_yaw_leaves_gravity_projection_invariant() {
+        let (gx0, gy0) = in_plane_gravity_from_tilts(0.0, 0.0, 0.0, G);
+        for yaw in [-3.0, -1.2, 0.4, 1.7, 3.1] {
+            let (gx, gy) = in_plane_gravity_from_tilts(yaw, 0.0, 0.0, G);
+            assert!((gx - gx0).abs() < TOL, "yaw {yaw} changed gx: {gx}");
+            assert!((gy - gy0).abs() < TOL, "yaw {yaw} changed gy: {gy}");
+        }
+    }
+
+    #[test]
+    fn side_tilt_scales_in_plane_up_component_by_cosine() {
+        // Matches UpstreamDrift's scalar projected_gravity = g·cos(inclination).
+        for side in [0.0, 0.2, 0.6, 1.0, 1.5] {
+            let (_, gy) = in_plane_gravity_from_tilts(0.0, side, 0.0, G);
+            assert!(
+                (gy + G * side.cos()).abs() < 1e-12,
+                "side tilt {side}: expected {}, got {gy}",
+                -G * side.cos()
+            );
+        }
+    }
+
+    #[test]
+    fn projection_never_amplifies_gravity() {
+        for yaw in [-2.0, 0.0, 1.3] {
+            for side in [-1.4, 0.0, 0.9] {
+                for fwd in [-0.8, 0.0, 1.1] {
+                    let (gx, gy) = in_plane_gravity_from_tilts(yaw, side, fwd, G);
+                    assert!(gx * gx + gy * gy <= G * G + 1e-9);
+                }
+            }
+        }
+    }
+}

--- a/rust_core/swing-core/src/wasm_bindings/mod.rs
+++ b/rust_core/swing-core/src/wasm_bindings/mod.rs
@@ -1,0 +1,7 @@
+//! WASM (wasm-bindgen) bindings, split by concern.
+//!
+//! Only compiled with the `wasm` feature (wasm-pack builds with
+//! `--features wasm --no-default-features`). Each submodule mirrors one
+//! domain module under `swing/`.
+
+pub mod wasm_swing;

--- a/rust_core/swing-core/src/wasm_bindings/wasm_swing.rs
+++ b/rust_core/swing-core/src/wasm_bindings/wasm_swing.rs
@@ -1,0 +1,125 @@
+//! wasm-bindgen bindings for `swing::pendulum` and `swing::plane`.
+//!
+//! Flat `Vec<f64>` payloads cross the JS boundary as `Float64Array`
+//! (row-major); the web app reshapes them. Struct fields are `f64` and Copy,
+//! so wasm-bindgen auto-generates getters/setters.
+
+use wasm_bindgen::prelude::*;
+
+use crate::swing::pendulum::{self, PendulumParameters, PendulumState};
+use crate::swing::plane;
+
+#[wasm_bindgen]
+impl PendulumParameters {
+    /// Construct parameters; throws on physically invalid values.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn wasm_new(
+        m1: f64,
+        l1: f64,
+        lc1: f64,
+        i1: f64,
+        m2: f64,
+        l2: f64,
+        lc2: f64,
+        i2: f64,
+        d1: f64,
+        d2: f64,
+    ) -> Result<PendulumParameters, JsError> {
+        let params = Self {
+            m1,
+            l1,
+            lc1,
+            i1,
+            m2,
+            l2,
+            lc2,
+            i2,
+            d1,
+            d2,
+        };
+        params.validate().map_err(|e| JsError::new(&e))?;
+        Ok(params)
+    }
+
+    /// Default golf-swing parameters (UpstreamDrift reference constants).
+    #[wasm_bindgen(js_name = "golfDefault")]
+    pub fn wasm_golf_default() -> PendulumParameters {
+        Self::golf_default()
+    }
+}
+
+#[wasm_bindgen]
+impl PendulumState {
+    #[wasm_bindgen(constructor)]
+    pub fn wasm_new(theta1: f64, theta2: f64, omega1: f64, omega2: f64) -> PendulumState {
+        Self {
+            theta1,
+            theta2,
+            omega1,
+            omega2,
+        }
+    }
+}
+
+/// Plane rotation matrix as a row-major `Float64Array` of length 9.
+#[wasm_bindgen(js_name = "planeRotation")]
+pub fn wasm_plane_rotation(yaw: f64, side_tilt: f64, fwd_tilt: f64) -> Vec<f64> {
+    let r = plane::plane_rotation(yaw, side_tilt, fwd_tilt);
+    (0..3)
+        .flat_map(|i| (0..3).map(move |j| (i, j)))
+        .map(|(i, j)| r[(i, j)])
+        .collect()
+}
+
+/// In-plane gravity `[g_x, g_y]` from the three tilt angles and `g` [m/s²].
+#[wasm_bindgen(js_name = "inPlaneGravity")]
+pub fn wasm_in_plane_gravity(yaw: f64, side_tilt: f64, fwd_tilt: f64, g: f64) -> Vec<f64> {
+    let (gx, gy) = plane::in_plane_gravity_from_tilts(yaw, side_tilt, fwd_tilt, g);
+    vec![gx, gy]
+}
+
+/// One RK4 step; throws on a singular mass matrix.
+#[wasm_bindgen(js_name = "step")]
+pub fn wasm_step(
+    params: &PendulumParameters,
+    state: &PendulumState,
+    gx: f64,
+    gy: f64,
+    dt: f64,
+) -> Result<PendulumState, JsError> {
+    pendulum::rk4_step(params, state, (gx, gy), dt).map_err(|e| JsError::new(&e))
+}
+
+/// Simulate `n_steps` RK4 steps.
+///
+/// Returns a row-major `Float64Array` of `(n_steps + 1) * 4` floats:
+/// `[theta1, theta2, omega1, omega2]` per state, initial state included.
+#[wasm_bindgen(js_name = "simulate")]
+pub fn wasm_simulate(
+    params: &PendulumParameters,
+    initial: &PendulumState,
+    gx: f64,
+    gy: f64,
+    dt: f64,
+    n_steps: usize,
+) -> Result<Vec<f64>, JsError> {
+    let states =
+        pendulum::simulate(params, initial, (gx, gy), dt, n_steps).map_err(|e| JsError::new(&e))?;
+    let mut out = Vec::with_capacity(states.len() * 4);
+    for s in states {
+        out.extend_from_slice(&[s.theta1, s.theta2, s.omega1, s.omega2]);
+    }
+    Ok(out)
+}
+
+/// Total mechanical energy [J] under in-plane gravity `(gx, gy)`.
+#[wasm_bindgen(js_name = "totalEnergy")]
+pub fn wasm_total_energy(
+    params: &PendulumParameters,
+    state: &PendulumState,
+    gx: f64,
+    gy: f64,
+) -> f64 {
+    pendulum::total_energy(params, state, (gx, gy))
+}

--- a/rust_core/tools-core/src/ball_flight.rs
+++ b/rust_core/tools-core/src/ball_flight.rs
@@ -593,6 +593,71 @@ impl BallProperties {
             self.mass, self.diameter
         )
     }
+
+    #[getter]
+    fn get_mass(&self) -> f64 {
+        self.mass
+    }
+    #[setter]
+    fn set_mass(&mut self, value: f64) {
+        self.mass = value;
+    }
+    #[getter]
+    fn get_diameter(&self) -> f64 {
+        self.diameter
+    }
+    #[setter]
+    fn set_diameter(&mut self, value: f64) {
+        self.diameter = value;
+    }
+    #[getter]
+    fn get_cd0(&self) -> f64 {
+        self.cd0
+    }
+    #[setter]
+    fn set_cd0(&mut self, value: f64) {
+        self.cd0 = value;
+    }
+    #[getter]
+    fn get_cd1(&self) -> f64 {
+        self.cd1
+    }
+    #[setter]
+    fn set_cd1(&mut self, value: f64) {
+        self.cd1 = value;
+    }
+    #[getter]
+    fn get_cd2(&self) -> f64 {
+        self.cd2
+    }
+    #[setter]
+    fn set_cd2(&mut self, value: f64) {
+        self.cd2 = value;
+    }
+    #[getter]
+    fn get_cl0(&self) -> f64 {
+        self.cl0
+    }
+    #[setter]
+    fn set_cl0(&mut self, value: f64) {
+        self.cl0 = value;
+    }
+    #[getter]
+    fn get_cl1(&self) -> f64 {
+        self.cl1
+    }
+    #[setter]
+    fn set_cl1(&mut self, value: f64) {
+        self.cl1 = value;
+    }
+    #[getter]
+    fn get_cl2(&self) -> f64 {
+        self.cl2
+    }
+    #[setter]
+    fn set_cl2(&mut self, value: f64) {
+        self.cl2 = value;
+    }
 }
 
 #[cfg(feature = "python")]
@@ -620,6 +685,20 @@ impl LaunchConditions {
             self.velocity, self.launch_angle, self.spin_rate
         )
     }
+
+    /// Set the spin axis as a (not necessarily normalized) 3-vector.
+    ///
+    /// The default constructor pins pure backspin (`[0, -1, 0]`); this
+    /// setter lets Python callers (swing_sim flight facade, #4107) pass
+    /// tilted spin axes derived from impact solvers.
+    fn set_spin_axis(&mut self, x: f64, y: f64, z: f64) {
+        self.spin_axis = Vector3::new(x, y, z);
+    }
+
+    /// Return the spin axis as an `(x, y, z)` tuple.
+    fn get_spin_axis(&self) -> (f64, f64, f64) {
+        (self.spin_axis.x, self.spin_axis.y, self.spin_axis.z)
+    }
 }
 
 #[cfg(feature = "python")]
@@ -630,6 +709,37 @@ impl EnvironmentalConditions {
     #[pyo3(text_signature = "()")]
     fn py_new() -> Self {
         Self::default()
+    }
+
+    /// Set the wind velocity vector [m/s].
+    fn set_wind(&mut self, x: f64, y: f64, z: f64) {
+        self.wind_velocity = Vector3::new(x, y, z);
+    }
+
+    /// Return the wind velocity as an `(x, y, z)` tuple.
+    fn get_wind(&self) -> (f64, f64, f64) {
+        (
+            self.wind_velocity.x,
+            self.wind_velocity.y,
+            self.wind_velocity.z,
+        )
+    }
+
+    #[getter]
+    fn get_air_density(&self) -> f64 {
+        self.air_density
+    }
+    #[setter]
+    fn set_air_density(&mut self, value: f64) {
+        self.air_density = value;
+    }
+    #[getter]
+    fn get_gravity(&self) -> f64 {
+        self.gravity
+    }
+    #[setter]
+    fn set_gravity(&mut self, value: f64) {
+        self.gravity = value;
     }
 }
 
@@ -655,6 +765,18 @@ impl TrajectoryPoint {
     #[getter]
     fn spin_rate(&self) -> f64 {
         self.spin
+    }
+    #[getter]
+    fn vx(&self) -> f64 {
+        self.velocity.x
+    }
+    #[getter]
+    fn vy(&self) -> f64 {
+        self.velocity.y
+    }
+    #[getter]
+    fn vz(&self) -> f64 {
+        self.velocity.z
     }
 
     fn __repr__(&self) -> String {
@@ -691,6 +813,50 @@ impl TrajectoryAnalysis {
             self.carry_distance, self.max_height, self.flight_time
         )
     }
+}
+
+/// Simulate a complete ball flight trajectory (Python entry point).
+///
+/// Thin wrapper over [`simulate_trajectory`] that converts the release-mode
+/// precondition `assert!`s into `ValueError`s so invalid Python input never
+/// panics across the FFI boundary. Consumed by
+/// `src/shared/python/swing_sim/flight/_rust_facade.py` (#4107).
+#[cfg(feature = "python")]
+#[pyo3::prelude::pyfunction]
+#[pyo3(name = "simulate_trajectory")]
+pub fn py_simulate_trajectory(
+    ball: BallProperties,
+    env: EnvironmentalConditions,
+    launch: LaunchConditions,
+    max_time: f64,
+    dt: f64,
+) -> pyo3::PyResult<Vec<TrajectoryPoint>> {
+    use pyo3::exceptions::PyValueError;
+    if !(launch.velocity.is_finite() && launch.velocity > 0.0) {
+        return Err(PyValueError::new_err(format!(
+            "Launch velocity must be finite and positive, got {}",
+            launch.velocity
+        )));
+    }
+    if !(dt.is_finite() && dt > 0.0) {
+        return Err(PyValueError::new_err(format!(
+            "Time step must be finite and positive, got {dt}"
+        )));
+    }
+    if !(max_time.is_finite() && max_time > 0.0) {
+        return Err(PyValueError::new_err(format!(
+            "Max time must be finite and positive, got {max_time}"
+        )));
+    }
+    Ok(simulate_trajectory(&ball, &env, &launch, max_time, dt))
+}
+
+/// Analyze a completed trajectory (Python entry point).
+#[cfg(feature = "python")]
+#[pyo3::prelude::pyfunction]
+#[pyo3(name = "analyze_trajectory")]
+pub fn py_analyze_trajectory(trajectory: Vec<TrajectoryPoint>) -> TrajectoryAnalysis {
+    analyze_trajectory(&trajectory)
 }
 
 // ── WASM bindings ────────────────────────────────────────────────────────────

--- a/rust_core/tools-core/src/lib.rs
+++ b/rust_core/tools-core/src/lib.rs
@@ -42,6 +42,8 @@ fn tools_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<atmosphere::AtmosphereProperties>()?;
     m.add_class::<rrt::Obstacle>()?;
     m.add_class::<rrt::RRTPlanner>()?;
+    m.add_function(wrap_pyfunction!(ball_flight::py_simulate_trajectory, m)?)?;
+    m.add_function(wrap_pyfunction!(ball_flight::py_analyze_trajectory, m)?)?;
     m.add_function(wrap_pyfunction!(math::py_lerp, m)?)?;
     m.add_function(wrap_pyfunction!(math::py_clamp, m)?)?;
     m.add_function(wrap_pyfunction!(math::py_deg_to_rad, m)?)?;

--- a/src/rate_of_closure/derivation.py
+++ b/src/rate_of_closure/derivation.py
@@ -23,6 +23,7 @@ from ._contracts import ensure
 from .model import ImpactResult, ImpactScenario, solve
 
 __all__ = [
+    "LAUNCH_EXPLANATIONS",
     "METRIC_EXPLANATIONS",
     "RESULT_EXPLANATIONS",
     "DerivationStep",
@@ -156,6 +157,53 @@ METRIC_EXPLANATIONS: dict[str, str] = {
         "face due to rotation alone. The toe outruns the heel on every "
         "closing delivery — the same rigid-body effect that produces "
         "the reference-point path gap."
+    ),
+}
+
+
+#: Click-through explanation for every simulation launch-number row.
+LAUNCH_EXPLANATIONS: dict[str, str] = {
+    "ball_speed_mph": (
+        "Post-impact ball speed from the rigid-body COR impulse solve "
+        "(swing_sim.impact): the effective-mass momentum exchange along "
+        "the delivered face normal, reduced for off-center strikes by "
+        "the clubhead MOI. Divided by clubhead speed this is the smash "
+        "factor (~1.48-1.50 for a well-struck driver)."
+    ),
+    "launch_angle_deg": (
+        "Vertical angle of the ball's launch velocity above the ground "
+        "plane. The D-plane compromise: the ball leaves close to the "
+        "delivered face normal (dynamic loft), pulled slightly toward "
+        "the club path — typically 10-16 deg for a driver."
+    ),
+    "launch_azimuth_deg": (
+        "Horizontal launch direction relative to the target line "
+        "(positive = right, matching the club-path sign convention). "
+        "Dominated by the delivered face angle, with a smaller path "
+        "contribution."
+    ),
+    "spin_rpm": (
+        "Total spin rate from the friction impulse of the impact solve "
+        "(2/7 rolling-cap Coulomb model) plus gear-effect spin from the "
+        "head's rotation recoil on off-center strikes. Driver band "
+        "roughly 2,000-3,500 rpm."
+    ),
+    "carry_m": (
+        "Carry distance from the selected literature flight model "
+        "(swing_sim.flight): the integrated trajectory's horizontal "
+        "distance at the terminal ground event, no roll-out."
+    ),
+    "max_height_m": (
+        "Apex height of the integrated trajectory — the peak of the "
+        "lift-vs-gravity balance; typical driver apex is 25-40 m."
+    ),
+    "flight_time_s": (
+        "Total time aloft from launch to the terminal ground event of "
+        "the flight integration (typically 5-7 s for a driver)."
+    ),
+    "landing_angle_deg": (
+        "Descent angle below horizontal at the terminal ground event; "
+        "steeper landings stop faster (driver band roughly 35-45 deg)."
     ),
 }
 

--- a/src/rate_of_closure/simulation/__init__.py
+++ b/src/rate_of_closure/simulation/__init__.py
@@ -1,0 +1,52 @@
+"""Simulation session for the Rate of Closure explorer (epic #4103).
+
+Orchestrates a full swing -> impact -> flight run:
+
+* :mod:`.sources` — app-frame swing sources (manual constant-twist,
+  double pendulum via ``swing_sim``, and a planar triple pendulum).
+* :mod:`.session` — the :class:`~rate_of_closure.simulation.session.
+  SimulationRun` record and the orchestration entry points, including
+  the impact-time scrubber math (the swing translates so the clubhead
+  at time tau meets the fixed ball).
+* :mod:`.isa` — thin adapter over the rotation converter's screw-axis
+  extraction (one file to touch when the Rust surface lands, #4108).
+* :mod:`.export` — CSV time-series and JSON summary export.
+"""
+
+from __future__ import annotations
+
+from .export import run_to_json_dict, write_csv, write_json
+from .isa import screw_axis_samples
+from .session import (
+    BALL_POSITION_M,
+    SimulationConfig,
+    SimulationRun,
+    delivery_at,
+    run_simulation,
+)
+from .sources import (
+    SOURCE_KINDS,
+    AppFrameSwing,
+    ManualSwingSource,
+    TriplePendulumParameters,
+    TriplePendulumSwing,
+    make_source,
+)
+
+__all__ = [
+    "BALL_POSITION_M",
+    "SOURCE_KINDS",
+    "AppFrameSwing",
+    "ManualSwingSource",
+    "SimulationConfig",
+    "SimulationRun",
+    "TriplePendulumParameters",
+    "TriplePendulumSwing",
+    "delivery_at",
+    "make_source",
+    "run_simulation",
+    "run_to_json_dict",
+    "screw_axis_samples",
+    "write_csv",
+    "write_json",
+]

--- a/src/rate_of_closure/simulation/export.py
+++ b/src/rate_of_closure/simulation/export.py
@@ -1,0 +1,153 @@
+"""Run data export: CSV time series and JSON summary/params.
+
+One :class:`~rate_of_closure.simulation.session.SimulationRun` becomes:
+
+* a CSV with one row per sample — swing rows (clubhead position and
+  speed) followed by flight rows (ball position and speed), phase-tagged
+  so the two series stay distinguishable in a flat file; and
+* a JSON document carrying the request parameters, the delivery and
+  launch summaries, and both time series.
+
+All values are SI + app frame (x target, y up, z right), matching the
+in-memory record; display units are a UI concern.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from rate_of_closure._contracts import require
+from rate_of_closure.simulation.session import SimulationRun
+
+__all__ = ["CSV_COLUMNS", "run_to_json_dict", "series_rows", "write_csv", "write_json"]
+
+#: CSV column order (kept stable for downstream consumers).
+CSV_COLUMNS: tuple[str, ...] = (
+    "phase",
+    "t_s",
+    "x_m",
+    "y_m",
+    "z_m",
+    "speed_mps",
+)
+
+
+def series_rows(
+    run: SimulationRun,
+) -> list[tuple[str, float, float, float, float, float]]:
+    """Flatten the swing and flight series into phase-tagged rows."""
+    rows: list[tuple[str, float, float, float, float, float]] = []
+    for t, pos, twist in zip(
+        run.swing_times, run.swing_positions, run.swing_twists, strict=True
+    ):
+        rows.append(
+            (
+                "swing",
+                float(t),
+                float(pos[0]),
+                float(pos[1]),
+                float(pos[2]),
+                float(np.linalg.norm(twist[3:])),
+            )
+        )
+    t0 = run.impact_time_s
+    for t, pos, vel in zip(
+        run.flight_times, run.flight_positions, run.flight_velocities, strict=True
+    ):
+        rows.append(
+            (
+                "flight",
+                t0 + float(t),
+                float(pos[0]),
+                float(pos[1]),
+                float(pos[2]),
+                float(np.linalg.norm(vel)),
+            )
+        )
+    return rows
+
+
+def write_csv(run: SimulationRun, path: str | Path) -> None:
+    """Write the run's time series as CSV.
+
+    Args:
+        run: The simulation run to export.
+        path: Destination file path.
+    """
+    require(isinstance(run, SimulationRun), "run must be a SimulationRun", run)
+    with Path(path).open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(CSV_COLUMNS)
+        writer.writerows(series_rows(run))
+
+
+def run_to_json_dict(run: SimulationRun) -> dict[str, Any]:
+    """The run as a JSON-serialisable dictionary.
+
+    Args:
+        run: The simulation run to export.
+
+    Returns:
+        Parameters, summaries, and both time series; non-finite floats
+        are rendered as ``None`` for strict-JSON consumers.
+    """
+    require(isinstance(run, SimulationRun), "run must be a SimulationRun", run)
+    config = run.config
+    scenario = config.scenario
+
+    def _clean(value: float) -> float | None:
+        return float(value) if math.isfinite(value) else None
+
+    return {
+        "format": "rate_of_closure.simulation_run/1",
+        "parameters": {
+            "source_kind": config.source_kind,
+            "club": config.club.name,
+            "flight_model": config.flight_model,
+            "impact_time_s": run.impact_time_s,
+            "swing_duration_s": config.swing_duration_s,
+            "plane_tilts_deg": {
+                "yaw": config.plane.yaw_deg,
+                "side_tilt": config.plane.side_tilt_deg,
+                "forward_tilt": config.plane.forward_tilt_deg,
+            },
+            "scenario": {
+                "clubhead_speed_mph": scenario.clubhead_speed_mph,
+                "omega_plane_dps": scenario.omega_plane_dps,
+                "omega_shaft_dps": scenario.omega_shaft_dps,
+                "lie_angle_deg": scenario.lie_angle_deg,
+                "com_to_face_mm": scenario.com_to_face_mm,
+                "impact_offset_toe_mm": scenario.impact_offset_toe_mm,
+                "impact_offset_high_mm": scenario.impact_offset_high_mm,
+                "contact_duration_us": scenario.contact_duration_us,
+            },
+        },
+        "delivery": {
+            "clubhead_speed_mps": float(np.linalg.norm(run.delivery.clubhead_velocity)),
+            "spin_loft_deg": run.delivery.spin_loft_deg,
+            "face_to_path_deg": run.delivery.face_to_path_deg,
+            "spin_axis_tilt_deg": run.delivery.spin_axis_tilt_deg,
+        },
+        "launch": {key: _clean(value) for key, value in run.launch.items()},
+        "series": {
+            "columns": list(CSV_COLUMNS),
+            "rows": [list(row) for row in series_rows(run)],
+        },
+    }
+
+
+def write_json(run: SimulationRun, path: str | Path) -> None:
+    """Write the run's summary + series as a JSON document.
+
+    Args:
+        run: The simulation run to export.
+        path: Destination file path.
+    """
+    with Path(path).open("w", encoding="utf-8") as handle:
+        json.dump(run_to_json_dict(run), handle, indent=2)

--- a/src/rate_of_closure/simulation/isa.py
+++ b/src/rate_of_closure/simulation/isa.py
@@ -1,0 +1,86 @@
+"""Thin adapter over the rotation converter's screw-axis extraction.
+
+Per the #4108 recon, ALL instantaneous-screw-axis (ISA) computation for
+the simulation goes through this one module:
+
+* ``rotation_converter`` emits a ``DeprecationWarning`` at import (the
+  package is migrating to the Rust ``tools_core.math_primitives``, which
+  has no se(3)/screw surface yet) — the import is confined here and the
+  warning suppressed, so the eventual migration touches one file.
+* ``extract_screw_axes_from_trajectory`` returns per-step rotation
+  ANGLES, not rates — this adapter divides ``theta`` by the sampling
+  ``dt`` to report deg/s.
+* The ISA is ill-conditioned as the per-step ``theta`` approaches zero,
+  so callers should sample densely near impact (the session's uniform
+  1 ms grid) and treat near-zero-rate entries as "no meaningful axis".
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+
+from rate_of_closure._contracts import require
+
+__all__ = ["MIN_RATE_DPS", "screw_axis_samples"]
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    from rotation_converter.screw_visualization import (
+        extract_screw_axes_from_trajectory,
+    )
+
+#: Below this rotation rate the extracted axis direction is numerically
+#: meaningless (theta -> 0 ill-conditioning); callers should skip it.
+MIN_RATE_DPS = 1.0
+
+
+def screw_axis_samples(
+    poses: Sequence[np.ndarray] | np.ndarray, dt: float
+) -> list[dict[str, Any]]:
+    """Instantaneous screw axes for a uniformly sampled pose trajectory.
+
+    Args:
+        poses: N SE(3) matrices (sequence of 4x4 arrays or an (N, 4, 4)
+            array), uniformly spaced ``dt`` seconds apart, N >= 2.
+        dt: Sampling interval [s], > 0.
+
+    Returns:
+        N-1 dicts with keys ``axis`` (unit 3-vector, world frame),
+        ``point`` (3-vector on the axis, world frame), ``pitch``
+        (translation per radian; ``inf`` for pure translation),
+        ``rate_dps`` (rotation rate, degrees per second), ``r_isa_m``
+        (distance from the segment midpoint to the axis, meters;
+        ``inf`` when the rate is below :data:`MIN_RATE_DPS`), and
+        ``midpoint``.
+    """
+    require(math.isfinite(dt) and dt > 0.0, "dt must be finite and > 0", dt)
+    pose_list = [np.asarray(p, dtype=float) for p in poses]
+    require(len(pose_list) >= 2, "need at least 2 poses", len(pose_list))
+
+    out: list[dict[str, Any]] = []
+    for raw in extract_screw_axes_from_trajectory(pose_list):
+        rate_dps = math.degrees(float(raw["theta"])) / dt
+        axis = np.asarray(raw["axis"], dtype=float)
+        point = np.asarray(raw["point"], dtype=float)
+        midpoint = np.asarray(raw["midpoint"], dtype=float)
+        if rate_dps >= MIN_RATE_DPS:
+            to_axis = midpoint - point
+            r_isa = float(np.linalg.norm(to_axis - float(to_axis @ axis) * axis))
+        else:
+            r_isa = math.inf
+        out.append(
+            {
+                "axis": axis,
+                "point": point,
+                "pitch": float(raw["pitch"]),
+                "rate_dps": rate_dps,
+                "r_isa_m": r_isa,
+                "midpoint": midpoint,
+            }
+        )
+    return out

--- a/src/rate_of_closure/simulation/session.py
+++ b/src/rate_of_closure/simulation/session.py
@@ -1,0 +1,349 @@
+"""Simulation session: swing -> impact -> flight, one exportable record.
+
+The orchestration seam of the epic (#4103): a :class:`SimulationConfig`
+selects a swing source (manual constant-twist scenario, double pendulum,
+or triple pendulum), a swing-plane orientation, a club, and a flight
+model; :func:`run_simulation` samples the swing, forms the delivery at
+the impact instant, solves the impact through ``swing_sim.impact`` (with
+the club package's bulge/roll face-normal callable wired in), derives
+launch conditions, and integrates the flight through
+``swing_sim.flight``.
+
+Impact-time scrubber convention: the ball sits at the FIXED world
+position :data:`BALL_POSITION_M`; scrubbing the impact time ``tau``
+translates the whole swing so the clubhead at ``tau`` meets the ball
+(``offset = ball - clubhead(tau)``). :func:`delivery_at` returns the
+live delivery numbers for any ``tau`` without running impact + flight.
+
+Everything here is in the app frame (x target, y up, z right); frame
+adapters convert at the flight boundary.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from rate_of_closure._contracts import ensure, require
+from rate_of_closure.club import ClubSpec, face_normal_at_offset
+from rate_of_closure.model import MPH_PER_MPS, ImpactScenario
+from rate_of_closure.simulation.sources import make_source
+from shared.python.swing_sim.flight import (
+    derive_launch_conditions,
+    from_flight_frame,
+    to_flight_frame,
+)
+from shared.python.swing_sim.flight import simulate as flight_simulate
+from shared.python.swing_sim.flight.registry import FlightModelType
+from shared.python.swing_sim.impact import (
+    GOLF_BALL_RADIUS_M,
+    DeliveryDerived,
+    DeliveryParameters,
+    ImpactModelType,
+    ImpactParameters,
+    ImpactSolverAPI,
+    PostImpactState,
+    derive_delivery,
+)
+from shared.python.swing_sim.swing_source import SwingSource
+from shared.python.swing_sim.types import PlaneOrientation
+
+__all__ = [
+    "BALL_POSITION_M",
+    "SimulationConfig",
+    "SimulationRun",
+    "delivery_at",
+    "run_simulation",
+]
+
+#: Fixed world position of the ball (app frame): on the target line at
+#: the origin, resting on the ground plane.
+BALL_POSITION_M = np.array([0.0, GOLF_BALL_RADIUS_M, 0.0])
+
+#: Delivery angles are clamped inside the impact package's ±89° domain.
+_MAX_DELIVERY_ANGLE_DEG = 89.0
+
+#: Uniform sampling step for the stored swing time series [s]. Dense
+#: enough for screw-axis extraction near impact (recon #4108).
+_SAMPLE_DT_S = 1e-3
+
+
+@dataclass(frozen=True)
+class SimulationConfig:
+    """One simulation request.
+
+    Args:
+        scenario: The explorer scenario — the manual source wraps it as a
+            constant twist; every source takes its impact offsets from it.
+        club: Club spec used for loft, head mass, MOI, CG depth, and the
+            bulge/roll face-normal callable.
+        source_kind: ``"manual"``, ``"double_pendulum"``, or
+            ``"triple_pendulum"``.
+        plane: Swing-plane orientation (three sequential tilts).
+        impact_time_s: Impact instant tau within the swing, seconds; the
+            scrubber drives this. ``None`` picks the instant of maximum
+            clubhead speed.
+        flight_model: ``swing_sim.flight`` registry model name.
+        swing_duration_s: Pendulum integration length [s].
+    """
+
+    scenario: ImpactScenario
+    club: ClubSpec
+    source_kind: str = "manual"
+    plane: PlaneOrientation = field(default_factory=PlaneOrientation)
+    impact_time_s: float | None = None
+    flight_model: str = "waterloo_penner"
+    swing_duration_s: float = 1.5
+
+    def __post_init__(self) -> None:
+        require(
+            isinstance(self.scenario, ImpactScenario),
+            "scenario must be an ImpactScenario",
+            self.scenario,
+        )
+        require(isinstance(self.club, ClubSpec), "club must be a ClubSpec", self.club)
+        FlightModelType(self.flight_model)  # raises ValueError on unknown names
+        if self.impact_time_s is not None:
+            require(
+                math.isfinite(self.impact_time_s) and self.impact_time_s >= 0.0,
+                "impact_time_s must be finite and >= 0",
+                self.impact_time_s,
+            )
+        require(
+            math.isfinite(self.swing_duration_s) and self.swing_duration_s > 0.0,
+            "swing_duration_s must be finite and > 0",
+            self.swing_duration_s,
+        )
+
+
+@dataclass(frozen=True)
+class SimulationRun:
+    """One complete swing -> impact -> flight record (app frame).
+
+    Attributes:
+        config: The request that produced this run.
+        swing_times: (N,) swing sample times [s].
+        swing_positions: (N, 3) clubhead positions, ball-aligned (the
+            swing is translated so the clubhead meets the ball at tau).
+        swing_poses: (N, 4, 4) ball-aligned SE(3) clubhead poses.
+        swing_twists: (N, 6) world twists ``[wx, wy, wz, vx, vy, vz]``.
+        impact_time_s: The impact instant tau actually used.
+        delivery: Delivery numbers + D-plane diagnostics at tau.
+        post_impact: Post-impact ball and club state.
+        launch: Launch summary (mph / deg / rpm plus flight metrics).
+        flight_times: (M,) flight sample times [s] (from impact).
+        flight_positions: (M, 3) ball positions from the ball position.
+        flight_velocities: (M, 3) ball velocities.
+    """
+
+    config: SimulationConfig
+    swing_times: np.ndarray
+    swing_positions: np.ndarray
+    swing_poses: np.ndarray
+    swing_twists: np.ndarray
+    impact_time_s: float
+    delivery: DeliveryDerived
+    post_impact: PostImpactState
+    launch: dict[str, float]
+    flight_times: np.ndarray
+    flight_positions: np.ndarray
+    flight_velocities: np.ndarray
+
+    @property
+    def total_duration_s(self) -> float:
+        """Swing duration plus flight time — the playback timeline span."""
+        flight_span = float(self.flight_times[-1]) if len(self.flight_times) else 0.0
+        return float(self.swing_times[-1]) + flight_span
+
+
+def _clamped_angle(value_deg: float) -> float:
+    """Clamp an angle into the impact package's delivery domain."""
+    return max(-_MAX_DELIVERY_ANGLE_DEG, min(_MAX_DELIVERY_ANGLE_DEG, value_deg))
+
+
+def _delivery_parameters(
+    velocity: np.ndarray, scenario: ImpactScenario, club: ClubSpec
+) -> DeliveryParameters:
+    """Delivery numbers from a sampled clubhead velocity (app frame).
+
+    The face is delivered square to the target (face angle 0) with the
+    club's static loft as dynamic loft; path and attack angles come from
+    the sampled velocity direction. Impact offsets carry over from the
+    scenario. Residual lie rotation is zero — the offsets are already
+    expressed in the face's toe/high axes.
+    """
+    speed = float(np.linalg.norm(velocity))
+    require(speed > 1e-6, "clubhead speed at impact must be > 0", speed)
+    path_deg = math.degrees(math.atan2(float(velocity[2]), float(velocity[0])))
+    aoa_deg = math.degrees(
+        math.atan2(
+            float(velocity[1]), math.hypot(float(velocity[0]), float(velocity[2]))
+        )
+    )
+    return DeliveryParameters(
+        clubhead_speed_mps=speed,
+        club_path_deg=_clamped_angle(path_deg),
+        face_angle_deg=0.0,
+        attack_angle_deg=_clamped_angle(aoa_deg),
+        dynamic_loft_deg=_clamped_angle(club.loft_deg),
+        lie_deg=0.0,
+        impact_offset_toe_mm=scenario.impact_offset_toe_mm,
+        impact_offset_high_mm=scenario.impact_offset_high_mm,
+    )
+
+
+def delivery_at(
+    source: SwingSource,
+    tau: float,
+    scenario: ImpactScenario,
+    club: ClubSpec,
+) -> DeliveryDerived:
+    """Live delivery numbers for the scrubber at impact time ``tau``.
+
+    Args:
+        source: An app-frame swing source.
+        tau: Impact instant within ``[0, source.duration]``.
+        scenario: Scenario carrying the impact offsets.
+        club: Club providing the dynamic loft.
+
+    Returns:
+        The delivery vectors + D-plane diagnostics at ``tau``.
+    """
+    sample = source.sample(tau)
+    params = _delivery_parameters(sample.twist[3:], scenario, club)
+    return derive_delivery(params, clubhead_angular_velocity=sample.twist[:3])
+
+
+def _auto_impact_time(source: SwingSource, times: np.ndarray) -> float:
+    """The sampled instant of maximum clubhead speed."""
+    speeds = [float(np.linalg.norm(source.sample(float(t)).twist[3:])) for t in times]
+    return float(times[int(np.argmax(speeds))])
+
+
+def _face_normal_callable(club: ClubSpec):  # type: ignore[no-untyped-def]
+    """Bulge/roll callable seam ``(toe_m, high_m) -> normal`` for the club."""
+
+    def _normal(toe_m: float, high_m: float) -> np.ndarray:
+        return np.array(face_normal_at_offset(club, toe_m * 1e3, high_m * 1e3))
+
+    return _normal
+
+
+def _launch_summary(
+    post: PostImpactState, delivery: DeliveryDerived, flight: object
+) -> dict[str, float]:
+    """Flatten launch + flight numbers into the exportable summary dict."""
+    launch = derive_launch_conditions(
+        to_flight_frame(post.ball_velocity),
+        to_flight_frame(post.ball_angular_velocity),
+    )
+    return {
+        "ball_speed_mph": launch.ball_speed * MPH_PER_MPS,
+        "launch_angle_deg": math.degrees(launch.launch_angle),
+        # Flight-frame azimuth is + toward +y (left); app convention is
+        # + right of target, so the sign flips.
+        "launch_azimuth_deg": -math.degrees(launch.azimuth_angle),
+        "spin_rpm": launch.spin_rate,
+        "spin_axis_tilt_deg": delivery.spin_axis_tilt_deg,
+        "carry_m": float(flight.carry_distance),  # type: ignore[attr-defined]
+        "max_height_m": float(flight.max_height),  # type: ignore[attr-defined]
+        "flight_time_s": float(flight.flight_time),  # type: ignore[attr-defined]
+        "landing_angle_deg": float(flight.landing_angle),  # type: ignore[attr-defined]
+    }
+
+
+def run_simulation(config: SimulationConfig) -> SimulationRun:
+    """Run one full swing -> impact -> flight simulation.
+
+    Args:
+        config: The simulation request.
+
+    Returns:
+        A complete, exportable :class:`SimulationRun`.
+    """
+    source = make_source(
+        config.source_kind,
+        config.scenario,
+        plane=config.plane,
+        duration=config.swing_duration_s,
+    )
+    n = int(round(source.duration / _SAMPLE_DT_S))
+    times = np.linspace(0.0, source.duration, max(n, 2) + 1)
+
+    tau = (
+        min(max(config.impact_time_s, 0.0), source.duration)
+        if config.impact_time_s is not None
+        else _auto_impact_time(source, times)
+    )
+
+    # Scrubber math: translate the swing so the clubhead at tau meets
+    # the fixed ball.
+    impact_sample = source.sample(tau)
+    offset = BALL_POSITION_M - impact_sample.pose[:3, 3]
+
+    samples = [source.sample(float(t)) for t in times]
+    poses = np.stack([s.pose for s in samples])
+    poses[:, :3, 3] += offset
+    positions = poses[:, :3, 3].copy()
+    twists = np.stack([s.twist for s in samples])
+
+    delivery = delivery_at(source, tau, config.scenario, config.club)
+    solver = ImpactSolverAPI(
+        ImpactModelType.RIGID_BODY,
+        ImpactParameters(cg_depth=config.club.cg_depth_m),
+    )
+    post = solver.solve_with_gear_effect(
+        timestamp=tau,
+        clubhead_velocity=delivery.clubhead_velocity,
+        clubhead_orientation=delivery.face_normal,
+        impact_offset=delivery.impact_offset,
+        clubhead_mass=config.club.head_mass_kg,
+        clubhead_moi=config.club.moi_about_shaft_kg_m2,
+        face_normal_at_offset=_face_normal_callable(config.club),
+        record=False,
+    )
+
+    flight = flight_simulate(
+        derive_launch_conditions(
+            to_flight_frame(post.ball_velocity),
+            to_flight_frame(post.ball_angular_velocity),
+        ),
+        model_name=config.flight_model,
+    )
+    flight_times = np.array([p.time for p in flight.trajectory])
+    flight_positions = (
+        from_flight_frame(flight.to_position_array()) + BALL_POSITION_M
+        if len(flight.trajectory)
+        else np.zeros((0, 3))
+    )
+    flight_velocities = (
+        from_flight_frame(np.array([p.velocity for p in flight.trajectory]))
+        if len(flight.trajectory)
+        else np.zeros((0, 3))
+    )
+
+    run = SimulationRun(
+        config=config,
+        swing_times=times,
+        swing_positions=positions,
+        swing_poses=poses,
+        swing_twists=twists,
+        impact_time_s=tau,
+        delivery=delivery,
+        post_impact=post,
+        launch=_launch_summary(post, delivery, flight),
+        flight_times=flight_times,
+        flight_positions=flight_positions,
+        flight_velocities=flight_velocities,
+    )
+    ensure(
+        bool(
+            np.allclose(
+                source.sample(tau).pose[:3, 3] + offset, BALL_POSITION_M, atol=1e-9
+            )
+        ),
+        "clubhead at tau must coincide with the ball position",
+    )
+    return run

--- a/src/rate_of_closure/simulation/sources.py
+++ b/src/rate_of_closure/simulation/sources.py
@@ -1,0 +1,444 @@
+"""App-frame swing sources for the simulation session (epic #4103).
+
+Every source satisfies the :class:`shared.python.swing_sim.swing_source.
+SwingSource` protocol (``duration`` + ``sample(t) -> SwingSample``) and
+returns samples in the APP frame — the AffineDrift launch-monitor
+convention (x target, y up, z right) used by the rate-of-closure model
+and the 3D scene. The shared ``swing_sim`` dynamics run in the swing
+frame (x forward, y left, z up — identical to the flight frame), so
+pendulum sources are wrapped in :class:`AppFrameSwing`.
+
+Sources:
+
+* :class:`ManualSwingSource` — wraps an existing
+  :class:`~rate_of_closure.model.ImpactScenario` as a trivial
+  constant-twist source: straight-line reference-point travel plus the
+  scenario's constant angular velocity, square at mid-window.
+* ``DoublePendulumSwing`` (from ``swing_sim``) via :func:`make_source`.
+* :class:`TriplePendulumSwing` — planar three-link pendulum on the same
+  oriented plane, integrated with the same classical RK4. New model
+  (the shared package only ships the double pendulum, recon #4105).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from rate_of_closure._contracts import require
+from rate_of_closure.model import ImpactScenario, solve
+from shared.python.swing_sim import reference
+from shared.python.swing_sim.swing_source import DoublePendulumSwing, SwingSource
+from shared.python.swing_sim.types import (
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+)
+
+__all__ = [
+    "SOURCE_KINDS",
+    "APP_FROM_SWING",
+    "AppFrameSwing",
+    "ManualSwingSource",
+    "TriplePendulumParameters",
+    "TriplePendulumSwing",
+    "make_source",
+]
+
+#: Swing-source kinds accepted by :func:`make_source`, in UI order.
+SOURCE_KINDS: tuple[str, ...] = ("manual", "double_pendulum", "triple_pendulum")
+
+#: Rotation taking swing/flight-frame vectors (x fwd, y left, z up) into
+#: app-frame vectors (x target, y up, z right): app y = swing z,
+#: app z = -swing y.
+APP_FROM_SWING = np.array(
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        [0.0, -1.0, 0.0],
+    ]
+)
+
+
+def _rodrigues(axis_omega: np.ndarray, dt: float) -> np.ndarray:
+    """Rotation matrix for spinning at ``axis_omega`` [rad/s] for ``dt`` s."""
+    theta = float(np.linalg.norm(axis_omega)) * dt
+    if abs(theta) < 1e-15:
+        return np.eye(3)
+    axis = axis_omega / np.linalg.norm(axis_omega)
+    k = np.array(
+        [
+            [0.0, -axis[2], axis[1]],
+            [axis[2], 0.0, -axis[0]],
+            [-axis[1], axis[0], 0.0],
+        ]
+    )
+    return np.asarray(
+        np.eye(3) + math.sin(theta) * k + (1.0 - math.cos(theta)) * (k @ k)
+    )
+
+
+class AppFrameSwing:
+    """Adapter re-expressing a swing-frame :class:`SwingSource` in the app frame.
+
+    Positions, rotations, and twists are rotated by
+    :data:`APP_FROM_SWING`; timing is passed through unchanged.
+    """
+
+    def __init__(self, inner: SwingSource) -> None:
+        require(
+            isinstance(inner, SwingSource),
+            "inner must satisfy the SwingSource protocol",
+            inner,
+        )
+        self._inner = inner
+
+    @property
+    def inner(self) -> SwingSource:
+        """The wrapped swing-frame source."""
+        return self._inner
+
+    @property
+    def duration(self) -> float:
+        """Total duration [s] of the wrapped swing."""
+        return float(self._inner.duration)
+
+    def sample(self, t: float) -> SwingSample:
+        """Sample the wrapped source and rotate the result into the app frame."""
+        s = self._inner.sample(t)
+        c = APP_FROM_SWING
+        pose = np.eye(4)
+        pose[:3, :3] = c @ s.pose[:3, :3]
+        pose[:3, 3] = c @ s.pose[:3, 3]
+        twist = np.concatenate([c @ s.twist[:3], c @ s.twist[3:]])
+        return SwingSample(t=s.t, pose=pose, twist=twist)
+
+
+class ManualSwingSource:
+    """Constant-twist source built from an :class:`ImpactScenario` (app frame).
+
+    The clubhead reference point travels dead down the target line at the
+    scenario speed while the head spins at the scenario's constant angular
+    velocity — exactly the twist model of the explorer, extended over a
+    short time window. The head is square (identity rotation, reference at
+    the origin) at the window midpoint, matching the explorer's "instant
+    of maximum compression" convention.
+    """
+
+    def __init__(self, scenario: ImpactScenario, duration: float = 0.06) -> None:
+        require(
+            isinstance(scenario, ImpactScenario),
+            "scenario must be an ImpactScenario",
+            scenario,
+        )
+        require(
+            math.isfinite(duration) and duration > 0.0,
+            "duration must be finite and > 0",
+            duration,
+        )
+        self._scenario = scenario
+        self._duration = float(duration)
+        result = solve(scenario)
+        self._omega = np.radians(np.array(result.omega_dps))
+        speed_mps = result.reference_speed_mph * 0.44704
+        self._velocity = np.array([speed_mps, 0.0, 0.0])
+
+    @property
+    def scenario(self) -> ImpactScenario:
+        """The wrapped scenario."""
+        return self._scenario
+
+    @property
+    def duration(self) -> float:
+        """Window length [s]."""
+        return self._duration
+
+    def sample(self, t: float) -> SwingSample:
+        """Clubhead sample at ``t``; square at the window midpoint."""
+        require(math.isfinite(t), "t must be finite", t)
+        require(
+            -1e-9 <= t <= self._duration + 1e-9,
+            "t must be within [0, duration]",
+            t,
+        )
+        t = min(max(t, 0.0), self._duration)
+        dt = t - self._duration / 2.0
+        pose = np.eye(4)
+        pose[:3, :3] = _rodrigues(self._omega, dt)
+        pose[:3, 3] = self._velocity * dt
+        twist = np.concatenate([self._omega, self._velocity])
+        return SwingSample(t=t, pose=pose, twist=twist)
+
+
+# ── Triple pendulum ─────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TriplePendulumParameters:
+    """Planar three-link pendulum parameters, absolute-angle formulation.
+
+    Per link i: mass ``m`` [kg], length ``l`` [m], COM distance from the
+    proximal joint ``lc`` [m], and inertia about the COM ``i_com``
+    [kg·m²]. ``damping`` are viscous joint coefficients on the RELATIVE
+    joint rates (shoulder, elbow, wrist).
+    """
+
+    m: tuple[float, float, float]
+    l: tuple[float, float, float]  # noqa: E741 — matches the double-pendulum naming
+    lc: tuple[float, float, float]
+    i_com: tuple[float, float, float]
+    damping: tuple[float, float, float] = (0.4, 0.3, 0.25)
+
+    def __post_init__(self) -> None:
+        for name in ("m", "l", "lc", "i_com"):
+            for value in getattr(self, name):
+                require(
+                    math.isfinite(value) and value > 0.0,
+                    f"{name} entries must be finite and > 0",
+                    value,
+                )
+        for value in self.damping:
+            require(
+                math.isfinite(value) and value >= 0.0,
+                "damping entries must be finite and >= 0",
+                value,
+            )
+        for lc_i, l_i in zip(self.lc, self.l, strict=True):
+            require(lc_i <= l_i, "lc must not exceed l", lc_i)
+
+    @classmethod
+    def golf_default(cls) -> TriplePendulumParameters:
+        """Upper arm + forearm + club, splitting the shared golf defaults.
+
+        The 0.75 m / 7.5 kg arm of the double-pendulum default becomes an
+        upper arm and a forearm; the club link reuses the shared shaft +
+        clubhead composition so total reach and club inertia match the
+        double model.
+        """
+        upper = (4.5, 0.40, 0.40 * 0.45, (1.0 / 12.0) * 4.5 * 0.40**2)
+        fore = (3.0, 0.35, 0.35 * 0.45, (1.0 / 12.0) * 3.0 * 0.35**2)
+        # Club: 1.0 m shaft (0.15 kg, COM at 43%) + 0.20 kg head at the tip.
+        length, ms, mh = 1.0, 0.15, 0.20
+        m_club = ms + mh
+        shaft_com = length * 0.43
+        lc_club = (shaft_com * ms + length * mh) / m_club
+        i_shaft_com = (1.0 / 12.0) * ms * length * length
+        parallel = ms * (shaft_com - lc_club) ** 2 + mh * (length - lc_club) ** 2
+        club = (m_club, length, lc_club, i_shaft_com + parallel)
+        return cls(
+            m=(upper[0], fore[0], club[0]),
+            l=(upper[1], fore[1], club[1]),
+            lc=(upper[2], fore[2], club[2]),
+            i_com=(upper[3], fore[3], club[3]),
+        )
+
+
+def _triple_a_matrix(p: TriplePendulumParameters) -> np.ndarray:
+    """Coefficient matrix ``a[i, k]``: dr_ci/dphi_k magnitude factors."""
+    a = np.zeros((3, 3))
+    for i in range(3):
+        for k in range(3):
+            if k < i:
+                a[i, k] = p.l[k]
+            elif k == i:
+                a[i, k] = p.lc[i]
+    return a
+
+
+def triple_derivatives(
+    p: TriplePendulumParameters,
+    state: np.ndarray,
+    g_inplane: tuple[float, float],
+) -> np.ndarray:
+    """State derivatives for the unforced triple pendulum.
+
+    ``state`` is ``[phi1, phi2, phi3, dphi1, dphi2, dphi3]`` with
+    absolute angles from the in-plane downward vertical. Standard n-link
+    absolute-angle equations: ``M(phi) ddphi + C(phi, dphi) + G(phi) +
+    D(dphi) = 0`` with ``beta[k, j] = sum_i m_i a_ik a_ij``.
+    """
+    phi = state[:3]
+    dphi = state[3:]
+    a = _triple_a_matrix(p)
+    m_arr = np.array(p.m)
+    beta = np.einsum("i,ik,ij->kj", m_arr, a, a)
+
+    diff = phi[:, None] - phi[None, :]
+    mass = beta * np.cos(diff) + np.diag(p.i_com)
+    coriolis = (beta * np.sin(diff)) @ (dphi**2)
+
+    gx, gy = g_inplane
+    weights = m_arr @ a  # sum_i m_i a_ik per coordinate k
+    gravity = -weights * (gx * np.cos(phi) + gy * np.sin(phi))
+
+    # Damping on relative joint rates: psi_dot = J dphi.
+    j = np.array([[1.0, 0.0, 0.0], [-1.0, 1.0, 0.0], [0.0, -1.0, 1.0]])
+    damping = j.T @ (np.array(p.damping) * (j @ dphi))
+
+    ddphi = np.linalg.solve(mass, -(coriolis + gravity + damping))
+    return np.concatenate([dphi, ddphi])
+
+
+def triple_total_energy(
+    p: TriplePendulumParameters,
+    state: np.ndarray,
+    g_inplane: tuple[float, float],
+) -> float:
+    """Total mechanical energy [J] (kinetic + in-plane gravitational)."""
+    phi = state[:3]
+    dphi = state[3:]
+    a = _triple_a_matrix(p)
+    m_arr = np.array(p.m)
+    beta = np.einsum("i,ik,ij->kj", m_arr, a, a)
+    mass = beta * np.cos(phi[:, None] - phi[None, :]) + np.diag(p.i_com)
+    kinetic = 0.5 * float(dphi @ mass @ dphi)
+
+    gx, gy = g_inplane
+    e_x, e_y = np.sin(phi), -np.cos(phi)
+    potential = 0.0
+    for i in range(3):
+        cx = sum(p.l[j] * e_x[j] for j in range(i)) + p.lc[i] * e_x[i]
+        cy = sum(p.l[j] * e_y[j] for j in range(i)) + p.lc[i] * e_y[i]
+        potential -= p.m[i] * (gx * cx + gy * cy)
+    return kinetic + potential
+
+
+class TriplePendulumSwing:
+    """Planar triple pendulum on an oriented plane (swing frame).
+
+    Same posture as :class:`DoublePendulumSwing`: integrate once at
+    construction with classical RK4 on a uniform grid, then sample by
+    linear interpolation. Wrap in :class:`AppFrameSwing` for the app.
+    """
+
+    def __init__(
+        self,
+        parameters: TriplePendulumParameters | None = None,
+        plane: PlaneOrientation | None = None,
+        initial_state: np.ndarray | None = None,
+        duration: float = 1.5,
+        dt: float = 1e-3,
+        gravity_m_s2: float = 9.80665,
+    ) -> None:
+        require(
+            math.isfinite(duration) and duration > 0.0,
+            "duration must be finite and > 0",
+            duration,
+        )
+        require(math.isfinite(dt) and 0.0 < dt <= duration, "invalid dt", dt)
+        self._p = parameters or TriplePendulumParameters.golf_default()
+        self._plane = plane or PlaneOrientation()
+        self._dt = float(dt)
+        self._n_steps = int(round(duration / dt))
+        self._duration = self._n_steps * self._dt
+
+        self._plane_r = reference.plane_rotation(
+            self._plane.yaw_rad, self._plane.side_tilt_rad, self._plane.forward_tilt_rad
+        )
+        self._g_inplane = reference.in_plane_gravity(self._plane_r, gravity_m_s2)
+
+        state = (
+            np.asarray(initial_state, dtype=float)
+            if initial_state is not None
+            else np.array(
+                [-math.pi / 2.0, -math.pi / 2.0, -math.pi / 2.0, 0.0, 0.0, 0.0]
+            )
+        )
+        require(state.shape == (6,), "initial_state must be a 6-vector", state.shape)
+        self._states = np.empty((self._n_steps + 1, 6))
+        self._states[0] = state
+        for i in range(self._n_steps):
+            self._states[i + 1] = self._rk4_step(self._states[i])
+
+    def _rk4_step(self, y: np.ndarray) -> np.ndarray:
+        dt = self._dt
+        f = lambda s: triple_derivatives(self._p, s, self._g_inplane)  # noqa: E731
+        k1 = f(y)
+        k2 = f(y + dt / 2.0 * k1)
+        k3 = f(y + dt / 2.0 * k2)
+        k4 = f(y + dt * k3)
+        return np.asarray(y + dt / 6.0 * (k1 + 2.0 * k2 + 2.0 * k3 + k4))
+
+    @property
+    def parameters(self) -> TriplePendulumParameters:
+        """Pendulum parameters used for the integration."""
+        return self._p
+
+    @property
+    def plane(self) -> PlaneOrientation:
+        """Swing-plane orientation."""
+        return self._plane
+
+    @property
+    def duration(self) -> float:
+        """Total duration [s] of the integrated swing."""
+        return self._duration
+
+    def sample(self, t: float) -> SwingSample:
+        """Clubhead (tip of link 3) sample at ``t``, swing frame."""
+        require(math.isfinite(t), "t must be finite", t)
+        require(
+            -1e-9 <= t <= self._duration + 1e-9,
+            "t must be within [0, duration]",
+            t,
+        )
+        t = min(max(t, 0.0), self._duration)
+        idx = t / self._dt
+        i0 = min(int(idx), self._n_steps)
+        i1 = min(i0 + 1, self._n_steps)
+        frac = idx - i0
+        row = (1.0 - frac) * self._states[i0] + frac * self._states[i1]
+        phi, dphi = row[:3], row[3:]
+
+        lengths = np.array(self._p.l)
+        x = float(np.sum(lengths * np.sin(phi)))
+        y = float(-np.sum(lengths * np.cos(phi)))
+        vx = float(np.sum(lengths * np.cos(phi) * dphi))
+        vy = float(np.sum(lengths * np.sin(phi) * dphi))
+
+        r_plane = self._plane_r
+        x_axis, normal, up_axis = r_plane[:, 0], r_plane[:, 1], r_plane[:, 2]
+        position = x * x_axis + y * up_axis
+        c3, s3 = math.cos(phi[2]), math.sin(phi[2])
+        local = np.array([[c3, 0.0, s3], [0.0, 1.0, 0.0], [-s3, 0.0, c3]])
+        pose = np.eye(4)
+        pose[:3, :3] = r_plane @ local
+        pose[:3, 3] = position
+        twist = np.concatenate([float(dphi[2]) * normal, vx * x_axis + vy * up_axis])
+        return SwingSample(t=t, pose=pose, twist=twist)
+
+
+def make_source(
+    kind: str,
+    scenario: ImpactScenario,
+    plane: PlaneOrientation | None = None,
+    duration: float = 1.5,
+) -> SwingSource:
+    """Build an app-frame swing source by kind.
+
+    Args:
+        kind: One of :data:`SOURCE_KINDS`.
+        scenario: The manual scenario (used directly by ``"manual"``;
+            pendulum kinds use it only for impact offsets downstream).
+        plane: Swing-plane orientation for the pendulum kinds.
+        duration: Pendulum integration length [s].
+
+    Returns:
+        A source whose samples are in the app frame.
+    """
+    require(kind in SOURCE_KINDS, f"unknown swing source kind {kind!r}", kind)
+    if kind == "manual":
+        return ManualSwingSource(scenario)
+    if kind == "double_pendulum":
+        # Start on the target side (theta1 = -pi/2, arm horizontal) so
+        # the gravity-driven downswing carries the clubhead TOWARD the
+        # target (+x) at the bottom of the arc.
+        start = PendulumState(theta1=-math.pi / 2.0, theta2=0.0, omega1=0.0, omega2=0.0)
+        return AppFrameSwing(
+            DoublePendulumSwing(
+                plane=plane, initial_state=start, duration=duration, backend="auto"
+            )
+        )
+    return AppFrameSwing(TriplePendulumSwing(plane=plane, duration=duration))

--- a/src/rate_of_closure/ui/pyqt6/inspector_view.py
+++ b/src/rate_of_closure/ui/pyqt6/inspector_view.py
@@ -1,0 +1,160 @@
+"""Run-data inspector: sortable time-series table + summary + export.
+
+Shows one :class:`~rate_of_closure.simulation.session.SimulationRun` as
+a sortable table of the phase-tagged time series (the same rows the CSV
+export writes) with the impact/launch/flight summary numbers above it,
+and offers CSV / JSON export through the shared
+:mod:`rate_of_closure.simulation.export` functions.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rate_of_closure.simulation import SimulationRun, write_csv, write_json
+from rate_of_closure.simulation.export import CSV_COLUMNS, series_rows
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["InspectorView"]
+
+_SUMMARY_ORDER: tuple[tuple[str, str, str], ...] = (
+    ("ball_speed_mph", "Ball Speed", "mph"),
+    ("launch_angle_deg", "Launch Angle", "°"),
+    ("launch_azimuth_deg", "Launch Azimuth", "°"),
+    ("spin_rpm", "Spin", "rpm"),
+    ("carry_m", "Carry", "m"),
+    ("max_height_m", "Apex", "m"),
+    ("flight_time_s", "Flight Time", "s"),
+    ("landing_angle_deg", "Landing Angle", "°"),
+)
+
+
+class _NumericItem(QTableWidgetItem):
+    """Table item sorting numerically on its stored value."""
+
+    def __init__(self, value: float, text: str) -> None:
+        super().__init__(text)
+        self.setData(Qt.ItemDataRole.UserRole, value)
+        self.setFlags(self.flags() & ~Qt.ItemFlag.ItemIsEditable)
+
+    def __lt__(self, other: QTableWidgetItem) -> bool:
+        mine = self.data(Qt.ItemDataRole.UserRole)
+        theirs = other.data(Qt.ItemDataRole.UserRole)
+        if isinstance(mine, float) and isinstance(theirs, float):
+            return mine < theirs
+        return super().__lt__(other)
+
+
+class InspectorView(QWidget):
+    """Sortable inspector over one simulation run, with export buttons."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._run: SimulationRun | None = None
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+
+        header = QHBoxLayout()
+        self._summary_label = QLabel("Run a simulation to populate the inspector.")
+        self._summary_label.setWordWrap(True)
+        header.addWidget(self._summary_label, stretch=1)
+
+        self._export_csv_button = QPushButton("Export CSV…")
+        self._export_csv_button.setToolTip(
+            "Write the phase-tagged time series (swing + flight) as CSV."
+        )
+        self._export_csv_button.setEnabled(False)
+        self._export_csv_button.clicked.connect(self._on_export_csv)
+        header.addWidget(self._export_csv_button)
+
+        self._export_json_button = QPushButton("Export JSON…")
+        self._export_json_button.setToolTip(
+            "Write parameters, delivery/launch summaries, and the time "
+            "series as a JSON document."
+        )
+        self._export_json_button.setEnabled(False)
+        self._export_json_button.clicked.connect(self._on_export_json)
+        header.addWidget(self._export_json_button)
+        layout.addLayout(header)
+
+        self._table = QTableWidget(0, len(CSV_COLUMNS))
+        self._table.setHorizontalHeaderLabels(list(CSV_COLUMNS))
+        self._table.setSortingEnabled(True)
+        self._table.verticalHeader().setVisible(False)  # type: ignore[union-attr]
+        layout.addWidget(self._table)
+
+    # ── public API ──────────────────────────────────────────────────
+    def set_run(self, run: SimulationRun | None) -> None:
+        """Populate (or clear, with ``None``) the inspector."""
+        self._run = run
+        self._export_csv_button.setEnabled(run is not None)
+        self._export_json_button.setEnabled(run is not None)
+        self._table.setSortingEnabled(False)
+        self._table.setRowCount(0)
+        if run is None:
+            self._summary_label.setText("Run a simulation to populate the inspector.")
+            return
+
+        launch = run.launch
+        parts = [
+            f"{label} {launch[key]:.1f} {unit}" for key, label, unit in _SUMMARY_ORDER
+        ]
+        self._summary_label.setText(
+            f"{run.config.club.name} — {run.config.source_kind.replace('_', ' ')} "
+            f"swing, impact at {run.impact_time_s:.3f} s.  " + " · ".join(parts)
+        )
+
+        rows = series_rows(run)
+        self._table.setRowCount(len(rows))
+        for r, row in enumerate(rows):
+            phase_item = QTableWidgetItem(str(row[0]))
+            phase_item.setFlags(phase_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            self._table.setItem(r, 0, phase_item)
+            for c, value in enumerate(row[1:], start=1):
+                self._table.setItem(r, c, _NumericItem(float(value), f"{value:.4f}"))
+        self._table.setSortingEnabled(True)
+
+    def run(self) -> SimulationRun | None:
+        """The run currently inspected, if any."""
+        return self._run
+
+    # ── internals ──────────────────────────────────────────────────
+    def _export(self, kind: str) -> None:
+        if self._run is None:
+            return
+        caption = f"Export Simulation Run ({kind.upper()})"
+        pattern = f"{kind.upper()} files (*.{kind});;All files (*)"
+        path, _selected = QFileDialog.getSaveFileName(
+            self, caption, f"simulation_run.{kind}", pattern
+        )
+        if not path:
+            return
+        try:
+            if kind == "csv":
+                write_csv(self._run, path)
+            else:
+                write_json(self._run, path)
+        except OSError as exc:  # surface disk/permission problems
+            logger.warning("export failed: %s", exc)
+            QMessageBox.warning(self, "Export Failed", str(exc))
+
+    def _on_export_csv(self) -> None:
+        self._export("csv")
+
+    def _on_export_json(self) -> None:
+        self._export("json")

--- a/src/rate_of_closure/ui/pyqt6/main_window.py
+++ b/src/rate_of_closure/ui/pyqt6/main_window.py
@@ -16,12 +16,9 @@ from __future__ import annotations
 import logging
 import math
 
-from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
     QFrame,
     QGroupBox,
-    QHBoxLayout,
-    QLabel,
     QMainWindow,
     QScrollArea,
     QSplitter,
@@ -41,6 +38,8 @@ from rate_of_closure.model import ImpactScenario, closure_metrics, solve
 from rate_of_closure.ui.pyqt6.club_view import Club3DView, SweepView
 from rate_of_closure.ui.pyqt6.controls_panel import ControlsPanel
 from rate_of_closure.ui.pyqt6.derivation_view import DerivationView
+from rate_of_closure.ui.pyqt6.result_row import ResultRow as _ResultRow
+from rate_of_closure.ui.pyqt6.simulation_tab import SimulationTab
 from rate_of_closure.units import convert_from_canonical
 
 logger = logging.getLogger(__name__)
@@ -113,49 +112,6 @@ _QUANTITY_ROWS: dict[str, str] = {
 }
 
 
-class _ResultRow(QFrame):
-    """A clickable result box: label left, live value right.
-
-    Clicking (or keyboard-activating) the row emits ``clicked`` with the
-    result field name so the window can show the explanation.
-    """
-
-    clicked = pyqtSignal(str)
-
-    def __init__(self, field: str, label: str) -> None:
-        super().__init__()
-        self._field = field
-        self.setObjectName("resultRow")
-        self.setFrameShape(QFrame.Shape.StyledPanel)
-        self.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.setFocusPolicy(Qt.FocusPolicy.TabFocus)
-        self.setToolTip("Click for the explanation and derivation trace")
-        self.setAccessibleName(label)
-
-        row = QHBoxLayout(self)
-        row.setContentsMargins(10, 6, 10, 6)
-        name = QLabel(label)
-        row.addWidget(name)
-        row.addStretch(1)
-        self.value_label = QLabel("—")
-        font = self.value_label.font()
-        font.setBold(True)
-        self.value_label.setFont(font)
-        row.addWidget(self.value_label)
-
-    def mousePressEvent(self, event) -> None:  # type: ignore[no-untyped-def]  # noqa: N802
-        """Emit the field name; keep default frame behaviour."""
-        self.clicked.emit(self._field)
-        super().mousePressEvent(event)
-
-    def keyPressEvent(self, event) -> None:  # type: ignore[no-untyped-def]  # noqa: N802
-        """Space/Return activate the row, matching button conventions."""
-        if event.key() in (Qt.Key.Key_Space, Qt.Key.Key_Return):
-            self.clicked.emit(self._field)
-            return
-        super().keyPressEvent(event)
-
-
 class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
     """Interactive explorer for rotation-induced impact-point deviations."""
 
@@ -169,6 +125,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         self._club_view = Club3DView()
         self._sweep_view = SweepView()
         self._derivation_view = DerivationView()
+        self._simulation_tab = SimulationTab()
 
         left_content = QWidget()
         left_layout = QVBoxLayout(left_content)
@@ -191,6 +148,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         tabs.addTab(self._club_view, "3D Clubhead")
         tabs.addTab(self._sweep_view, "Closure Sweep")
         tabs.addTab(self._derivation_view, "Derivation && Traceability")
+        tabs.addTab(self._simulation_tab, "Simulation")
 
         splitter = QSplitter()
         splitter.addWidget(left)
@@ -285,6 +243,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         self._club_view.set_scenario(scenario)
         self._sweep_view.set_scenario(scenario)
         self._derivation_view.set_scenario(scenario)
+        self._simulation_tab.set_scenario(scenario)
         status_bar = self.statusBar()
         if status_bar is None:  # pragma: no cover - Qt always provides one here
             return
@@ -298,6 +257,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         )
 
     def closeEvent(self, event) -> None:  # type: ignore[no-untyped-def]  # noqa: N802
-        """Stop the animation timer before the window goes away."""
+        """Stop the animation timers before the window goes away."""
         self._club_view.stop()
+        self._simulation_tab.stop()
         super().closeEvent(event)

--- a/src/rate_of_closure/ui/pyqt6/result_row.py
+++ b/src/rate_of_closure/ui/pyqt6/result_row.py
@@ -1,0 +1,53 @@
+"""Shared clickable result-row widget for the PyQt6 explorer.
+
+Used by the main window's deviation/metric boxes and the Simulation
+tab's launch-number box: label on the left, live bold value on the
+right, click (or Space/Return) emits the row's field name so the host
+can show the matching explanation text.
+"""
+
+from __future__ import annotations
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel
+
+__all__ = ["ResultRow"]
+
+
+class ResultRow(QFrame):
+    """A clickable result box: label left, live value right."""
+
+    clicked = pyqtSignal(str)
+
+    def __init__(self, field: str, label: str) -> None:
+        super().__init__()
+        self._field = field
+        self.setObjectName("resultRow")
+        self.setFrameShape(QFrame.Shape.StyledPanel)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setFocusPolicy(Qt.FocusPolicy.TabFocus)
+        self.setToolTip("Click for the explanation and derivation trace")
+        self.setAccessibleName(label)
+
+        row = QHBoxLayout(self)
+        row.setContentsMargins(10, 6, 10, 6)
+        name = QLabel(label)
+        row.addWidget(name)
+        row.addStretch(1)
+        self.value_label = QLabel("—")
+        font = self.value_label.font()
+        font.setBold(True)
+        self.value_label.setFont(font)
+        row.addWidget(self.value_label)
+
+    def mousePressEvent(self, event) -> None:  # type: ignore[no-untyped-def]  # noqa: N802
+        """Emit the field name; keep default frame behaviour."""
+        self.clicked.emit(self._field)
+        super().mousePressEvent(event)
+
+    def keyPressEvent(self, event) -> None:  # type: ignore[no-untyped-def]  # noqa: N802
+        """Space/Return activate the row, matching button conventions."""
+        if event.key() in (Qt.Key.Key_Space, Qt.Key.Key_Return):
+            self.clicked.emit(self._field)
+            return
+        super().keyPressEvent(event)

--- a/src/rate_of_closure/ui/pyqt6/simulation_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/simulation_tab.py
@@ -1,0 +1,367 @@
+"""The Simulation tab: swing source, plane tilts, club, scrub, run.
+
+Hosts the whole simulation session UI (epic #4103): swing-source picker
+(manual scenario / double pendulum / triple pendulum), the three
+sequential plane-tilt inputs, a club picker (reusing the shared club
+library), the flight-model picker, the Run button, the impact-time
+scrubber (the ball is fixed; scrubbing tau translates the swing so the
+clubhead at tau meets it, with delivery numbers updating live), the 3D
+scene with playback + toggles (:class:`SimulationView`), the launch
+result rows with click-through explanations, and the run-data inspector
+with CSV/JSON export (:class:`InspectorView`).
+
+Every input carries sourced hover guidance (FIELD_GUIDANCE pattern);
+the tab consumes complete scenarios from the main window (LoD) and
+builds :class:`SimulationConfig` objects for the session layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import numpy as np
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QAbstractSpinBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QMessageBox,
+    QPushButton,
+    QSlider,
+    QSplitter,
+    QTabWidget,
+    QTextBrowser,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rate_of_closure.club import club_names, get_club
+from rate_of_closure.derivation import LAUNCH_EXPLANATIONS
+from rate_of_closure.model import ImpactScenario
+from rate_of_closure.simulation import (
+    SOURCE_KINDS,
+    SimulationConfig,
+    SimulationRun,
+    delivery_at,
+    make_source,
+    run_simulation,
+)
+from rate_of_closure.ui.pyqt6.inspector_view import InspectorView
+from rate_of_closure.ui.pyqt6.result_row import ResultRow
+from rate_of_closure.ui.pyqt6.simulation_view import SimulationView
+from rate_of_closure.units import FIELD_GUIDANCE
+from shared.python.swing_sim.flight.registry import FlightModelType
+from shared.python.swing_sim.types import PlaneOrientation
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["LAUNCH_ROWS", "SOURCE_LABELS", "SimulationTab"]
+
+#: Source kind -> Title Case combo label (order matches SOURCE_KINDS).
+SOURCE_LABELS: dict[str, str] = {
+    "manual": "Manual Scenario (Constant Twist)",
+    "double_pendulum": "Double Pendulum",
+    "triple_pendulum": "Triple Pendulum",
+}
+
+#: (launch field, Title Case label, unit suffix) in display order. Every
+#: field must have an entry in LAUNCH_EXPLANATIONS (test-enforced).
+LAUNCH_ROWS: tuple[tuple[str, str, str], ...] = (
+    ("ball_speed_mph", "Ball Speed", " mph"),
+    ("launch_angle_deg", "Launch Angle", "°"),
+    ("launch_azimuth_deg", "Launch Azimuth", "°"),
+    ("spin_rpm", "Total Spin", " rpm"),
+    ("carry_m", "Carry Distance", " m"),
+    ("max_height_m", "Apex Height", " m"),
+    ("flight_time_s", "Flight Time", " s"),
+    ("landing_angle_deg", "Landing Angle", "°"),
+)
+
+_TILT_SPECS: tuple[tuple[str, str, str], ...] = (
+    ("yaw_deg", "Plane Yaw", "plane_yaw_deg"),
+    ("side_tilt_deg", "Plane Side Tilt", "plane_side_tilt_deg"),
+    ("forward_tilt_deg", "Plane Forward Tilt", "plane_forward_tilt_deg"),
+)
+
+_SCRUB_STEPS = 1000
+
+
+class SimulationTab(QWidget):
+    """Simulation session tab (controls left, scene/inspector right)."""
+
+    #: Emitted with the SimulationRun after every successful run.
+    runCompleted = pyqtSignal(object)  # noqa: N815 - Qt signal convention
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._scenario = ImpactScenario(clubhead_speed_mph=113.0)
+        self._run: SimulationRun | None = None
+        self._tau: float | None = None  # None = auto (max clubhead speed)
+        self._source = None  # cached app-frame source for live scrubbing
+        self._rows: dict[str, ResultRow] = {}
+
+        self._view = SimulationView()
+        self._inspector = InspectorView()
+
+        left = QWidget()
+        left_layout = QVBoxLayout(left)
+        left_layout.addWidget(self._build_setup_box())
+        left_layout.addWidget(self._build_scrub_box())
+        left_layout.addWidget(self._build_launch_box())
+        left_layout.addWidget(self._build_explanation_box())
+        left_layout.addStretch(1)
+        left.setMinimumWidth(320)
+
+        right = QTabWidget()
+        right.addTab(self._view, "Scene")
+        right.addTab(self._inspector, "Inspector")
+
+        splitter = QSplitter()
+        splitter.addWidget(left)
+        splitter.addWidget(right)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(splitter)
+
+        self._show_explanation(LAUNCH_ROWS[0][0])
+
+    # ── construction ────────────────────────────────────────────────
+    def _build_setup_box(self) -> QGroupBox:
+        box = QGroupBox("Simulation Setup")
+        form = QFormLayout(box)
+
+        self._source_combo = QComboBox()
+        self._source_combo.addItems([SOURCE_LABELS[kind] for kind in SOURCE_KINDS])
+        self._source_combo.setToolTip(FIELD_GUIDANCE["swing_source"])
+        self._source_combo.currentIndexChanged.connect(self._invalidate_source)
+        form.addRow("Swing Source", self._source_combo)
+
+        self._tilt_spins: dict[str, QDoubleSpinBox] = {}
+        for attr, label, guidance_key in _TILT_SPECS:
+            spin = QDoubleSpinBox()
+            spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+            spin.setKeyboardTracking(False)
+            spin.setDecimals(1)
+            spin.setRange(-90.0, 90.0)
+            spin.setSuffix(" deg")
+            spin.setToolTip(FIELD_GUIDANCE[guidance_key])
+            spin.valueChanged.connect(self._invalidate_source)
+            self._tilt_spins[attr] = spin
+            form.addRow(label, spin)
+        self._tilt_spins["side_tilt_deg"].setValue(-45.0)
+
+        self._club_combo = QComboBox()
+        self._club_combo.addItems(club_names())
+        self._club_combo.setToolTip(FIELD_GUIDANCE["club_selection"])
+        form.addRow("Club", self._club_combo)
+
+        self._flight_combo = QComboBox()
+        self._flight_combo.addItems([m.value for m in FlightModelType])
+        self._flight_combo.setCurrentText("waterloo_penner")
+        self._flight_combo.setToolTip(FIELD_GUIDANCE["flight_model"])
+        form.addRow("Flight Model", self._flight_combo)
+
+        self._run_button = QPushButton("Run Simulation")
+        self._run_button.setToolTip(
+            "Generate the swing, solve the impact at the scrubbed instant, "
+            "and integrate the ball flight."
+        )
+        self._run_button.clicked.connect(self.run_now)
+        form.addRow(self._run_button)
+        return box
+
+    def _build_scrub_box(self) -> QGroupBox:
+        box = QGroupBox("Impact Time (Scrub the Swing Onto the Ball)")
+        layout = QVBoxLayout(box)
+
+        row = QHBoxLayout()
+        self._scrub_slider = QSlider(Qt.Orientation.Horizontal)
+        self._scrub_slider.setRange(0, _SCRUB_STEPS)
+        self._scrub_slider.setValue(_SCRUB_STEPS // 2)
+        self._scrub_slider.setToolTip(FIELD_GUIDANCE["impact_time_scrub"])
+        self._scrub_slider.valueChanged.connect(self._on_scrub_moved)
+        self._scrub_slider.sliderReleased.connect(self._on_scrub_released)
+        row.addWidget(self._scrub_slider, stretch=1)
+        self._scrub_label = QLabel("auto")
+        self._scrub_label.setFixedWidth(72)
+        row.addWidget(self._scrub_label)
+        layout.addLayout(row)
+
+        self._auto_tau_button = QPushButton("Auto (Max Clubhead Speed)")
+        self._auto_tau_button.setToolTip(
+            "Reset the impact instant to the sampled moment of maximum clubhead speed."
+        )
+        self._auto_tau_button.clicked.connect(self._on_auto_tau)
+        layout.addWidget(self._auto_tau_button)
+
+        self._delivery_label = QLabel("—")
+        self._delivery_label.setWordWrap(True)
+        layout.addWidget(self._delivery_label)
+        return box
+
+    def _build_launch_box(self) -> QGroupBox:
+        box = QGroupBox("Launch Numbers")
+        layout = QVBoxLayout(box)
+        layout.setSpacing(4)
+        for field, label, _unit in LAUNCH_ROWS:
+            row = ResultRow(field, label)
+            row.clicked.connect(self._show_explanation)
+            self._rows[field] = row
+            layout.addWidget(row)
+        return box
+
+    def _build_explanation_box(self) -> QGroupBox:
+        box = QGroupBox("What This Number Means")
+        layout = QVBoxLayout(box)
+        self._explanation = QTextBrowser()
+        self._explanation.setOpenExternalLinks(False)
+        self._explanation.setMinimumHeight(90)
+        self._explanation.setMaximumHeight(150)
+        layout.addWidget(self._explanation)
+        return box
+
+    # ── public API ──────────────────────────────────────────────────
+    def set_scenario(self, scenario: ImpactScenario) -> None:
+        """Adopt the explorer's scenario (drives the manual source)."""
+        self._scenario = scenario
+        self._invalidate_source()
+
+    def plane(self) -> PlaneOrientation:
+        """The plane orientation described by the tilt inputs."""
+        return PlaneOrientation(
+            yaw_deg=self._tilt_spins["yaw_deg"].value(),
+            side_tilt_deg=self._tilt_spins["side_tilt_deg"].value(),
+            forward_tilt_deg=self._tilt_spins["forward_tilt_deg"].value(),
+        )
+
+    def source_kind(self) -> str:
+        """The selected swing-source kind."""
+        return str(SOURCE_KINDS[int(self._source_combo.currentIndex())])
+
+    def config(self) -> SimulationConfig:
+        """The simulation request described by the controls."""
+        return SimulationConfig(
+            scenario=self._scenario,
+            club=get_club(self._club_combo.currentText()),
+            source_kind=self.source_kind(),
+            plane=self.plane(),
+            impact_time_s=self._tau,
+            flight_model=self._flight_combo.currentText(),
+        )
+
+    def run_now(self) -> SimulationRun | None:
+        """Run the simulation and populate the scene + inspector."""
+        try:
+            run = run_simulation(self.config())
+        except Exception as exc:  # noqa: BLE001 — surface physics failures
+            logger.warning("simulation failed: %s", exc)
+            QMessageBox.warning(self, "Simulation Failed", str(exc))
+            return None
+        self._run = run
+        self._tau = run.impact_time_s
+        self._sync_scrub_slider(run.impact_time_s)
+        self._view.set_run(run)
+        self._inspector.set_run(run)
+        for field, _label, unit in LAUNCH_ROWS:
+            value = run.launch[field]
+            text = f"{value:+.1f}{unit}" if math.isfinite(value) else "—"
+            self._rows[field].value_label.setText(text)
+        self._update_delivery_label(run.impact_time_s)
+        self.runCompleted.emit(run)
+        return run
+
+    def last_run(self) -> SimulationRun | None:
+        """The most recent successful run, if any."""
+        return self._run
+
+    def view(self) -> SimulationView:
+        """The 3D scene (playback controls live on it)."""
+        return self._view
+
+    def inspector(self) -> InspectorView:
+        """The run-data inspector."""
+        return self._inspector
+
+    def stop(self) -> None:
+        """Stop the playback timer (window close and tests)."""
+        self._view.stop()
+
+    # ── internals ──────────────────────────────────────────────────
+    def _ensure_source(self):  # type: ignore[no-untyped-def]
+        if self._source is None:
+            self._source = make_source(
+                self.source_kind(), self._scenario, plane=self.plane()
+            )
+        return self._source
+
+    def _invalidate_source(self, *_args: object) -> None:
+        self._source = None
+        if self._tau is not None:
+            self._update_delivery_label(self._tau)
+
+    def _scrub_time(self, value: int) -> float:
+        source = self._ensure_source()
+        return value / _SCRUB_STEPS * float(source.duration)
+
+    def _sync_scrub_slider(self, tau: float) -> None:
+        source = self._ensure_source()
+        value = (
+            round(tau / source.duration * _SCRUB_STEPS) if source.duration > 0.0 else 0
+        )
+        self._scrub_slider.blockSignals(True)
+        self._scrub_slider.setValue(value)
+        self._scrub_slider.blockSignals(False)
+        self._scrub_label.setText(f"{tau * 1000.0:.1f} ms")
+
+    def _update_delivery_label(self, tau: float) -> None:
+        try:
+            source = self._ensure_source()
+            delivery = delivery_at(
+                source, tau, self._scenario, get_club(self._club_combo.currentText())
+            )
+        except Exception as exc:  # noqa: BLE001 — zero-speed instants etc.
+            self._delivery_label.setText(f"No delivery at this instant ({exc})")
+            return
+        velocity = delivery.clubhead_velocity
+        speed_mph = float(np.linalg.norm(velocity)) * 2.2369362920544025
+        path = math.degrees(math.atan2(float(velocity[2]), float(velocity[0])))
+        aoa = math.degrees(
+            math.atan2(
+                float(velocity[1]),
+                math.hypot(float(velocity[0]), float(velocity[2])),
+            )
+        )
+        self._delivery_label.setText(
+            f"Delivery at τ: {speed_mph:.1f} mph, path {path:+.1f}°, "
+            f"AoA {aoa:+.1f}°, spin loft {delivery.spin_loft_deg:.1f}°"
+        )
+
+    def _on_scrub_moved(self, value: int) -> None:
+        tau = self._scrub_time(value)
+        self._tau = tau
+        self._scrub_label.setText(f"{tau * 1000.0:.1f} ms")
+        self._update_delivery_label(tau)
+        # Dragging updates delivery live; the full impact + flight rerun
+        # happens on release (or immediately for programmatic setValue).
+        if not self._scrub_slider.isSliderDown() and self._run is not None:
+            self.run_now()
+
+    def _on_scrub_released(self) -> None:
+        if self._run is not None:
+            self.run_now()
+
+    def _on_auto_tau(self) -> None:
+        self._tau = None
+        self.run_now()
+
+    def _show_explanation(self, field: str) -> None:
+        labels = {key: label for key, label, _unit in LAUNCH_ROWS}
+        text = LAUNCH_EXPLANATIONS.get(field, "")
+        self._explanation.setHtml(f"<b>{labels.get(field, field)}</b><br/>{text}")

--- a/src/rate_of_closure/ui/pyqt6/simulation_view.py
+++ b/src/rate_of_closure/ui/pyqt6/simulation_view.py
@@ -1,0 +1,420 @@
+"""3D scene + full video playback controls for the simulation session.
+
+Renders one :class:`~rate_of_closure.simulation.session.SimulationRun`:
+the swing path with the clubhead marker at the playback instant, the
+fixed ball (own checkbox), the ground plane (own checkbox), the flight
+trajectory polyline, and a toggleable instantaneous-screw-axis overlay
+computed through the one thin ISA adapter (recon #4108).
+
+Playback is a full video bar — play/pause, a scrub slider over the
+whole swing + flight timeline, frame step +/-, a loop toggle, and rate
+presets where 1x maps animation wall time to simulated time.
+
+Colors come from the shared UpstreamDrift theme palette
+(``get_chart_color``); no app colors are hard-coded here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSlider,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rate_of_closure.simulation import (
+    BALL_POSITION_M,
+    SimulationRun,
+    screw_axis_samples,
+)
+from rate_of_closure.simulation.isa import MIN_RATE_DPS
+from rate_of_closure.units import FIELD_GUIDANCE
+
+try:  # Theme palette (optional in standalone/vendored use).
+    from shared.python.theme.matplotlib_style import get_chart_color
+except ImportError:  # pragma: no cover - theme package always ships in-repo
+
+    def get_chart_color(index: int) -> str:
+        """Matplotlib cycle colors as a theme-neutral fallback."""
+        return f"C{index % 10}"
+
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["RATE_PRESETS", "SimulationView"]
+
+#: Playback-rate presets, in combo order. 1x is real time: one second
+#: of wall clock advances one second of simulated time.
+RATE_PRESETS: tuple[tuple[str, float], ...] = (
+    ("0.1×", 0.1),
+    ("0.25×", 0.25),
+    ("0.5×", 0.5),
+    ("1× real-time", 1.0),
+    ("2×", 2.0),
+)
+
+_TIMER_INTERVAL_MS = 40
+_SLIDER_STEPS = 1000
+_BALL_DRAW_RADIUS_M = 0.03  # slightly over scale so the ball stays visible
+
+
+class SimulationView(QWidget):
+    """Animated 3D scene of one simulation run with video controls."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._figure = Figure(figsize=(5, 5), tight_layout=True)
+        self._canvas = FigureCanvas(self._figure)
+        self._axes = self._figure.add_subplot(111, projection="3d")
+
+        self._run: SimulationRun | None = None
+        self._screws: list[dict] | None = None
+        self._time = 0.0
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(self._build_playback_bar())
+        layout.addLayout(self._build_toggle_bar())
+        layout.addWidget(self._canvas)
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(_TIMER_INTERVAL_MS)
+        self._timer.timeout.connect(self._advance)
+
+    # ── construction ────────────────────────────────────────────────
+    def _build_playback_bar(self) -> QHBoxLayout:
+        bar = QHBoxLayout()
+        bar.setContentsMargins(4, 4, 4, 0)
+
+        self._play_button = QPushButton("Play")
+        self._play_button.setCheckable(True)
+        self._play_button.setFixedWidth(64)
+        self._play_button.setToolTip("Play or pause the swing + flight playback.")
+        self._play_button.toggled.connect(self._on_play_toggled)
+        bar.addWidget(self._play_button)
+
+        self._step_back_button = QPushButton("−1 frame")
+        self._step_back_button.setToolTip("Step one sample backward.")
+        self._step_back_button.clicked.connect(lambda: self.step_frames(-1))
+        bar.addWidget(self._step_back_button)
+
+        self._step_forward_button = QPushButton("+1 frame")
+        self._step_forward_button.setToolTip("Step one sample forward.")
+        self._step_forward_button.clicked.connect(lambda: self.step_frames(1))
+        bar.addWidget(self._step_forward_button)
+
+        self._position_slider = QSlider(Qt.Orientation.Horizontal)
+        self._position_slider.setRange(0, _SLIDER_STEPS)
+        self._position_slider.setToolTip(
+            "Scrub the playback instant across the whole swing + flight timeline."
+        )
+        self._position_slider.valueChanged.connect(self._on_slider_moved)
+        bar.addWidget(self._position_slider, stretch=1)
+
+        self._time_label = QLabel("0.000 s")
+        self._time_label.setFixedWidth(72)
+        bar.addWidget(self._time_label)
+
+        self._loop_check = QCheckBox("Loop")
+        self._loop_check.setToolTip("Restart playback when the timeline ends.")
+        bar.addWidget(self._loop_check)
+
+        bar.addWidget(QLabel("Rate"))
+        self._rate_combo = QComboBox()
+        self._rate_combo.addItems([name for name, _ in RATE_PRESETS])
+        self._rate_combo.setCurrentIndex(3)  # 1x real-time
+        self._rate_combo.setToolTip(
+            "Playback rate: 1× maps animation time to simulated time; "
+            "slower presets reveal the impact window."
+        )
+        bar.addWidget(self._rate_combo)
+        return bar
+
+    def _build_toggle_bar(self) -> QHBoxLayout:
+        bar = QHBoxLayout()
+        bar.setContentsMargins(4, 0, 4, 0)
+        self._ball_check = QCheckBox("Ball")
+        self._ball_check.setChecked(True)
+        self._ball_check.setToolTip(FIELD_GUIDANCE["ball_visible"])
+        self._ground_check = QCheckBox("Ground")
+        self._ground_check.setChecked(True)
+        self._ground_check.setToolTip(FIELD_GUIDANCE["ground_visible"])
+        self._screw_check = QCheckBox("Screw Axis")
+        self._screw_check.setChecked(False)
+        self._screw_check.setToolTip(FIELD_GUIDANCE["screw_axis_visible"])
+        for check in (self._ball_check, self._ground_check, self._screw_check):
+            check.toggled.connect(lambda _checked: self._draw())
+            bar.addWidget(check)
+        bar.addStretch(1)
+        return bar
+
+    # ── public API ──────────────────────────────────────────────────
+    def set_run(self, run: SimulationRun | None) -> None:
+        """Adopt a run (or clear with ``None``) and reset the timeline."""
+        self._run = run
+        self._screws = None
+        self._time = 0.0
+        self._sync_slider()
+        self._draw()
+
+    def run(self) -> SimulationRun | None:
+        """The run currently rendered, if any."""
+        return self._run
+
+    def playback_time(self) -> float:
+        """Current playback instant [s] on the swing + flight timeline."""
+        return self._time
+
+    def set_playback_time(self, t: float) -> None:
+        """Move the playback instant (clamped to the timeline)."""
+        if self._run is None:
+            return
+        self._time = min(max(t, 0.0), self._run.total_duration_s)
+        self._sync_slider()
+        self._draw()
+
+    def playback_rate(self) -> float:
+        """The selected playback-rate multiplier."""
+        return RATE_PRESETS[self._rate_combo.currentIndex()][1]
+
+    def set_playback_rate(self, multiplier: float) -> None:
+        """Select the nearest rate preset to ``multiplier``."""
+        index = int(np.argmin([abs(rate - multiplier) for _, rate in RATE_PRESETS]))
+        self._rate_combo.setCurrentIndex(index)
+
+    def step_frames(self, frames: int) -> None:
+        """Step the playback instant by whole swing-sample intervals."""
+        if self._run is None:
+            return
+        dt = float(self._run.swing_times[1] - self._run.swing_times[0])
+        self.set_playback_time(self._time + frames * dt)
+
+    def is_playing(self) -> bool:
+        """Whether the playback timer is running."""
+        return self._timer.isActive()
+
+    def set_looping(self, looping: bool) -> None:
+        """Set the loop toggle."""
+        self._loop_check.setChecked(looping)
+
+    def stop(self) -> None:
+        """Stop the playback timer (window close and tests)."""
+        self._timer.stop()
+        self._play_button.setChecked(False)
+
+    # ── internals ──────────────────────────────────────────────────
+    def _on_play_toggled(self, playing: bool) -> None:
+        self._play_button.setText("Pause" if playing else "Play")
+        if playing and self._run is not None:
+            self._timer.start()
+        else:
+            self._timer.stop()
+
+    def _on_slider_moved(self, value: int) -> None:
+        if self._run is None:
+            return
+        t = value / _SLIDER_STEPS * self._run.total_duration_s
+        if abs(t - self._time) > 1e-12:
+            self._time = t
+            self._draw()
+
+    def _sync_slider(self) -> None:
+        total = self._run.total_duration_s if self._run is not None else 0.0
+        value = round(self._time / total * _SLIDER_STEPS) if total > 0.0 else 0
+        self._position_slider.blockSignals(True)
+        self._position_slider.setValue(value)
+        self._position_slider.blockSignals(False)
+        self._time_label.setText(f"{self._time:.3f} s")
+
+    def _advance(self) -> None:
+        if self._run is None:
+            return
+        self._time += _TIMER_INTERVAL_MS / 1000.0 * self.playback_rate()
+        total = self._run.total_duration_s
+        if self._time > total:
+            if self._loop_check.isChecked():
+                self._time = 0.0
+            else:
+                self._time = total
+                self._play_button.setChecked(False)
+        self._sync_slider()
+        self._draw()
+
+    def _screw_entries(self) -> list[dict]:
+        if self._run is None:
+            return []
+        if self._screws is None:
+            dt = float(self._run.swing_times[1] - self._run.swing_times[0])
+            self._screws = screw_axis_samples(self._run.swing_poses, dt)
+        return self._screws
+
+    @staticmethod
+    def _display(points: np.ndarray) -> np.ndarray:
+        """App frame (x target, y up, z right) -> matplotlib display axes."""
+        return np.asarray(points)[..., [2, 0, 1]]
+
+    def _draw_ball(self) -> None:
+        u = np.linspace(0.0, 2.0 * np.pi, 16)
+        v = np.linspace(0.0, np.pi, 12)
+        r = _BALL_DRAW_RADIUS_M
+        x = BALL_POSITION_M[0] + r * np.outer(np.cos(u), np.sin(v))
+        y = BALL_POSITION_M[1] + r * np.outer(np.sin(u), np.sin(v))
+        z = BALL_POSITION_M[2] + r * np.outer(np.ones_like(u), np.cos(v))
+        pts = self._display(np.stack([x, y, z], axis=-1))
+        self._axes.plot_surface(
+            pts[..., 0],
+            pts[..., 1],
+            pts[..., 2],
+            color=get_chart_color(4),
+            alpha=0.9,
+            linewidth=0.0,
+            shade=True,
+        )
+
+    def _draw_ground(self, extent: float) -> None:
+        grid = np.linspace(-extent, extent, 2)
+        gx, gz = np.meshgrid(grid, grid)
+        gy = np.zeros_like(gx)
+        pts = self._display(np.stack([gx, gy, gz], axis=-1))
+        self._axes.plot_surface(
+            pts[..., 0],
+            pts[..., 1],
+            pts[..., 2],
+            color=get_chart_color(7),
+            alpha=0.12,
+            linewidth=0.0,
+            shade=False,
+        )
+
+    def _draw_screw_axis(self, index: int, extent: float) -> None:
+        entries = self._screw_entries()
+        if not entries:
+            return
+        entry = entries[min(index, len(entries) - 1)]
+        if entry["rate_dps"] < MIN_RATE_DPS:
+            return
+        axis, point = entry["axis"], entry["point"]
+        length = extent * 1.2
+        line = np.vstack([point - length * axis, point + length * axis])
+        pts = self._display(line)
+        self._axes.plot(
+            pts[:, 0],
+            pts[:, 1],
+            pts[:, 2],
+            color=get_chart_color(5),
+            lw=1.6,
+            ls="--",
+            label=(
+                f"screw axis — {entry['rate_dps']:.0f} °/s, "
+                f"pitch {entry['pitch']:.3f} m/rad, "
+                f"R_ISA {entry['r_isa_m']:.2f} m"
+            ),
+        )
+
+    def _draw(self) -> None:
+        axes = self._axes
+        elev, azim = float(axes.elev), float(axes.azim)
+        axes.clear()
+        run = self._run
+        if run is None:
+            axes.set_title("Run a simulation to populate the scene")
+            self._canvas.draw_idle()
+            return
+
+        swing_end = float(run.swing_times[-1])
+        in_flight = self._time > run.impact_time_s
+        index = int(
+            np.searchsorted(run.swing_times, min(self._time, swing_end), side="left")
+        )
+        index = min(index, len(run.swing_times) - 1)
+
+        # Scene extent: the swing envelope, or the flight envelope once
+        # the playback instant is past impact.
+        if in_flight and len(run.flight_positions):
+            extent = max(5.0, float(np.max(np.abs(run.flight_positions))) * 1.05)
+        else:
+            extent = max(
+                1.0,
+                float(np.max(np.abs(run.swing_positions))) * 1.1,
+            )
+
+        if self._ground_check.isChecked():
+            self._draw_ground(extent)
+        if self._ball_check.isChecked():
+            self._draw_ball()
+
+        # Swing path: full arc faint, traversed portion solid, head marker.
+        full = self._display(run.swing_positions)
+        axes.plot(
+            full[:, 0],
+            full[:, 1],
+            full[:, 2],
+            color=get_chart_color(0),
+            lw=0.8,
+            alpha=0.35,
+        )
+        done = self._display(run.swing_positions[: index + 1])
+        axes.plot(
+            done[:, 0],
+            done[:, 1],
+            done[:, 2],
+            color=get_chart_color(0),
+            lw=2.0,
+            label="clubhead path",
+        )
+        head = self._display(run.swing_positions[index])
+        axes.scatter(*head, color=get_chart_color(1), s=45, zorder=5)
+
+        # Flight trajectory: traversed portion once past impact.
+        if len(run.flight_positions):
+            flight_t = self._time - run.impact_time_s
+            n_flight = int(np.searchsorted(run.flight_times, flight_t, side="right"))
+            traj = self._display(run.flight_positions)
+            axes.plot(
+                traj[:, 0],
+                traj[:, 1],
+                traj[:, 2],
+                color=get_chart_color(2),
+                lw=0.8,
+                alpha=0.35,
+            )
+            if n_flight > 1:
+                done_traj = self._display(run.flight_positions[:n_flight])
+                axes.plot(
+                    done_traj[:, 0],
+                    done_traj[:, 1],
+                    done_traj[:, 2],
+                    color=get_chart_color(2),
+                    lw=2.0,
+                    label="ball flight",
+                )
+                ball = self._display(run.flight_positions[n_flight - 1])
+                axes.scatter(*ball, color=get_chart_color(4), s=25, zorder=5)
+
+        if self._screw_check.isChecked() and not in_flight:
+            self._draw_screw_axis(index, extent)
+
+        axes.set_xlim(-extent, extent)
+        axes.set_ylim(-extent, extent)
+        axes.set_zlim(0.0 if in_flight else -extent * 0.4, extent)
+        axes.view_init(elev=elev, azim=azim)
+        axes.set_xlabel("z — right of target [m]")
+        axes.set_ylabel("x — target line [m]")
+        axes.set_zlabel("y — up [m]")
+        phase = "flight" if in_flight else "swing"
+        axes.set_title(
+            f"t = {self._time:.3f} s ({phase}) — impact at {run.impact_time_s:.3f} s"
+        )
+        axes.legend(loc="upper left", fontsize=8)
+        self._canvas.draw_idle()

--- a/src/rate_of_closure/units.py
+++ b/src/rate_of_closure/units.py
@@ -144,4 +144,55 @@ FIELD_GUIDANCE: dict[str, str] = {
         "usually similar to bulge on drivers. Source: typical published "
         "fitting values."
     ),
+    "swing_source": (
+        "Suggested range: Manual Scenario replays the explorer's "
+        "constant-twist delivery; Double and Triple Pendulum generate a "
+        "gravity-driven swing on the oriented plane. Source: classic "
+        "double-pendulum golf models (Cochran & Stobbs; Jorgensen, The "
+        "Physics of Golf)."
+    ),
+    "plane_yaw_deg": (
+        "Suggested range: -20 to +20 deg rotation of the swing plane "
+        "about the vertical (aim left/right of the target line). "
+        "Source: 3-D swing-plane studies collected in the AffineDrift "
+        "closure-rate dossier."
+    ),
+    "plane_side_tilt_deg": (
+        "Suggested range: -60 to -35 deg side tilt for a driver (a "
+        "vertical plane is 0; tour driver swing planes lean roughly "
+        "45-55 deg from vertical). Source: published 3-D swing-plane "
+        "measurements."
+    ),
+    "plane_forward_tilt_deg": (
+        "Suggested range: -10 to +10 deg forward/back tilt of the "
+        "in-plane upright axis. Source: published 3-D swing-plane "
+        "measurements."
+    ),
+    "impact_time_scrub": (
+        "Suggested range: anywhere inside the swing; the default is the "
+        "instant of maximum clubhead speed. Scrubbing moves the swing "
+        "relative to the fixed ball so the clubhead meets it at the "
+        "chosen instant. Source: launch-monitor impact-timing "
+        "convention (maximum-compression reference)."
+    ),
+    "flight_model": (
+        "Suggested range: Waterloo/Penner for driver work; the other "
+        "entries are literature models useful for cross-checks. "
+        "Source: Penner (2003) and the citations carried on each model "
+        "in the shared flight package."
+    ),
+    "ball_visible": (
+        "Suggested range: on to show the ball at its fixed impact "
+        "position. Source: launch-monitor convention of a fixed ball "
+        "and a swing delivered to it."
+    ),
+    "ground_visible": (
+        "Suggested range: on to show the ground plane for spatial "
+        "reference. Source: standard 3-D golf-scene convention."
+    ),
+    "screw_axis_visible": (
+        "Suggested range: on to overlay the clubhead's instantaneous "
+        "screw axis near the playback instant. Source: the AffineDrift "
+        "closure-rate derivation (omega/v = 1/R_ISA)."
+    ),
 }

--- a/src/rate_of_closure/web/src/App.tsx
+++ b/src/rate_of_closure/web/src/App.tsx
@@ -12,6 +12,7 @@
 import { useMemo, useState } from "react";
 
 import { ClubCanvas } from "./components/ClubCanvas";
+import { SimulationPanel } from "./components/SimulationPanel";
 import { ClubPanel } from "./components/ClubPanel";
 import { Derivation } from "./components/Derivation";
 import { type HeadMesh } from "./model/mesh";
@@ -120,7 +121,7 @@ const UNIT_LABELS: Record<Quantity, string> = {
   length: "Length",
 };
 
-const TABS = ["Explorer", "Derivation & Traceability"] as const;
+const TABS = ["Explorer", "Derivation & Traceability", "Simulation"] as const;
 
 export default function App() {
   const [scenario, setScenario] = useState<ImpactScenario>(DEFAULT_SCENARIO);
@@ -235,7 +236,11 @@ export default function App() {
         ))}
       </nav>
 
-      {tab === TABS[1] ? (
+      {tab === TABS[2] ? (
+        // Static loft mirrors the desktop default driver; the full club
+        // picker joins the web simulation with the P7 WASM port.
+        <SimulationPanel scenario={scenario} loftDeg={10.5} />
+      ) : tab === TABS[1] ? (
         <Derivation scenario={scenario} />
       ) : (
         <div className="grid gap-6 lg:grid-cols-[340px_1fr]">

--- a/src/rate_of_closure/web/src/components/SimulationPanel.tsx
+++ b/src/rate_of_closure/web/src/components/SimulationPanel.tsx
@@ -1,0 +1,470 @@
+/**
+ * Simulation tab for the web clone (epic #4103, practical parity).
+ *
+ * Mirrors the PyQt6 Simulation tab where practical: swing-source picker
+ * (manual constant twist / double pendulum), plane-tilt inputs with
+ * sourced hover guidance, impact-time scrubber (fixed ball, the swing
+ * translates so the clubhead at tau meets it, delivery updating live),
+ * launch-number readout, a canvas scene with ball/ground toggles + the
+ * flight trajectory polyline, video-style playback (play/pause, timeline
+ * scrub, rate presets incl. 1x real-time, loop), and JSON export as a
+ * download. Screw-axis overlay is deliberately absent on web — it lands
+ * with the WASM kernels in P7 (see model/simulation.ts).
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  BALL_POSITION,
+  runSimulation,
+  type SimulationInput,
+  type SimulationRunTs,
+  type WebSourceKind,
+} from "../model/simulation";
+import { FIELD_GUIDANCE } from "../model/units";
+import { type ImpactScenario } from "../model/impact";
+
+const RATE_PRESETS: Array<{ label: string; rate: number }> = [
+  { label: "0.1×", rate: 0.1 },
+  { label: "0.25×", rate: 0.25 },
+  { label: "0.5×", rate: 0.5 },
+  { label: "1× real-time", rate: 1.0 },
+  { label: "2×", rate: 2.0 },
+];
+
+const LAUNCH_ROWS: Array<{ key: keyof SimulationRunTs["launch"]; label: string; unit: string }> = [
+  { key: "ballSpeedMph", label: "Ball Speed", unit: "mph" },
+  { key: "launchAngleDeg", label: "Launch Angle", unit: "°" },
+  { key: "launchAzimuthDeg", label: "Launch Azimuth", unit: "°" },
+  { key: "spinRpm", label: "Total Spin", unit: "rpm" },
+  { key: "carryM", label: "Carry", unit: "m" },
+  { key: "maxHeightM", label: "Apex", unit: "m" },
+  { key: "flightTimeS", label: "Flight Time", unit: "s" },
+  { key: "landingAngleDeg", label: "Landing Angle", unit: "°" },
+];
+
+interface Props {
+  scenario: ImpactScenario;
+  loftDeg: number;
+}
+
+export function SimulationPanel({ scenario, loftDeg }: Props) {
+  const [sourceKind, setSourceKind] = useState<WebSourceKind>("manual");
+  const [tilts, setTilts] = useState({ yaw: 0, side: -45, forward: 0 });
+  const [tauMs, setTauMs] = useState<number | null>(null);
+  const [run, setRun] = useState<SimulationRunTs | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [loop, setLoop] = useState(false);
+  const [rate, setRate] = useState(1.0);
+  const [time, setTime] = useState(0);
+  const [showBall, setShowBall] = useState(true);
+  const [showGround, setShowGround] = useState(true);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const input: SimulationInput = useMemo(
+    () => ({
+      sourceKind,
+      clubheadSpeedMph: scenario.clubheadSpeedMph,
+      omegaDps: [0, 0, 0],
+      loftDeg,
+      impactOffsetToeMm: scenario.impactOffsetToeMm,
+      impactOffsetHighMm: scenario.impactOffsetHighMm,
+      planeYawDeg: tilts.yaw,
+      planeSideTiltDeg: tilts.side,
+      planeForwardTiltDeg: tilts.forward,
+      impactTimeS: tauMs === null ? null : tauMs / 1000.0,
+      swingDurationS: 1.5,
+    }),
+    [sourceKind, scenario, loftDeg, tilts, tauMs],
+  );
+
+  const doRun = () => {
+    const result = runSimulation(input);
+    setRun(result);
+    setTime(0);
+    setPlaying(false);
+  };
+
+  // Playback clock: advance simulated time at the selected rate.
+  useEffect(() => {
+    if (!playing || !run) return undefined;
+    let last = performance.now();
+    let raf = 0;
+    const tick = (now: number) => {
+      const dt = ((now - last) / 1000.0) * rate;
+      last = now;
+      setTime((t) => {
+        const next = t + dt;
+        if (next > run.totalDurationS) {
+          if (loop) return 0;
+          setPlaying(false);
+          return run.totalDurationS;
+        }
+        return next;
+      });
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, run, rate, loop]);
+
+  // Scene drawing: side-on orthographic projection (x right, y up).
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const { width, height } = canvas;
+    ctx.clearRect(0, 0, width, height);
+    if (!run) {
+      ctx.fillStyle = "#64748b";
+      ctx.font = "14px sans-serif";
+      ctx.fillText("Run a simulation to populate the scene.", 16, 28);
+      return;
+    }
+
+    const swingEnd = run.swing[run.swing.length - 1].t;
+    const inFlight = time > run.impactTimeS;
+    // Extent: swing envelope near impact, flight envelope once airborne.
+    const extentX = inFlight
+      ? Math.max(10, ...run.flight.map((p) => Math.abs(p.position[0]))) * 1.05
+      : Math.max(1.5, ...run.swing.map((p) => Math.abs(p.position[0]))) * 1.15;
+    const extentY = inFlight
+      ? Math.max(5, ...run.flight.map((p) => p.position[1])) * 1.3
+      : Math.max(1.5, ...run.swing.map((p) => Math.abs(p.position[1]))) * 1.15;
+    const originX = inFlight ? 30 : width / 2;
+    const scaleX = (width - 60) / (inFlight ? extentX : 2 * extentX);
+    const scaleY = (height - 40) / (inFlight ? extentY : 2 * extentY);
+    const s = Math.min(scaleX, scaleY);
+    const groundY = inFlight ? height - 24 : height / 2 + extentY * s * 0.5;
+    const px = (x: number) => originX + x * s;
+    const py = (y: number) => groundY - y * s;
+
+    if (showGround) {
+      ctx.strokeStyle = "#475569";
+      ctx.beginPath();
+      ctx.moveTo(0, py(0));
+      ctx.lineTo(width, py(0));
+      ctx.stroke();
+    }
+    if (showBall) {
+      ctx.fillStyle = "#facc15";
+      ctx.beginPath();
+      ctx.arc(px(BALL_POSITION[0]), py(BALL_POSITION[1]), 4, 0, 2 * Math.PI);
+      ctx.fill();
+    }
+
+    // Swing path (faint full arc + traversed portion + head marker).
+    const drawPath = (
+      points: Array<{ position: [number, number, number] }>,
+      color: string,
+      widthPx: number,
+    ) => {
+      if (points.length < 2) return;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = widthPx;
+      ctx.beginPath();
+      points.forEach((point, index) => {
+        const cx = px(point.position[0]);
+        const cy = py(point.position[1]);
+        if (index === 0) ctx.moveTo(cx, cy);
+        else ctx.lineTo(cx, cy);
+      });
+      ctx.stroke();
+      ctx.lineWidth = 1;
+    };
+    drawPath(run.swing, "rgba(56,189,248,0.25)", 1);
+    const swingIndex = Math.min(
+      run.swing.length - 1,
+      Math.round((Math.min(time, swingEnd) / swingEnd) * (run.swing.length - 1)),
+    );
+    drawPath(run.swing.slice(0, swingIndex + 1), "#38bdf8", 2);
+    const head = run.swing[swingIndex].position;
+    ctx.fillStyle = "#f472b6";
+    ctx.beginPath();
+    ctx.arc(px(head[0]), py(head[1]), 4, 0, 2 * Math.PI);
+    ctx.fill();
+
+    // Flight trajectory polyline (faint + traversed).
+    drawPath(run.flight, "rgba(52,211,153,0.25)", 1);
+    if (inFlight) {
+      const flightT = time - run.impactTimeS;
+      const upto = run.flight.filter((p) => p.time <= flightT);
+      drawPath(upto, "#34d399", 2);
+      if (upto.length) {
+        const ball = upto[upto.length - 1].position;
+        ctx.fillStyle = "#facc15";
+        ctx.beginPath();
+        ctx.arc(px(ball[0]), py(ball[1]), 3, 0, 2 * Math.PI);
+        ctx.fill();
+      }
+    }
+
+    ctx.fillStyle = "#94a3b8";
+    ctx.font = "12px sans-serif";
+    ctx.fillText(
+      `t = ${time.toFixed(3)} s (${inFlight ? "flight" : "swing"}) — impact at ${run.impactTimeS.toFixed(3)} s`,
+      12,
+      16,
+    );
+  }, [run, time, showBall, showGround]);
+
+  const exportJson = () => {
+    if (!run) return;
+    const doc = {
+      format: "rate_of_closure.simulation_run.web/1",
+      parameters: input,
+      launch: run.launch,
+      impactTimeS: run.impactTimeS,
+      series: {
+        swing: run.swing,
+        flight: run.flight,
+      },
+    };
+    const blob = new Blob([JSON.stringify(doc, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "simulation_run.json";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const swingDuration = run ? run.swing[run.swing.length - 1].t : 1.5;
+  const numberInput = (
+    label: string,
+    value: number,
+    guidanceKey: string,
+    onChange: (value: number) => void,
+  ) => (
+    <label className="mb-2 block text-sm" title={FIELD_GUIDANCE[guidanceKey]}>
+      <span className="mb-1 flex justify-between text-slate-300">
+        <span>{label}</span>
+        <span className="text-slate-500">deg</span>
+      </span>
+      <input
+        type="number"
+        inputMode="decimal"
+        value={value}
+        title={FIELD_GUIDANCE[guidanceKey]}
+        onChange={(e) => {
+          const parsed = Number(e.target.value);
+          if (Number.isFinite(parsed)) onChange(parsed);
+        }}
+        className="no-spinner w-full rounded border border-slate-700 bg-slate-800 px-2 py-1.5 text-slate-100 focus:border-blue-500 focus:outline-none"
+      />
+    </label>
+  );
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[340px_1fr]">
+      <section aria-label="Simulation setup" className="space-y-4">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5 shadow-lg shadow-black/20 backdrop-blur">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Simulation Setup
+          </h2>
+          <label
+            className="mb-3 block text-sm"
+            title={FIELD_GUIDANCE.swingSource}
+          >
+            <span className="mb-1 block text-slate-300">Swing Source</span>
+            <select
+              value={sourceKind}
+              title={FIELD_GUIDANCE.swingSource}
+              onChange={(e) => setSourceKind(e.target.value as WebSourceKind)}
+              className="w-full rounded border border-slate-700 bg-slate-800 px-2 py-1.5 text-slate-100 focus:border-blue-500 focus:outline-none"
+            >
+              <option value="manual">Manual Scenario (Constant Twist)</option>
+              <option value="double_pendulum">Double Pendulum</option>
+            </select>
+          </label>
+          {numberInput("Plane Yaw", tilts.yaw, "planeYawDeg", (v) =>
+            setTilts((t) => ({ ...t, yaw: v })),
+          )}
+          {numberInput("Plane Side Tilt", tilts.side, "planeSideTiltDeg", (v) =>
+            setTilts((t) => ({ ...t, side: v })),
+          )}
+          {numberInput(
+            "Plane Forward Tilt",
+            tilts.forward,
+            "planeForwardTiltDeg",
+            (v) => setTilts((t) => ({ ...t, forward: v })),
+          )}
+          <label
+            className="mb-3 block text-sm"
+            title={FIELD_GUIDANCE.impactTimeScrub}
+          >
+            <span className="mb-1 flex justify-between text-slate-300">
+              <span>Impact Time τ</span>
+              <span className="text-slate-500">
+                {tauMs === null ? "auto" : `${tauMs.toFixed(0)} ms`}
+              </span>
+            </span>
+            <input
+              type="range"
+              min={0}
+              max={swingDuration * 1000}
+              step={1}
+              value={tauMs ?? (run ? run.impactTimeS * 1000 : swingDuration * 500)}
+              title={FIELD_GUIDANCE.impactTimeScrub}
+              onChange={(e) => setTauMs(Number(e.target.value))}
+              onMouseUp={doRun}
+              onTouchEnd={doRun}
+              className="w-full"
+            />
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={doRun}
+              className="flex-1 rounded-lg border border-sky-400/60 bg-sky-500/10 px-3 py-2 text-sm font-semibold text-sky-300 transition-all hover:bg-sky-500/20"
+            >
+              Run Simulation
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setTauMs(null);
+                doRun();
+              }}
+              className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-300 hover:border-slate-500"
+            >
+              Auto τ
+            </button>
+            <button
+              type="button"
+              onClick={exportJson}
+              disabled={!run}
+              className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-300 hover:border-slate-500 disabled:opacity-40"
+            >
+              Export JSON
+            </button>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5 shadow-lg shadow-black/20 backdrop-blur">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Launch Numbers
+          </h2>
+          <div className="grid gap-2">
+            {LAUNCH_ROWS.map(({ key, label, unit }) => (
+              <div
+                key={key}
+                className="flex items-center justify-between rounded-lg border border-slate-800/80 bg-slate-900/50 px-3 py-2 text-sm"
+              >
+                <span className="text-slate-400">{label}</span>
+                <span className="font-semibold tabular-nums text-slate-100">
+                  {run ? `${run.launch[key].toFixed(1)} ${unit}` : "—"}
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="mt-3 text-xs text-slate-500">
+            Physics parity-pinned against the Python session (pendulum RK4,
+            rigid-body COR impact, Waterloo/Penner flight). Gear effect,
+            triple pendulum, and the screw-axis overlay arrive with the
+            WASM kernels in P7.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-4 shadow-lg shadow-black/20 backdrop-blur">
+          <div className="mb-2 flex flex-wrap items-center gap-2 text-sm">
+            <button
+              type="button"
+              onClick={() => setPlaying((p) => !p && run !== null)}
+              disabled={!run}
+              className="rounded border border-slate-700 bg-slate-800 px-3 py-1 text-slate-200 hover:border-slate-500 disabled:opacity-40"
+            >
+              {playing ? "Pause" : "Play"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setTime((t) => Math.max(0, t - 0.001))}
+              disabled={!run}
+              className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-slate-300 disabled:opacity-40"
+            >
+              −1 frame
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setTime((t) => Math.min(run?.totalDurationS ?? 0, t + 0.001))
+              }
+              disabled={!run}
+              className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-slate-300 disabled:opacity-40"
+            >
+              +1 frame
+            </button>
+            <input
+              type="range"
+              min={0}
+              max={run?.totalDurationS ?? 1}
+              step={0.001}
+              value={time}
+              onChange={(e) => setTime(Number(e.target.value))}
+              disabled={!run}
+              className="min-w-32 flex-1"
+              aria-label="Playback timeline"
+            />
+            <span className="tabular-nums text-slate-400">
+              {time.toFixed(3)} s
+            </span>
+            <label className="flex items-center gap-1 text-slate-300">
+              <input
+                type="checkbox"
+                checked={loop}
+                onChange={(e) => setLoop(e.target.checked)}
+              />
+              Loop
+            </label>
+            <select
+              value={rate}
+              onChange={(e) => setRate(Number(e.target.value))}
+              className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-slate-100"
+              aria-label="Playback rate"
+            >
+              {RATE_PRESETS.map(({ label, rate: r }) => (
+                <option key={label} value={r}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <label
+              className="flex items-center gap-1 text-slate-300"
+              title={FIELD_GUIDANCE.ballVisible}
+            >
+              <input
+                type="checkbox"
+                checked={showBall}
+                onChange={(e) => setShowBall(e.target.checked)}
+              />
+              Ball
+            </label>
+            <label
+              className="flex items-center gap-1 text-slate-300"
+              title={FIELD_GUIDANCE.groundVisible}
+            >
+              <input
+                type="checkbox"
+                checked={showGround}
+                onChange={(e) => setShowGround(e.target.checked)}
+              />
+              Ground
+            </label>
+          </div>
+          <canvas
+            ref={canvasRef}
+            width={860}
+            height={480}
+            className="w-full rounded-lg border border-slate-800 bg-slate-950/60"
+            aria-label="Simulation scene (side view)"
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/rate_of_closure/web/src/model/flight.ts
+++ b/src/rate_of_closure/web/src/model/flight.ts
@@ -1,0 +1,166 @@
+/**
+ * Launch derivation + Waterloo/Penner flight model for the web clone
+ * (epic #4103). Ports swing_sim/flight/launch.py and the Waterloo/Penner
+ * model of swing_sim/flight/models.py with fixed-step RK4 (Python uses
+ * scipy RK45; the parity tests band the difference).
+ *
+ * NOTE (P7): replaced by the tools-core ball_flight WASM kernel.
+ */
+
+import {
+  AIR_DENSITY_KG_M3,
+  GOLF_BALL_MASS_KG,
+  GOLF_BALL_RADIUS_M,
+  GRAVITY_M_S2,
+  MAX_LIFT_COEFFICIENT,
+  add,
+  cross,
+  norm,
+  scale,
+  sub,
+  type Vec3,
+} from "./simulation";
+
+const RPM_TO_RAD_S = (2.0 * Math.PI) / 60.0;
+const deg = (r: number): number => (r * 180.0) / Math.PI;
+
+// --- Launch derivation + Waterloo/Penner flight --------------------------
+
+export interface Launch {
+  ballSpeedMps: number;
+  launchAngleRad: number;
+  azimuthRad: number;
+  spinRpm: number;
+  spinAxis: Vec3; // flight frame, unit
+}
+
+/** Port of swing_sim/flight/launch.py (flight-frame inputs). */
+export function deriveLaunch(velFlight: Vec3, spinFlight: Vec3): Launch {
+  const speed = norm(velFlight);
+  const horiz = Math.hypot(velFlight[0], velFlight[1]);
+  const launchAngleRad =
+    horiz < 1e-12 ? Math.PI / 2.0 : Math.atan2(velFlight[2], horiz);
+  const azimuthRad = horiz > 1e-12 ? Math.atan2(velFlight[1], velFlight[0]) : 0.0;
+  const spinRadS = norm(spinFlight);
+  const spinAxis: Vec3 =
+    spinRadS > 1e-12 ? scale(spinFlight, 1.0 / spinRadS) : [0, -1, 0];
+  return {
+    ballSpeedMps: speed,
+    launchAngleRad,
+    azimuthRad,
+    spinRpm: spinRadS / RPM_TO_RAD_S,
+    spinAxis,
+  };
+}
+
+export interface FlightPoint {
+  time: number;
+  position: Vec3; // flight frame
+  velocity: Vec3;
+}
+
+export interface FlightResult {
+  trajectory: FlightPoint[];
+  carryM: number;
+  maxHeightM: number;
+  flightTimeS: number;
+  landingAngleDeg: number;
+  lateralM: number;
+}
+
+/**
+ * Waterloo/Penner model (quadratic Cd, power-law Cl), fixed-step RK4 with
+ * linear interpolation to the ground crossing. Python uses scipy RK45; the
+ * parity tests band the difference.
+ */
+export function simulateFlight(
+  launch: Launch,
+  maxTime = 10.0,
+  dt = 0.001,
+  sampleEvery = 10,
+): FlightResult {
+  const [cd0, cd1, cd2, cl1, cl2] = [0.21, 0.05, 0.02, 0.7, 0.645];
+  const area = Math.PI * GOLF_BALL_RADIUS_M ** 2;
+  const omega = scale(launch.spinAxis, launch.spinRpm * RPM_TO_RAD_S);
+  const omegaMag = norm(omega);
+
+  const accel = (v: Vec3): Vec3 => {
+    const speed = norm(v);
+    if (speed < 0.1) return [0, 0, -GRAVITY_M_S2];
+    const vu = scale(v, 1.0 / speed);
+    const s = (omegaMag * GOLF_BALL_RADIUS_M) / speed;
+    const cd = cd0 + cd1 * s + cd2 * s * s;
+    const cl = Math.min(MAX_LIFT_COEFFICIENT, s > 0 ? cl1 * s ** cl2 : 0.0);
+    const q = 0.5 * AIR_DENSITY_KG_M3 * speed * speed * (area / GOLF_BALL_MASS_KG);
+    let acc = scale(vu, -q * cd);
+    if (omegaMag > 0) {
+      const c = cross(scale(omega, 1.0 / omegaMag), vu);
+      const cNorm = norm(c);
+      if (cNorm > 1e-10) acc = add(acc, scale(c, (q * cl) / cNorm));
+    }
+    return [acc[0], acc[1], acc[2] - GRAVITY_M_S2];
+  };
+
+  let pos: Vec3 = [0, 0, 0];
+  let vel: Vec3 = [
+    launch.ballSpeedMps * Math.cos(launch.launchAngleRad) * Math.cos(launch.azimuthRad),
+    launch.ballSpeedMps * Math.cos(launch.launchAngleRad) * Math.sin(launch.azimuthRad),
+    launch.ballSpeedMps * Math.sin(launch.launchAngleRad),
+  ];
+  const trajectory: FlightPoint[] = [{ time: 0, position: pos, velocity: vel }];
+  let maxHeight = 0.0;
+  let t = 0.0;
+  let step = 0;
+
+  while (t < maxTime) {
+    // RK4 on (pos, vel).
+    const k1v = accel(vel);
+    const k1p = vel;
+    const k2v = accel(add(vel, scale(k1v, dt / 2)));
+    const k2p = add(vel, scale(k1v, dt / 2));
+    const k3v = accel(add(vel, scale(k2v, dt / 2)));
+    const k3p = add(vel, scale(k2v, dt / 2));
+    const k4v = accel(add(vel, scale(k3v, dt)));
+    const k4p = add(vel, scale(k3v, dt));
+    const nextVel = add(
+      vel,
+      scale(add(add(k1v, scale(add(k2v, k3v), 2)), k4v), dt / 6),
+    );
+    const nextPos = add(
+      pos,
+      scale(add(add(k1p, scale(add(k2p, k3p), 2)), k4p), dt / 6),
+    );
+    t += dt;
+    step += 1;
+
+    if (nextPos[2] < 0.0 && t > dt) {
+      // Linear interpolation to the ground crossing.
+      const frac = pos[2] / (pos[2] - nextPos[2]);
+      const tGround = t - dt + frac * dt;
+      const posGround = add(pos, scale(sub(nextPos, pos), frac));
+      const velGround = add(vel, scale(sub(nextVel, vel), frac));
+      trajectory.push({ time: tGround, position: posGround, velocity: velGround });
+      pos = posGround;
+      vel = velGround;
+      t = tGround;
+      break;
+    }
+    pos = nextPos;
+    vel = nextVel;
+    maxHeight = Math.max(maxHeight, pos[2]);
+    if (step % sampleEvery === 0) {
+      trajectory.push({ time: t, position: pos, velocity: vel });
+    }
+  }
+
+  const vHoriz = Math.hypot(vel[0], vel[1]);
+  return {
+    trajectory,
+    carryM: Math.hypot(pos[0], pos[1]),
+    maxHeightM: maxHeight,
+    flightTimeS: t,
+    landingAngleDeg: vHoriz > 0.1 ? deg(Math.atan2(-vel[2], vHoriz)) : 90.0,
+    lateralM: pos[1],
+  };
+}
+

--- a/src/rate_of_closure/web/src/model/simulation.test.ts
+++ b/src/rate_of_closure/web/src/model/simulation.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Parity pins for the simulation port against the canonical Python
+ * implementation (pytest: tests/rate_of_closure/test_simulation.py and the
+ * pin-generation snippet recorded in the PR). Tight tolerances where the
+ * TS code is a formula-for-formula port (pendulum RK4, impact, launch);
+ * banded for flight, where scipy RK45 vs fixed-step RK4 differ only by
+ * integration error.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BALL_POSITION,
+  deriveLaunch,
+  golfDefaultParams,
+  inPlaneGravity,
+  runSimulation,
+  simulateFlight,
+  simulatePendulum,
+  solveImpact,
+  toFlightFrame,
+  type SimulationInput,
+} from "./simulation";
+
+const MANUAL_INPUT: SimulationInput = {
+  sourceKind: "manual",
+  clubheadSpeedMph: 113.0,
+  omegaDps: [0, 0, 0],
+  loftDeg: 10.5,
+  impactOffsetToeMm: 0,
+  impactOffsetHighMm: 0,
+  planeYawDeg: 0,
+  planeSideTiltDeg: -45,
+  planeForwardTiltDeg: 0,
+  impactTimeS: null,
+  swingDurationS: 1.5,
+};
+
+describe("pendulum parity (Python reference.py pins)", () => {
+  it("matches the golf-default derived parameters", () => {
+    const p = golfDefaultParams();
+    expect(p.lc1).toBeCloseTo(0.3375, 12);
+    expect(p.i1).toBeCloseTo(1.2058593750000002, 12);
+    expect(p.lc2).toBeCloseTo(0.7557142857142858, 12);
+    expect(p.i2).toBeCloseTo(0.24023500000000003, 12);
+  });
+
+  it("projects gravity into a -45 deg side-tilted plane like Python", () => {
+    const [gx, gy] = inPlaneGravity(0, (-45 * Math.PI) / 180, 0);
+    expect(gx).toBeCloseTo(0.0, 12);
+    expect(gy).toBeCloseTo(-6.934348715723057, 9);
+  });
+
+  it("pins the RK4 state at steps 100 and 500 (dt = 1 ms)", () => {
+    const g: [number, number] = [0.0, -6.934348715723057];
+    const states = simulatePendulum(
+      golfDefaultParams(),
+      [-Math.PI / 2, 0, 0, 0],
+      g,
+      1e-3,
+      500,
+    );
+    const s100 = states[100];
+    expect(s100[0]).toBeCloseTo(-1.500595794495213, 9);
+    expect(s100[1]).toBeCloseTo(-0.08686334675252501, 9);
+    expect(s100[2]).toBeCloseTo(1.3853526740573519, 9);
+    expect(s100[3]).toBeCloseTo(-1.6717820546064868, 9);
+    const s500 = states[500];
+    expect(s500[0]).toBeCloseTo(-0.14330846248913331, 8);
+    expect(s500[1]).toBeCloseTo(-1.0243002763264488, 8);
+    expect(s500[2]).toBeCloseTo(4.3312528971086515, 8);
+    expect(s500[3]).toBeCloseTo(-0.06751810436510605, 8);
+  });
+});
+
+describe("impact + launch parity (Python impact/models.py pins)", () => {
+  const impact = solveImpact({
+    clubheadSpeedMps: 50.51552,
+    clubPathDeg: 2.0,
+    faceAngleDeg: 0.0,
+    attackAngleDeg: -1.5,
+    dynamicLoftDeg: 10.5,
+    impactOffsetToeMm: 0,
+    impactOffsetHighMm: 0,
+  });
+
+  it("pins the post-impact ball velocity", () => {
+    expect(impact.ballVelocity[0]).toBeCloseTo(72.26017152461, 8);
+    expect(impact.ballVelocity[1]).toBeCloseTo(13.392631176960073, 8);
+    expect(impact.ballVelocity[2]).toBeCloseTo(0.0, 10);
+  });
+
+  it("pins the friction-spin vector (t x n axis, 2/7 cap)", () => {
+    expect(impact.ballAngularVelocity[0]).toBeCloseTo(-10.752451814588115, 7);
+    expect(impact.ballAngularVelocity[1]).toBeCloseTo(58.015038431649145, 7);
+    expect(impact.ballAngularVelocity[2]).toBeCloseTo(351.43999531631596, 6);
+  });
+
+  it("pins the derived launch conditions", () => {
+    const launch = deriveLaunch(
+      toFlightFrame(impact.ballVelocity),
+      toFlightFrame(impact.ballAngularVelocity),
+    );
+    expect(launch.ballSpeedMps).toBeCloseTo(73.49078145324175, 8);
+    expect((launch.launchAngleRad * 180) / Math.PI).toBeCloseTo(10.5, 8);
+    expect(launch.spinRpm).toBeCloseTo(3402.9736730363547, 6);
+    expect(launch.spinAxis[0]).toBeCloseTo(-0.030173125408675523, 8);
+    expect(launch.spinAxis[1]).toBeCloseTo(-0.9861976817154181, 8);
+    expect(launch.spinAxis[2]).toBeCloseTo(0.16279961634539392, 8);
+  });
+
+  it("bands the Waterloo/Penner flight vs scipy RK45 (Python pins)", () => {
+    const launch = deriveLaunch(
+      toFlightFrame(impact.ballVelocity),
+      toFlightFrame(impact.ballAngularVelocity),
+    );
+    const flight = simulateFlight(launch);
+    // Python (solve_ivp RK45): carry 239.468 m, max height 26.193 m,
+    // flight time 6.054 s, landing angle 33.885 deg, lateral 14.624 m.
+    expect(flight.carryM).toBeGreaterThan(239.468 * 0.99);
+    expect(flight.carryM).toBeLessThan(239.468 * 1.01);
+    expect(flight.maxHeightM).toBeGreaterThan(26.193 * 0.98);
+    expect(flight.maxHeightM).toBeLessThan(26.193 * 1.02);
+    expect(flight.flightTimeS).toBeGreaterThan(6.054 * 0.99);
+    expect(flight.flightTimeS).toBeLessThan(6.054 * 1.01);
+    expect(flight.landingAngleDeg).toBeGreaterThan(33.885 - 1.0);
+    expect(flight.landingAngleDeg).toBeLessThan(33.885 + 1.0);
+  });
+});
+
+describe("session orchestration", () => {
+  it("manual run produces plausible driver numbers (Python band)", () => {
+    const run = runSimulation(MANUAL_INPUT);
+    expect(run.launch.ballSpeedMph).toBeGreaterThan(130);
+    expect(run.launch.ballSpeedMph).toBeLessThan(185);
+    expect(run.launch.launchAngleDeg).toBeGreaterThan(5);
+    expect(run.launch.launchAngleDeg).toBeLessThan(20);
+    expect(run.launch.spinRpm).toBeGreaterThan(1000);
+    expect(run.launch.spinRpm).toBeLessThan(5000);
+    expect(run.launch.carryM).toBeGreaterThan(150);
+    expect(run.launch.carryM).toBeLessThan(320);
+  });
+
+  it("scrubbing tau makes the clubhead meet the fixed ball", () => {
+    for (const tau of [0.01, 0.03, 0.045]) {
+      const run = runSimulation({ ...MANUAL_INPUT, impactTimeS: tau });
+      expect(run.impactTimeS).toBeCloseTo(tau, 9);
+      const index = run.swing.findIndex(
+        (sample) => Math.abs(sample.t - tau) < 5e-4,
+      );
+      const position = run.swing[index].position;
+      expect(position[0]).toBeCloseTo(BALL_POSITION[0], 6);
+      expect(position[1]).toBeCloseTo(BALL_POSITION[1], 6);
+      expect(position[2]).toBeCloseTo(BALL_POSITION[2], 6);
+    }
+  });
+
+  it("double-pendulum run swings toward the target and launches the ball", () => {
+    const run = runSimulation({
+      ...MANUAL_INPUT,
+      sourceKind: "double_pendulum",
+    });
+    expect(run.launch.ballSpeedMph).toBeGreaterThan(0);
+    expect(run.launch.carryM).toBeGreaterThan(0);
+    expect(run.flight.length).toBeGreaterThan(2);
+    expect(run.totalDurationS).toBeGreaterThan(run.impactTimeS);
+  });
+
+  it("flight starts at the ball position (app frame)", () => {
+    const run = runSimulation(MANUAL_INPUT);
+    expect(run.flight[0].position[0]).toBeCloseTo(BALL_POSITION[0], 9);
+    expect(run.flight[0].position[1]).toBeCloseTo(BALL_POSITION[1], 9);
+    expect(run.flight[0].position[2]).toBeCloseTo(BALL_POSITION[2], 9);
+  });
+});

--- a/src/rate_of_closure/web/src/model/simulation.ts
+++ b/src/rate_of_closure/web/src/model/simulation.ts
@@ -1,0 +1,439 @@
+/**
+ * Simulation session physics for the web clone (epic #4103).
+ *
+ * Minimal TypeScript port of the Python session pipeline — double-pendulum
+ * swing (RK4, port of shared/python/swing_sim/reference.py), rigid-body COR
+ * impact with the 2/7 rolling-cap friction spin (scalar-MOI path of
+ * swing_sim/impact/models.py), launch derivation, and the Waterloo/Penner
+ * flight model (swing_sim/flight/models.py) integrated with fixed-step RK4.
+ *
+ * Parity: pinned in simulation.test.ts against the pytest numbers (tight
+ * for the shared-formula pendulum/impact/launch math, banded for flight
+ * where scipy RK45 and this RK4 differ by integration error only).
+ *
+ * NOTE (P7): this hand port is a stopgap — the swing-core / tools-core
+ * WASM kernels replace this module in epic phase P7, which also brings the
+ * gear-effect model, the triple pendulum, and the screw-axis overlay to
+ * the web. Skipped here on purpose.
+ *
+ * Frames: app frame is x target, y up, z right; the flight math runs in
+ * the UpstreamDrift flight frame (x forward, y left, z up).
+ */
+
+export type Vec3 = [number, number, number];
+
+import {
+  deriveLaunch,
+  simulateFlight,
+  type FlightPoint,
+} from "./flight";
+
+export { deriveLaunch, simulateFlight } from "./flight";
+export type { FlightPoint, FlightResult, Launch } from "./flight";
+
+// --- Constants (vendored, same citations as the Python packages) --------
+export const GRAVITY_M_S2 = 9.80665;
+export const AIR_DENSITY_KG_M3 = 1.225;
+export const GOLF_BALL_MASS_KG = 0.04593;
+export const GOLF_BALL_RADIUS_M = 0.04267 / 2.0;
+export const GOLF_BALL_MOI_KG_M2 =
+  (2.0 / 5.0) * GOLF_BALL_MASS_KG * GOLF_BALL_RADIUS_M ** 2;
+export const DRIVER_COR = 0.83;
+export const DRIVER_MASS_KG = 0.2;
+export const DRIVER_MOI_KG_M2 = 4.5e-4;
+export const MAX_LIFT_COEFFICIENT = 0.155;
+export const MPH_PER_MPS = 1.0 / 0.44704;
+const SPHERE_ROLLING_CAP = 2.0 / 7.0;
+const FRICTION_COEFFICIENT = 0.4;
+
+// --- Small vector helpers ------------------------------------------------
+export const dot = (a: Vec3, b: Vec3): number => a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+export const cross = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+export const norm = (a: Vec3): number => Math.hypot(a[0], a[1], a[2]);
+export const scale = (a: Vec3, s: number): Vec3 => [a[0] * s, a[1] * s, a[2] * s];
+export const add = (a: Vec3, b: Vec3): Vec3 => [a[0] + b[0], a[1] + b[1], a[2] + b[2]];
+export const sub = (a: Vec3, b: Vec3): Vec3 => [a[0] - b[0], a[1] - b[1], a[2] - b[2]];
+
+/** App frame (x target, y up, z right) -> flight frame (x fwd, y left, z up). */
+export const toFlightFrame = (v: Vec3): Vec3 => [v[0], -v[2], v[1]];
+/** Flight frame -> app frame. */
+export const fromFlightFrame = (v: Vec3): Vec3 => [v[0], v[2], -v[1]];
+
+// --- Double pendulum (port of swing_sim/reference.py) --------------------
+
+export interface PendulumParams {
+  m1: number;
+  l1: number;
+  lc1: number;
+  i1: number;
+  m2: number;
+  l2: number;
+  lc2: number;
+  i2: number;
+  d1: number;
+  d2: number;
+}
+
+/** UpstreamDrift golf defaults — same segment formulas as the Rust kernel. */
+export function golfDefaultParams(): PendulumParams {
+  const m1 = 7.5;
+  const l1 = 0.75;
+  const lc1 = l1 * 0.45;
+  const i1 = (1.0 / 12.0) * m1 * l1 * l1 + m1 * lc1 * lc1;
+  const l2 = 1.0;
+  const ms = 0.15;
+  const mh = 0.2;
+  const m2 = ms + mh;
+  const shaftCom = l2 * 0.43;
+  const lc2 = (shaftCom * ms + l2 * mh) / m2;
+  const iShaft = (1.0 / 12.0) * ms * l2 * l2;
+  const parallel = ms * (shaftCom - lc2) ** 2 + mh * (l2 - lc2) ** 2;
+  const i2 = iShaft + parallel + m2 * lc2 * lc2;
+  return { m1, l1, lc1, i1, m2, l2, lc2, i2, d1: 0.4, d2: 0.25 };
+}
+
+export type PendulumState = [number, number, number, number]; // th1, th2, w1, w2
+
+/** In-plane gravity components for the three sequential plane tilts (rad). */
+export function inPlaneGravity(
+  yaw: number,
+  sideTilt: number,
+  fwdTilt: number,
+  g = GRAVITY_M_S2,
+): [number, number] {
+  // g_world = (0, 0, -g) projected on the local x (col 0) and up (col 2)
+  // axes of Rz(yaw) Rx(side) Ry(fwd). Yaw (about world z) drops out of
+  // the world-z row: R[2][0] = -cos(side) sin(fwd), R[2][2] =
+  // cos(side) cos(fwd).
+  void yaw;
+  const cs = Math.cos(sideTilt);
+  const cf = Math.cos(fwdTilt);
+  const sf = Math.sin(fwdTilt);
+  return [g * cs * sf, -g * cs * cf];
+}
+
+function pendulumDerivatives(
+  p: PendulumParams,
+  y: PendulumState,
+  gInplane: [number, number],
+): PendulumState {
+  const [th1, th2, w1, w2] = y;
+  const cos2 = Math.cos(th2);
+  const m11 = p.i1 + p.i2 + p.m2 * p.l1 * p.l1 + 2.0 * p.m2 * p.l1 * p.lc2 * cos2;
+  const m12 = p.i2 + p.m2 * p.l1 * p.lc2 * cos2;
+  const m22 = p.i2;
+  const h = -p.m2 * p.l1 * p.lc2 * Math.sin(th2);
+  const c1 = h * (2.0 * w1 * w2 + w2 * w2);
+  const c2 = -h * w1 * w1;
+  const [gx, gy] = gInplane;
+  const t12 = th1 + th2;
+  const a1 = p.m1 * p.lc1 + p.m2 * p.l1;
+  const a2 = p.m2 * p.lc2;
+  const g1 =
+    -a1 * (gx * Math.cos(th1) + gy * Math.sin(th1)) -
+    a2 * (gx * Math.cos(t12) + gy * Math.sin(t12));
+  const g2 = -a2 * (gx * Math.cos(t12) + gy * Math.sin(t12));
+  const d1 = p.d1 * w1;
+  const d2 = p.d2 * w2;
+  const det = m11 * m22 - m12 * m12;
+  const rhs1 = -(c1 + g1 + d1);
+  const rhs2 = -(c2 + g2 + d2);
+  const acc1 = (m22 * rhs1 - m12 * rhs2) / det;
+  const acc2 = (-m12 * rhs1 + m11 * rhs2) / det;
+  return [w1, w2, acc1, acc2];
+}
+
+/** One classical RK4 step (same evaluation order as the Python oracle). */
+export function pendulumRk4Step(
+  p: PendulumParams,
+  y: PendulumState,
+  gInplane: [number, number],
+  dt: number,
+): PendulumState {
+  const f = (v: PendulumState) => pendulumDerivatives(p, v, gInplane);
+  const addS = (a: PendulumState, s: number, b: PendulumState): PendulumState => [
+    a[0] + s * b[0],
+    a[1] + s * b[1],
+    a[2] + s * b[2],
+    a[3] + s * b[3],
+  ];
+  const k1 = f(y);
+  const k2 = f(addS(y, dt / 2.0, k1));
+  const k3 = f(addS(y, dt / 2.0, k2));
+  const k4 = f(addS(y, dt, k3));
+  return [0, 1, 2, 3].map(
+    (i) => y[i] + (dt / 6.0) * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]),
+  ) as PendulumState;
+}
+
+/** Integrate nSteps RK4 steps; returns nSteps + 1 states incl. the initial. */
+export function simulatePendulum(
+  p: PendulumParams,
+  initial: PendulumState,
+  gInplane: [number, number],
+  dt: number,
+  nSteps: number,
+): PendulumState[] {
+  const out: PendulumState[] = [initial];
+  let current = initial;
+  for (let i = 0; i < nSteps; i += 1) {
+    current = pendulumRk4Step(p, current, gInplane, dt);
+    out.push(current);
+  }
+  return out;
+}
+
+// --- Impact (scalar-MOI path of swing_sim/impact/models.py) --------------
+
+export interface DeliveryInput {
+  clubheadSpeedMps: number;
+  clubPathDeg: number;
+  faceAngleDeg: number;
+  attackAngleDeg: number;
+  dynamicLoftDeg: number;
+  impactOffsetToeMm: number;
+  impactOffsetHighMm: number;
+}
+
+export interface ImpactOutput {
+  ballVelocity: Vec3; // app frame [m/s]
+  ballAngularVelocity: Vec3; // app frame [rad/s]
+}
+
+const rad = (deg: number): number => (deg * Math.PI) / 180.0;
+const deg = (r: number): number => (r * 180.0) / Math.PI;
+
+/**
+ * Rigid-body COR impulse solve in the app frame (ball initially at rest).
+ * Off-center offsets reduce the effective club mass via the scalar MOI;
+ * friction spin uses the 2/7 rolling cap with the t x n axis (bug-fixed
+ * sign, matching the Python port). Gear effect: P7 (WASM).
+ */
+export function solveImpact(input: DeliveryInput): ImpactOutput {
+  const path = rad(input.clubPathDeg);
+  const face = rad(input.faceAngleDeg);
+  const aoa = rad(input.attackAngleDeg);
+  const loft = rad(input.dynamicLoftDeg);
+
+  const vHat: Vec3 = [
+    Math.cos(aoa) * Math.cos(path),
+    Math.sin(aoa),
+    Math.cos(aoa) * Math.sin(path),
+  ];
+  const n: Vec3 = [
+    Math.cos(loft) * Math.cos(face),
+    Math.sin(loft),
+    Math.cos(loft) * Math.sin(face),
+  ];
+  const vClub = scale(vHat, input.clubheadSpeedMps);
+
+  const rOffset = Math.hypot(
+    input.impactOffsetToeMm / 1000.0,
+    input.impactOffsetHighMm / 1000.0,
+  );
+  const mClubEff =
+    rOffset > 1e-6
+      ? 1.0 / (1.0 / DRIVER_MASS_KG + (rOffset * rOffset) / DRIVER_MOI_KG_M2)
+      : DRIVER_MASS_KG;
+
+  const vApproach = dot(vClub, n);
+  const mEff =
+    (GOLF_BALL_MASS_KG * mClubEff) / (GOLF_BALL_MASS_KG + mClubEff);
+  const j = (1.0 + DRIVER_COR) * mEff * vApproach;
+  const ballVelocity = scale(n, j / GOLF_BALL_MASS_KG);
+
+  // Friction spin (2/7 rolling cap, axis t x n).
+  const vTangent = sub(vClub, scale(n, vApproach));
+  const tangentMag = norm(vTangent);
+  let ballAngularVelocity: Vec3 = [0, 0, 0];
+  if (tangentMag > 1e-6) {
+    const tDir = scale(vTangent, 1.0 / tangentMag);
+    const spinAxis = cross(tDir, n);
+    const jFriction = Math.min(
+      FRICTION_COEFFICIENT * j,
+      GOLF_BALL_MASS_KG * tangentMag * SPHERE_ROLLING_CAP,
+    );
+    const spinMagnitude = jFriction / (GOLF_BALL_MOI_KG_M2 / GOLF_BALL_RADIUS_M);
+    ballAngularVelocity = scale(spinAxis, spinMagnitude);
+  }
+  return { ballVelocity, ballAngularVelocity };
+}
+
+// --- Session orchestration ----------------------------------------------
+
+export const BALL_POSITION: Vec3 = [0.0, GOLF_BALL_RADIUS_M, 0.0];
+
+export type WebSourceKind = "manual" | "double_pendulum";
+
+export interface SimulationInput {
+  sourceKind: WebSourceKind;
+  clubheadSpeedMph: number; // manual source
+  omegaDps: Vec3; // manual source angular velocity (app frame, deg/s)
+  loftDeg: number;
+  impactOffsetToeMm: number;
+  impactOffsetHighMm: number;
+  planeYawDeg: number;
+  planeSideTiltDeg: number;
+  planeForwardTiltDeg: number;
+  impactTimeS: number | null; // null = auto (max clubhead speed)
+  swingDurationS: number;
+}
+
+export interface SwingSampleTs {
+  t: number;
+  position: Vec3; // app frame, ball-aligned
+  velocity: Vec3;
+}
+
+export interface SimulationRunTs {
+  swing: SwingSampleTs[];
+  impactTimeS: number;
+  totalDurationS: number;
+  launch: {
+    ballSpeedMph: number;
+    launchAngleDeg: number;
+    launchAzimuthDeg: number;
+    spinRpm: number;
+    carryM: number;
+    maxHeightM: number;
+    flightTimeS: number;
+    landingAngleDeg: number;
+  };
+  flight: FlightPoint[]; // app frame, ball-aligned positions
+}
+
+const clampAngle = (value: number): number => Math.max(-89, Math.min(89, value));
+
+function swingSamples(input: SimulationInput): SwingSampleTs[] {
+  const dt = 1e-3;
+  if (input.sourceKind === "manual") {
+    const duration = 0.06;
+    const speed = input.clubheadSpeedMph / MPH_PER_MPS;
+    const omega = scale(input.omegaDps, Math.PI / 180.0);
+    const samples: SwingSampleTs[] = [];
+    for (let t = 0.0; t <= duration + 1e-9; t += dt) {
+      const rel = t - duration / 2.0;
+      // Straight-line reference travel; rotation only affects the pose,
+      // which the web scene does not render — velocity is constant.
+      void omega;
+      samples.push({
+        t,
+        position: [speed * rel, 0, 0],
+        velocity: [speed, 0, 0],
+      });
+    }
+    return samples;
+  }
+  // Double pendulum on the oriented plane (swing frame), adapted to app.
+  const p = golfDefaultParams();
+  const g = inPlaneGravity(
+    rad(input.planeYawDeg),
+    rad(input.planeSideTiltDeg),
+    rad(input.planeForwardTiltDeg),
+  );
+  const nSteps = Math.round(input.swingDurationS / dt);
+  const states = simulatePendulum(p, [-Math.PI / 2, 0, 0, 0], g, dt, nSteps);
+  // Plane axes in the swing world frame, then app frame via
+  // (x, y, z)_app = (x, z, -y)_swing.
+  const yaw = rad(input.planeYawDeg);
+  const side = rad(input.planeSideTiltDeg);
+  const fwd = rad(input.planeForwardTiltDeg);
+  const cy = Math.cos(yaw);
+  const sy = Math.sin(yaw);
+  const cs = Math.cos(side);
+  const ss = Math.sin(side);
+  const cf = Math.cos(fwd);
+  const sf = Math.sin(fwd);
+  // Columns of Rz(yaw) Rx(side) Ry(fwd): local x (col 0) and up (col 2).
+  const xAxisSwing: Vec3 = [cy * cf - sy * ss * sf, sy * cf + cy * ss * sf, -cs * sf];
+  const upAxisSwing: Vec3 = [cy * sf + sy * ss * cf, sy * sf - cy * ss * cf, cs * cf];
+  const xAxis = fromFlightFrame(xAxisSwing);
+  const upAxis = fromFlightFrame(upAxisSwing);
+  return states.map((state, index) => {
+    const [th1, th2, w1, w2] = state;
+    const t12 = th1 + th2;
+    const x = p.l1 * Math.sin(th1) + p.l2 * Math.sin(t12);
+    const yLoc = -(p.l1 * Math.cos(th1) + p.l2 * Math.cos(t12));
+    const vx = p.l1 * Math.cos(th1) * w1 + p.l2 * Math.cos(t12) * (w1 + w2);
+    const vy = p.l1 * Math.sin(th1) * w1 + p.l2 * Math.sin(t12) * (w1 + w2);
+    return {
+      t: index * dt,
+      position: add(scale(xAxis, x), scale(upAxis, yLoc)),
+      velocity: add(scale(xAxis, vx), scale(upAxis, vy)),
+    };
+  });
+}
+
+/** Run the full swing -> impact -> flight pipeline (web parity port). */
+export function runSimulation(input: SimulationInput): SimulationRunTs {
+  const swing = swingSamples(input);
+  let impactIndex: number;
+  if (input.impactTimeS === null) {
+    let best = 0;
+    let bestSpeed = -1;
+    swing.forEach((sample, index) => {
+      const speed = norm(sample.velocity);
+      if (speed > bestSpeed) {
+        bestSpeed = speed;
+        best = index;
+      }
+    });
+    impactIndex = best;
+  } else {
+    const clamped = Math.max(
+      0,
+      Math.min(input.impactTimeS, swing[swing.length - 1].t),
+    );
+    impactIndex = Math.round(clamped / (swing[1].t - swing[0].t));
+  }
+  const impactSample = swing[impactIndex];
+  const offset = sub(BALL_POSITION, impactSample.position);
+  const aligned = swing.map((sample) => ({
+    ...sample,
+    position: add(sample.position, offset),
+  }));
+
+  const v = impactSample.velocity;
+  const speed = norm(v);
+  const delivery: DeliveryInput = {
+    clubheadSpeedMps: speed,
+    clubPathDeg: clampAngle(deg(Math.atan2(v[2], v[0]))),
+    faceAngleDeg: 0.0,
+    attackAngleDeg: clampAngle(deg(Math.atan2(v[1], Math.hypot(v[0], v[2])))),
+    dynamicLoftDeg: input.loftDeg,
+    impactOffsetToeMm: input.impactOffsetToeMm,
+    impactOffsetHighMm: input.impactOffsetHighMm,
+  };
+  const impact = solveImpact(delivery);
+  const launch = deriveLaunch(
+    toFlightFrame(impact.ballVelocity),
+    toFlightFrame(impact.ballAngularVelocity),
+  );
+  const flightResult = simulateFlight(launch);
+  const flight = flightResult.trajectory.map((point) => ({
+    ...point,
+    position: add(fromFlightFrame(point.position), BALL_POSITION),
+    velocity: fromFlightFrame(point.velocity),
+  }));
+
+  return {
+    swing: aligned,
+    impactTimeS: impactSample.t,
+    totalDurationS: aligned[aligned.length - 1].t + flightResult.flightTimeS,
+    launch: {
+      ballSpeedMph: launch.ballSpeedMps * MPH_PER_MPS,
+      launchAngleDeg: deg(launch.launchAngleRad),
+      launchAzimuthDeg: -deg(launch.azimuthRad),
+      spinRpm: launch.spinRpm,
+      carryM: flightResult.carryM,
+      maxHeightM: flightResult.maxHeightM,
+      flightTimeS: flightResult.flightTimeS,
+      landingAngleDeg: flightResult.landingAngleDeg,
+    },
+    flight,
+  };
+}

--- a/src/rate_of_closure/web/src/model/units.ts
+++ b/src/rate_of_closure/web/src/model/units.ts
@@ -104,4 +104,34 @@ export const FIELD_GUIDANCE: Record<string, string> = {
     "Suggested range: 250-330 mm vertical (crown-sole) face radius, " +
     "usually similar to bulge on drivers. Source: typical published " +
     "fitting values.",
+  swingSource:
+    "Suggested range: Manual Scenario replays the explorer's " +
+    "constant-twist delivery; Double Pendulum generates a gravity-driven " +
+    "swing on the oriented plane. Source: classic double-pendulum golf " +
+    "models (Cochran & Stobbs; Jorgensen, The Physics of Golf).",
+  planeYawDeg:
+    "Suggested range: -20 to +20 deg rotation of the swing plane about " +
+    "the vertical (aim left/right of the target line). Source: 3-D " +
+    "swing-plane studies collected in the AffineDrift closure-rate " +
+    "dossier.",
+  planeSideTiltDeg:
+    "Suggested range: -60 to -35 deg side tilt for a driver (a vertical " +
+    "plane is 0; tour driver swing planes lean roughly 45-55 deg from " +
+    "vertical). Source: published 3-D swing-plane measurements.",
+  planeForwardTiltDeg:
+    "Suggested range: -10 to +10 deg forward/back tilt of the in-plane " +
+    "upright axis. Source: published 3-D swing-plane measurements.",
+  impactTimeScrub:
+    "Suggested range: anywhere inside the swing; the default is the " +
+    "instant of maximum clubhead speed. Scrubbing moves the swing " +
+    "relative to the fixed ball so the clubhead meets it at the chosen " +
+    "instant. Source: launch-monitor impact-timing convention " +
+    "(maximum-compression reference).",
+  ballVisible:
+    "Suggested range: on to show the ball at its fixed impact position. " +
+    "Source: launch-monitor convention of a fixed ball and a swing " +
+    "delivered to it.",
+  groundVisible:
+    "Suggested range: on to show the ground line for spatial reference. " +
+    "Source: standard golf-scene convention.",
 };

--- a/src/shared/python/swing_sim/__init__.py
+++ b/src/shared/python/swing_sim/__init__.py
@@ -1,0 +1,37 @@
+"""Shared swing simulation package (epic #4103, P0 foundation #4104).
+
+Curated façade for the swing → impact → ball-flight platform's swing stage:
+value types, the :class:`SwingSource` protocol, the double-pendulum swing
+source, and backend discovery. Physics kernels live in the
+``rust_core/swing-core`` Rust crate (Python wheel ``swing_core``, WASM NPM
+package for the web app); :mod:`.reference` is the pure-Python parity
+oracle and one-shot fallback.
+"""
+
+from __future__ import annotations
+
+from ._rust_facade import rust_available
+from .swing_source import DoublePendulumSwing, SwingSource
+from .types import (
+    DEFAULT_GRAVITY_M_S2,
+    PendulumParameters,
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+    SwingTrajectory,
+)
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "DEFAULT_GRAVITY_M_S2",
+    "DoublePendulumSwing",
+    "PendulumParameters",
+    "PendulumState",
+    "PlaneOrientation",
+    "SwingSample",
+    "SwingSource",
+    "SwingTrajectory",
+    "__version__",
+    "rust_available",
+]

--- a/src/shared/python/swing_sim/_rust_facade.py
+++ b/src/shared/python/swing_sim/_rust_facade.py
@@ -1,0 +1,161 @@
+"""Rust-accelerated swing dynamics façade (STRICT posture).
+
+Mirrors the posture of :mod:`shared.python.signal_toolkit.bilateral_rust`:
+the ``swing_core`` wheel is imported at module level; hot-loop entry points
+raise ``ImportError`` with an actionable message at call time when the wheel
+is missing. We deliberately do NOT silently substitute the ~100x slower
+pure-Python path for the integration loop — that would mask deployment
+misconfiguration. One-shot analysis calls may fall back explicitly via
+:func:`shared.python.swing_sim.reference.simulate`.
+
+PyO3 submodule import gotcha: ``swing_core`` exposes ``swing`` as a runtime
+PyO3 submodule (an attribute, not a filesystem module), so we must use
+``from swing_core import swing`` — ``import swing_core.swing`` fails.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from .types import PendulumParameters, PendulumState
+
+logger = logging.getLogger(__name__)
+
+_MISSING_WHEEL_MESSAGE = (
+    "swing_core Rust extension is not installed; the swing integration hot "
+    "loop requires it. Build/install it with "
+    "`pip install rust_core/swing-core` or "
+    "`maturin develop -m rust_core/swing-core/Cargo.toml`. For one-shot "
+    "analysis you may explicitly fall back to "
+    "shared.python.swing_sim.reference.simulate."
+)
+
+try:
+    # Runtime PyO3 submodule: attribute access on the parent, never
+    # `import swing_core.swing`.
+    from swing_core import swing as _rust_swing
+
+    _RUST_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised on machines without wheel
+    _rust_swing = None
+    _RUST_AVAILABLE = False
+    logger.warning(
+        "swing_sim._rust_facade: swing_core wheel not available; hot-loop "
+        "calls will raise ImportError. See docs/development/rust-setup.md"
+    )
+
+
+def rust_available() -> bool:
+    """Return whether the ``swing_core`` Rust wheel is importable."""
+    return _RUST_AVAILABLE
+
+
+def _require_rust() -> Any:
+    if not _RUST_AVAILABLE:
+        raise ImportError(_MISSING_WHEEL_MESSAGE)
+    return _rust_swing
+
+
+def _to_rust_params(p: PendulumParameters) -> Any:
+    rust = _require_rust()
+    return rust.PendulumParameters(
+        p.m1, p.l1, p.lc1, p.i1, p.m2, p.l2, p.lc2, p.i2, p.d1, p.d2
+    )
+
+
+def _to_rust_state(s: PendulumState) -> Any:
+    rust = _require_rust()
+    return rust.PendulumState(s.theta1, s.theta2, s.omega1, s.omega2)
+
+
+def plane_rotation_rust(yaw: float, side_tilt: float, fwd_tilt: float) -> np.ndarray:
+    """World-from-plane rotation matrix (3x3) — Rust path."""
+    rust = _require_rust()
+    return np.asarray(
+        rust.plane_rotation(float(yaw), float(side_tilt), float(fwd_tilt)),
+        dtype=np.float64,
+    )
+
+
+def in_plane_gravity_rust(
+    yaw: float, side_tilt: float, fwd_tilt: float, g: float
+) -> tuple[float, float]:
+    """In-plane gravity ``(g_x, g_y)`` from tilt angles — Rust path."""
+    rust = _require_rust()
+    gx, gy = rust.in_plane_gravity(
+        float(yaw), float(side_tilt), float(fwd_tilt), float(g)
+    )
+    return float(gx), float(gy)
+
+
+def step_rust(
+    params: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+    dt: float,
+) -> PendulumState:
+    """One RK4 step — Rust path.
+
+    Raises:
+        ImportError: If the ``swing_core`` wheel is not installed.
+        ValueError: If the mass matrix is numerically singular.
+    """
+    rust = _require_rust()
+    out = rust.step(
+        _to_rust_params(params),
+        _to_rust_state(state),
+        float(g_inplane[0]),
+        float(g_inplane[1]),
+        float(dt),
+    )
+    return PendulumState(
+        theta1=out.theta1, theta2=out.theta2, omega1=out.omega1, omega2=out.omega2
+    )
+
+
+def simulate_rust(
+    params: PendulumParameters,
+    initial: PendulumState,
+    g_inplane: tuple[float, float],
+    dt: float,
+    n_steps: int,
+) -> np.ndarray:
+    """Simulate ``n_steps`` RK4 steps — Rust path (hot loop).
+
+    Returns an ``(n_steps + 1, 4)`` array of rows
+    ``[theta1, theta2, omega1, omega2]`` including the initial state.
+
+    Raises:
+        ImportError: If the ``swing_core`` wheel is not installed.
+        ValueError: If any step encounters a singular mass matrix.
+    """
+    rust = _require_rust()
+    flat = rust.simulate(
+        _to_rust_params(params),
+        _to_rust_state(initial),
+        float(g_inplane[0]),
+        float(g_inplane[1]),
+        float(dt),
+        int(n_steps),
+    )
+    return np.asarray(flat, dtype=np.float64).reshape(int(n_steps) + 1, 4)
+
+
+def total_energy_rust(
+    params: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+) -> float:
+    """Total mechanical energy [J] — Rust path."""
+    rust = _require_rust()
+    return float(
+        rust.total_energy(
+            _to_rust_params(params),
+            _to_rust_state(state),
+            float(g_inplane[0]),
+            float(g_inplane[1]),
+        )
+    )

--- a/src/shared/python/swing_sim/flight/__init__.py
+++ b/src/shared/python/swing_sim/flight/__init__.py
@@ -1,0 +1,58 @@
+"""Ball-flight subpackage of :mod:`shared.python.swing_sim` (epic #4103, #4107).
+
+Self-facaded port of UpstreamDrift's pure-Python flight stack
+(``physics/flight_models.py`` and the launch-derivation seam of
+``physics/swing_ball_flight_pipeline.py``): seven literature flight models
+behind :class:`FlightModelRegistry`, scipy ``solve_ivp`` RK45 integration
+with a terminal ground event, a public launch-conditions deriver, frame
+adapters between the app frame (x target / y up / z right) and the flight
+frame (x forward / y left / z up), and a graceful Rust fast path backed by
+the canonical ``rust_core/tools-core/src/ball_flight.rs`` kernel.
+
+Import from this facade only; module layout underneath is private.
+"""
+
+from __future__ import annotations
+
+from ._rust_facade import is_rust_available, simulate_trajectory_rust
+from .frames import from_flight_frame, to_flight_frame
+from .launch import derive_launch_conditions
+from .models import (
+    BallFlightModel,
+    ConstantCoefficientModel,
+    ConstantCoefficientSpec,
+    MacDonaldHanzelyModel,
+    WaterlooPennerModel,
+)
+from .pipeline import FlightSimulatorProtocol, simulate
+from .registry import FlightModelRegistry, FlightModelType, compare_models
+from .types import (
+    DEFAULT_BACKSPIN_AXIS,
+    FlightResult,
+    LaunchConditions,
+    TrajectoryPoint,
+    compute_flight_metrics,
+)
+
+__all__ = [
+    "DEFAULT_BACKSPIN_AXIS",
+    "BallFlightModel",
+    "ConstantCoefficientModel",
+    "ConstantCoefficientSpec",
+    "FlightModelRegistry",
+    "FlightModelType",
+    "FlightResult",
+    "FlightSimulatorProtocol",
+    "LaunchConditions",
+    "MacDonaldHanzelyModel",
+    "TrajectoryPoint",
+    "WaterlooPennerModel",
+    "compare_models",
+    "compute_flight_metrics",
+    "derive_launch_conditions",
+    "from_flight_frame",
+    "is_rust_available",
+    "simulate",
+    "simulate_trajectory_rust",
+    "to_flight_frame",
+]

--- a/src/shared/python/swing_sim/flight/_constants.py
+++ b/src/shared/python/swing_sim/flight/_constants.py
@@ -1,0 +1,59 @@
+"""Vendored physical constants for the ball-flight package (with citations).
+
+Vendored from UpstreamDrift ``src/shared/python/core/physics_constants.py``
+so :mod:`shared.python.swing_sim.flight` stays self-contained (epic #4103,
+flight port #4107). Kept in a flight-private module (rather than a shared
+``swing_sim/constants.py``) so parallel domain ports (impact, #4106) cannot
+conflict on one shared file; promote to a shared module when a second
+subpackage needs the same values.
+
+Every constant records units and source in its docstring.
+"""
+
+from __future__ import annotations
+
+import math
+
+GRAVITY_M_S2 = 9.80665
+"""Standard gravity [m/s^2] — NIST CODATA 2018."""
+
+AIR_DENSITY_SEA_LEVEL_KG_M3 = 1.225
+"""Air density at sea level, 15 C [kg/m^3] — ISA Standard Atmosphere."""
+
+GOLF_BALL_MASS_KG = 0.04593
+"""Maximum golf ball mass (1.620 oz) [kg] — USGA Rule 5-1."""
+
+GOLF_BALL_DIAMETER_M = 0.04267
+"""Minimum golf ball diameter (1.680 in) [m] — USGA Rule 5-2."""
+
+GOLF_BALL_RADIUS_M = GOLF_BALL_DIAMETER_M / 2.0
+"""Minimum golf ball radius [m] — derived from USGA Rule 5-2."""
+
+MAX_GOLF_BALL_LIFT_COEFFICIENT = 0.155
+"""Physical cap on the golf-ball lift coefficient [-] — Penner (2003) fit
+ceiling used by the UpstreamDrift flight models."""
+
+MIN_SPEED_THRESHOLD_M_S = 0.1
+"""Minimum speed for aerodynamic force evaluation [m/s] — numerical guard."""
+
+NUMERICAL_EPSILON = 1e-10
+"""Epsilon for vector normalisation [-] — numerical guard."""
+
+MPH_TO_MPS = 0.44704
+"""Miles per hour to metres per second [(m/s)/mph] — NIST (exact)."""
+
+RPM_TO_RAD_S = 2.0 * math.pi / 60.0
+"""Revolutions per minute to radians per second [(rad/s)/RPM] — exact."""
+
+__all__ = [
+    "AIR_DENSITY_SEA_LEVEL_KG_M3",
+    "GOLF_BALL_DIAMETER_M",
+    "GOLF_BALL_MASS_KG",
+    "GOLF_BALL_RADIUS_M",
+    "GRAVITY_M_S2",
+    "MAX_GOLF_BALL_LIFT_COEFFICIENT",
+    "MIN_SPEED_THRESHOLD_M_S",
+    "MPH_TO_MPS",
+    "NUMERICAL_EPSILON",
+    "RPM_TO_RAD_S",
+]

--- a/src/shared/python/swing_sim/flight/_rust_facade.py
+++ b/src/shared/python/swing_sim/flight/_rust_facade.py
@@ -1,0 +1,165 @@
+"""Rust-accelerated ball-flight facade (GRACEFUL dual-path posture).
+
+Mirrors UpstreamDrift ``physics/aerodynamics/_rust_facade.py``: the
+``tools_core`` wheel is probed at import time and callers choose the fast
+path via :func:`is_rust_available`. Unlike the swing-dynamics facade
+(strict, bilateral_rust posture), flight is perfectly serviceable in
+scipy, so absence of the wheel never raises at import — the scipy models
+in :mod:`shared.python.swing_sim.flight.models` are the fallback.
+
+The canonical Rust implementation is
+``rust_core/tools-core/src/ball_flight.rs`` (its header notes it replaces
+the UpstreamDrift Numba version). Its native frame is the app frame
+(x downrange, y up, z lateral/right); this facade converts results into
+the flight frame (x forward, y left, z up) used across this package.
+
+Requires a ``tools_core`` wheel that exposes ``simulate_trajectory``
+(added alongside this package); older wheels that only ship the classes
+report unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import numpy as np
+
+from .frames import from_flight_frame, to_flight_frame
+from .types import (
+    FlightResult,
+    LaunchConditions,
+    TrajectoryPoint,
+    compute_flight_metrics,
+)
+
+logger = logging.getLogger(__name__)
+
+RUST_MODEL_NAME = "tools-core Rust RK4"
+
+_RUST_AVAILABLE = False
+_rust: Any = None
+
+try:
+    import tools_core
+
+    _rust = tools_core
+    _RUST_AVAILABLE = bool(
+        hasattr(_rust, "simulate_trajectory")
+        and hasattr(_rust, "BallProperties")
+        and hasattr(_rust, "EnvironmentalConditions")
+        and hasattr(_rust, "LaunchConditions")
+    )
+    if _RUST_AVAILABLE:
+        logger.info("tools_core ball_flight kernel loaded (Rust fast path)")
+    else:
+        logger.info(
+            "tools_core installed but simulate_trajectory missing (older wheel) "
+            "— using pure-Python scipy flight models."
+        )
+except ImportError:  # pragma: no cover - exercised on machines without wheel
+    logger.info(
+        "tools_core not installed — using pure-Python scipy flight models. "
+        "Install with `pip install rust_core/tools-core`."
+    )
+
+
+def is_rust_available() -> bool:
+    """Return True when the Rust ball-flight kernel is loaded."""
+    return _RUST_AVAILABLE
+
+
+def _build_rust_inputs(
+    launch: LaunchConditions,
+) -> tuple[Any, Any, Any]:
+    """Construct ``tools_core`` ball/env/launch objects from a launch spec."""
+    ball = _rust.BallProperties()
+    ball.mass = float(launch.ball_mass)
+    ball.diameter = 2.0 * float(launch.ball_radius)
+
+    env = _rust.EnvironmentalConditions()
+    env.air_density = float(launch.air_density)
+    env.gravity = float(launch.gravity)
+    wind_flight = launch.get_wind_vector()
+    if float(np.linalg.norm(wind_flight)) > 0.0:
+        wind_app = from_flight_frame(wind_flight)
+        env.set_wind(float(wind_app[0]), float(wind_app[1]), float(wind_app[2]))
+
+    rust_launch = _rust.LaunchConditions(
+        float(launch.ball_speed),
+        math.degrees(launch.launch_angle),
+        math.degrees(launch.azimuth_angle),
+        float(launch.spin_rate),
+    )
+    spin_vec_flight = launch.get_spin_vector()
+    spin_mag = float(np.linalg.norm(spin_vec_flight))
+    if spin_mag > 0.0:
+        axis_app = from_flight_frame(spin_vec_flight / spin_mag)
+        rust_launch.set_spin_axis(
+            float(axis_app[0]), float(axis_app[1]), float(axis_app[2])
+        )
+    return ball, env, rust_launch
+
+
+def simulate_trajectory_rust(
+    launch: LaunchConditions,
+    max_time: float = 10.0,
+    dt: float = 0.01,
+) -> FlightResult:
+    """Simulate a trajectory with the ``tools_core`` Rust RK4 kernel.
+
+    Args:
+        launch: Flight-frame launch conditions (radians / RPM / SI).
+        max_time: Maximum simulated time [s], > 0.
+        dt: Fixed RK4 step [s], > 0.
+
+    Returns:
+        :class:`FlightResult` with the trajectory converted to the flight
+        frame (x forward, y left, z up).
+
+    Raises:
+        ImportError: If the Rust kernel is unavailable (use
+            :func:`is_rust_available` and fall back to the scipy models).
+        ValueError: If ``launch.ball_speed``, ``max_time``, or ``dt`` is
+            not positive (validated here so the Rust precondition
+            ``assert!`` never panics across the FFI boundary).
+    """
+    if not _RUST_AVAILABLE:
+        raise ImportError(
+            "tools_core ball-flight kernel is not available; fall back to "
+            "shared.python.swing_sim.flight.models (scipy). Build the wheel "
+            "with `pip install rust_core/tools-core`."
+        )
+    if launch is None:
+        raise ValueError("launch must be provided")
+    if launch.ball_speed <= 0.0:
+        raise ValueError(f"ball_speed must be > 0; got {launch.ball_speed!r}")
+    if not (math.isfinite(max_time) and max_time > 0.0):
+        raise ValueError(f"max_time must be finite and > 0; got {max_time!r}")
+    if not (math.isfinite(dt) and dt > 0.0):
+        raise ValueError(f"dt must be finite and > 0; got {dt!r}")
+
+    ball, env, rust_launch = _build_rust_inputs(launch)
+    raw_points = _rust.simulate_trajectory(ball, env, rust_launch, max_time, dt)
+
+    points: list[TrajectoryPoint] = []
+    for p in raw_points:
+        pos_app = np.array([p.x, p.y, p.z])
+        vel_app = np.array([p.vx, p.vy, p.vz])
+        points.append(
+            TrajectoryPoint(
+                time=float(p.time),
+                position=to_flight_frame(pos_app),
+                velocity=to_flight_frame(vel_app),
+            )
+        )
+
+    return compute_flight_metrics(points, RUST_MODEL_NAME)
+
+
+__all__ = [
+    "RUST_MODEL_NAME",
+    "is_rust_available",
+    "simulate_trajectory_rust",
+]

--- a/src/shared/python/swing_sim/flight/frames.py
+++ b/src/shared/python/swing_sim/flight/frames.py
@@ -1,0 +1,65 @@
+"""Frame adapters between the app frame and the UpstreamDrift flight frame.
+
+- Flight frame (UpstreamDrift physics stack, and everything inside
+  :mod:`shared.python.swing_sim.flight`): x forward, y left, z up.
+- App frame (Tools AffineDrift / ``tools_core.ball_flight`` Rust kernel):
+  x target (downrange), y up, z right.
+
+Both are right-handed, related by a pure rotation, so the same adapter
+applies to positions, velocities, angular velocities, and spin axes.
+
+Mapping: app x = flight x; app y = flight z; app z = -flight y.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _validated(vec: np.ndarray, name: str) -> np.ndarray:
+    """Return ``vec`` as a float array of shape (3,) or (N, 3)."""
+    arr = np.asarray(vec, dtype=float)
+    if arr.shape != (3,) and not (arr.ndim == 2 and arr.shape[1] == 3):
+        raise ValueError(f"{name} must have shape (3,) or (N, 3); got {arr.shape}")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} must be finite")
+    return arr
+
+
+def to_flight_frame(vec_app: np.ndarray) -> np.ndarray:
+    """Convert vector(s) from the app frame to the flight frame.
+
+    Args:
+        vec_app: Vector(s) in the app frame (x target, y up, z right),
+            shape (3,) or (N, 3).
+
+    Returns:
+        Vector(s) in the flight frame (x forward, y left, z up), same shape.
+    """
+    arr = _validated(vec_app, "vec_app")
+    out = np.empty_like(arr)
+    out[..., 0] = arr[..., 0]
+    out[..., 1] = -arr[..., 2]
+    out[..., 2] = arr[..., 1]
+    return out
+
+
+def from_flight_frame(vec_flight: np.ndarray) -> np.ndarray:
+    """Convert vector(s) from the flight frame to the app frame.
+
+    Args:
+        vec_flight: Vector(s) in the flight frame (x forward, y left, z up),
+            shape (3,) or (N, 3).
+
+    Returns:
+        Vector(s) in the app frame (x target, y up, z right), same shape.
+    """
+    arr = _validated(vec_flight, "vec_flight")
+    out = np.empty_like(arr)
+    out[..., 0] = arr[..., 0]
+    out[..., 1] = arr[..., 2]
+    out[..., 2] = -arr[..., 1]
+    return out
+
+
+__all__ = ["from_flight_frame", "to_flight_frame"]

--- a/src/shared/python/swing_sim/flight/launch.py
+++ b/src/shared/python/swing_sim/flight/launch.py
@@ -1,0 +1,84 @@
+"""Launch-condition derivation from post-impact ball kinematics.
+
+Public, tested port of ``_LaunchConditionsDeriver`` from UpstreamDrift
+``src/shared/python/physics/swing_ball_flight_pipeline.py`` (epic #4103,
+flight port #4107): post-impact ball velocity/spin vectors in the flight
+frame (x forward / y left / z up) → speed, launch angle, azimuth, spin
+rate [RPM], and unit spin axis, packed as
+:class:`~shared.python.swing_sim.flight.types.LaunchConditions`.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from ._constants import RPM_TO_RAD_S
+from .types import DEFAULT_BACKSPIN_AXIS, LaunchConditions
+
+_EPS = 1e-12
+
+
+def derive_launch_conditions(
+    ball_velocity: np.ndarray,
+    ball_angular_velocity: np.ndarray,
+) -> LaunchConditions:
+    """Return :class:`LaunchConditions` from post-impact ball kinematics.
+
+    Args:
+        ball_velocity: Post-impact ball velocity [m/s], shape (3,), flight
+            frame (x forward, y left, z up).
+        ball_angular_velocity: Post-impact ball angular velocity [rad/s],
+            shape (3,), flight frame.
+
+    Returns:
+        LaunchConditions ready for any :class:`BallFlightModel` — speed,
+        launch angle from the horizontal plane [rad], azimuth (bearing from
+        +x, positive toward +y) [rad], spin rate [RPM], and unit spin axis.
+
+    Raises:
+        ValueError: If either vector is not a finite 3-vector.
+    """
+    vel = np.asarray(ball_velocity, dtype=float)
+    spin_w = np.asarray(ball_angular_velocity, dtype=float)
+    for name, vec in (
+        ("ball_velocity", vel),
+        ("ball_angular_velocity", spin_w),
+    ):
+        if vec.shape != (3,):
+            raise ValueError(f"{name} must be shape (3,); got {vec.shape}")
+        if not np.all(np.isfinite(vec)):
+            raise ValueError(f"{name} must be finite; got {vec!r}")
+
+    speed = float(math.hypot(vel[0], vel[1], vel[2]))
+
+    # Launch angle from the horizontal plane, radians.
+    horiz_speed = float(math.hypot(vel[0], vel[1]))
+    if horiz_speed < _EPS:
+        launch_angle_rad = math.pi / 2.0
+    else:
+        launch_angle_rad = float(math.atan2(vel[2], horiz_speed))
+
+    # Azimuth angle (compass bearing, 0 = forward = +x), radians.
+    azimuth_rad = 0.0
+    if horiz_speed > _EPS:
+        azimuth_rad = float(math.atan2(vel[1], vel[0]))
+
+    spin_rate_rad_s = float(math.hypot(spin_w[0], spin_w[1], spin_w[2]))
+    spin_rate_rpm = spin_rate_rad_s / RPM_TO_RAD_S
+    if spin_rate_rad_s > _EPS:
+        spin_axis = spin_w / spin_rate_rad_s
+    else:
+        spin_axis = np.array(DEFAULT_BACKSPIN_AXIS)
+
+    return LaunchConditions(
+        ball_speed=speed,
+        launch_angle=launch_angle_rad,
+        azimuth_angle=azimuth_rad,
+        spin_rate=spin_rate_rpm,
+        spin_axis=(float(spin_axis[0]), float(spin_axis[1]), float(spin_axis[2])),
+    )
+
+
+__all__ = ["derive_launch_conditions"]

--- a/src/shared/python/swing_sim/flight/models.py
+++ b/src/shared/python/swing_sim/flight/models.py
@@ -1,0 +1,391 @@
+"""Literature ball-flight models (scipy ``solve_ivp`` RK45 integration).
+
+Ported from UpstreamDrift ``src/shared/python/physics/flight_models.py``
+(epic #4103, flight port #4107), rewritten self-contained: the
+:class:`BallFlightModel` base with the unified ODE loop and terminal ground
+event, the Waterloo/Penner quadratic-coefficient model, the
+MacDonald-Hanzely spin-decay model, and the constant-coefficient model
+family parameterised by :class:`ConstantCoefficientSpec` (name /
+description / reference metadata preserved as the citation trail).
+"""
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import cast
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+from ._constants import (
+    MAX_GOLF_BALL_LIFT_COEFFICIENT,
+    MIN_SPEED_THRESHOLD_M_S,
+    NUMERICAL_EPSILON,
+    RPM_TO_RAD_S,
+)
+from .types import (
+    FlightResult,
+    LaunchConditions,
+    TrajectoryPoint,
+    compute_flight_metrics,
+)
+
+
+def _capped_lift_coefficient(value: float) -> float:
+    """Return a physically bounded golf-ball lift coefficient."""
+    if value <= 0.0:
+        return 0.0
+    return min(MAX_GOLF_BALL_LIFT_COEFFICIENT, value)
+
+
+def _spin_ratio_lift_coefficient(spin_ratio: float, max_coefficient: float) -> float:
+    """Calibrate low-spin lift without letting high-spin shots balloon."""
+    if spin_ratio <= 0.0 or max_coefficient <= 0.0:
+        return 0.0
+    return _capped_lift_coefficient(min(max_coefficient, 1.7 * spin_ratio))
+
+
+class BallFlightModel(ABC):
+    """Base class for flight models (shared ODE loop and metrics)."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Return the display name of the flight model."""
+        ...
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        """Return a short description of the model approach."""
+        ...
+
+    @property
+    @abstractmethod
+    def reference(self) -> str:
+        """Return the citation or reference for the model."""
+        ...
+
+    @abstractmethod
+    def simulate(
+        self, launch: LaunchConditions, max_time: float = 10.0, dt: float = 0.01
+    ) -> FlightResult:
+        """Simulate ball flight and return the trajectory result."""
+        ...
+
+    def _compute_metrics(self, trajectory: list[TrajectoryPoint]) -> FlightResult:
+        """Delegate to the shared module-level metrics computation."""
+        return compute_flight_metrics(trajectory, self.name)
+
+    def _run_ode_simulation(
+        self,
+        launch: LaunchConditions,
+        deriv_func: Callable[[float, np.ndarray], np.ndarray],
+        max_time: float,
+        dt: float,
+    ) -> FlightResult:
+        """Unified ODE integration loop with a terminal ground event.
+
+        Preconditions: ``launch`` provided, ``max_time > 0``, ``0 < dt``.
+        """
+        if launch is None:
+            raise ValueError("launch must be provided")
+        if not (math.isfinite(max_time) and max_time > 0.0):
+            raise ValueError(f"max_time must be finite and > 0; got {max_time!r}")
+        if not (math.isfinite(dt) and dt > 0.0):
+            raise ValueError(f"dt must be finite and > 0; got {dt!r}")
+        v0 = launch.get_initial_velocity()
+        y0 = np.array([0.0, 0.0, 0.0, v0[0], v0[1], v0[2]])
+
+        def ground_ev(t: float, y: np.ndarray) -> float:
+            """Return the ball height for ground-contact event detection."""
+            return float(y[2])
+
+        # Type-safe attribute assignment for solve_ivp
+        setattr(ground_ev, "terminal", True)  # noqa: B010
+        setattr(ground_ev, "direction", -1)  # noqa: B010
+
+        sol = solve_ivp(
+            deriv_func,
+            (0, max_time),
+            y0,
+            method="RK45",
+            events=ground_ev,
+            dense_output=True,
+            max_step=0.1,
+        )
+
+        t_eval = np.arange(0, sol.t[-1], dt)
+        points = [
+            TrajectoryPoint(float(t), sol.sol(t)[:3], sol.sol(t)[3:]) for t in t_eval
+        ]
+        if sol.t[-1] not in t_eval:
+            points.append(
+                TrajectoryPoint(float(sol.t[-1]), sol.y[:3, -1], sol.y[3:, -1])
+            )
+
+        return self._compute_metrics(points)
+
+
+class WaterlooPennerModel(BallFlightModel):
+    """Waterloo/Penner model implementation."""
+
+    def __init__(
+        self,
+        cd0: float = 0.21,
+        cd1: float = 0.05,
+        cd2: float = 0.02,
+        cl0: float = 0.00,
+        cl1: float = 0.70,
+        cl2: float = 0.645,
+        cl_max: float = MAX_GOLF_BALL_LIFT_COEFFICIENT,
+    ) -> None:
+        self.params = (cd0, cd1, cd2, cl0, cl1, cl2, cl_max)
+
+    @property
+    def name(self) -> str:
+        """Return the Waterloo/Penner model name."""
+        return "Waterloo/Penner"
+
+    @property
+    def description(self) -> str:
+        """Return the Waterloo/Penner model description."""
+        return "Waterloo quadratic Cd with Penner spin-ratio lift fit"
+
+    @property
+    def reference(self) -> str:
+        """Return the Waterloo/Penner model citation."""
+        return "Penner (2003); McPhee et al. (Waterloo)"
+
+    def simulate(
+        self, launch: LaunchConditions, max_time: float = 10.0, dt: float = 0.01
+    ) -> FlightResult:
+        """Simulate flight using the quadratic-Cd / power-law-Cl model."""
+        if launch is None:
+            raise ValueError("launch must be provided")
+        cd0, cd1, cd2, cl0, cl1, cl2, cl_max = self.params
+        omega_v = launch.get_spin_vector()
+        omega_m = math.hypot(omega_v[0], omega_v[1], omega_v[2])
+        wind_v = launch.get_wind_vector()
+        area = math.pi * launch.ball_radius**2
+
+        def derivatives(t: float, y: np.ndarray) -> np.ndarray:
+            """Compute state derivatives using quadratic Cd/Cl aerodynamics."""
+            if t is None:
+                raise ValueError("t must be provided")
+            v_val = cast(np.ndarray, y[3:])
+            v_rel = v_val - wind_v
+            speed = math.hypot(v_rel[0], v_rel[1], v_rel[2])
+            if speed < MIN_SPEED_THRESHOLD_M_S:
+                return np.array(
+                    [v_val[0], v_val[1], v_val[2], 0.0, 0.0, -launch.gravity]
+                )
+
+            vu = v_rel / speed
+            s = (omega_m * launch.ball_radius) / speed
+            cd = cd0 + cd1 * s + cd2 * s**2
+            cl_val = cl0 + cl1 * s**cl2 if s > 0.0 else cl0
+            cl = min(cl_max, _capped_lift_coefficient(cl_val))
+
+            acc = (
+                -(0.5 * launch.air_density * speed**2 * cd * area / launch.ball_mass)
+                * vu
+            )
+            if omega_m > 0:
+                cross = np.cross(omega_v / omega_m, vu)
+                cross_norm = math.hypot(cross[0], cross[1], cross[2])
+                if cross_norm > NUMERICAL_EPSILON:
+                    acc += (
+                        0.5
+                        * launch.air_density
+                        * speed**2
+                        * cl
+                        * area
+                        / launch.ball_mass
+                    ) * (cross / cross_norm)
+
+            acc[2] -= launch.gravity
+            return np.array([v_val[0], v_val[1], v_val[2], acc[0], acc[1], acc[2]])
+
+        return self._run_ode_simulation(launch, derivatives, max_time, dt)
+
+
+class MacDonaldHanzelyModel(BallFlightModel):
+    """MacDonald-Hanzely model implementation."""
+
+    def __init__(
+        self, cd: float = 0.225, cl: float = 0.20, decay: float = 0.05
+    ) -> None:
+        self.cd, self.cl, self.decay = cd, cl, decay
+
+    @property
+    def name(self) -> str:
+        """Return the MacDonald-Hanzely model name."""
+        return "MacDonald-Hanzely"
+
+    @property
+    def description(self) -> str:
+        """Return the MacDonald-Hanzely model description."""
+        return "ODE model with exponential spin decay"
+
+    @property
+    def reference(self) -> str:
+        """Return the MacDonald-Hanzely model citation."""
+        return "MacDonald & Hanzely (1991)"
+
+    def simulate(
+        self, launch: LaunchConditions, max_time: float = 10.0, dt: float = 0.01
+    ) -> FlightResult:
+        """Simulate flight using the MacDonald-Hanzely spin-decay model."""
+        if launch is None:
+            raise ValueError("launch must be provided")
+        omega_0 = launch.spin_rate * RPM_TO_RAD_S
+        spin_axis = launch.get_spin_vector()
+        spin_norm = math.hypot(spin_axis[0], spin_axis[1], spin_axis[2])
+        if spin_norm > 0:
+            spin_axis = spin_axis / spin_norm
+        wind_v = launch.get_wind_vector()
+        area = math.pi * launch.ball_radius**2
+        k_drag = 0.5 * launch.air_density * area * self.cd / launch.ball_mass
+
+        def derivatives(t: float, y: np.ndarray) -> np.ndarray:
+            """Compute state derivatives with exponential spin decay."""
+            if t is None:
+                raise ValueError("t must be provided")
+            v_val = cast(np.ndarray, y[3:])
+            v_rel = v_val - wind_v
+            speed = math.hypot(v_rel[0], v_rel[1], v_rel[2])
+            if speed < MIN_SPEED_THRESHOLD_M_S:
+                return np.array(
+                    [v_val[0], v_val[1], v_val[2], 0.0, 0.0, -launch.gravity]
+                )
+
+            omega = omega_0 * math.exp(-self.decay * t)
+            vu = v_rel / speed
+            acc = -k_drag * speed**2 * vu
+
+            if omega > 0:
+                spin_ratio = omega * launch.ball_radius / speed
+                cl_eff = _spin_ratio_lift_coefficient(spin_ratio, self.cl)
+                cross = np.cross(spin_axis, vu)
+                cross_norm = math.hypot(cross[0], cross[1], cross[2])
+                if cross_norm > NUMERICAL_EPSILON:
+                    acc += (
+                        0.5
+                        * launch.air_density
+                        * area
+                        * cl_eff
+                        * speed**2
+                        / launch.ball_mass
+                    ) * (cross / cross_norm)
+
+            acc[2] -= launch.gravity
+            return np.array([v_val[0], v_val[1], v_val[2], acc[0], acc[1], acc[2]])
+
+        return self._run_ode_simulation(launch, derivatives, max_time, dt)
+
+
+@dataclass(frozen=True)
+class ConstantCoefficientSpec:
+    """Specification for constant coefficient flight models.
+
+    Attributes:
+        name: Display name for the model.
+        description: Short description of the model.
+        reference: Citation or reference for the model.
+        cd: Drag coefficient [unitless].
+        cl: Lift coefficient [unitless].
+        spin_decay: Spin decay rate [1/s]. Use 0.0 to disable decay.
+    """
+
+    name: str
+    description: str
+    reference: str
+    cd: float
+    cl: float
+    spin_decay: float
+
+
+class ConstantCoefficientModel(BallFlightModel):
+    """Flight model using constant Cd/Cl with optional spin decay."""
+
+    def __init__(self, spec: ConstantCoefficientSpec) -> None:
+        self._spec = spec
+
+    @property
+    def name(self) -> str:
+        """Return the model name from the specification."""
+        return self._spec.name
+
+    @property
+    def description(self) -> str:
+        """Return the model description from the specification."""
+        return self._spec.description
+
+    @property
+    def reference(self) -> str:
+        """Return the model citation from the specification."""
+        return self._spec.reference
+
+    def simulate(
+        self, launch: LaunchConditions, max_time: float = 10.0, dt: float = 0.01
+    ) -> FlightResult:
+        """Simulate flight using constant drag and lift coefficients."""
+        if launch is None:
+            raise ValueError("launch must be provided")
+        omega_0 = launch.spin_rate * RPM_TO_RAD_S
+        spin_axis = launch.get_spin_vector()
+        spin_norm = math.hypot(spin_axis[0], spin_axis[1], spin_axis[2])
+        if spin_norm > 0:
+            spin_axis = spin_axis / spin_norm
+        wind_v = launch.get_wind_vector()
+        area = math.pi * launch.ball_radius**2
+        k_drag = 0.5 * launch.air_density * area * self._spec.cd / launch.ball_mass
+
+        def derivatives(t: float, y: np.ndarray) -> np.ndarray:
+            """Compute state derivatives with constant coefficients and decay."""
+            if t is None:
+                raise ValueError("t must be provided")
+            v_val = cast(np.ndarray, y[3:])
+            v_rel = v_val - wind_v
+            speed = math.hypot(v_rel[0], v_rel[1], v_rel[2])
+            if speed < MIN_SPEED_THRESHOLD_M_S:
+                return np.array(
+                    [v_val[0], v_val[1], v_val[2], 0.0, 0.0, -launch.gravity]
+                )
+
+            omega = omega_0 * math.exp(-self._spec.spin_decay * t)
+            vu = v_rel / speed
+            acc = -k_drag * speed**2 * vu
+
+            if omega > 0:
+                spin_ratio = omega * launch.ball_radius / speed
+                cl_eff = _spin_ratio_lift_coefficient(spin_ratio, self._spec.cl)
+                cross = np.cross(spin_axis, vu)
+                cross_norm = math.hypot(cross[0], cross[1], cross[2])
+                if cross_norm > NUMERICAL_EPSILON:
+                    acc += (
+                        0.5
+                        * launch.air_density
+                        * area
+                        * cl_eff
+                        * speed**2
+                        / launch.ball_mass
+                    ) * (cross / cross_norm)
+
+            acc[2] -= launch.gravity
+            return np.array([v_val[0], v_val[1], v_val[2], acc[0], acc[1], acc[2]])
+
+        return self._run_ode_simulation(launch, derivatives, max_time, dt)
+
+
+__all__ = [
+    "BallFlightModel",
+    "ConstantCoefficientModel",
+    "ConstantCoefficientSpec",
+    "MacDonaldHanzelyModel",
+    "WaterlooPennerModel",
+]

--- a/src/shared/python/swing_sim/flight/pipeline.py
+++ b/src/shared/python/swing_sim/flight/pipeline.py
@@ -1,0 +1,75 @@
+"""Flight-pipeline seam: DI protocol + one-call convenience simulate.
+
+Mirrors the DI design of UpstreamDrift
+``src/shared/python/physics/swing_ball_flight_pipeline.py``
+(``FlightSimulatorProtocol``): the impact stage (#4106) derives
+:class:`LaunchConditions` via
+:func:`shared.python.swing_sim.flight.launch.derive_launch_conditions`
+and plugs them straight into any :class:`FlightSimulatorProtocol`
+implementation — every :class:`BallFlightModel` already satisfies it,
+and tests inject mocks.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .registry import FlightModelRegistry, FlightModelType
+from .types import FlightResult, LaunchConditions
+
+
+@runtime_checkable
+class FlightSimulatorProtocol(Protocol):
+    """Minimal protocol for any ball-flight simulator.
+
+    Satisfied by every :class:`BallFlightModel` in this package; the Rust
+    facade's :func:`simulate_trajectory_rust` can be adapted trivially.
+    Tests inject mocks.
+    """
+
+    def simulate(
+        self,
+        launch: LaunchConditions,
+        max_time: float = 10.0,
+        dt: float = 0.01,
+    ) -> FlightResult:
+        """Return a :class:`FlightResult` for the given launch conditions."""
+        ...
+
+
+def simulate(
+    launch: LaunchConditions,
+    model_name: str = "waterloo_penner",
+    max_time: float = 10.0,
+    dt: float = 0.01,
+) -> FlightResult:
+    """Simulate a ball flight with a registry model selected by name.
+
+    Args:
+        launch: Flight-frame launch conditions (radians / RPM / SI).
+        model_name: A :class:`FlightModelType` value string, e.g.
+            ``"waterloo_penner"`` or ``"macdonald_hanzely"``.
+        max_time: Maximum simulated time [s], > 0.
+        dt: Trajectory sampling interval [s], > 0.
+
+    Returns:
+        The :class:`FlightResult` from the selected model.
+
+    Raises:
+        ValueError: If ``launch`` is missing or ``model_name`` is not a
+            known :class:`FlightModelType` value.
+    """
+    if launch is None:
+        raise ValueError("launch must be provided")
+    try:
+        model_type = FlightModelType(model_name)
+    except ValueError as exc:
+        valid = ", ".join(m.value for m in FlightModelType)
+        raise ValueError(
+            f"unknown flight model {model_name!r}; valid names: {valid}"
+        ) from exc
+    model = FlightModelRegistry.get_model(model_type)
+    return model.simulate(launch, max_time=max_time, dt=dt)
+
+
+__all__ = ["FlightSimulatorProtocol", "simulate"]

--- a/src/shared/python/swing_sim/flight/registry.py
+++ b/src/shared/python/swing_sim/flight/registry.py
@@ -1,0 +1,134 @@
+"""Flight model registry — all 7 literature models with citation metadata.
+
+Ported from UpstreamDrift ``src/shared/python/physics/flight_models.py``
+(``FlightModelType``, ``FlightModelRegistry``, ``compare_models``) for
+epic #4103 / flight port #4107. The five constant-coefficient presets keep
+their ``ConstantCoefficientSpec`` name/description/reference metadata —
+that is the citation trail.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from .models import (
+    BallFlightModel,
+    ConstantCoefficientModel,
+    ConstantCoefficientSpec,
+    MacDonaldHanzelyModel,
+    WaterlooPennerModel,
+)
+from .types import FlightResult, LaunchConditions
+
+
+class FlightModelType(Enum):
+    """Available ball flight physics models."""
+
+    WATERLOO_PENNER = "waterloo_penner"
+    MACDONALD_HANZELY = "macdonald_hanzely"
+    NATHAN = "nathan"
+    BALLANTYNE = "ballantyne"
+    JCOLE = "jcole"
+    ROSPIE_DL = "rospie_dl"
+    CHARRY_L3 = "charry_l3"
+
+
+_CONSTANT_COEFFICIENT_SPECS: dict[FlightModelType, ConstantCoefficientSpec] = {
+    FlightModelType.NATHAN: ConstantCoefficientSpec(
+        name="Nathan",
+        description="Constant Cd/Cl model with spin decay",
+        reference="Nathan et al. (2018)",
+        cd=0.22,
+        cl=0.24,
+        spin_decay=0.03,
+    ),
+    FlightModelType.BALLANTYNE: ConstantCoefficientSpec(
+        name="Ballantyne",
+        description="Constant Cd/Cl model for steady spin",
+        reference="Ballantyne et al. (2012)",
+        cd=0.20,
+        cl=0.18,
+        spin_decay=0.02,
+    ),
+    FlightModelType.JCOLE: ConstantCoefficientSpec(
+        name="J. Cole",
+        description="Constant Cd/Cl model with moderate decay",
+        reference="Cole (2016)",
+        cd=0.23,
+        cl=0.22,
+        spin_decay=0.04,
+    ),
+    FlightModelType.ROSPIE_DL: ConstantCoefficientSpec(
+        name="Rospie DL",
+        description="Constant Cd/Cl model tuned for driver launch",
+        reference="Rospie & Layton (2014)",
+        cd=0.21,
+        cl=0.19,
+        spin_decay=0.03,
+    ),
+    FlightModelType.CHARRY_L3: ConstantCoefficientSpec(
+        name="Charry L3",
+        description="Constant Cd/Cl model with higher drag",
+        reference="Charry et al. (2017)",
+        cd=0.24,
+        cl=0.21,
+        spin_decay=0.05,
+    ),
+}
+
+
+class FlightModelRegistry:
+    """Registry for managing flight models."""
+
+    _models: dict[FlightModelType, BallFlightModel] = {}
+
+    @classmethod
+    def get_model(cls, model_type: FlightModelType) -> BallFlightModel:
+        """Return the flight model instance for the given model type."""
+        if model_type is None:
+            raise ValueError("model_type must be provided")
+        if not cls._models:
+            cls._initialize()
+        return cls._models[model_type]
+
+    @classmethod
+    def get_all_models(cls) -> list[BallFlightModel]:
+        """Return all registered flight model instances."""
+        if not cls._models:
+            cls._initialize()
+        return list(cls._models.values())
+
+    @classmethod
+    def reset(cls) -> None:
+        """Clear the registry, forcing re-initialization on next access.
+
+        Use in test teardown to prevent cross-test pollution from the shared
+        class-level ``_models`` dict (UpstreamDrift issue #1775).
+        """
+        cls._models.clear()
+
+    @classmethod
+    def _initialize(cls) -> None:
+        cls._models[FlightModelType.WATERLOO_PENNER] = WaterlooPennerModel()
+        cls._models[FlightModelType.MACDONALD_HANZELY] = MacDonaldHanzelyModel()
+        for model_type, spec in _CONSTANT_COEFFICIENT_SPECS.items():
+            cls._models[model_type] = ConstantCoefficientModel(spec)
+
+
+def compare_models(
+    launch: LaunchConditions, models: list[BallFlightModel]
+) -> dict[str, FlightResult]:
+    """Compare multiple models for the same launch conditions."""
+    if launch is None:
+        raise ValueError("launch must be provided")
+    results = {}
+    for model in models:
+        results[model.name] = model.simulate(launch)
+    return results
+
+
+__all__ = [
+    "FlightModelRegistry",
+    "FlightModelType",
+    "compare_models",
+]

--- a/src/shared/python/swing_sim/flight/tests/__init__.py
+++ b/src/shared/python/swing_sim/flight/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for :mod:`shared.python.swing_sim.flight` (epic #4103, #4107)."""

--- a/src/shared/python/swing_sim/flight/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/flight/tests/test_contract_api.py
@@ -1,0 +1,81 @@
+"""Contract test pinning the public API surface of swing_sim.flight.
+
+Downstream consumers (impact stage #4106, UpstreamDrift, web backend)
+import from the subpackage facade only; this test fails loudly when the
+surface changes so removals are always deliberate.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import shared.python.swing_sim.flight as flight
+
+EXPECTED_PUBLIC_API = {
+    "DEFAULT_BACKSPIN_AXIS",
+    "BallFlightModel",
+    "ConstantCoefficientModel",
+    "ConstantCoefficientSpec",
+    "FlightModelRegistry",
+    "FlightModelType",
+    "FlightResult",
+    "FlightSimulatorProtocol",
+    "LaunchConditions",
+    "MacDonaldHanzelyModel",
+    "TrajectoryPoint",
+    "WaterlooPennerModel",
+    "compare_models",
+    "compute_flight_metrics",
+    "derive_launch_conditions",
+    "from_flight_frame",
+    "is_rust_available",
+    "simulate",
+    "simulate_trajectory_rust",
+    "to_flight_frame",
+}
+
+
+@pytest.mark.contract
+def test_public_api_surface_is_pinned() -> None:
+    assert set(flight.__all__) == EXPECTED_PUBLIC_API
+
+
+@pytest.mark.contract
+def test_all_exports_resolve() -> None:
+    for name in flight.__all__:
+        assert getattr(flight, name) is not None, f"{name} did not resolve"
+
+
+@pytest.mark.contract
+def test_swing_sim_top_level_facade_unchanged() -> None:
+    """The flight port must not widen the parent swing_sim facade (#4104)."""
+    import shared.python.swing_sim as swing_sim
+
+    assert "flight" not in swing_sim.__all__
+
+
+@pytest.mark.contract
+def test_value_types_are_frozen_dataclasses() -> None:
+    for cls in (
+        flight.LaunchConditions,
+        flight.TrajectoryPoint,
+        flight.FlightResult,
+        flight.ConstantCoefficientSpec,
+    ):
+        assert dataclasses.is_dataclass(cls), f"{cls.__name__} not a dataclass"
+        assert cls.__dataclass_params__.frozen, f"{cls.__name__} must be frozen"
+
+
+@pytest.mark.contract
+def test_model_type_values_are_pinned() -> None:
+    assert {m.value for m in flight.FlightModelType} == {
+        "waterloo_penner",
+        "macdonald_hanzely",
+        "nathan",
+        "ballantyne",
+        "jcole",
+        "rospie_dl",
+        "charry_l3",
+    }

--- a/src/shared/python/swing_sim/flight/tests/test_frames.py
+++ b/src/shared/python/swing_sim/flight/tests/test_frames.py
@@ -1,0 +1,52 @@
+"""Frame-adapter tests: app frame <-> flight frame, both directions."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.flight import from_flight_frame, to_flight_frame
+
+
+@pytest.mark.unit
+def test_basis_vectors_map_correctly() -> None:
+    # App frame: x target, y up, z right. Flight frame: x fwd, y left, z up.
+    np.testing.assert_allclose(
+        to_flight_frame(np.array([1.0, 0.0, 0.0])), [1.0, 0.0, 0.0]
+    )
+    np.testing.assert_allclose(
+        to_flight_frame(np.array([0.0, 1.0, 0.0])), [0.0, 0.0, 1.0]
+    )  # app up -> flight up
+    np.testing.assert_allclose(
+        to_flight_frame(np.array([0.0, 0.0, 1.0])), [0.0, -1.0, 0.0]
+    )  # app right -> flight -left
+
+
+@pytest.mark.unit
+def test_round_trip_is_identity_both_directions() -> None:
+    rng = np.random.default_rng(42)
+    vecs = rng.normal(size=(64, 3))
+    np.testing.assert_allclose(from_flight_frame(to_flight_frame(vecs)), vecs)
+    np.testing.assert_allclose(to_flight_frame(from_flight_frame(vecs)), vecs)
+    single = np.array([1.5, -2.0, 0.25])
+    np.testing.assert_allclose(from_flight_frame(to_flight_frame(single)), single)
+
+
+@pytest.mark.unit
+def test_adapters_are_proper_rotations() -> None:
+    """Norms and handedness (cross products) are preserved."""
+    rng = np.random.default_rng(7)
+    a, b = rng.normal(size=3), rng.normal(size=3)
+    fa, fb = to_flight_frame(a), to_flight_frame(b)
+    assert np.linalg.norm(fa) == pytest.approx(np.linalg.norm(a))
+    np.testing.assert_allclose(
+        np.cross(fa, fb), to_flight_frame(np.cross(a, b)), atol=1e-12
+    )
+
+
+@pytest.mark.unit
+def test_rejects_bad_shapes_and_nonfinite() -> None:
+    with pytest.raises(ValueError, match="shape"):
+        to_flight_frame(np.zeros(4))
+    with pytest.raises(ValueError, match="finite"):
+        from_flight_frame(np.array([np.inf, 0.0, 0.0]))

--- a/src/shared/python/swing_sim/flight/tests/test_launch_deriver.py
+++ b/src/shared/python/swing_sim/flight/tests/test_launch_deriver.py
@@ -1,0 +1,63 @@
+"""Launch-deriver round-trip tests (post-impact vectors -> LaunchConditions)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.flight import (
+    DEFAULT_BACKSPIN_AXIS,
+    derive_launch_conditions,
+)
+from shared.python.swing_sim.flight._constants import RPM_TO_RAD_S
+
+
+@pytest.mark.unit
+def test_derive_recovers_speed_angles_and_spin() -> None:
+    vel = np.array([60.0, 5.0, 15.0])
+    spin = 300.0 * np.array([0.0, -1.0, 0.0])  # pure backspin, 300 rad/s
+
+    launch = derive_launch_conditions(vel, spin)
+
+    assert launch.ball_speed == pytest.approx(float(np.linalg.norm(vel)))
+    horiz = math.hypot(vel[0], vel[1])
+    assert launch.launch_angle == pytest.approx(math.atan2(vel[2], horiz))
+    assert launch.azimuth_angle == pytest.approx(math.atan2(vel[1], vel[0]))
+    assert launch.spin_rate == pytest.approx(300.0 / RPM_TO_RAD_S)
+    assert launch.spin_axis == pytest.approx((0.0, -1.0, 0.0))
+
+
+@pytest.mark.unit
+def test_derived_conditions_round_trip_through_launch_vectors() -> None:
+    """get_initial_velocity / get_spin_vector reproduce the input vectors."""
+    vel = np.array([55.0, -8.0, 12.0])
+    spin = np.array([30.0, -280.0, 45.0])
+
+    launch = derive_launch_conditions(vel, spin)
+
+    np.testing.assert_allclose(launch.get_initial_velocity(), vel, atol=1e-9)
+    np.testing.assert_allclose(launch.get_spin_vector(), spin, atol=1e-9)
+
+
+@pytest.mark.unit
+def test_vertical_launch_pins_angle_to_pi_over_two() -> None:
+    launch = derive_launch_conditions(np.array([0.0, 0.0, 30.0]), np.zeros(3))
+    assert launch.launch_angle == pytest.approx(math.pi / 2.0)
+    assert launch.azimuth_angle == 0.0
+
+
+@pytest.mark.unit
+def test_zero_spin_defaults_to_backspin_axis() -> None:
+    launch = derive_launch_conditions(np.array([50.0, 0.0, 10.0]), np.zeros(3))
+    assert launch.spin_rate == 0.0
+    assert launch.spin_axis == pytest.approx(DEFAULT_BACKSPIN_AXIS)
+
+
+@pytest.mark.unit
+def test_rejects_malformed_vectors() -> None:
+    with pytest.raises(ValueError, match="ball_velocity"):
+        derive_launch_conditions(np.array([1.0, 2.0]), np.zeros(3))
+    with pytest.raises(ValueError, match="ball_angular_velocity"):
+        derive_launch_conditions(np.zeros(3), np.array([np.nan, 0.0, 0.0]))

--- a/src/shared/python/swing_sim/flight/tests/test_models_physics.py
+++ b/src/shared/python/swing_sim/flight/tests/test_models_physics.py
@@ -1,0 +1,134 @@
+"""Physics sanity tests for the ported flight models.
+
+Ballistic limit, carry monotonicity, ground-event termination, and
+cross-model carry spread for a standard driver launch.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.flight import (
+    FlightModelRegistry,
+    LaunchConditions,
+    WaterlooPennerModel,
+)
+
+# Standard driver launch: ~74 m/s (165 mph) ball speed, 12 deg, 2600 RPM.
+DRIVER_LAUNCH = LaunchConditions(
+    ball_speed=74.0,
+    launch_angle=math.radians(12.0),
+    spin_rate=2600.0,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Iterator[None]:
+    """Prevent cross-test pollution of the class-level model dict."""
+    FlightModelRegistry.reset()
+    yield
+    FlightModelRegistry.reset()
+
+
+def _vacuum_range(speed: float, angle: float, g: float) -> float:
+    """Analytic drag-free projectile range for a ground-level launch."""
+    return speed * speed * math.sin(2.0 * angle) / g
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_no_spin_low_speed_approaches_vacuum_projectile() -> None:
+    """A slow spinless launch stays within a small drag margin of vacuum."""
+    speed, angle = 10.0, math.radians(30.0)
+    launch = LaunchConditions(ball_speed=speed, launch_angle=angle, spin_rate=0.0)
+    result = WaterlooPennerModel().simulate(launch)
+
+    expected = _vacuum_range(speed, angle, launch.gravity)
+    assert result.carry_distance <= expected  # drag only removes range
+    assert result.carry_distance > 0.90 * expected  # small drag margin
+    expected_h = (speed * math.sin(angle)) ** 2 / (2.0 * launch.gravity)
+    assert result.max_height == pytest.approx(expected_h, rel=0.10)
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_carry_is_monotonic_in_ball_speed() -> None:
+    model = WaterlooPennerModel()
+    carries = []
+    for speed in (40.0, 50.0, 60.0, 70.0, 80.0):
+        launch = LaunchConditions(
+            ball_speed=speed, launch_angle=math.radians(12.0), spin_rate=2600.0
+        )
+        carries.append(model.simulate(launch).carry_distance)
+    assert all(b > a for a, b in zip(carries, carries[1:], strict=False))
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_ground_event_terminates_trajectory() -> None:
+    result = WaterlooPennerModel().simulate(DRIVER_LAUNCH, max_time=60.0)
+    final = result.trajectory[-1]
+    # Terminal event: final height at the ground, not at max_time.
+    assert final.position[2] == pytest.approx(0.0, abs=1e-6)
+    assert result.flight_time < 60.0
+    assert result.landing_angle > 0.0  # descending at landing
+    # Interior of the trajectory is strictly above ground.
+    heights = result.to_position_array()[1:-1, 2]
+    assert np.all(heights > -1e-9)
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_backspin_increases_peak_height() -> None:
+    model = WaterlooPennerModel()
+    no_spin = LaunchConditions(
+        ball_speed=74.0, launch_angle=math.radians(12.0), spin_rate=0.0
+    )
+    assert model.simulate(DRIVER_LAUNCH).max_height > model.simulate(no_spin).max_height
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_cross_model_carry_spread_for_driver_launch() -> None:
+    """All 7 models land a standard driver launch in a plausible carry band."""
+    carries: dict[str, float] = {}
+    for model in FlightModelRegistry.get_all_models():
+        result = model.simulate(DRIVER_LAUNCH, max_time=20.0)
+        carries[model.name] = result.carry_distance
+    assert len(carries) == 7
+    for name, carry in carries.items():
+        assert 150.0 <= carry <= 320.0, f"{name} carry {carry:.1f} m out of band"
+
+
+@pytest.mark.physics
+@pytest.mark.unit
+def test_pure_backspin_launch_stays_on_target_line() -> None:
+    """Zero azimuth + pure backspin gives no lateral deviation."""
+    result = WaterlooPennerModel().simulate(DRIVER_LAUNCH)
+    assert abs(result.lateral_deviation) < 1e-6
+
+
+@pytest.mark.unit
+def test_launch_conditions_validation() -> None:
+    with pytest.raises(ValueError, match="ball_speed"):
+        LaunchConditions(ball_speed=-1.0, launch_angle=0.2)
+    with pytest.raises(ValueError, match="launch_angle"):
+        LaunchConditions(ball_speed=70.0, launch_angle=12.0)  # degrees passed
+    with pytest.raises(ValueError, match="spin_rate"):
+        LaunchConditions(ball_speed=70.0, launch_angle=0.2, spin_rate=-5.0)
+    with pytest.raises(ValueError, match="unit vector"):
+        LaunchConditions(ball_speed=70.0, launch_angle=0.2, spin_axis=(0.0, -2.0, 0.0))
+
+
+@pytest.mark.unit
+def test_from_imperial_converts_units() -> None:
+    launch = LaunchConditions.from_imperial(
+        ball_speed_mph=165.0, launch_angle_deg=12.0, spin_rate_rpm=2600.0
+    )
+    assert launch.ball_speed == pytest.approx(165.0 * 0.44704)
+    assert launch.launch_angle == pytest.approx(math.radians(12.0))
+    assert launch.spin_rate == 2600.0

--- a/src/shared/python/swing_sim/flight/tests/test_parity_rust_flight.py
+++ b/src/shared/python/swing_sim/flight/tests/test_parity_rust_flight.py
@@ -1,0 +1,99 @@
+"""Rust <-> Python ball-flight parity (graceful skip without the wheel).
+
+The ``tools_core`` Rust kernel and the Python Waterloo/Penner model share
+the same quadratic drag law and defaults (cd0=0.21, cd1=0.05, cd2=0.02),
+so a zero-spin trajectory must agree to integrator tolerance (fixed-step
+RK4 vs adaptive RK45 + dt-quantised ground stop). Lift laws differ
+(quadratic-polynomial vs Penner power fit), so spinning shots are only
+compared coarsely.
+
+Skips cleanly when ``tools_core`` is absent or is an older wheel that
+does not expose ``simulate_trajectory``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from shared.python.swing_sim.flight import (
+    LaunchConditions,
+    WaterlooPennerModel,
+    is_rust_available,
+    simulate_trajectory_rust,
+)
+
+pytestmark = pytest.mark.skipif(
+    not is_rust_available(),
+    reason=(
+        "tools_core wheel absent or too old (no simulate_trajectory); "
+        "Rust ball-flight fast path unavailable on this interpreter"
+    ),
+)
+
+
+@pytest.mark.parity
+@pytest.mark.physics
+def test_zero_spin_trajectory_matches_penner_within_tolerance() -> None:
+    launch = LaunchConditions(
+        ball_speed=70.0, launch_angle=math.radians(12.0), spin_rate=0.0
+    )
+    rust = simulate_trajectory_rust(launch, max_time=20.0, dt=0.005)
+    python = WaterlooPennerModel().simulate(launch, max_time=20.0, dt=0.005)
+
+    assert rust.carry_distance == pytest.approx(python.carry_distance, rel=0.02)
+    assert rust.max_height == pytest.approx(python.max_height, rel=0.02)
+    assert rust.flight_time == pytest.approx(python.flight_time, rel=0.02)
+    assert rust.landing_angle == pytest.approx(python.landing_angle, abs=2.0)
+
+
+@pytest.mark.parity
+@pytest.mark.physics
+def test_spinning_driver_shot_agrees_coarsely() -> None:
+    """Different lift laws: expect the same plausible band, not tight parity.
+
+    The Rust kernel uses a quadratic-polynomial Cl (cl1=0.38) with 0.08 1/s
+    spin decay; Penner uses a capped power-law fit — the Rust carry is
+    systematically shorter for a spinning driver shot.
+    """
+    launch = LaunchConditions(
+        ball_speed=74.0, launch_angle=math.radians(12.0), spin_rate=2600.0
+    )
+    rust = simulate_trajectory_rust(launch, max_time=20.0, dt=0.005)
+    python = WaterlooPennerModel().simulate(launch, max_time=20.0, dt=0.005)
+
+    assert 150.0 <= rust.carry_distance <= 320.0
+    assert 150.0 <= python.carry_distance <= 320.0
+    assert rust.carry_distance < python.carry_distance  # weaker lift law
+    # Backspin lifts both above the no-spin trajectory of the same launch.
+    no_spin = LaunchConditions(
+        ball_speed=74.0, launch_angle=math.radians(12.0), spin_rate=0.0
+    )
+    assert rust.max_height > simulate_trajectory_rust(no_spin).max_height
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_rust_result_is_flight_frame() -> None:
+    """Facade output uses the flight frame: height on z, lateral on y."""
+    launch = LaunchConditions(
+        ball_speed=70.0, launch_angle=math.radians(12.0), spin_rate=0.0
+    )
+    result = simulate_trajectory_rust(launch)
+    pos = result.to_position_array()
+    assert pos[:, 2].max() > 1.0  # height accumulates on z (flight up)
+    assert abs(pos[-1, 1]) < 1e-6  # no lateral deviation without spin
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_rust_wrapper_validates_preconditions() -> None:
+    good = LaunchConditions(ball_speed=70.0, launch_angle=0.2)
+    with pytest.raises(ValueError, match="max_time"):
+        simulate_trajectory_rust(good, max_time=0.0)
+    with pytest.raises(ValueError, match="dt"):
+        simulate_trajectory_rust(good, dt=-0.01)
+    zero_speed = LaunchConditions(ball_speed=0.0, launch_angle=0.2)
+    with pytest.raises(ValueError, match="ball_speed"):
+        simulate_trajectory_rust(zero_speed)

--- a/src/shared/python/swing_sim/flight/tests/test_pipeline.py
+++ b/src/shared/python/swing_sim/flight/tests/test_pipeline.py
@@ -1,0 +1,74 @@
+"""Pipeline-seam tests: DI protocol conformance and convenience simulate."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+
+import pytest
+
+from shared.python.swing_sim.flight import (
+    FlightModelRegistry,
+    FlightResult,
+    FlightSimulatorProtocol,
+    LaunchConditions,
+    TrajectoryPoint,
+    WaterlooPennerModel,
+    simulate,
+)
+
+LAUNCH = LaunchConditions(
+    ball_speed=74.0, launch_angle=math.radians(12.0), spin_rate=2600.0
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Iterator[None]:
+    """Prevent cross-test pollution of the class-level model dict."""
+    FlightModelRegistry.reset()
+    yield
+    FlightModelRegistry.reset()
+
+
+@pytest.mark.contract
+def test_every_registry_model_satisfies_protocol() -> None:
+    for model in FlightModelRegistry.get_all_models():
+        assert isinstance(model, FlightSimulatorProtocol)
+
+
+@pytest.mark.contract
+def test_mock_simulator_satisfies_protocol() -> None:
+    class _Mock:
+        def simulate(
+            self,
+            launch: LaunchConditions,
+            max_time: float = 10.0,
+            dt: float = 0.01,
+        ) -> FlightResult:
+            point = TrajectoryPoint(0.0, [0.0, 0.0, 0.0], [1.0, 0.0, 0.0])
+            return FlightResult((point,), "mock")
+
+    assert isinstance(_Mock(), FlightSimulatorProtocol)
+
+
+@pytest.mark.unit
+def test_simulate_default_model_is_waterloo_penner() -> None:
+    result = simulate(LAUNCH)
+    reference = WaterlooPennerModel().simulate(LAUNCH)
+    assert result.model_name == "Waterloo/Penner"
+    assert result.carry_distance == pytest.approx(reference.carry_distance)
+
+
+@pytest.mark.unit
+def test_simulate_selects_model_by_name() -> None:
+    result = simulate(LAUNCH, model_name="macdonald_hanzely")
+    assert result.model_name == "MacDonald-Hanzely"
+    assert result.carry_distance > 0.0
+
+
+@pytest.mark.unit
+def test_simulate_rejects_unknown_model_and_missing_launch() -> None:
+    with pytest.raises(ValueError, match="unknown flight model"):
+        simulate(LAUNCH, model_name="not_a_model")
+    with pytest.raises(ValueError, match="launch"):
+        simulate(None)  # type: ignore[arg-type]

--- a/src/shared/python/swing_sim/flight/tests/test_registry.py
+++ b/src/shared/python/swing_sim/flight/tests/test_registry.py
@@ -1,0 +1,76 @@
+"""Registry completeness: all 7 literature models with citation metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from shared.python.swing_sim.flight import (
+    BallFlightModel,
+    FlightModelRegistry,
+    FlightModelType,
+    MacDonaldHanzelyModel,
+    WaterlooPennerModel,
+)
+
+EXPECTED_MODELS = {
+    FlightModelType.WATERLOO_PENNER: "Penner (2003); McPhee et al. (Waterloo)",
+    FlightModelType.MACDONALD_HANZELY: "MacDonald & Hanzely (1991)",
+    FlightModelType.NATHAN: "Nathan et al. (2018)",
+    FlightModelType.BALLANTYNE: "Ballantyne et al. (2012)",
+    FlightModelType.JCOLE: "Cole (2016)",
+    FlightModelType.ROSPIE_DL: "Rospie & Layton (2014)",
+    FlightModelType.CHARRY_L3: "Charry et al. (2017)",
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> Iterator[None]:
+    """Prevent cross-test pollution of the class-level model dict."""
+    FlightModelRegistry.reset()
+    yield
+    FlightModelRegistry.reset()
+
+
+@pytest.mark.unit
+def test_registry_has_all_seven_models() -> None:
+    models = FlightModelRegistry.get_all_models()
+    assert len(models) == 7
+    assert len(FlightModelType) == 7
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("model_type", list(FlightModelType))
+def test_every_model_resolves_with_metadata(model_type: FlightModelType) -> None:
+    model = FlightModelRegistry.get_model(model_type)
+    assert isinstance(model, BallFlightModel)
+    assert model.name
+    assert model.description
+    assert model.reference == EXPECTED_MODELS[model_type]
+
+
+@pytest.mark.unit
+def test_named_models_use_dedicated_classes() -> None:
+    assert isinstance(
+        FlightModelRegistry.get_model(FlightModelType.WATERLOO_PENNER),
+        WaterlooPennerModel,
+    )
+    assert isinstance(
+        FlightModelRegistry.get_model(FlightModelType.MACDONALD_HANZELY),
+        MacDonaldHanzelyModel,
+    )
+
+
+@pytest.mark.unit
+def test_get_model_requires_model_type() -> None:
+    with pytest.raises(ValueError, match="model_type"):
+        FlightModelRegistry.get_model(None)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_reset_forces_reinitialization() -> None:
+    first = FlightModelRegistry.get_model(FlightModelType.NATHAN)
+    FlightModelRegistry.reset()
+    second = FlightModelRegistry.get_model(FlightModelType.NATHAN)
+    assert first is not second

--- a/src/shared/python/swing_sim/flight/types.py
+++ b/src/shared/python/swing_sim/flight/types.py
@@ -1,0 +1,258 @@
+"""Ball-flight value types (DbC-validated dataclasses).
+
+Ported from UpstreamDrift ``src/shared/python/physics/flight_models.py``
+(``UnifiedLaunchConditions``, ``TrajectoryPoint``, ``FlightResult``) for
+epic #4103 / flight port #4107, rewritten self-contained.
+
+Frame convention (UpstreamDrift flight frame): x forward, y left, z up.
+Use :mod:`shared.python.swing_sim.flight.frames` to convert to the app
+frame (x target, y up, z right).
+
+Units: SI throughout; angular fields are radians; ``spin_rate`` is RPM.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from ._constants import (
+    AIR_DENSITY_SEA_LEVEL_KG_M3,
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+    GRAVITY_M_S2,
+    MIN_SPEED_THRESHOLD_M_S,
+    MPH_TO_MPS,
+    RPM_TO_RAD_S,
+)
+
+DEFAULT_BACKSPIN_AXIS = (0.0, -1.0, 0.0)
+"""Pure-backspin unit axis in the flight frame (x fwd / y left / z up)."""
+
+
+@dataclass(frozen=True)
+class LaunchConditions:
+    """Launch conditions with explicit units.
+
+    ``ball_speed`` is m/s; angular fields are radians; ``spin_rate`` is RPM;
+    ``wind_speed`` is m/s; mass, radius, density, and gravity are SI units.
+
+    ``spin_axis`` (optional) is a unit 3-vector in the flight frame. When
+    provided it overrides the legacy ``spin_axis_angle`` decomposition in
+    :meth:`get_spin_vector`, so post-impact spin vectors derived by
+    :func:`shared.python.swing_sim.flight.launch.derive_launch_conditions`
+    round-trip exactly.
+    """
+
+    ball_speed: float
+    launch_angle: float
+    azimuth_angle: float = 0.0
+    spin_rate: float = 2500.0
+    spin_axis_angle: float = 0.0
+    spin_axis: tuple[float, float, float] | None = None
+    ball_mass: float = GOLF_BALL_MASS_KG
+    ball_radius: float = GOLF_BALL_RADIUS_M
+    air_density: float = AIR_DENSITY_SEA_LEVEL_KG_M3
+    gravity: float = GRAVITY_M_S2
+    wind_speed: float = 0.0
+    wind_direction: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate finiteness, signs, and angle ranges (DbC preconditions)."""
+        scalars = {
+            "ball_speed": self.ball_speed,
+            "launch_angle": self.launch_angle,
+            "azimuth_angle": self.azimuth_angle,
+            "spin_rate": self.spin_rate,
+            "spin_axis_angle": self.spin_axis_angle,
+            "ball_mass": self.ball_mass,
+            "ball_radius": self.ball_radius,
+            "air_density": self.air_density,
+            "gravity": self.gravity,
+            "wind_speed": self.wind_speed,
+            "wind_direction": self.wind_direction,
+        }
+        for name, value in scalars.items():
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite; got {value!r}")
+        if self.ball_speed < 0.0:
+            raise ValueError(f"ball_speed must be >= 0; got {self.ball_speed!r}")
+        if self.spin_rate < 0.0:
+            raise ValueError(f"spin_rate must be RPM and >= 0; got {self.spin_rate!r}")
+        for name in ("ball_mass", "ball_radius", "air_density", "gravity"):
+            if scalars[name] <= 0.0:
+                raise ValueError(f"{name} must be > 0; got {scalars[name]!r}")
+        if not abs(self.launch_angle) <= math.pi / 2.0:
+            raise ValueError(
+                "launch_angle is radians and must be within [-pi/2, pi/2] — "
+                "did you pass degrees? Use from_imperial()."
+            )
+        if self.spin_axis is not None:
+            axis = np.asarray(self.spin_axis, dtype=float)
+            if axis.shape != (3,) or not np.all(np.isfinite(axis)):
+                raise ValueError(f"spin_axis must be a finite 3-vector; got {axis!r}")
+            norm = float(np.linalg.norm(axis))
+            if abs(norm - 1.0) > 1e-6:
+                raise ValueError(f"spin_axis must be a unit vector; |axis|={norm!r}")
+            object.__setattr__(
+                self, "spin_axis", (float(axis[0]), float(axis[1]), float(axis[2]))
+            )
+
+    @classmethod
+    def from_imperial(
+        cls,
+        ball_speed_mph: float,
+        launch_angle_deg: float,
+        spin_rate_rpm: float,
+        azimuth_angle_deg: float = 0.0,
+        spin_axis_angle_deg: float = 0.0,
+        wind_speed_mph: float = 0.0,
+        wind_direction_deg: float = 0.0,
+    ) -> LaunchConditions:
+        """Create launch conditions from imperial units."""
+        if ball_speed_mph is None:
+            raise ValueError("ball_speed_mph must be provided")
+        return cls(
+            ball_speed=ball_speed_mph * MPH_TO_MPS,
+            launch_angle=math.radians(launch_angle_deg),
+            azimuth_angle=math.radians(azimuth_angle_deg),
+            spin_rate=spin_rate_rpm,
+            spin_axis_angle=math.radians(spin_axis_angle_deg),
+            wind_speed=wind_speed_mph * MPH_TO_MPS,
+            wind_direction=math.radians(wind_direction_deg),
+        )
+
+    def get_initial_velocity(self) -> np.ndarray:
+        """Compute the 3D initial velocity vector from launch angles and speed."""
+        ca, sa = math.cos(self.azimuth_angle), math.sin(self.azimuth_angle)
+        cv, sv = math.cos(self.launch_angle), math.sin(self.launch_angle)
+        return np.array(
+            [self.ball_speed * cv * ca, self.ball_speed * cv * sa, self.ball_speed * sv]
+        )
+
+    def get_spin_vector(self) -> np.ndarray:
+        """Compute the 3D spin vector [rad/s] in the flight frame.
+
+        When ``spin_axis`` is set, returns ``omega * spin_axis``; otherwise
+        uses the legacy backspin/sidespin decomposition from
+        ``spin_axis_angle`` (UpstreamDrift behaviour).
+        """
+        omega = self.spin_rate * RPM_TO_RAD_S
+        if self.spin_axis is not None:
+            return omega * np.asarray(self.spin_axis, dtype=float)
+        backspin = omega * math.cos(self.spin_axis_angle)
+        sidespin = omega * math.sin(self.spin_axis_angle)
+        return np.array(
+            [
+                sidespin * math.sin(self.azimuth_angle),
+                -backspin,
+                sidespin * math.cos(self.azimuth_angle),
+            ]
+        )
+
+    def get_wind_vector(self) -> np.ndarray:
+        """Compute the 3D wind velocity vector from speed and direction."""
+        return np.array(
+            [
+                -self.wind_speed * math.cos(self.wind_direction),
+                -self.wind_speed * math.sin(self.wind_direction),
+                0.0,
+            ]
+        )
+
+
+@dataclass(frozen=True)
+class TrajectoryPoint:
+    """Single point in a flight trajectory (flight frame, SI units)."""
+
+    time: float
+    position: np.ndarray = field(repr=False)
+    velocity: np.ndarray = field(repr=False)
+
+    def __post_init__(self) -> None:
+        """Coerce vectors to float arrays and validate shapes/finiteness."""
+        if not math.isfinite(self.time) or self.time < 0.0:
+            raise ValueError(f"time must be finite and >= 0; got {self.time!r}")
+        position = np.asarray(self.position, dtype=float)
+        velocity = np.asarray(self.velocity, dtype=float)
+        for name, vec in (("position", position), ("velocity", velocity)):
+            if vec.shape != (3,):
+                raise ValueError(f"{name} must be shape (3,); got {vec.shape}")
+            if not np.all(np.isfinite(vec)):
+                raise ValueError(f"{name} must be finite; got {vec!r}")
+        object.__setattr__(self, "position", position)
+        object.__setattr__(self, "velocity", velocity)
+
+
+@dataclass(frozen=True)
+class FlightResult:
+    """Result of a ball-flight simulation.
+
+    ``trajectory`` is time-ordered; scalar metrics are derived from it
+    (carry [m], max height [m], flight time [s], landing angle [deg,
+    positive downward], lateral deviation [m, +left in the flight frame]).
+    """
+
+    trajectory: tuple[TrajectoryPoint, ...]
+    model_name: str
+    carry_distance: float = 0.0
+    max_height: float = 0.0
+    flight_time: float = 0.0
+    landing_angle: float = 0.0
+    lateral_deviation: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Normalise the trajectory container to a tuple."""
+        object.__setattr__(self, "trajectory", tuple(self.trajectory))
+
+    def to_position_array(self) -> np.ndarray:
+        """Convert trajectory to an Nx3 position array."""
+        if not self.trajectory:
+            return np.zeros((0, 3))
+        return np.array([p.position for p in self.trajectory])
+
+
+def compute_flight_metrics(
+    trajectory: list[TrajectoryPoint] | tuple[TrajectoryPoint, ...],
+    model_name: str,
+) -> FlightResult:
+    """Standardised metrics computation shared by all backends.
+
+    Ported from ``BallFlightModel._compute_metrics`` in UpstreamDrift's
+    ``flight_models.py`` (consolidated for DRY there; module-level here so
+    the Rust facade reuses it).
+    """
+    if trajectory is None:
+        raise ValueError("trajectory must be provided")
+    points = tuple(trajectory)
+    if not points:
+        return FlightResult((), model_name)
+
+    pos = np.array([p.position for p in points])
+    carry = math.hypot(float(pos[-1, 0]), float(pos[-1, 1]))
+    max_h = float(np.max(pos[:, 2]))
+    time = points[-1].time
+    lateral = float(pos[-1, 1])
+
+    angle = 0.0
+    if len(points) >= 2:
+        v = points[-1].velocity
+        v_horiz = math.hypot(float(v[0]), float(v[1]))
+        angle = (
+            math.degrees(math.atan2(-float(v[2]), v_horiz))
+            if v_horiz > MIN_SPEED_THRESHOLD_M_S
+            else 90.0
+        )
+
+    return FlightResult(points, model_name, carry, max_h, time, angle, lateral)
+
+
+__all__ = [
+    "DEFAULT_BACKSPIN_AXIS",
+    "FlightResult",
+    "LaunchConditions",
+    "TrajectoryPoint",
+    "compute_flight_metrics",
+]

--- a/src/shared/python/swing_sim/impact/__init__.py
+++ b/src/shared/python/swing_sim/impact/__init__.py
@@ -1,0 +1,92 @@
+"""Impact physics subpackage for swing_sim (epic #4103, issue #4106).
+
+Self-façaded: downstream code imports from
+``shared.python.swing_sim.impact`` only. The rigid-body COR impulse model
+(with the 2/7 rolling-cap friction spin derivation), spring-damper model,
+energy-balance validator, and recorder are ported from UpstreamDrift's
+``src/shared/python/physics/impact_model`` package; the delivery
+front-end (:mod:`.delivery`) and the physics-based gear effect
+(:mod:`.gear_effect`) are new in Tools.
+
+The parent ``swing_sim/__init__.py`` façade is wired up during epic
+integration; do not add impact exports there from this subpackage.
+"""
+
+from __future__ import annotations
+
+from .constants import (
+    DRIVER_CG_DEPTH_M,
+    DRIVER_COR,
+    DRIVER_MASS_KG,
+    DRIVER_MOI_KG_M2,
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_MOMENT_OF_INERTIA_KG_M2,
+    GOLF_BALL_RADIUS_M,
+    TYPICAL_CONTACT_DURATION_S,
+)
+from .delivery import (
+    DeliveryDerived,
+    DeliveryParameters,
+    derive_delivery,
+    to_pre_impact_state,
+)
+from .gear_effect import (
+    FaceNormalAtOffset,
+    GearEffectResult,
+    compute_gear_effect,
+    resolve_contact_normal,
+)
+from .models import (
+    SPHERE_ROLLING_CAP_FACTOR,
+    FiniteTimeImpactModel,
+    ImpactModel,
+    RigidBodyImpactModel,
+    SpringDamperImpactModel,
+    create_impact_model,
+    face_basis,
+    offset_to_face_vector,
+)
+from .solver import ImpactRecorder, ImpactSolverAPI
+from .types import (
+    ImpactEvent,
+    ImpactModelType,
+    ImpactParameters,
+    PostImpactState,
+    PreImpactState,
+)
+from .utils import validate_energy_balance
+
+__all__ = [
+    "DRIVER_CG_DEPTH_M",
+    "DRIVER_COR",
+    "DRIVER_MASS_KG",
+    "DRIVER_MOI_KG_M2",
+    "GOLF_BALL_MASS_KG",
+    "GOLF_BALL_MOMENT_OF_INERTIA_KG_M2",
+    "GOLF_BALL_RADIUS_M",
+    "SPHERE_ROLLING_CAP_FACTOR",
+    "TYPICAL_CONTACT_DURATION_S",
+    "DeliveryDerived",
+    "DeliveryParameters",
+    "FaceNormalAtOffset",
+    "FiniteTimeImpactModel",
+    "GearEffectResult",
+    "ImpactEvent",
+    "ImpactModel",
+    "ImpactModelType",
+    "ImpactParameters",
+    "ImpactRecorder",
+    "ImpactSolverAPI",
+    "PostImpactState",
+    "PreImpactState",
+    "RigidBodyImpactModel",
+    "SpringDamperImpactModel",
+    "compute_gear_effect",
+    "create_impact_model",
+    "derive_delivery",
+    "face_basis",
+    "offset_to_face_vector",
+    "resolve_contact_normal",
+    "to_pre_impact_state",
+    "validate_energy_balance",
+]

--- a/src/shared/python/swing_sim/impact/constants.py
+++ b/src/shared/python/swing_sim/impact/constants.py
@@ -1,0 +1,69 @@
+"""Vendored physical constants for the impact package (SI units).
+
+Vendored from UpstreamDrift ``src/shared/python/core/physics_constants.py``
+so that swing_sim stays self-contained (Tools must NOT import
+upstream-drift; the dependency arrow points the other way — UD vendors
+Tools). Each constant carries its original citation.
+
+Epic #4103 / issue #4106.
+"""
+
+from __future__ import annotations
+
+# --- Golf ball (USGA equipment rules) ------------------------------------
+GOLF_BALL_MASS_KG = 0.04593
+"""Maximum golf ball mass (1.620 oz). Source: USGA Rule 5-1."""
+
+GOLF_BALL_DIAMETER_M = 0.04267
+"""Minimum golf ball diameter (1.680 in). Source: USGA Rule 5-2."""
+
+GOLF_BALL_RADIUS_M = GOLF_BALL_DIAMETER_M / 2.0
+"""Minimum golf ball radius (derived from USGA Rule 5-2)."""
+
+GOLF_BALL_MOMENT_OF_INERTIA_KG_M2 = (
+    (2.0 / 5.0) * GOLF_BALL_MASS_KG * GOLF_BALL_RADIUS_M**2
+)
+"""Golf ball MOI, uniform solid-sphere approximation (2/5 m r^2)."""
+
+# --- Driver clubhead ------------------------------------------------------
+DRIVER_COR = 0.83
+"""Driver coefficient of restitution. Source: USGA/R&A CT limit
+(~0.83 equivalent COR)."""
+
+DRIVER_MOI_KG_M2 = 4.5e-4
+"""Driver clubhead MOI about CG (perpendicular to face).
+Source: typical driver specs."""
+
+DRIVER_MASS_KG = 0.200
+"""Typical driver clubhead mass. Source: industry standard specs."""
+
+DRIVER_LOFT_RAD = 0.18325957145940461  # math.radians(10.5)
+"""Typical driver loft (10.5 deg). Source: modern trade average."""
+
+DRIVER_LIE_RAD = 1.0471975511965976  # math.radians(60.0)
+"""Typical driver lie angle (60 deg). Source: industry standard specs."""
+
+DRIVER_CG_DEPTH_M = 0.035
+"""Typical driver CG depth behind the face plane [m]. Modern drivers place
+the CG 30-40 mm rearward of the face; the front-to-back lever arm is what
+produces gear-effect spin on off-center hits. Source: published driver CG
+measurements (e.g. Golf Laboratories / manufacturer spec sheets, ~1.2-1.6
+in). New in Tools; not present in the UpstreamDrift constant set."""
+
+# --- Contact --------------------------------------------------------------
+TYPICAL_CONTACT_DURATION_S = 0.0005
+"""Typical ball-clubface contact time. Source: high-speed video studies."""
+
+__all__ = [
+    "DRIVER_CG_DEPTH_M",
+    "DRIVER_COR",
+    "DRIVER_LIE_RAD",
+    "DRIVER_LOFT_RAD",
+    "DRIVER_MASS_KG",
+    "DRIVER_MOI_KG_M2",
+    "GOLF_BALL_DIAMETER_M",
+    "GOLF_BALL_MASS_KG",
+    "GOLF_BALL_MOMENT_OF_INERTIA_KG_M2",
+    "GOLF_BALL_RADIUS_M",
+    "TYPICAL_CONTACT_DURATION_S",
+]

--- a/src/shared/python/swing_sim/impact/delivery.py
+++ b/src/shared/python/swing_sim/impact/delivery.py
@@ -1,0 +1,278 @@
+"""Delivery front-end: launch-monitor parameters -> impact-model inputs.
+
+New in Tools (epic #4103 / issue #4106); no upstream equivalent exists in
+UpstreamDrift.
+
+Frame and sign conventions (AffineDrift frame)
+----------------------------------------------
+All vectors are expressed in the AffineDrift frame:
+
+- ``x`` = target line, ``y`` = up, ``z`` = right (right-handed).
+- Club path (+) = in-to-out: the clubhead travels right of the target
+  line at impact (+z velocity component, right-handed player).
+- Face angle (+) = open: the face normal points right of the target
+  (+z component).
+- Attack angle (+) = hitting up (+y velocity component).
+- Dynamic loft (+) tilts the face normal upward (+y component).
+- Impact offset: toe (+) and high (+) in millimetres, converted to the
+  impact model's ``[horizontal, vertical]`` metre offsets. For a
+  right-handed player the toe axis is +z (see
+  :func:`.models.face_basis`).
+
+The impact model itself (:mod:`.models`) is frame-agnostic — it consumes
+whatever consistent right-handed SI frame the vectors are given in — so
+the vectors built here feed it directly with no further mapping. (For
+reference, UpstreamDrift's physics stack uses x forward / y left / z up;
+that adapter concern lives at the UD boundary, not here.)
+
+Angle composition:
+
+    v_hat = [cos(AoA) cos(path), sin(AoA), cos(AoA) sin(path)]
+    n_hat = [cos(loft) cos(face), sin(loft), cos(loft) sin(face)]
+
+Dynamic loft and face angle are launch-monitor MEASUREMENTS of the
+delivered normal, so delivered lie is already reflected in them;
+``lie_deg`` here is the residual toe-up(+)/toe-down(-) rotation of the
+face about its own normal, used only to orient the toe/high offset axes
+(``[h, v] = R(lie) [toe, high]``).
+
+Spin loft and D-plane diagnostics
+---------------------------------
+Spin loft is the 3-D angle between the delivered face normal and the club
+path vector: ``spin_loft = arccos(v_hat . n_hat)``. The D-plane is the
+plane spanned by ``v_hat`` and ``n_hat``; in the classic approximation
+(Jorgensen, *The Physics of Golf*; TrackMan D-plane literature) the ball
+launches close to the face normal and spins about the D-plane's normal:
+
+    spin_axis = unit(v_hat x n_hat)
+
+For a square face this axis is horizontal (+z, pure backspin). A
+face-minus-path difference tilts it; the reported tilt angle is
+
+    tilt = atan2(-axis_y_component, in-plane horizontal component)
+
+signed so positive tilt = fade/slice-side spin (curves right for a
+right-handed player) and negative = draw/hook-side.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from .constants import DRIVER_MASS_KG, DRIVER_MOI_KG_M2
+from .models import _norm
+from .types import PreImpactState
+
+_MM_TO_M = 1e-3
+_MAX_ANGLE_DEG = 89.0
+
+
+@dataclass(frozen=True)
+class DeliveryParameters:
+    """Launch-monitor-style delivery numbers (degrees, m/s, mm).
+
+    Attributes:
+        clubhead_speed_mps: Clubhead speed at impact [m/s] (> 0)
+        club_path_deg: Club path [deg]; + = in-to-out
+        face_angle_deg: Face angle [deg]; + = open (right of target)
+        attack_angle_deg: Attack angle [deg]; + = hitting up
+        dynamic_loft_deg: Delivered (dynamic) loft [deg]
+        lie_deg: Residual delivered lie rotation about the face normal
+            [deg]; + = toe up. Orients the offset axes only (see module
+            docstring).
+        impact_offset_toe_mm: Impact offset toward the toe [mm]
+        impact_offset_high_mm: Impact offset up the face [mm]
+    """
+
+    clubhead_speed_mps: float
+    club_path_deg: float = 0.0
+    face_angle_deg: float = 0.0
+    attack_angle_deg: float = 0.0
+    dynamic_loft_deg: float = 10.5
+    lie_deg: float = 0.0
+    impact_offset_toe_mm: float = 0.0
+    impact_offset_high_mm: float = 0.0
+
+    def __post_init__(self) -> None:
+        require(
+            math.isfinite(self.clubhead_speed_mps) and self.clubhead_speed_mps > 0,
+            "clubhead_speed_mps must be positive and finite",
+            self.clubhead_speed_mps,
+        )
+        for name in (
+            "club_path_deg",
+            "face_angle_deg",
+            "attack_angle_deg",
+            "dynamic_loft_deg",
+            "lie_deg",
+        ):
+            value = getattr(self, name)
+            require(
+                math.isfinite(value) and abs(value) <= _MAX_ANGLE_DEG,
+                f"{name} must be finite and within +/-{_MAX_ANGLE_DEG} deg",
+                value,
+            )
+        for name in ("impact_offset_toe_mm", "impact_offset_high_mm"):
+            require(
+                math.isfinite(getattr(self, name)),
+                f"{name} must be finite",
+                getattr(self, name),
+            )
+
+
+@dataclass(frozen=True)
+class DeliveryDerived:
+    """Impact-model inputs plus D-plane diagnostics (AffineDrift frame).
+
+    Attributes:
+        clubhead_velocity: Clubhead velocity vector [m/s] (3,)
+        face_normal: Unit delivered face normal (3,)
+        impact_offset: (2,) [horizontal, vertical] offset [m] in the
+            impact model's convention (lie-rotated toe/high offsets)
+        clubhead_angular_velocity: Head angular velocity [rad/s] (3,);
+            zeros unless supplied by a richer swing source
+        spin_loft_deg: 3-D angle between face normal and club path [deg]
+        face_to_path_deg: Face angle minus club path [deg] (horizontal)
+        spin_axis: Unit D-plane spin axis (3,); +z = pure backspin
+        spin_axis_tilt_deg: Signed spin-axis tilt [deg]; + = fade side
+    """
+
+    clubhead_velocity: np.ndarray
+    face_normal: np.ndarray
+    impact_offset: np.ndarray
+    clubhead_angular_velocity: np.ndarray
+    spin_loft_deg: float
+    face_to_path_deg: float
+    spin_axis: np.ndarray
+    spin_axis_tilt_deg: float
+
+
+def derive_delivery(
+    params: DeliveryParameters,
+    clubhead_angular_velocity: np.ndarray | None = None,
+) -> DeliveryDerived:
+    """Convert delivery parameters into impact-model inputs + diagnostics.
+
+    Args:
+        params: Launch-monitor-style delivery parameters.
+        clubhead_angular_velocity: Optional head angular velocity [rad/s]
+            (3,) from a richer swing source; defaults to zeros.
+
+    Returns:
+        :class:`DeliveryDerived` in the AffineDrift frame.
+    """
+    path = math.radians(params.club_path_deg)
+    face = math.radians(params.face_angle_deg)
+    aoa = math.radians(params.attack_angle_deg)
+    loft = math.radians(params.dynamic_loft_deg)
+    lie = math.radians(params.lie_deg)
+
+    v_hat = np.array(
+        [
+            math.cos(aoa) * math.cos(path),
+            math.sin(aoa),
+            math.cos(aoa) * math.sin(path),
+        ]
+    )
+    n_hat = np.array(
+        [
+            math.cos(loft) * math.cos(face),
+            math.sin(loft),
+            math.cos(loft) * math.sin(face),
+        ]
+    )
+    clubhead_velocity = params.clubhead_speed_mps * v_hat
+
+    # Lie rotates the toe/high axes about the face normal (+ = toe up):
+    # [h, v] = R(lie) [toe, high].
+    toe_m = params.impact_offset_toe_mm * _MM_TO_M
+    high_m = params.impact_offset_high_mm * _MM_TO_M
+    cos_l, sin_l = math.cos(lie), math.sin(lie)
+    impact_offset = np.array(
+        [toe_m * cos_l - high_m * sin_l, toe_m * sin_l + high_m * cos_l]
+    )
+
+    # D-plane diagnostics (see module docstring for the derivation).
+    cos_spin_loft = float(np.clip(np.dot(v_hat, n_hat), -1.0, 1.0))
+    spin_loft_deg = math.degrees(math.acos(cos_spin_loft))
+
+    axis_raw = np.cross(v_hat, n_hat)
+    axis_mag = _norm(axis_raw)
+    if axis_mag > 1e-12:
+        spin_axis = axis_raw / axis_mag
+    else:  # Zero spin loft: degenerate D-plane, report pure-backspin axis.
+        spin_axis = np.array([0.0, 0.0, 1.0])
+    horizontal = math.hypot(float(spin_axis[0]), float(spin_axis[2]))
+    spin_axis_tilt_deg = math.degrees(math.atan2(-float(spin_axis[1]), horizontal))
+
+    omega = (
+        np.asarray(clubhead_angular_velocity, dtype=float)
+        if clubhead_angular_velocity is not None
+        else np.zeros(3)
+    )
+
+    return DeliveryDerived(
+        clubhead_velocity=clubhead_velocity,
+        face_normal=n_hat,
+        impact_offset=impact_offset,
+        clubhead_angular_velocity=omega,
+        spin_loft_deg=spin_loft_deg,
+        face_to_path_deg=params.face_angle_deg - params.club_path_deg,
+        spin_axis=spin_axis,
+        spin_axis_tilt_deg=spin_axis_tilt_deg,
+    )
+
+
+def to_pre_impact_state(
+    params: DeliveryParameters,
+    clubhead_mass: float = DRIVER_MASS_KG,
+    clubhead_moi: float = DRIVER_MOI_KG_M2,
+    clubhead_moi_tensor: np.ndarray | None = None,
+    ball_velocity: np.ndarray | None = None,
+    ball_angular_velocity: np.ndarray | None = None,
+    clubhead_angular_velocity: np.ndarray | None = None,
+) -> PreImpactState:
+    """Build a :class:`.types.PreImpactState` from delivery parameters.
+
+    Args:
+        params: Launch-monitor-style delivery parameters.
+        clubhead_mass: Clubhead mass [kg]
+        clubhead_moi: Scalar clubhead MOI about CG [kg.m^2]
+        clubhead_moi_tensor: Optional 3x3 clubhead MOI tensor (enables the
+            full 3-D effective-mass treatment in :mod:`.models`)
+        ball_velocity: Ball velocity [m/s] (default: at rest)
+        ball_angular_velocity: Ball spin [rad/s] (default: none)
+        clubhead_angular_velocity: Head angular velocity [rad/s]
+            (default: zeros)
+
+    Returns:
+        A pre-impact state carrying the delivered vectors AND the impact
+        offset, so off-center hits get the MOI effective-mass reduction.
+    """
+    derived = derive_delivery(params, clubhead_angular_velocity)
+    return PreImpactState(
+        clubhead_velocity=derived.clubhead_velocity,
+        clubhead_angular_velocity=derived.clubhead_angular_velocity,
+        clubhead_orientation=derived.face_normal,
+        ball_position=np.zeros(3),
+        ball_velocity=(
+            np.asarray(ball_velocity, dtype=float)
+            if ball_velocity is not None
+            else np.zeros(3)
+        ),
+        ball_angular_velocity=(
+            np.asarray(ball_angular_velocity, dtype=float)
+            if ball_angular_velocity is not None
+            else np.zeros(3)
+        ),
+        clubhead_mass=clubhead_mass,
+        clubhead_loft=math.radians(params.dynamic_loft_deg),
+        clubhead_moi=clubhead_moi,
+        impact_offset=derived.impact_offset,
+        clubhead_moi_tensor=clubhead_moi_tensor,
+    )

--- a/src/shared/python/swing_sim/impact/gear_effect.py
+++ b/src/shared/python/swing_sim/impact/gear_effect.py
@@ -1,0 +1,203 @@
+"""Physics-based gear-effect spin from off-center impact.
+
+New in Tools (epic #4103 / issue #4106). Replaces the empirical
+three-constant model from UpstreamDrift
+``physics/impact_model/utils.py::compute_gear_effect_spin`` with a
+first-principles derivation.
+
+Mechanism
+---------
+An off-center normal impulse ``J n`` applied at CG-to-contact offset ``r``
+exerts a torque impulse ``r x (-J n)`` on the clubhead, so the head picks
+up a rotation recoil ``d_omega = I^-1 (r x (-J n))`` during contact
+(``I`` scalar or full 3x3 tensor). Because the head CG sits a depth ``d``
+BEHIND the face plane, the contact point is ``r = r_plane + d n`` and the
+rotating face sweeps the contact point tangentially:
+
+    v_surface = ramp * (d_omega x r)
+
+(``ramp = 1/2``: the recoil builds roughly linearly from zero over the
+contact, so the time-averaged surface velocity is half the final value).
+The ball "gears" against this moving surface — friction drags the ball
+surface with the face, producing spin opposite the head's recoil, via the
+same Coulomb friction impulse capped at the rolling-without-slip limit
+(``J_f = min(mu J, m_ball v_t 2/7)``, see
+:data:`.models.SPHERE_ROLLING_CAP_FACTOR`) used for loft-driven spin.
+
+Qualitative signatures reproduced (right-handed player, AffineDrift frame
+x target / y up / z right, toe axis +z):
+
+- Toe hit (+toe): head recoils about -y (toe twists open/back), face
+  surface sweeps toe-ward under the ball, friction drags the ball toward
+  +z at the back of the ball => +y ball spin = draw-side spin.
+- High hit (+high): head recoils about +z (loft increases), face sweeps
+  upward under the ball => -z spin component = reduced backspin.
+
+Bulge/roll seam
+---------------
+Face curvature is club data, not impact physics, so it enters through the
+optional ``face_normal_at_offset(toe_m, high_m) -> normal`` callable
+(provided by the app's club package): the local normal at the offset
+replaces the nominal face normal for the impulse direction, starting a
+toe hit further right (open) so the gear-effect draw spin curves it back —
+keeping swing_sim app-agnostic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from .constants import (
+    DRIVER_CG_DEPTH_M,
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_MOMENT_OF_INERTIA_KG_M2,
+    GOLF_BALL_RADIUS_M,
+)
+from .models import SPHERE_ROLLING_CAP_FACTOR, _norm, offset_to_face_vector
+
+FaceNormalAtOffset = Callable[[float, float], np.ndarray]
+"""Callable seam for bulge/roll: ``(toe_m, high_m) -> local face normal``."""
+
+_CONTACT_RAMP_FACTOR = 0.5
+"""Time-average factor for the head recoil built up during contact."""
+
+
+@dataclass(frozen=True)
+class GearEffectResult:
+    """Result of the physics-based gear-effect computation.
+
+    Attributes:
+        ball_spin_delta: Additional ball spin from gear effect [rad/s] (3,)
+        head_angular_velocity_delta: Head rotation recoil acquired during
+            contact [rad/s] (3,)
+        contact_normal: Unit face normal actually used at the contact point
+            (local bulge/roll normal when a curvature callable was
+            supplied) (3,)
+        tangential_surface_speed: Time-averaged tangential face-surface
+            speed at the contact point [m/s]
+    """
+
+    ball_spin_delta: np.ndarray
+    head_angular_velocity_delta: np.ndarray
+    contact_normal: np.ndarray
+    tangential_surface_speed: float
+
+
+def resolve_contact_normal(
+    impact_offset: np.ndarray,
+    face_normal: np.ndarray,
+    face_normal_at_offset: FaceNormalAtOffset | None = None,
+) -> np.ndarray:
+    """Unit contact normal: local bulge/roll normal if supplied, else nominal.
+
+    Args:
+        impact_offset: (2,) offset [m] [toe (+), high (+)]
+        face_normal: Nominal face normal (3,)
+        face_normal_at_offset: Optional club-package callable returning the
+            local face normal at ``(toe_m, high_m)`` (bulge/roll curvature).
+
+    Returns:
+        Unit normal (3,) used for the impulse direction.
+    """
+    offset = np.asarray(impact_offset, dtype=float).reshape(-1)
+    require(offset.size == 2, "impact_offset must have exactly 2 components")
+    if face_normal_at_offset is not None:
+        n = np.asarray(face_normal_at_offset(float(offset[0]), float(offset[1])))
+    else:
+        n = np.asarray(face_normal, dtype=float)
+    n_mag = _norm(n)
+    require(n_mag > 1e-10, "contact normal must be non-zero")
+    return n / n_mag
+
+
+def compute_gear_effect(
+    impact_offset: np.ndarray,
+    face_normal: np.ndarray,
+    normal_impulse: float,
+    clubhead_moi: float | np.ndarray,
+    cg_depth_m: float = DRIVER_CG_DEPTH_M,
+    friction_coefficient: float = 0.4,
+    reference_up: np.ndarray | None = None,
+    face_normal_at_offset: FaceNormalAtOffset | None = None,
+) -> GearEffectResult:
+    """Compute gear-effect spin from the head's rotation recoil.
+
+    Args:
+        impact_offset: (2,) offset from head CG in the face plane [m]
+            [horizontal (+ = toe), vertical (+ = high)]
+        face_normal: Nominal clubface normal (3,), need not be unit length
+        normal_impulse: Normal impulse magnitude J from the base COR
+            solve [N.s] (non-negative)
+        clubhead_moi: Scalar clubhead MOI about the CG [kg.m^2], or a full
+            3x3 MOI tensor in the same frame as the vectors
+        cg_depth_m: CG distance behind the face plane [m] (front-to-back
+            lever arm; zero depth means no tangential sweep and no gear
+            spin from in-plane offsets)
+        friction_coefficient: Ball-face Coulomb friction coefficient
+        reference_up: Optional world-up hint for the face basis
+        face_normal_at_offset: Optional bulge/roll callable (see module
+            docstring)
+
+    Returns:
+        :class:`GearEffectResult` with the ball spin delta, head recoil,
+        contact normal, and tangential surface speed.
+    """
+    require(normal_impulse >= 0.0, "normal_impulse must be non-negative")
+    require(cg_depth_m >= 0.0, "cg_depth_m must be non-negative")
+    require(friction_coefficient >= 0.0, "friction_coefficient non-negative")
+
+    n = resolve_contact_normal(impact_offset, face_normal, face_normal_at_offset)
+    offset = np.asarray(impact_offset, dtype=float).reshape(-1)
+
+    # CG-to-contact vector: in-plane offset (built on the NOMINAL normal's
+    # face basis so curvature does not skew the geometry) plus CG depth.
+    nominal = np.asarray(face_normal, dtype=float)
+    nominal = nominal / _norm(nominal)
+    r_plane = offset_to_face_vector(offset, nominal, reference_up)
+    r_contact = r_plane + cg_depth_m * nominal
+
+    # Head rotation recoil from the torque impulse of the reaction -J n.
+    torque_impulse = np.cross(r_contact, -normal_impulse * n)
+    if isinstance(clubhead_moi, np.ndarray) and clubhead_moi.shape == (3, 3):
+        d_omega = np.linalg.solve(np.asarray(clubhead_moi, dtype=float), torque_impulse)
+    else:
+        moi_scalar = float(np.asarray(clubhead_moi, dtype=float).reshape(-1)[0])
+        require(moi_scalar > 0.0, "clubhead_moi must be positive")
+        d_omega = torque_impulse / moi_scalar
+
+    # Time-averaged tangential surface velocity of the face at the contact.
+    v_surface = _CONTACT_RAMP_FACTOR * np.cross(d_omega, r_contact)
+    v_tangent = v_surface - float(np.dot(v_surface, n)) * n
+    v_t = _norm(v_tangent)
+
+    if v_t <= 1e-9 or normal_impulse <= 0.0:
+        return GearEffectResult(
+            ball_spin_delta=np.zeros(3),
+            head_angular_velocity_delta=d_omega,
+            contact_normal=n,
+            tangential_surface_speed=0.0,
+        )
+
+    # Friction drags the ball surface WITH the moving face (the ball gears
+    # against the face), capped at the rolling-without-slip limit.
+    t_dir = v_tangent / v_t
+    j_friction = min(
+        friction_coefficient * normal_impulse,
+        GOLF_BALL_MASS_KG * v_t * SPHERE_ROLLING_CAP_FACTOR,
+    )
+    # Friction impulse J_f t_dir acts at the ball contact point -R n:
+    # torque = (-R n) x (J_f t_dir) => spin axis = (t_dir x n).
+    spin_axis = np.cross(t_dir, n)
+    spin_magnitude = j_friction * GOLF_BALL_RADIUS_M / GOLF_BALL_MOMENT_OF_INERTIA_KG_M2
+
+    return GearEffectResult(
+        ball_spin_delta=spin_magnitude * spin_axis,
+        head_angular_velocity_delta=d_omega,
+        contact_normal=n,
+        tangential_surface_speed=v_t,
+    )

--- a/src/shared/python/swing_sim/impact/models.py
+++ b/src/shared/python/swing_sim/impact/models.py
@@ -1,0 +1,454 @@
+"""Impact models (rigid-body COR impulse, spring-damper, finite-time).
+
+Ported from UpstreamDrift ``src/shared/python/physics/impact_model/models.py``
+(epic #4103 / issue #4106), rewritten self-contained against the vendored
+:mod:`.constants` and the Tools shared :mod:`shared.python.contracts`.
+
+Changes from the UpstreamDrift source:
+
+- Full 3-D inertia treatment (opt-in): when ``PreImpactState`` carries a
+  3x3 ``clubhead_moi_tensor``, the effective club mass for an off-center
+  hit is computed from the exact rigid-body impulse denominator
+
+      1 / m_eff = 1/m_club + (r x n)^T I^-1 (r x n)
+
+  where ``r`` is the CG-to-contact vector and ``n`` the face normal. This
+  is the club-side term of
+  ``J = (1/m_ball + 1/m_club + n . ((I^-1 (r x n)) x r))^-1 (1+e) v_rel``
+  (the triple product identity gives
+  ``n . ((I^-1 (r x n)) x r) = (r x n)^T I^-1 (r x n)``).
+  The scalar-MOI fallback ``1/m + |r|^2 / I`` is preserved and is exactly
+  reproduced by a diagonal tensor ``I * eye(3)`` because ``r`` lies in the
+  face plane (``r`` perpendicular to ``n`` implies ``|r x n| = |r|``).
+  Any CG-depth component of ``r`` along ``n`` drops out of ``r x n`` and
+  therefore never affects the normal-impulse effective mass.
+- Friction-spin axis sign fix (found during the port): the source used
+  ``n x t`` which spins a lofted strike toward topspin and contradicts
+  its own pre-existing-spin slip reduction; the physical torque axis is
+  ``t x n`` (see the inline derivation in ``_compute_friction_spin``).
+"""
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from shared.python.contracts import precondition, require, require_finite
+
+from .constants import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_MOMENT_OF_INERTIA_KG_M2,
+    GOLF_BALL_RADIUS_M,
+)
+from .types import ImpactModelType, ImpactParameters, PostImpactState, PreImpactState
+
+# Rolling-without-slip tangential-impulse factor for a uniform solid sphere.
+#
+# Derivation (UpstreamDrift #7054). A tangential friction impulse ``J_f``
+# applied at the ball surface (lever arm = radius R) changes the
+# contact-point tangential velocity by both a linear and an angular
+# contribution:
+#   * CoM tangential velocity change:        dV     = J_f / m
+#   * surface speed from spin-up:            R*dOmega = J_f*R^2 / I
+# Rolling without slip is reached when the contact point stops sliding,
+# i.e. when dV + R*dOmega equals the effective tangential approach speed:
+#   J_f*(1/m + R^2/I) = v_t   =>   J_f = v_t / (1/m + R^2/I).
+# For a uniform solid sphere I = (2/5) m R^2, so R^2/I = 5/(2m) and
+#   J_f = v_t / (1/m + 5/(2m)) = m*v_t * (2/7).
+# Ref: Cross, "Grip-slip behavior of a bouncing ball",
+# Am. J. Phys. 70, 1093 (2002).
+SPHERE_ROLLING_CAP_FACTOR = 2.0 / 7.0
+
+_DEFAULT_REFERENCE_UP = np.array([0.0, 1.0, 0.0])
+_FALLBACK_REFERENCE_UP = np.array([0.0, 0.0, 1.0])
+
+
+def _norm(vector: np.ndarray) -> float:
+    """Euclidean norm of a small vector."""
+    flat = np.asarray(vector, dtype=float).reshape(-1)
+    return 0.0 if flat.size == 0 else float(math.sqrt(float(np.dot(flat, flat))))
+
+
+def face_basis(
+    face_normal: np.ndarray,
+    reference_up: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return the (toe_axis, up_axis) face-plane basis for a face normal.
+
+    ``up_axis`` is the projection of ``reference_up`` (default world up,
+    AffineDrift +y) onto the face plane; ``toe_axis = n x up_axis`` so that
+    for a target-facing normal ``n = +x`` in the AffineDrift frame
+    (x target, y up, z right) the toe axis is ``+z`` — the toe of a
+    right-handed player's club points right of the target line.
+
+    Args:
+        face_normal: Face normal vector (3,), need not be unit length.
+        reference_up: World-up hint (3,); defaults to [0, 1, 0]. If the
+            normal is (near-)parallel to it, [0, 0, 1] is used instead.
+
+    Returns:
+        Tuple ``(toe_axis, up_axis)`` of orthonormal vectors in the face
+        plane (both perpendicular to the normal).
+    """
+    n = np.asarray(face_normal, dtype=float)
+    n_mag = _norm(n)
+    require(n_mag > 1e-10, "face_normal must be non-zero")
+    n = n / n_mag
+    up = (
+        np.asarray(reference_up, dtype=float)
+        if reference_up is not None
+        else _DEFAULT_REFERENCE_UP
+    )
+    up_axis = up - float(np.dot(up, n)) * n
+    if _norm(up_axis) < 1e-8:
+        up_axis = _FALLBACK_REFERENCE_UP - float(np.dot(_FALLBACK_REFERENCE_UP, n)) * n
+    up_axis = up_axis / _norm(up_axis)
+    toe_axis = np.cross(n, up_axis)
+    return toe_axis, up_axis
+
+
+def offset_to_face_vector(
+    impact_offset: np.ndarray,
+    face_normal: np.ndarray,
+    reference_up: np.ndarray | None = None,
+) -> np.ndarray:
+    """Lift a 2-D face offset [horizontal, vertical] to a 3-D vector.
+
+    The result lies in the face plane:
+    ``r = horizontal * toe_axis + vertical * up_axis``.
+
+    Args:
+        impact_offset: (2,) offset [m] [horizontal (+ toe), vertical (+ high)]
+        face_normal: Face normal (3,)
+        reference_up: Optional world-up hint for the face basis.
+
+    Returns:
+        (3,) CG-to-contact offset within the face plane [m].
+    """
+    offset = np.asarray(impact_offset, dtype=float).reshape(-1)
+    require(offset.size == 2, "impact_offset must have exactly 2 components")
+    toe_axis, up_axis = face_basis(face_normal, reference_up)
+    lifted: np.ndarray = offset[0] * toe_axis + offset[1] * up_axis
+    return lifted
+
+
+class ImpactModel(ABC):
+    """Abstract base class for impact models."""
+
+    @abstractmethod
+    def solve(
+        self,
+        pre_state: PreImpactState,
+        params: ImpactParameters,
+    ) -> PostImpactState:
+        """Solve the impact and return post-impact state."""
+        ...
+
+
+class RigidBodyImpactModel(ImpactModel):
+    """Rigid body collision with coefficient of restitution.
+
+    Uses instantaneous impulse-momentum equations with COR to compute
+    post-impact velocities. Off-center hits reduce the effective club mass
+    via the clubhead MOI (scalar or full 3x3 tensor, see module docstring).
+    """
+
+    def _compute_effective_club_mass(self, pre_state: PreImpactState) -> float:
+        """Effective club mass along the contact normal.
+
+        Scalar path: ``1 / (1/m + |r|^2 / I)`` with ``|r|`` the in-plane
+        offset magnitude. Tensor path (opt-in via ``clubhead_moi_tensor``):
+        ``1 / (1/m + (r x n)^T I^-1 (r x n))``.
+        """
+        if pre_state is None:
+            raise ValueError("pre_state must be provided")
+        m_club = pre_state.clubhead_mass
+        if pre_state.impact_offset is None:
+            return m_club
+
+        offset = np.asarray(pre_state.impact_offset, dtype=float).reshape(-1)
+        r_offset = _norm(offset)
+        if r_offset <= 1e-6:
+            return m_club
+
+        if pre_state.clubhead_moi_tensor is not None:
+            tensor = np.asarray(pre_state.clubhead_moi_tensor, dtype=float)
+            require(tensor.shape == (3, 3), "clubhead_moi_tensor must be 3x3")
+            n = pre_state.clubhead_orientation / _norm(pre_state.clubhead_orientation)
+            r_vec = offset_to_face_vector(offset, n)
+            r_cross_n = np.cross(r_vec, n)
+            angular_term = float(r_cross_n @ np.linalg.solve(tensor, r_cross_n))
+            return 1.0 / (1.0 / m_club + angular_term)
+
+        if pre_state.clubhead_moi > 0:
+            return 1.0 / (1.0 / m_club + r_offset**2 / pre_state.clubhead_moi)
+        return m_club
+
+    def _compute_impulse(
+        self,
+        v_rel: np.ndarray,
+        n: np.ndarray,
+        m_club_effective: float,
+        cor: float,
+    ) -> tuple[float, float]:
+        """Normal impulse magnitude and approach speed along ``n``."""
+        if v_rel is None:
+            raise ValueError("v_rel must be provided")
+        v_approach = float(np.dot(v_rel, n))
+        m_eff = (GOLF_BALL_MASS_KG * m_club_effective) / (
+            GOLF_BALL_MASS_KG + m_club_effective
+        )
+        j = (1 + cor) * m_eff * v_approach
+        return j, v_approach
+
+    def _compute_friction_spin(
+        self,
+        pre_state: PreImpactState,
+        v_rel: np.ndarray,
+        v_approach: float,
+        n: np.ndarray,
+        j: float,
+        friction_coefficient: float,
+    ) -> np.ndarray:
+        """Ball spin after the Coulomb friction impulse (2/7 rolling cap)."""
+        if pre_state is None:
+            raise ValueError("pre_state must be provided")
+        v_tangent = v_rel - v_approach * n
+        tangent_mag = _norm(v_tangent)
+        if tangent_mag <= 1e-6:
+            return pre_state.ball_angular_velocity.copy()
+
+        tangent_dir = v_tangent / tangent_mag
+        # Spin axis: friction drags the ball's contact surface along the
+        # face's relative tangential motion t; the impulse J_f*t acts at
+        # the ball contact point -R*n, so torque = (-R n) x (J_f t) and the
+        # axis is t x n. (Sign fix vs the UpstreamDrift source, which used
+        # n x t and therefore spun a lofted strike toward TOPSPIN — also
+        # inconsistent with its own pre-existing-spin slip reduction
+        # below. For a lofted, target-bound strike in the AffineDrift
+        # frame this axis is +z: backspin points right of the target.)
+        spin_axis = np.cross(tangent_dir, n)
+        # Rolling cap relative to contact-point speed (pre-existing spin
+        # reduces sliding).
+        omega_contact = float(np.dot(pre_state.ball_angular_velocity, spin_axis))
+        v_t_eff = max(0.0, tangent_mag - omega_contact * GOLF_BALL_RADIUS_M)
+        # Coulomb friction impulse, capped at the rolling-without-slip
+        # impulse for a uniform solid sphere (J_f = m*v_t*2/7, see
+        # SPHERE_ROLLING_CAP_FACTOR derivation above).
+        j_friction = min(
+            float(friction_coefficient * j),
+            GOLF_BALL_MASS_KG * v_t_eff * SPHERE_ROLLING_CAP_FACTOR,
+        )
+        spin_magnitude = j_friction / (
+            GOLF_BALL_MOMENT_OF_INERTIA_KG_M2 / GOLF_BALL_RADIUS_M
+        )
+        return pre_state.ball_angular_velocity + spin_magnitude * spin_axis
+
+    def _compute_energy_transfer(
+        self,
+        pre_ball_velocity: np.ndarray,
+        post_ball_velocity: np.ndarray,
+    ) -> float:
+        """Ball kinetic-energy change across the impact [J]."""
+        if pre_ball_velocity is None:
+            raise ValueError("pre_ball_velocity must be provided")
+        ke_pre = (
+            0.5
+            * GOLF_BALL_MASS_KG
+            * float(np.dot(pre_ball_velocity, pre_ball_velocity))
+        )
+        ke_post = (
+            0.5
+            * GOLF_BALL_MASS_KG
+            * float(np.dot(post_ball_velocity, post_ball_velocity))
+        )
+        return ke_post - ke_pre
+
+    @precondition(
+        lambda self, pre_state, params: pre_state.clubhead_mass > 0,
+        "Clubhead mass must be positive",
+    )
+    @precondition(
+        lambda self, pre_state, params: 0 <= params.cor <= 1,
+        "Coefficient of restitution must be between 0 and 1",
+    )
+    @precondition(
+        lambda self, pre_state, params: params.friction_coefficient >= 0,
+        "Friction coefficient must be non-negative",
+    )
+    def solve(
+        self,
+        pre_state: PreImpactState,
+        params: ImpactParameters,
+    ) -> PostImpactState:
+        """Solve impact using rigid body collision model with MOI."""
+        require_finite(pre_state.clubhead_velocity, "clubhead_velocity")
+        require_finite(pre_state.ball_velocity, "ball_velocity")
+        require_finite(pre_state.clubhead_orientation, "clubhead_orientation")
+        n_mag = _norm(pre_state.clubhead_orientation)
+        require(n_mag > 1e-10, "clubhead_orientation must be non-zero")
+
+        m_club_effective = self._compute_effective_club_mass(pre_state)
+        n = pre_state.clubhead_orientation / n_mag
+        v_rel = pre_state.clubhead_velocity - pre_state.ball_velocity
+
+        j, v_approach = self._compute_impulse(v_rel, n, m_club_effective, params.cor)
+
+        v_ball_post = pre_state.ball_velocity + (j / GOLF_BALL_MASS_KG) * n
+        v_club_post = pre_state.clubhead_velocity - (j / pre_state.clubhead_mass) * n
+
+        ball_spin = self._compute_friction_spin(
+            pre_state, v_rel, v_approach, n, j, params.friction_coefficient
+        )
+        energy_transfer = self._compute_energy_transfer(
+            pre_state.ball_velocity, v_ball_post
+        )
+        impact_loc = (
+            np.asarray(pre_state.impact_offset, dtype=float).copy()
+            if pre_state.impact_offset is not None
+            else np.zeros(2)
+        )
+
+        return PostImpactState(
+            ball_velocity=v_ball_post,
+            ball_angular_velocity=ball_spin,
+            clubhead_velocity=v_club_post,
+            clubhead_angular_velocity=pre_state.clubhead_angular_velocity.copy(),
+            contact_duration=0.0,
+            energy_transfer=energy_transfer,
+            impact_location=impact_loc,
+        )
+
+
+class SpringDamperImpactModel(ImpactModel):
+    """Spring-damper (Kelvin-Voigt) compliant contact model.
+
+    Uses semi-implicit integration of spring-damper contact to compute
+    force and velocity evolution during impact.
+    """
+
+    @precondition(lambda self, dt=1e-7: dt > 0, "Time step must be positive")
+    def __init__(self, dt: float = 1e-7) -> None:
+        """Initialize spring-damper model.
+
+        Args:
+            dt: Integration time step [s]. Default: 0.1 us (1e-7 s).
+        """
+        if dt is None:
+            raise ValueError("dt must be provided")
+        self.dt = dt
+
+    @precondition(
+        lambda self, pre_state, params: pre_state.clubhead_mass > 0,
+        "Clubhead mass must be positive",
+    )
+    @precondition(
+        lambda self, pre_state, params: params.contact_stiffness > 0,
+        "Contact stiffness must be positive",
+    )
+    def solve(
+        self,
+        pre_state: PreImpactState,
+        params: ImpactParameters,
+    ) -> PostImpactState:
+        """Solve impact using spring-damper contact model."""
+        if pre_state is None:
+            raise ValueError("pre_state must be provided")
+        m_ball = GOLF_BALL_MASS_KG
+        m_club = pre_state.clubhead_mass
+        n = pre_state.clubhead_orientation / _norm(pre_state.clubhead_orientation)
+
+        # Tiny clearance avoids dt-dependent overshoot at contact onset.
+        initial_gap = GOLF_BALL_RADIUS_M * 1e-4
+        x_ball: np.ndarray = (GOLF_BALL_RADIUS_M + initial_gap) * n
+        v_ball: np.ndarray = pre_state.ball_velocity.copy()
+        x_club: np.ndarray = np.zeros(3)
+        v_club: np.ndarray = pre_state.clubhead_velocity.copy()
+
+        contact_time = 0.0
+        max_time = 0.005  # 5 ms max contact time [s]
+        max_steps = int(max_time / self.dt)
+        max_force = 1e5  # [N] limit to prevent numerical blow-up
+
+        for _ in range(max_steps):
+            gap = float(np.dot(x_ball - x_club, n)) - GOLF_BALL_RADIUS_M
+
+            if gap < 0:  # In contact (penetration)
+                penetration = -gap
+                v_rel_normal = float(np.dot(v_ball - v_club, n))
+                f_spring = params.contact_stiffness * penetration
+                f_damper = -params.contact_damping * v_rel_normal
+                f_magnitude = max(0.0, min(f_spring + f_damper, max_force))
+                f_contact = f_magnitude * n
+
+                # Semi-implicit Euler: velocities first, then positions.
+                v_ball = v_ball + (f_contact / m_ball) * self.dt
+                v_club = v_club - (f_contact / m_club) * self.dt
+                x_ball = x_ball + v_ball * self.dt
+                x_club = x_club + v_club * self.dt
+                contact_time += self.dt
+            elif contact_time > 0:
+                break  # Was in contact but now separated.
+            else:
+                # Pre-contact: advance positions only.
+                x_ball = x_ball + v_ball * self.dt
+                x_club = x_club + v_club * self.dt
+
+        ke_pre = (
+            0.5
+            * m_ball
+            * float(np.dot(pre_state.ball_velocity, pre_state.ball_velocity))
+        )
+        ke_post = 0.5 * m_ball * float(np.dot(v_ball, v_ball))
+
+        return PostImpactState(
+            ball_velocity=v_ball,
+            ball_angular_velocity=pre_state.ball_angular_velocity.copy(),
+            clubhead_velocity=v_club,
+            clubhead_angular_velocity=pre_state.clubhead_angular_velocity.copy(),
+            contact_duration=contact_time,
+            energy_transfer=ke_post - ke_pre,
+            impact_location=np.zeros(2),
+        )
+
+
+class FiniteTimeImpactModel(ImpactModel):
+    """Finite-time impulse-momentum model.
+
+    Uses the rigid-body result but reports the specified contact duration.
+    """
+
+    def solve(
+        self,
+        pre_state: PreImpactState,
+        params: ImpactParameters,
+    ) -> PostImpactState:
+        """Solve impact using finite-time model."""
+        if pre_state is None:
+            raise ValueError("pre_state must be provided")
+        result = RigidBodyImpactModel().solve(pre_state, params)
+        return PostImpactState(
+            ball_velocity=result.ball_velocity,
+            ball_angular_velocity=result.ball_angular_velocity,
+            clubhead_velocity=result.clubhead_velocity,
+            clubhead_angular_velocity=result.clubhead_angular_velocity,
+            contact_duration=params.contact_duration,
+            energy_transfer=result.energy_transfer,
+            impact_location=result.impact_location,
+        )
+
+
+def create_impact_model(model_type: ImpactModelType) -> ImpactModel:
+    """Factory function to create an impact model instance."""
+    if model_type == ImpactModelType.RIGID_BODY:
+        return RigidBodyImpactModel()
+    if model_type == ImpactModelType.SPRING_DAMPER:
+        # Annotated local: the contract-decorated __init__ obscures the
+        # constructor's return type from mypy.
+        spring_model: ImpactModel = SpringDamperImpactModel()
+        return spring_model
+    if model_type == ImpactModelType.FINITE_TIME:
+        return FiniteTimeImpactModel()
+    raise ValueError(f"Unknown impact model type: {model_type}")

--- a/src/shared/python/swing_sim/impact/solver.py
+++ b/src/shared/python/swing_sim/impact/solver.py
@@ -1,0 +1,471 @@
+"""Impact recorder and engine-agnostic solver API.
+
+Ported from UpstreamDrift ``src/shared/python/physics/impact_model/solver.py``
+(epic #4103 / issue #4106), rewritten self-contained.
+
+Changes from the UpstreamDrift source:
+
+- BUG FIX (recon #4104, defect a): ``solve_with_gear_effect`` previously
+  computed the base impulse WITHOUT the impact offset — the
+  ``PreImpactState`` it built silently dropped ``impact_offset``, so
+  off-center hits skipped the MOI effective-mass reduction and launched
+  at full center-strike ball speed. The offset is now carried into the
+  pre-impact state (and the recorded event), so off-center ball speed is
+  correctly lower than a center strike.
+- Gear effect is now the physics-derived head-recoil model from
+  :mod:`.gear_effect` (the three empirical scaling constants are gone),
+  with an optional ``face_normal_at_offset`` bulge/roll callable supplied
+  by the app's club package.
+- ``solve_impact`` accepts optional ``impact_offset`` /
+  ``clubhead_moi`` / ``clubhead_moi_tensor`` passthroughs.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import numpy as np
+
+from shared.python.contracts import precondition
+
+from .constants import DRIVER_MASS_KG, DRIVER_MOI_KG_M2, GOLF_BALL_MASS_KG
+from .gear_effect import FaceNormalAtOffset, compute_gear_effect, resolve_contact_normal
+from .models import _norm, create_impact_model
+from .types import (
+    ImpactEvent,
+    ImpactModelType,
+    ImpactParameters,
+    PostImpactState,
+    PreImpactState,
+)
+from .utils import validate_energy_balance
+
+logger = logging.getLogger(__name__)
+
+
+class ImpactRecorder:
+    """Records impact events during simulation.
+
+    Surfaces pre-impact and post-impact states in recorder outputs and
+    provides energy-balance checks for each impact.
+    """
+
+    def __init__(self) -> None:
+        """Initialize impact recorder."""
+        self.events: list[ImpactEvent] = []
+        self._impact_counter = 0
+
+    def record_impact(
+        self,
+        timestamp: float,
+        pre_state: PreImpactState,
+        post_state: PostImpactState,
+        params: ImpactParameters,
+        model_type: ImpactModelType = ImpactModelType.RIGID_BODY,
+    ) -> ImpactEvent:
+        """Record an impact event.
+
+        Args:
+            timestamp: Simulation time [s]
+            pre_state: Pre-impact state
+            post_state: Post-impact state
+            params: Impact parameters used
+            model_type: Type of impact model used
+
+        Returns:
+            Recorded ImpactEvent
+        """
+        if timestamp is None:
+            raise ValueError("timestamp must be provided")
+        energy_balance = validate_energy_balance(pre_state, post_state, params)
+
+        event = ImpactEvent(
+            timestamp=timestamp,
+            pre_state=pre_state,
+            post_state=post_state,
+            energy_balance=energy_balance,
+            impact_id=self._impact_counter,
+            model_type=model_type,
+        )
+        self.events.append(event)
+        self._impact_counter += 1
+
+        logger.info(
+            "Impact #%d recorded at t=%.4fs, ball speed: %.1f m/s, energy loss: %.1f%%",
+            event.impact_id,
+            timestamp,
+            energy_balance["ball_launch_speed"],
+            100.0 * energy_balance["energy_loss_ratio"],
+        )
+        return event
+
+    def get_all_events(self) -> list[ImpactEvent]:
+        """Get all recorded impact events."""
+        return self.events.copy()
+
+    def export_to_dict(self) -> dict:
+        """Export all events as dictionary for JSON serialization."""
+        events_data = [
+            {
+                "impact_id": event.impact_id,
+                "timestamp": event.timestamp,
+                "model_type": event.model_type.name,
+                "pre_impact": {
+                    "clubhead_velocity": event.pre_state.clubhead_velocity.tolist(),
+                    "ball_velocity": event.pre_state.ball_velocity.tolist(),
+                    "ball_spin": event.pre_state.ball_angular_velocity.tolist(),
+                },
+                "post_impact": {
+                    "ball_velocity": event.post_state.ball_velocity.tolist(),
+                    "ball_spin": event.post_state.ball_angular_velocity.tolist(),
+                    "clubhead_velocity": event.post_state.clubhead_velocity.tolist(),
+                    "contact_duration": event.post_state.contact_duration,
+                    "energy_transfer": event.post_state.energy_transfer,
+                },
+                "energy_balance": event.energy_balance,
+            }
+            for event in self.events
+        ]
+        return {
+            "num_impacts": len(self.events),
+            "events": events_data,
+            "summary": self.get_summary(),
+        }
+
+    def get_summary(self) -> dict[str, float]:
+        """Get summary statistics for all impacts."""
+        if not self.events:
+            return {"num_impacts": 0}
+        speeds = [e.energy_balance["ball_launch_speed"] for e in self.events]
+        losses = [e.energy_balance["energy_loss_ratio"] for e in self.events]
+        return {
+            "num_impacts": len(self.events),
+            "mean_ball_speed": float(np.mean(speeds)),
+            "max_ball_speed": float(np.max(speeds)),
+            "mean_energy_loss_ratio": float(np.mean(losses)),
+        }
+
+    def reset(self) -> None:
+        """Clear all recorded events."""
+        self.events.clear()
+        self._impact_counter = 0
+
+
+class ImpactSolverAPI:
+    """Engine-agnostic API for impact solving.
+
+    Provides a unified interface for different physics engines, with
+    optional recording and energy/COR/spin validation.
+    """
+
+    def __init__(
+        self,
+        model_type: ImpactModelType = ImpactModelType.RIGID_BODY,
+        params: ImpactParameters | None = None,
+    ) -> None:
+        """Initialize impact solver.
+
+        Args:
+            model_type: Type of impact model to use
+            params: Impact parameters (uses defaults if None)
+        """
+        if model_type is None:
+            raise ValueError("model_type must be provided")
+        self.model_type = model_type
+        self.model = create_impact_model(model_type)
+        self.params = params or ImpactParameters()
+        self.recorder = ImpactRecorder()
+
+    def _build_pre_state(
+        self,
+        clubhead_velocity: np.ndarray,
+        clubhead_orientation: np.ndarray,
+        ball_velocity: np.ndarray | None,
+        ball_angular_velocity: np.ndarray | None,
+        clubhead_mass: float,
+        impact_offset: np.ndarray | None,
+        clubhead_moi: float,
+        clubhead_moi_tensor: np.ndarray | None,
+    ) -> PreImpactState:
+        """Assemble a PreImpactState, defaulting the ball to rest."""
+        return PreImpactState(
+            clubhead_velocity=np.asarray(clubhead_velocity, dtype=float),
+            clubhead_angular_velocity=np.zeros(3),
+            clubhead_orientation=np.asarray(clubhead_orientation, dtype=float),
+            ball_position=np.zeros(3),
+            ball_velocity=(
+                np.asarray(ball_velocity, dtype=float)
+                if ball_velocity is not None
+                else np.zeros(3)
+            ),
+            ball_angular_velocity=(
+                np.asarray(ball_angular_velocity, dtype=float)
+                if ball_angular_velocity is not None
+                else np.zeros(3)
+            ),
+            clubhead_mass=clubhead_mass,
+            clubhead_moi=clubhead_moi,
+            impact_offset=(
+                np.asarray(impact_offset, dtype=float)
+                if impact_offset is not None
+                else None
+            ),
+            clubhead_moi_tensor=clubhead_moi_tensor,
+        )
+
+    @precondition(
+        lambda self, timestamp, *args, **kwargs: timestamp >= 0,
+        "Timestamp must be non-negative",
+    )
+    def solve_impact(
+        self,
+        timestamp: float,
+        clubhead_velocity: np.ndarray,
+        clubhead_orientation: np.ndarray,
+        ball_velocity: np.ndarray | None = None,
+        ball_angular_velocity: np.ndarray | None = None,
+        clubhead_mass: float = DRIVER_MASS_KG,
+        impact_offset: np.ndarray | None = None,
+        clubhead_moi: float = DRIVER_MOI_KG_M2,
+        clubhead_moi_tensor: np.ndarray | None = None,
+        record: bool = True,
+    ) -> PostImpactState:
+        """Solve impact and optionally record the event.
+
+        Args:
+            timestamp: Current simulation time [s]
+            clubhead_velocity: Clubhead velocity [m/s] (3,)
+            clubhead_orientation: Clubface normal [unitless] (3,)
+            ball_velocity: Ball velocity (default: stationary) [m/s] (3,)
+            ball_angular_velocity: Ball spin (default: zero) [rad/s] (3,)
+            clubhead_mass: Clubhead mass [kg] (must be positive)
+            impact_offset: Optional face offset from CG [m] (2,)
+                [horizontal, vertical] — enables the MOI effective-mass
+                reduction for off-center strikes
+            clubhead_moi: Scalar clubhead MOI about CG [kg.m^2]
+            clubhead_moi_tensor: Optional 3x3 MOI tensor (full 3-D
+                effective-mass treatment)
+            record: Whether to record this impact
+
+        Returns:
+            Post-impact state
+        """
+        if timestamp is None:
+            raise ValueError("timestamp must be provided")
+        if clubhead_mass <= 0:
+            raise ValueError("Clubhead mass must be positive")
+        pre_state = self._build_pre_state(
+            clubhead_velocity,
+            clubhead_orientation,
+            ball_velocity,
+            ball_angular_velocity,
+            clubhead_mass,
+            impact_offset,
+            clubhead_moi,
+            clubhead_moi_tensor,
+        )
+        post_state = self.model.solve(pre_state, self.params)
+        if record:
+            self.recorder.record_impact(
+                timestamp, pre_state, post_state, self.params, self.model_type
+            )
+        return post_state
+
+    def solve_with_gear_effect(
+        self,
+        timestamp: float,
+        clubhead_velocity: np.ndarray,
+        clubhead_orientation: np.ndarray,
+        impact_offset: np.ndarray,
+        ball_velocity: np.ndarray | None = None,
+        clubhead_mass: float = DRIVER_MASS_KG,
+        clubhead_moi: float = DRIVER_MOI_KG_M2,
+        clubhead_moi_tensor: np.ndarray | None = None,
+        face_normal_at_offset: FaceNormalAtOffset | None = None,
+        record: bool = True,
+    ) -> PostImpactState:
+        """Solve an off-center impact with physics-based gear-effect spin.
+
+        The impact offset is carried into the base solve (bug fix, see
+        module docstring), the local bulge/roll normal (if a curvature
+        callable is given) sets the impulse direction, and the head's
+        rotation recoil adds gear-effect spin via :mod:`.gear_effect`.
+
+        Args:
+            timestamp: Current simulation time [s]
+            clubhead_velocity: Clubhead velocity [m/s] (3,)
+            clubhead_orientation: Nominal clubface normal (3,)
+            impact_offset: Offset from face center [m] (2,)
+                [horizontal (+ toe), vertical (+ high)]
+            ball_velocity: Ball velocity [m/s] (3,)
+            clubhead_mass: Clubhead mass [kg]
+            clubhead_moi: Scalar clubhead MOI about CG [kg.m^2]
+            clubhead_moi_tensor: Optional 3x3 MOI tensor
+            face_normal_at_offset: Optional bulge/roll callable
+                ``(toe_m, high_m) -> local normal`` from the club package
+            record: Whether to record this impact
+
+        Returns:
+            Post-impact state with gear-effect spin and head recoil.
+        """
+        if timestamp is None:
+            raise ValueError("timestamp must be provided")
+        offset = np.asarray(impact_offset, dtype=float)
+        contact_normal = resolve_contact_normal(
+            offset, clubhead_orientation, face_normal_at_offset
+        )
+
+        # Base solve WITH the offset so the MOI effective-mass reduction
+        # applies (previously the offset was silently dropped here).
+        pre_state = self._build_pre_state(
+            clubhead_velocity,
+            contact_normal,
+            ball_velocity,
+            None,
+            clubhead_mass,
+            offset,
+            clubhead_moi,
+            clubhead_moi_tensor,
+        )
+        post_state = self.model.solve(pre_state, self.params)
+
+        # Recover the normal impulse from the ball's velocity change.
+        delta_v = post_state.ball_velocity - pre_state.ball_velocity
+        normal_impulse = max(
+            0.0, GOLF_BALL_MASS_KG * float(np.dot(delta_v, contact_normal))
+        )
+
+        gear = compute_gear_effect(
+            impact_offset=offset,
+            face_normal=np.asarray(clubhead_orientation, dtype=float),
+            normal_impulse=normal_impulse,
+            clubhead_moi=(
+                clubhead_moi_tensor if clubhead_moi_tensor is not None else clubhead_moi
+            ),
+            cg_depth_m=self.params.cg_depth,
+            friction_coefficient=self.params.friction_coefficient,
+            face_normal_at_offset=face_normal_at_offset,
+        )
+
+        modified_post = PostImpactState(
+            ball_velocity=post_state.ball_velocity,
+            ball_angular_velocity=(
+                post_state.ball_angular_velocity + gear.ball_spin_delta
+            ),
+            clubhead_velocity=post_state.clubhead_velocity,
+            clubhead_angular_velocity=(
+                post_state.clubhead_angular_velocity + gear.head_angular_velocity_delta
+            ),
+            contact_duration=post_state.contact_duration,
+            energy_transfer=post_state.energy_transfer,
+            impact_location=offset,
+        )
+        if record:
+            self.recorder.record_impact(
+                timestamp, pre_state, modified_post, self.params, self.model_type
+            )
+        return modified_post
+
+    def get_energy_report(self) -> dict:
+        """Get energy balance report for all recorded impacts."""
+        if not self.recorder.events:
+            raise RuntimeError("No impacts recorded")
+        reports = [
+            {
+                "impact_id": event.impact_id,
+                "timestamp": event.timestamp,
+                "ke_pre": event.energy_balance["total_ke_pre"],
+                "ke_post": event.energy_balance["total_ke_post"],
+                "energy_lost": event.energy_balance["energy_lost"],
+                "loss_ratio": event.energy_balance["energy_loss_ratio"],
+                "ball_speed": event.energy_balance["ball_launch_speed"],
+            }
+            for event in self.recorder.events
+        ]
+        total_ke_pre = sum(r["ke_pre"] for r in reports)
+        total_ke_post = sum(r["ke_post"] for r in reports)
+        return {
+            "impacts": reports,
+            "total_ke_pre": total_ke_pre,
+            "total_ke_post": total_ke_post,
+            "total_energy_lost": total_ke_pre - total_ke_post,
+            "overall_loss_ratio": (
+                (total_ke_pre - total_ke_post) / total_ke_pre if total_ke_pre > 0 else 0
+            ),
+        }
+
+    def validate_cor_behavior(
+        self, tolerance: float = 0.05
+    ) -> dict[str, bool | float | str | int]:
+        """Validate COR behavior across recorded impacts.
+
+        Args:
+            tolerance: Acceptable deviation from expected COR
+
+        Returns:
+            Validation result with pass/fail and details
+        """
+        if tolerance is None:
+            raise ValueError("tolerance must be provided")
+        if not self.recorder.events:
+            raise RuntimeError("No impacts recorded")
+
+        expected_cor = self.params.cor
+        measured_cors = []
+        for event in self.recorder.events:
+            v_club_pre = _norm(event.pre_state.clubhead_velocity)
+            v_ball_pre = _norm(event.pre_state.ball_velocity)
+            v_club_post = _norm(event.post_state.clubhead_velocity)
+            v_ball_post = _norm(event.post_state.ball_velocity)
+            # COR = (v_ball_post - v_club_post) / (v_club_pre - v_ball_pre)
+            approach = v_club_pre - v_ball_pre
+            if approach > 0.1:  # Avoid division by small number
+                measured_cors.append((v_ball_post - v_club_post) / approach)
+
+        if not measured_cors:
+            raise RuntimeError("Could not compute COR")
+
+        mean_cor = float(np.mean(measured_cors))
+        deviation = abs(mean_cor - expected_cor)
+        return {
+            "valid": deviation <= tolerance,
+            "expected_cor": expected_cor,
+            "measured_cor_mean": mean_cor,
+            "deviation": deviation,
+            "tolerance": tolerance,
+            "num_samples": len(measured_cors),
+        }
+
+    def validate_spin_behavior(
+        self, max_spin_rpm: float = 10000
+    ) -> dict[str, bool | float | str | int]:
+        """Validate spin behavior is within physical limits.
+
+        Args:
+            max_spin_rpm: Maximum acceptable spin rate [RPM]
+
+        Returns:
+            Validation result with pass/fail and details
+        """
+        if max_spin_rpm is None:
+            raise ValueError("max_spin_rpm must be provided")
+        if not self.recorder.events:
+            raise RuntimeError("No impacts recorded")
+
+        max_spin_rad = max_spin_rpm * 2 * math.pi / 60  # Convert to rad/s
+        spins = [
+            _norm(event.post_state.ball_angular_velocity)
+            for event in self.recorder.events
+        ]
+        max_observed = float(np.max(spins))
+        return {
+            "valid": max_observed <= max_spin_rad,
+            "max_observed_rpm": max_observed * 60 / (2 * math.pi),
+            "max_allowed_rpm": max_spin_rpm,
+            "num_samples": len(spins),
+        }
+
+    def reset(self) -> None:
+        """Reset solver state and clear recorded impacts."""
+        self.recorder.reset()

--- a/src/shared/python/swing_sim/impact/tests/__init__.py
+++ b/src/shared/python/swing_sim/impact/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the swing_sim impact subpackage (epic #4103, issue #4106)."""

--- a/src/shared/python/swing_sim/impact/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/impact/tests/test_contract_api.py
@@ -1,0 +1,84 @@
+"""Contract test pinning the public API surface of swing_sim.impact.
+
+Downstream consumers (UpstreamDrift, the app's club package, web backend)
+import from this self-façaded subpackage only; this test fails loudly
+when the surface changes so removals are always deliberate. The parent
+``swing_sim`` façade is wired during epic integration and intentionally
+does NOT re-export impact symbols yet.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import shared.python.swing_sim.impact as impact
+
+EXPECTED_PUBLIC_API = {
+    "DRIVER_CG_DEPTH_M",
+    "DRIVER_COR",
+    "DRIVER_MASS_KG",
+    "DRIVER_MOI_KG_M2",
+    "GOLF_BALL_MASS_KG",
+    "GOLF_BALL_MOMENT_OF_INERTIA_KG_M2",
+    "GOLF_BALL_RADIUS_M",
+    "SPHERE_ROLLING_CAP_FACTOR",
+    "TYPICAL_CONTACT_DURATION_S",
+    "DeliveryDerived",
+    "DeliveryParameters",
+    "FaceNormalAtOffset",
+    "FiniteTimeImpactModel",
+    "GearEffectResult",
+    "ImpactEvent",
+    "ImpactModel",
+    "ImpactModelType",
+    "ImpactParameters",
+    "ImpactRecorder",
+    "ImpactSolverAPI",
+    "PostImpactState",
+    "PreImpactState",
+    "RigidBodyImpactModel",
+    "SpringDamperImpactModel",
+    "compute_gear_effect",
+    "create_impact_model",
+    "derive_delivery",
+    "face_basis",
+    "offset_to_face_vector",
+    "resolve_contact_normal",
+    "to_pre_impact_state",
+    "validate_energy_balance",
+}
+
+
+@pytest.mark.contract
+def test_public_api_surface_is_pinned() -> None:
+    assert set(impact.__all__) == EXPECTED_PUBLIC_API
+
+
+@pytest.mark.contract
+def test_all_exports_resolve() -> None:
+    for name in impact.__all__:
+        assert getattr(impact, name) is not None, f"{name} did not resolve"
+
+
+@pytest.mark.contract
+def test_parent_facade_untouched() -> None:
+    """Integration wires the parent façade later (epic #4103)."""
+    import shared.python.swing_sim as swing_sim
+
+    assert "ImpactSolverAPI" not in swing_sim.__all__
+
+
+@pytest.mark.contract
+def test_delivery_types_are_frozen_dataclasses() -> None:
+    for cls in (impact.DeliveryParameters, impact.DeliveryDerived):
+        assert dataclasses.is_dataclass(cls)
+        assert cls.__dataclass_params__.frozen  # type: ignore[attr-defined]
+
+
+@pytest.mark.contract
+def test_pre_impact_state_has_tensor_field() -> None:
+    fields = {f.name for f in dataclasses.fields(impact.PreImpactState)}
+    assert "impact_offset" in fields
+    assert "clubhead_moi_tensor" in fields

--- a/src/shared/python/swing_sim/impact/tests/test_delivery.py
+++ b/src/shared/python/swing_sim/impact/tests/test_delivery.py
@@ -1,0 +1,137 @@
+"""Delivery front-end tests: angle mapping, offsets, D-plane diagnostics."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.impact.delivery import (
+    DeliveryParameters,
+    derive_delivery,
+    to_pre_impact_state,
+)
+from shared.python.swing_sim.impact.models import RigidBodyImpactModel
+from shared.python.swing_sim.impact.types import ImpactParameters
+
+
+def _params(**kwargs: float) -> DeliveryParameters:
+    defaults: dict[str, float] = {"clubhead_speed_mps": 50.0}
+    defaults.update(kwargs)
+    return DeliveryParameters(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestDeliveryValidation:
+    def test_rejects_non_positive_speed(self) -> None:
+        with pytest.raises(ValueError, match="clubhead_speed_mps"):
+            DeliveryParameters(clubhead_speed_mps=0.0)
+
+    def test_rejects_non_finite_angle(self) -> None:
+        with pytest.raises(ValueError, match="face_angle_deg"):
+            _params(face_angle_deg=float("nan"))
+
+    def test_rejects_out_of_range_angle(self) -> None:
+        with pytest.raises(ValueError, match="club_path_deg"):
+            _params(club_path_deg=120.0)
+
+    def test_is_frozen(self) -> None:
+        params = _params()
+        with pytest.raises(AttributeError):
+            params.club_path_deg = 1.0  # type: ignore[misc]
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestDeliveryVectors:
+    def test_neutral_delivery_is_straight_normal(self) -> None:
+        """Zero path/face/AoA: velocity along +x, normal lofted in x-y."""
+        derived = derive_delivery(_params(dynamic_loft_deg=10.5))
+        loft = math.radians(10.5)
+        np.testing.assert_allclose(
+            derived.clubhead_velocity, [50.0, 0.0, 0.0], atol=1e-12
+        )
+        np.testing.assert_allclose(
+            derived.face_normal, [math.cos(loft), math.sin(loft), 0.0], atol=1e-12
+        )
+        np.testing.assert_allclose(derived.impact_offset, [0.0, 0.0], atol=1e-15)
+        assert derived.spin_loft_deg == pytest.approx(10.5)
+        assert derived.face_to_path_deg == pytest.approx(0.0)
+        np.testing.assert_allclose(derived.spin_axis, [0.0, 0.0, 1.0], atol=1e-9)
+        assert derived.spin_axis_tilt_deg == pytest.approx(0.0, abs=1e-9)
+
+    def test_in_to_out_path_moves_right(self) -> None:
+        derived = derive_delivery(_params(club_path_deg=4.0))
+        assert derived.clubhead_velocity[2] > 0.0  # +z = right
+
+    def test_open_face_points_right(self) -> None:
+        derived = derive_delivery(_params(face_angle_deg=3.0))
+        assert derived.face_normal[2] > 0.0
+
+    def test_positive_attack_angle_moves_up(self) -> None:
+        derived = derive_delivery(_params(attack_angle_deg=5.0))
+        assert derived.clubhead_velocity[1] > 0.0
+        assert float(np.linalg.norm(derived.clubhead_velocity)) == pytest.approx(50.0)
+
+    def test_spin_loft_is_loft_minus_attack_for_square_face(self) -> None:
+        derived = derive_delivery(_params(dynamic_loft_deg=12.0, attack_angle_deg=-3.0))
+        assert derived.spin_loft_deg == pytest.approx(15.0, abs=1e-9)
+
+    def test_open_face_tilts_spin_axis_fade_side(self) -> None:
+        """Face open of path (D-plane): positive tilt = fade/slice spin."""
+        fade = derive_delivery(_params(dynamic_loft_deg=10.5, face_angle_deg=4.0))
+        draw = derive_delivery(_params(dynamic_loft_deg=10.5, face_angle_deg=-4.0))
+        assert fade.spin_axis_tilt_deg > 0.0
+        assert draw.spin_axis_tilt_deg < 0.0
+        assert fade.spin_axis_tilt_deg == pytest.approx(
+            -draw.spin_axis_tilt_deg, rel=1e-9
+        )
+
+    def test_offset_millimetre_conversion(self) -> None:
+        derived = derive_delivery(
+            _params(impact_offset_toe_mm=12.0, impact_offset_high_mm=-5.0)
+        )
+        np.testing.assert_allclose(derived.impact_offset, [0.012, -0.005])
+
+    def test_lie_rotates_offset_axes(self) -> None:
+        """+90 deg toe-up lie maps a pure toe offset onto the vertical axis."""
+        derived = derive_delivery(_params(lie_deg=89.0, impact_offset_toe_mm=10.0))
+        assert derived.impact_offset[1] == pytest.approx(
+            0.010 * math.sin(math.radians(89.0))
+        )
+
+    def test_angular_velocity_passthrough(self) -> None:
+        omega = np.array([0.0, 1.0, 2.0])
+        derived = derive_delivery(_params(), clubhead_angular_velocity=omega)
+        np.testing.assert_allclose(derived.clubhead_angular_velocity, omega)
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestToPreImpactState:
+    def test_round_trip_neutral_delivery_launches_near_normal(self) -> None:
+        """End-to-end: neutral delivery -> impact solve -> straight launch."""
+        pre = to_pre_impact_state(_params(dynamic_loft_deg=10.5))
+        post = RigidBodyImpactModel().solve(pre, ImpactParameters())
+        v = post.ball_velocity / np.linalg.norm(post.ball_velocity)
+        # Ball launches along the face normal (rigid-body normal impulse).
+        np.testing.assert_allclose(v, pre.clubhead_orientation, atol=1e-12)
+        assert abs(v[2]) < 1e-12  # no sideways component
+        # Backspin about +z (sign-fixed friction spin axis).
+        assert post.ball_angular_velocity[2] > 0.0
+
+    def test_offset_carried_into_state(self) -> None:
+        pre = to_pre_impact_state(_params(impact_offset_toe_mm=20.0))
+        assert pre.impact_offset is not None
+        assert pre.impact_offset[0] == pytest.approx(0.020)
+
+    def test_tensor_passthrough(self) -> None:
+        tensor = 4.5e-4 * np.eye(3)
+        pre = to_pre_impact_state(_params(), clubhead_moi_tensor=tensor)
+        assert pre.clubhead_moi_tensor is tensor
+
+    def test_ball_defaults_to_rest(self) -> None:
+        pre = to_pre_impact_state(_params())
+        np.testing.assert_allclose(pre.ball_velocity, 0.0)
+        np.testing.assert_allclose(pre.ball_angular_velocity, 0.0)

--- a/src/shared/python/swing_sim/impact/tests/test_gear_effect.py
+++ b/src/shared/python/swing_sim/impact/tests/test_gear_effect.py
@@ -1,0 +1,201 @@
+"""Physics-based gear-effect tests: qualitative signatures + bulge seam.
+
+Signatures validated (right-handed player, AffineDrift frame
+x target / y up / z right; backspin axis = +z, draw-side spin = +y):
+
+- toe hit -> draw-side spin (+y)
+- heel hit -> fade-side spin (-y)
+- high hit -> reduced backspin (-z delta)
+- low hit -> added backspin (+z delta)
+- bulge partially offsets the toe-hit pull (starts the ball further right)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.impact.constants import (
+    DRIVER_MOI_KG_M2,
+    GOLF_BALL_MASS_KG,
+)
+from shared.python.swing_sim.impact.gear_effect import (
+    GearEffectResult,
+    compute_gear_effect,
+    resolve_contact_normal,
+)
+from shared.python.swing_sim.impact.models import SPHERE_ROLLING_CAP_FACTOR
+from shared.python.swing_sim.impact.solver import ImpactSolverAPI
+
+_N_SQUARE = np.array([1.0, 0.0, 0.0])
+_V_CLUB = np.array([50.0, 0.0, 0.0])
+_J_TYPICAL = 3.0  # [N.s] ~ (1+e) mu v for a 50 m/s driver strike
+
+
+def _gear(offset: np.ndarray, cg_depth_m: float | None = None) -> GearEffectResult:
+    if cg_depth_m is None:
+        return compute_gear_effect(
+            impact_offset=offset,
+            face_normal=_N_SQUARE,
+            normal_impulse=_J_TYPICAL,
+            clubhead_moi=DRIVER_MOI_KG_M2,
+        )
+    return compute_gear_effect(
+        impact_offset=offset,
+        face_normal=_N_SQUARE,
+        normal_impulse=_J_TYPICAL,
+        clubhead_moi=DRIVER_MOI_KG_M2,
+        cg_depth_m=cg_depth_m,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestGearEffectSignatures:
+    def test_toe_hit_gives_draw_side_spin(self) -> None:
+        result = _gear(np.array([0.02, 0.0]))
+        assert result.ball_spin_delta[1] > 0.0  # +y = draw (RH)
+        assert abs(result.ball_spin_delta[1]) > abs(result.ball_spin_delta[2])
+
+    def test_heel_hit_gives_fade_side_spin(self) -> None:
+        result = _gear(np.array([-0.02, 0.0]))
+        assert result.ball_spin_delta[1] < 0.0  # -y = fade (RH)
+
+    def test_high_hit_reduces_backspin(self) -> None:
+        result = _gear(np.array([0.0, 0.015]))
+        assert result.ball_spin_delta[2] < 0.0  # opposes +z backspin
+
+    def test_low_hit_adds_backspin(self) -> None:
+        result = _gear(np.array([0.0, -0.015]))
+        assert result.ball_spin_delta[2] > 0.0
+
+    def test_toe_and_heel_are_antisymmetric(self) -> None:
+        toe = _gear(np.array([0.02, 0.0]))
+        heel = _gear(np.array([-0.02, 0.0]))
+        np.testing.assert_allclose(
+            toe.ball_spin_delta, -heel.ball_spin_delta, atol=1e-12
+        )
+
+    def test_center_hit_produces_no_gear_spin(self) -> None:
+        result = _gear(np.zeros(2))
+        np.testing.assert_allclose(result.ball_spin_delta, 0.0)
+        assert result.tangential_surface_speed == 0.0
+
+    def test_zero_cg_depth_produces_no_gear_spin(self) -> None:
+        """No front-to-back lever arm -> no tangential sweep -> no spin."""
+        result = _gear(np.array([0.02, 0.0]), cg_depth_m=0.0)
+        np.testing.assert_allclose(result.ball_spin_delta, 0.0, atol=1e-12)
+
+    def test_toe_hit_head_recoil_opens_face(self) -> None:
+        """Toe hit twists the head about -y: the toe rotates backward."""
+        result = _gear(np.array([0.02, 0.0]))
+        assert result.head_angular_velocity_delta[1] < 0.0
+
+    def test_spin_scales_with_offset(self) -> None:
+        small = _gear(np.array([0.005, 0.0]))
+        large = _gear(np.array([0.02, 0.0]))
+        assert abs(large.ball_spin_delta[1]) > abs(small.ball_spin_delta[1])
+
+    def test_higher_moi_reduces_gear_spin(self) -> None:
+        """Forgiving (high-MOI) heads twist less and gear less."""
+        low = _gear(np.array([0.02, 0.0]))
+        high = compute_gear_effect(
+            impact_offset=np.array([0.02, 0.0]),
+            face_normal=_N_SQUARE,
+            normal_impulse=_J_TYPICAL,
+            clubhead_moi=4.0 * DRIVER_MOI_KG_M2,
+        )
+        assert abs(high.ball_spin_delta[1]) < abs(low.ball_spin_delta[1])
+
+    def test_tensor_moi_matches_matching_scalar(self) -> None:
+        scalar = _gear(np.array([0.02, 0.01]))
+        tensor = compute_gear_effect(
+            impact_offset=np.array([0.02, 0.01]),
+            face_normal=_N_SQUARE,
+            normal_impulse=_J_TYPICAL,
+            clubhead_moi=DRIVER_MOI_KG_M2 * np.eye(3),
+        )
+        np.testing.assert_allclose(
+            tensor.ball_spin_delta, scalar.ball_spin_delta, rtol=1e-12
+        )
+
+    def test_friction_cap_bounds_spin(self) -> None:
+        """The friction impulse never exceeds the 2/7 rolling cap."""
+        result = _gear(np.array([0.03, 0.0]))
+        i_ball_over_r = GOLF_BALL_MASS_KG * (2.0 / 5.0) * 0.021335
+        cap = (
+            GOLF_BALL_MASS_KG
+            * result.tangential_surface_speed
+            * SPHERE_ROLLING_CAP_FACTOR
+        ) / i_ball_over_r
+        assert float(np.linalg.norm(result.ball_spin_delta)) <= cap * (1.0 + 1e-9)
+
+    def test_negative_impulse_rejected(self) -> None:
+        with pytest.raises(ValueError, match="normal_impulse"):
+            compute_gear_effect(
+                impact_offset=np.array([0.02, 0.0]),
+                face_normal=_N_SQUARE,
+                normal_impulse=-1.0,
+                clubhead_moi=DRIVER_MOI_KG_M2,
+            )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestBulgeRollSeam:
+    @staticmethod
+    def _bulge_normal(toe_m: float, high_m: float) -> np.ndarray:
+        """Toy bulge/roll: convex face with 0.25 m radius of curvature."""
+        radius = 0.25
+        n = np.array([1.0, high_m / radius, toe_m / radius])
+        return n / np.linalg.norm(n)
+
+    def test_local_normal_resolution(self) -> None:
+        n = resolve_contact_normal(np.array([0.02, 0.0]), _N_SQUARE, self._bulge_normal)
+        assert n[2] > 0.0  # toe-side bulge normal points right (open)
+        assert float(np.linalg.norm(n)) == pytest.approx(1.0)
+
+    def test_bulge_partially_offsets_toe_hit_pull(self) -> None:
+        """Toe hit with bulge launches further right than with a flat face,
+        so the gear-effect draw spin curves it back toward the target."""
+        api_flat = ImpactSolverAPI()
+        flat = api_flat.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _N_SQUARE,
+            impact_offset=np.array([0.02, 0.0]),
+            record=False,
+        )
+        api_bulge = ImpactSolverAPI()
+        bulged = api_bulge.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _N_SQUARE,
+            impact_offset=np.array([0.02, 0.0]),
+            face_normal_at_offset=self._bulge_normal,
+            record=False,
+        )
+        # Launch direction gains a rightward (+z) component from bulge...
+        assert bulged.ball_velocity[2] > flat.ball_velocity[2]
+        # ...while the gear effect still adds draw-side spin on top of the
+        # open-local-normal friction spin (compare against the same local
+        # normal solved WITHOUT gear effect).
+        no_gear = ImpactSolverAPI().solve_impact(
+            0.0,
+            _V_CLUB,
+            self._bulge_normal(0.02, 0.0),
+            impact_offset=np.array([0.02, 0.0]),
+            record=False,
+        )
+        assert bulged.ball_angular_velocity[1] > no_gear.ball_angular_velocity[1]
+
+    def test_gear_solver_adds_head_recoil(self) -> None:
+        api = ImpactSolverAPI()
+        post = api.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _N_SQUARE,
+            impact_offset=np.array([0.02, 0.0]),
+            record=False,
+        )
+        assert post.clubhead_angular_velocity[1] < 0.0  # toe twists open

--- a/src/shared/python/swing_sim/impact/tests/test_models.py
+++ b/src/shared/python/swing_sim/impact/tests/test_models.py
@@ -1,0 +1,254 @@
+"""Impact model tests: port-parity pins, COR, spin cap, MOI effective mass.
+
+Includes the regression tests for both defects fixed relative to the
+UpstreamDrift source (recon #4104): (a) off-center hits must see the MOI
+effective-mass reduction; (b) opt-in full 3-D inertia tensor treatment.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.impact.constants import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+)
+from shared.python.swing_sim.impact.models import (
+    SPHERE_ROLLING_CAP_FACTOR,
+    FiniteTimeImpactModel,
+    RigidBodyImpactModel,
+    SpringDamperImpactModel,
+    create_impact_model,
+    face_basis,
+    offset_to_face_vector,
+)
+from shared.python.swing_sim.impact.types import (
+    ImpactModelType,
+    ImpactParameters,
+    PreImpactState,
+)
+
+
+def _pre_state(
+    club_speed: float = 50.0,
+    normal: np.ndarray | None = None,
+    impact_offset: np.ndarray | None = None,
+    clubhead_mass: float = 0.200,
+    clubhead_moi: float = 4.5e-4,
+    clubhead_moi_tensor: np.ndarray | None = None,
+) -> PreImpactState:
+    n = normal if normal is not None else np.array([1.0, 0.0, 0.0])
+    return PreImpactState(
+        clubhead_velocity=club_speed * np.array([1.0, 0.0, 0.0]),
+        clubhead_angular_velocity=np.zeros(3),
+        clubhead_orientation=n,
+        ball_position=np.zeros(3),
+        ball_velocity=np.zeros(3),
+        ball_angular_velocity=np.zeros(3),
+        clubhead_mass=clubhead_mass,
+        clubhead_moi=clubhead_moi,
+        impact_offset=impact_offset,
+        clubhead_moi_tensor=clubhead_moi_tensor,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestRigidBodyPins:
+    """Port-parity pins against hand-computed impulse cases."""
+
+    def test_center_strike_hand_computed_ball_speed(self) -> None:
+        """j = (1+e) mu v; v_ball = j / m_ball, for a square center hit."""
+        params = ImpactParameters(cor=0.83)
+        m_club, v_club = 0.200, 50.0
+        pre = _pre_state(club_speed=v_club, clubhead_mass=m_club)
+        post = RigidBodyImpactModel().solve(pre, params)
+
+        mu = (GOLF_BALL_MASS_KG * m_club) / (GOLF_BALL_MASS_KG + m_club)
+        j = (1 + 0.83) * mu * v_club
+        assert post.ball_velocity[0] == pytest.approx(j / GOLF_BALL_MASS_KG)
+        assert post.ball_velocity[1] == pytest.approx(0.0)
+        assert post.ball_velocity[2] == pytest.approx(0.0)
+        # Club slows by j / m_club along the normal.
+        assert post.clubhead_velocity[0] == pytest.approx(v_club - j / m_club)
+
+    def test_center_strike_smash_factor_plausible(self) -> None:
+        """Driver-like smash factor ~1.4-1.5 for a square center strike."""
+        pre = _pre_state(club_speed=50.0)
+        post = RigidBodyImpactModel().solve(pre, ImpactParameters(cor=0.83))
+        smash = float(np.linalg.norm(post.ball_velocity)) / 50.0
+        assert 1.35 < smash < 1.55
+
+    def test_cor_monotonicity_and_bounds(self) -> None:
+        """Higher COR launches the ball faster; e=0 vs e=1 pin."""
+        speeds = []
+        for cor in (0.0, 0.5, 0.83, 1.0):
+            post = RigidBodyImpactModel().solve(_pre_state(), ImpactParameters(cor=cor))
+            speeds.append(float(np.linalg.norm(post.ball_velocity)))
+        assert speeds == sorted(speeds)
+        # e=1 transfers exactly twice the impulse of e=0.
+        assert speeds[-1] == pytest.approx(2.0 * speeds[0])
+
+    def test_cor_out_of_range_rejected(self) -> None:
+        with pytest.raises(Exception, match="restitution"):
+            RigidBodyImpactModel().solve(_pre_state(), ImpactParameters(cor=1.5))
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestFrictionSpin:
+    def test_oblique_impact_spin_axis_and_cap(self) -> None:
+        """Lofted (oblique) strike: backspin about +z, capped at 2/7 limit."""
+        loft = np.radians(10.5)
+        n = np.array([np.cos(loft), np.sin(loft), 0.0])
+        pre = _pre_state(normal=n)
+        params = ImpactParameters(cor=0.83, friction_coefficient=10.0)
+        post = RigidBodyImpactModel().solve(pre, params)
+
+        # AffineDrift frame: backspin axis is +z for a target-bound shot.
+        assert post.ball_angular_velocity[2] > 0.0
+
+        # With absurd friction the cap must bind: J_f = m v_t (2/7).
+        v_rel = pre.clubhead_velocity
+        v_t = float(np.linalg.norm(v_rel - np.dot(v_rel, n) * n))
+        i_ball = (2.0 / 5.0) * GOLF_BALL_MASS_KG * GOLF_BALL_RADIUS_M**2
+        cap_spin = (
+            (GOLF_BALL_MASS_KG * v_t * SPHERE_ROLLING_CAP_FACTOR)
+            * GOLF_BALL_RADIUS_M
+            / i_ball
+        )
+        assert float(np.linalg.norm(post.ball_angular_velocity)) == pytest.approx(
+            cap_spin, rel=1e-9
+        )
+
+    def test_square_strike_produces_no_spin(self) -> None:
+        post = RigidBodyImpactModel().solve(_pre_state(), ImpactParameters())
+        assert np.allclose(post.ball_angular_velocity, 0.0)
+
+    def test_rolling_cap_factor_is_two_sevenths(self) -> None:
+        assert SPHERE_ROLLING_CAP_FACTOR == pytest.approx(2.0 / 7.0)
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestEffectiveMass:
+    """Regression tests for defect (a) and the 3-D tensor opt-in (b)."""
+
+    def test_off_center_ball_speed_below_center(self) -> None:
+        """Regression (a): off-center hits must launch slower than center."""
+        params = ImpactParameters(cor=0.83)
+        model = RigidBodyImpactModel()
+        center = model.solve(_pre_state(), params)
+        toe = model.solve(_pre_state(impact_offset=np.array([0.02, 0.0])), params)
+        v_center = float(np.linalg.norm(center.ball_velocity))
+        v_toe = float(np.linalg.norm(toe.ball_velocity))
+        assert v_toe < v_center
+
+    def test_off_center_effective_mass_hand_computed(self) -> None:
+        """m_eff = 1/(1/m + r^2/I) drives the reduced impulse."""
+        params = ImpactParameters(cor=0.83)
+        m_club, moi, r = 0.200, 4.5e-4, 0.02
+        pre = _pre_state(
+            impact_offset=np.array([r, 0.0]),
+            clubhead_mass=m_club,
+            clubhead_moi=moi,
+        )
+        post = RigidBodyImpactModel().solve(pre, params)
+        m_eff_club = 1.0 / (1.0 / m_club + r**2 / moi)
+        mu = (GOLF_BALL_MASS_KG * m_eff_club) / (GOLF_BALL_MASS_KG + m_eff_club)
+        j = (1 + 0.83) * mu * 50.0
+        assert post.ball_velocity[0] == pytest.approx(j / GOLF_BALL_MASS_KG)
+
+    def test_diagonal_tensor_reproduces_scalar(self) -> None:
+        """Regression (b): I*eye(3) tensor must match the scalar path."""
+        params = ImpactParameters(cor=0.83)
+        moi = 4.5e-4
+        offset = np.array([0.015, 0.01])
+        scalar_post = RigidBodyImpactModel().solve(
+            _pre_state(impact_offset=offset, clubhead_moi=moi), params
+        )
+        tensor_post = RigidBodyImpactModel().solve(
+            _pre_state(
+                impact_offset=offset,
+                clubhead_moi=0.0,  # must be ignored when tensor present
+                clubhead_moi_tensor=moi * np.eye(3),
+            ),
+            params,
+        )
+        np.testing.assert_allclose(
+            tensor_post.ball_velocity, scalar_post.ball_velocity, rtol=1e-12
+        )
+
+    def test_anisotropic_tensor_differs_from_scalar(self) -> None:
+        """A non-spherical tensor must change the off-center result."""
+        params = ImpactParameters(cor=0.83)
+        moi = 4.5e-4
+        offset = np.array([0.02, 0.0])
+        scalar_post = RigidBodyImpactModel().solve(
+            _pre_state(impact_offset=offset, clubhead_moi=moi), params
+        )
+        tensor = np.diag([moi, 5.0 * moi, moi])  # stiffer about the y axis
+        tensor_post = RigidBodyImpactModel().solve(
+            _pre_state(impact_offset=offset, clubhead_moi_tensor=tensor), params
+        )
+        # Toe offset twists about y: larger I_yy -> less mass loss -> faster.
+        assert float(np.linalg.norm(tensor_post.ball_velocity)) > float(
+            np.linalg.norm(scalar_post.ball_velocity)
+        )
+
+    def test_bad_tensor_shape_rejected(self) -> None:
+        pre = _pre_state(
+            impact_offset=np.array([0.02, 0.0]),
+            clubhead_moi_tensor=np.eye(2),
+        )
+        with pytest.raises(Exception, match="3x3"):
+            RigidBodyImpactModel().solve(pre, ImpactParameters())
+
+
+@pytest.mark.unit
+class TestFaceBasis:
+    def test_target_facing_normal_gives_rh_toe_axis(self) -> None:
+        """AffineDrift n=+x: toe axis is +z (right), up axis is +y."""
+        toe, up = face_basis(np.array([1.0, 0.0, 0.0]))
+        np.testing.assert_allclose(toe, [0.0, 0.0, 1.0], atol=1e-12)
+        np.testing.assert_allclose(up, [0.0, 1.0, 0.0], atol=1e-12)
+
+    def test_offset_lift_is_in_face_plane(self) -> None:
+        loft = np.radians(30.0)
+        n = np.array([np.cos(loft), np.sin(loft), 0.0])
+        r = offset_to_face_vector(np.array([0.01, 0.02]), n)
+        assert abs(float(np.dot(r, n))) < 1e-12
+        assert float(np.linalg.norm(r)) == pytest.approx(
+            np.hypot(0.01, 0.02), rel=1e-12
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestOtherModels:
+    def test_spring_damper_transfers_momentum(self) -> None:
+        model = SpringDamperImpactModel(dt=1e-6)
+        post = model.solve(_pre_state(), ImpactParameters())
+        assert post.ball_velocity[0] > 40.0
+        assert post.contact_duration > 0.0
+        assert post.clubhead_velocity[0] < 50.0
+
+    def test_finite_time_reports_configured_duration(self) -> None:
+        params = ImpactParameters(contact_duration=4.2e-4)
+        post = FiniteTimeImpactModel().solve(_pre_state(), params)
+        assert post.contact_duration == pytest.approx(4.2e-4)
+        rigid = RigidBodyImpactModel().solve(_pre_state(), params)
+        np.testing.assert_allclose(post.ball_velocity, rigid.ball_velocity)
+
+    def test_factory_covers_all_types(self) -> None:
+        assert isinstance(
+            create_impact_model(ImpactModelType.RIGID_BODY), RigidBodyImpactModel
+        )
+        assert isinstance(
+            create_impact_model(ImpactModelType.SPRING_DAMPER),
+            SpringDamperImpactModel,
+        )
+        assert isinstance(
+            create_impact_model(ImpactModelType.FINITE_TIME), FiniteTimeImpactModel
+        )

--- a/src/shared/python/swing_sim/impact/tests/test_solver.py
+++ b/src/shared/python/swing_sim/impact/tests/test_solver.py
@@ -1,0 +1,213 @@
+"""Solver API, recorder, and energy-balance tests.
+
+Includes the solver-level regression test for defect (a): the base
+impulse of ``solve_with_gear_effect`` must include the impact offset.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.impact.models import RigidBodyImpactModel
+from shared.python.swing_sim.impact.solver import ImpactRecorder, ImpactSolverAPI
+from shared.python.swing_sim.impact.types import (
+    ImpactModelType,
+    ImpactParameters,
+    PreImpactState,
+)
+from shared.python.swing_sim.impact.utils import validate_energy_balance
+
+_V_CLUB = np.array([50.0, 0.0, 0.0])
+_N_SQUARE = np.array([1.0, 0.0, 0.0])
+
+
+def _lofted_normal(loft_deg: float = 10.5) -> np.ndarray:
+    loft = np.radians(loft_deg)
+    return np.array([np.cos(loft), np.sin(loft), 0.0])
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestSolveImpact:
+    def test_solve_and_record(self) -> None:
+        api = ImpactSolverAPI()
+        post = api.solve_impact(0.0, _V_CLUB, _N_SQUARE)
+        assert post.ball_velocity[0] > 60.0
+        assert len(api.recorder.events) == 1
+
+    def test_record_flag_false_skips_recording(self) -> None:
+        api = ImpactSolverAPI()
+        api.solve_impact(0.0, _V_CLUB, _N_SQUARE, record=False)
+        assert api.recorder.events == []
+
+    def test_offset_passthrough_reduces_ball_speed(self) -> None:
+        api = ImpactSolverAPI()
+        center = api.solve_impact(0.0, _V_CLUB, _N_SQUARE, record=False)
+        toe = api.solve_impact(
+            0.0,
+            _V_CLUB,
+            _N_SQUARE,
+            impact_offset=np.array([0.02, 0.0]),
+            record=False,
+        )
+        assert float(np.linalg.norm(toe.ball_velocity)) < float(
+            np.linalg.norm(center.ball_velocity)
+        )
+
+    def test_negative_timestamp_rejected(self) -> None:
+        api = ImpactSolverAPI()
+        with pytest.raises(Exception, match="[Tt]imestamp"):
+            api.solve_impact(-1.0, _V_CLUB, _N_SQUARE)
+
+    def test_non_positive_mass_rejected(self) -> None:
+        api = ImpactSolverAPI()
+        with pytest.raises(ValueError, match="mass"):
+            api.solve_impact(0.0, _V_CLUB, _N_SQUARE, clubhead_mass=0.0)
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+@pytest.mark.regression
+class TestGearEffectSolveRegression:
+    """Defect (a): the offset must reach the base-impulse computation."""
+
+    def test_off_center_gear_solve_slower_than_center(self) -> None:
+        api = ImpactSolverAPI()
+        center = api.solve_impact(0.0, _V_CLUB, _lofted_normal(), record=False)
+        toe = api.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _lofted_normal(),
+            impact_offset=np.array([0.025, 0.0]),
+            record=False,
+        )
+        assert float(np.linalg.norm(toe.ball_velocity)) < float(
+            np.linalg.norm(center.ball_velocity)
+        )
+
+    def test_recorded_pre_state_carries_offset(self) -> None:
+        """The recorded event must expose the offset it was solved with."""
+        api = ImpactSolverAPI()
+        offset = np.array([0.015, -0.005])
+        api.solve_with_gear_effect(0.0, _V_CLUB, _lofted_normal(), impact_offset=offset)
+        (event,) = api.recorder.events
+        assert event.pre_state.impact_offset is not None
+        np.testing.assert_allclose(event.pre_state.impact_offset, offset)
+
+    def test_zero_offset_matches_plain_solve(self) -> None:
+        api = ImpactSolverAPI()
+        plain = api.solve_impact(0.0, _V_CLUB, _lofted_normal(), record=False)
+        geared = api.solve_with_gear_effect(
+            0.0,
+            _V_CLUB,
+            _lofted_normal(),
+            impact_offset=np.zeros(2),
+            record=False,
+        )
+        np.testing.assert_allclose(geared.ball_velocity, plain.ball_velocity)
+        np.testing.assert_allclose(
+            geared.ball_angular_velocity, plain.ball_angular_velocity, atol=1e-9
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestValidationAndReporting:
+    def _api_with_impacts(self) -> ImpactSolverAPI:
+        api = ImpactSolverAPI()
+        for i, speed in enumerate((45.0, 50.0, 55.0)):
+            api.solve_impact(float(i), speed * _N_SQUARE, _N_SQUARE)
+        return api
+
+    def test_cor_validation_within_tolerance(self) -> None:
+        result = self._api_with_impacts().validate_cor_behavior(tolerance=0.05)
+        assert result["valid"] is True
+        assert result["num_samples"] == 3
+
+    def test_spin_validation_square_strikes(self) -> None:
+        result = self._api_with_impacts().validate_spin_behavior()
+        assert result["valid"] is True
+
+    def test_energy_report_totals(self) -> None:
+        report = self._api_with_impacts().get_energy_report()
+        assert len(report["impacts"]) == 3
+        assert report["total_energy_lost"] > 0.0
+        assert 0.0 < report["overall_loss_ratio"] < 1.0
+
+    def test_reports_require_recorded_impacts(self) -> None:
+        api = ImpactSolverAPI()
+        with pytest.raises(RuntimeError, match="No impacts"):
+            api.get_energy_report()
+        with pytest.raises(RuntimeError, match="No impacts"):
+            api.validate_cor_behavior()
+
+    def test_reset_clears_recorder(self) -> None:
+        api = self._api_with_impacts()
+        api.reset()
+        assert api.recorder.events == []
+
+    def test_recorder_export_and_summary(self) -> None:
+        api = self._api_with_impacts()
+        exported = api.recorder.export_to_dict()
+        assert exported["num_impacts"] == 3
+        assert (
+            exported["summary"]["max_ball_speed"]
+            >= (exported["summary"]["mean_ball_speed"])
+        )
+        assert len(api.recorder.get_all_events()) == 3
+
+    def test_model_type_selection(self) -> None:
+        api = ImpactSolverAPI(model_type=ImpactModelType.FINITE_TIME)
+        post = api.solve_impact(0.0, _V_CLUB, _N_SQUARE, record=False)
+        assert post.contact_duration == pytest.approx(api.params.contact_duration)
+
+
+@pytest.mark.unit
+@pytest.mark.physics
+class TestEnergyBalance:
+    def test_energy_loss_matches_cor_expectation(self) -> None:
+        """For a center strike the COM-frame loss is 1/2 mu v^2 (1-e^2)."""
+        params = ImpactParameters(cor=0.83)
+        pre = PreImpactState(
+            clubhead_velocity=_V_CLUB.copy(),
+            clubhead_angular_velocity=np.zeros(3),
+            clubhead_orientation=_N_SQUARE.copy(),
+            ball_position=np.zeros(3),
+            ball_velocity=np.zeros(3),
+            ball_angular_velocity=np.zeros(3),
+        )
+        post = RigidBodyImpactModel().solve(pre, params)
+        balance = validate_energy_balance(pre, post, params)
+        assert balance["energy_lost"] == pytest.approx(
+            balance["expected_loss_j"], rel=1e-9
+        )
+        assert 0.0 < balance["energy_loss_ratio"] < 1.0
+
+    def test_elastic_impact_conserves_energy(self) -> None:
+        params = ImpactParameters(cor=1.0, friction_coefficient=0.0)
+        pre = PreImpactState(
+            clubhead_velocity=_V_CLUB.copy(),
+            clubhead_angular_velocity=np.zeros(3),
+            clubhead_orientation=_N_SQUARE.copy(),
+            ball_position=np.zeros(3),
+            ball_velocity=np.zeros(3),
+            ball_angular_velocity=np.zeros(3),
+        )
+        post = RigidBodyImpactModel().solve(pre, params)
+        balance = validate_energy_balance(pre, post, params)
+        assert balance["energy_lost"] == pytest.approx(0.0, abs=1e-9)
+
+
+@pytest.mark.unit
+class TestRecorder:
+    def test_ids_increment_and_reset(self) -> None:
+        recorder = ImpactRecorder()
+        assert recorder.get_summary() == {"num_impacts": 0}
+        api = ImpactSolverAPI()
+        api.solve_impact(0.0, _V_CLUB, _N_SQUARE)
+        api.solve_impact(1.0, _V_CLUB, _N_SQUARE)
+        ids = [e.impact_id for e in api.recorder.events]
+        assert ids == [0, 1]
+        api.recorder.reset()
+        assert api.recorder.events == []

--- a/src/shared/python/swing_sim/impact/types.py
+++ b/src/shared/python/swing_sim/impact/types.py
@@ -1,0 +1,151 @@
+"""Impact model value types.
+
+Ported from UpstreamDrift ``src/shared/python/physics/impact_model/types.py``
+(epic #4103 / issue #4106), rewritten self-contained against the vendored
+:mod:`.constants`.
+
+Changes from the UpstreamDrift source:
+
+- ``PreImpactState`` gains ``clubhead_moi_tensor`` — an optional 3x3 club
+  MOI tensor enabling the full 3-D effective-mass treatment
+  ``J = (1/m_ball + 1/m_club + (r x n) . I^-1 (r x n))^-1`` in
+  :mod:`.models` (scalar ``clubhead_moi`` fallback preserved).
+- ``ImpactParameters`` drops the three empirical gear-effect scaling
+  constants (``gear_effect_factor`` / ``h_scale`` / ``v_scale``); gear
+  effect is now derived from first principles in :mod:`.gear_effect` and
+  needs only ``cg_depth`` (CG distance behind the face plane).
+
+Frame note: the impact model itself is frame-agnostic — all vectors must
+simply share one right-handed Cartesian frame. The delivery front-end
+(:mod:`.delivery`) produces vectors in the AffineDrift frame
+(x = target line, y = up, z = right).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+
+import numpy as np
+
+from .constants import (
+    DRIVER_CG_DEPTH_M,
+    DRIVER_COR,
+    DRIVER_LIE_RAD,
+    DRIVER_LOFT_RAD,
+    DRIVER_MASS_KG,
+    DRIVER_MOI_KG_M2,
+    TYPICAL_CONTACT_DURATION_S,
+)
+
+
+class ImpactModelType(Enum):
+    """Types of impact physics models."""
+
+    RIGID_BODY = auto()  # Instantaneous impulse with COR
+    SPRING_DAMPER = auto()  # Kelvin-Voigt viscoelastic
+    FINITE_TIME = auto()  # Impulse-momentum with duration
+
+
+@dataclass
+class PreImpactState:
+    """State of ball and clubhead immediately before impact.
+
+    Attributes:
+        clubhead_velocity: Clubhead velocity [m/s] (3,)
+        clubhead_angular_velocity: Clubhead angular velocity [rad/s] (3,)
+        clubhead_orientation: Clubface normal vector [unitless] (3,)
+        ball_position: Ball center position [m] (3,)
+        ball_velocity: Ball velocity [m/s] (3,)
+        ball_angular_velocity: Ball spin [rad/s] (3,)
+        clubhead_mass: Effective clubhead mass [kg]
+        clubhead_loft: Clubface loft angle [rad]
+        clubhead_lie: Clubface lie angle [rad]
+        clubhead_moi: Clubhead scalar moment of inertia about CG [kg.m^2]
+        impact_offset: Impact location offset from CG on clubface [m] (2,)
+            [horizontal (+ = toe side), vertical (+ = high on face)]
+        clubhead_moi_tensor: Optional full 3x3 clubhead MOI tensor about the
+            CG [kg.m^2], expressed in the same frame as the vectors. When
+            provided it replaces the scalar ``clubhead_moi`` in the
+            effective-mass computation for off-center hits.
+    """
+
+    clubhead_velocity: np.ndarray
+    clubhead_angular_velocity: np.ndarray
+    clubhead_orientation: np.ndarray
+    ball_position: np.ndarray
+    ball_velocity: np.ndarray
+    ball_angular_velocity: np.ndarray
+    clubhead_mass: float = DRIVER_MASS_KG
+    clubhead_loft: float = DRIVER_LOFT_RAD
+    clubhead_lie: float = DRIVER_LIE_RAD
+    clubhead_moi: float = DRIVER_MOI_KG_M2
+    impact_offset: np.ndarray | None = None
+    clubhead_moi_tensor: np.ndarray | None = None
+
+
+@dataclass
+class PostImpactState:
+    """State of ball and clubhead immediately after impact.
+
+    Attributes:
+        ball_velocity: Ball launch velocity [m/s] (3,)
+        ball_angular_velocity: Ball spin [rad/s] (3,)
+        clubhead_velocity: Clubhead velocity after impact [m/s] (3,)
+        clubhead_angular_velocity: Clubhead angular velocity after [rad/s] (3,)
+        contact_duration: Duration of contact [s]
+        energy_transfer: Kinetic energy transferred to ball [J]
+        impact_location: Location of impact on clubface [m] (2,) [x, y]
+    """
+
+    ball_velocity: np.ndarray
+    ball_angular_velocity: np.ndarray
+    clubhead_velocity: np.ndarray
+    clubhead_angular_velocity: np.ndarray
+    contact_duration: float
+    energy_transfer: float
+    impact_location: np.ndarray
+
+
+@dataclass
+class ImpactParameters:
+    """Parameters for impact model.
+
+    Attributes:
+        cor: Coefficient of restitution (0-1)
+        contact_duration: Contact time [s]
+        contact_stiffness: Spring stiffness for compliant model [N/m]
+        contact_damping: Damping for compliant model [N.s/m]
+        friction_coefficient: Ball-face friction
+        cg_depth: Clubhead CG distance behind the face plane [m]; the
+            front-to-back lever arm driving physics-based gear effect
+            (:mod:`.gear_effect`).
+    """
+
+    cor: float = DRIVER_COR
+    contact_duration: float = TYPICAL_CONTACT_DURATION_S
+    contact_stiffness: float = 1e6  # [N/m]
+    contact_damping: float = 1e3  # [N.s/m]
+    friction_coefficient: float = 0.4
+    cg_depth: float = DRIVER_CG_DEPTH_M
+
+
+@dataclass
+class ImpactEvent:
+    """Complete record of a single impact event.
+
+    Attributes:
+        timestamp: Simulation time when impact occurred [s]
+        pre_state: State before impact
+        post_state: State after impact
+        energy_balance: Energy analysis results
+        impact_id: Unique identifier for this impact
+        model_type: Type of impact model used
+    """
+
+    timestamp: float
+    pre_state: PreImpactState
+    post_state: PostImpactState
+    energy_balance: dict[str, float]
+    impact_id: int
+    model_type: ImpactModelType

--- a/src/shared/python/swing_sim/impact/utils.py
+++ b/src/shared/python/swing_sim/impact/utils.py
@@ -1,0 +1,109 @@
+"""Impact energy-balance validation.
+
+Ported from UpstreamDrift ``src/shared/python/physics/impact_model/utils.py``
+(epic #4103 / issue #4106), rewritten self-contained against the vendored
+:mod:`.constants`.
+
+The empirical ``compute_gear_effect_spin`` (three tuned constants with a
+hard-coded world-up axis) present in the UpstreamDrift source is
+intentionally NOT ported; it is replaced by the physics-derived treatment
+in :mod:`.gear_effect`.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from .constants import GOLF_BALL_MASS_KG, GOLF_BALL_MOMENT_OF_INERTIA_KG_M2
+from .types import ImpactParameters, PostImpactState, PreImpactState
+
+
+def validate_energy_balance(
+    pre_state: PreImpactState,
+    post_state: PostImpactState,
+    params: ImpactParameters,
+) -> dict[str, float]:
+    """Validate energy balance before and after impact.
+
+    Total mechanical energy should be conserved up to COR losses:
+    the expected loss in the relative (COM) frame is
+    ``dKE = 1/2 * mu * v_rel_n^2 * (1 - e^2)``.
+
+    Args:
+        pre_state: Pre-impact state
+        post_state: Post-impact state
+        params: Impact parameters
+
+    Returns:
+        Dictionary with energy analysis results.
+    """
+    if pre_state is None:
+        raise ValueError("pre_state must be provided")
+    m_ball = GOLF_BALL_MASS_KG
+    m_club = pre_state.clubhead_mass
+    i_ball = GOLF_BALL_MOMENT_OF_INERTIA_KG_M2
+
+    n_raw = np.asarray(pre_state.clubhead_orientation, dtype=float).reshape(-1)
+    n_norm = math.sqrt(float(np.dot(n_raw, n_raw))) if n_raw.size > 0 else 0.0
+    n_unit = n_raw / n_norm if n_norm > 1e-12 else np.array([1.0, 0.0, 0.0])
+    v_rel = np.asarray(pre_state.clubhead_velocity, dtype=float) - np.asarray(
+        pre_state.ball_velocity, dtype=float
+    )
+    mu = (m_ball * m_club) / (m_ball + m_club)
+    expected_loss_j = (
+        0.5 * mu * float(np.dot(v_rel, n_unit)) ** 2 * (1.0 - params.cor**2)
+    )
+
+    ke_ball_pre = (
+        0.5 * m_ball * float(np.dot(pre_state.ball_velocity, pre_state.ball_velocity))
+    )
+    ke_ball_rot_pre = (
+        0.5
+        * i_ball
+        * float(
+            np.dot(pre_state.ball_angular_velocity, pre_state.ball_angular_velocity)
+        )
+    )
+    ke_club_pre = (
+        0.5
+        * m_club
+        * float(np.dot(pre_state.clubhead_velocity, pre_state.clubhead_velocity))
+    )
+    total_ke_pre = ke_ball_pre + ke_ball_rot_pre + ke_club_pre
+
+    ke_ball_post = (
+        0.5 * m_ball * float(np.dot(post_state.ball_velocity, post_state.ball_velocity))
+    )
+    ke_ball_rot_post = (
+        0.5
+        * i_ball
+        * float(
+            np.dot(post_state.ball_angular_velocity, post_state.ball_angular_velocity)
+        )
+    )
+    ke_club_post = (
+        0.5
+        * m_club
+        * float(np.dot(post_state.clubhead_velocity, post_state.clubhead_velocity))
+    )
+    total_ke_post = ke_ball_post + ke_ball_rot_post + ke_club_post
+
+    energy_lost = total_ke_pre - total_ke_post
+    expected_loss_factor = 1 - params.cor**2  # COR relates velocities, not energy
+
+    return {
+        "total_ke_pre": float(total_ke_pre),
+        "total_ke_post": float(total_ke_post),
+        "energy_lost": float(energy_lost),
+        "energy_loss_ratio": (
+            float(energy_lost / total_ke_pre) if total_ke_pre > 0 else 0.0
+        ),
+        "expected_loss_factor": expected_loss_factor,
+        "expected_loss_j": float(expected_loss_j),
+        "ball_ke_post": float(ke_ball_post),
+        "ball_launch_speed": float(
+            math.sqrt(float(np.dot(post_state.ball_velocity, post_state.ball_velocity)))
+        ),
+    }

--- a/src/shared/python/swing_sim/reference.py
+++ b/src/shared/python/swing_sim/reference.py
@@ -1,0 +1,213 @@
+"""Pure-Python reference implementation of the swing dynamics.
+
+Mirrors ``rust_core/swing-core/src/swing`` operation-for-operation (same
+formula grouping and evaluation order) so it can serve as:
+
+1. the parity oracle for the Rust kernel (``parity``-marked tests), and
+2. the fallback backend for one-shot calls on machines without the wheel.
+
+Hot integration loops must use the Rust backend via
+:mod:`shared.python.swing_sim._rust_facade` — this module is deliberately
+unoptimised Python.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from .types import PendulumParameters, PendulumState
+
+MASS_MATRIX_SINGULAR_TOLERANCE = 1e-12
+"""Numerical tolerance for detecting singular mass matrices."""
+
+
+def plane_rotation(yaw: float, side_tilt: float, fwd_tilt: float) -> np.ndarray:
+    """World-from-plane rotation matrix ``Rz(yaw) @ Rx(side) @ Ry(fwd)``.
+
+    Columns are the plane's local axes in world coordinates: column 0 =
+    in-plane horizontal, column 1 = plane normal, column 2 = in-plane up.
+    All angles in radians.
+    """
+    for name, value in (("yaw", yaw), ("side_tilt", side_tilt), ("fwd_tilt", fwd_tilt)):
+        require(math.isfinite(value), f"{name} must be finite", value)
+    cy, sy = math.cos(yaw), math.sin(yaw)
+    cs, ss = math.cos(side_tilt), math.sin(side_tilt)
+    cf, sf = math.cos(fwd_tilt), math.sin(fwd_tilt)
+    rz = np.array([[cy, -sy, 0.0], [sy, cy, 0.0], [0.0, 0.0, 1.0]])
+    rx = np.array([[1.0, 0.0, 0.0], [0.0, cs, -ss], [0.0, ss, cs]])
+    ry = np.array([[cf, 0.0, sf], [0.0, 1.0, 0.0], [-sf, 0.0, cf]])
+    return np.asarray(rz @ rx @ ry)
+
+
+def in_plane_gravity(plane_r: np.ndarray, g: float) -> tuple[float, float]:
+    """Project world gravity ``(0, 0, -g)`` into the swing plane.
+
+    Returns ``(g_x_inplane, g_y_inplane)`` along the plane's local
+    horizontal and local up axes. The EOM consumes this 2-vector directly.
+    """
+    require(math.isfinite(g) and g >= 0.0, "g must be finite and >= 0", g)
+    r = np.asarray(plane_r, dtype=np.float64)
+    require(r.shape == (3, 3), "plane_r must be a 3x3 matrix", r.shape)
+    g_world = np.array([0.0, 0.0, -g])
+    gx = float(g_world @ r[:, 0])
+    gy = float(g_world @ r[:, 2])
+    return gx, gy
+
+
+def in_plane_gravity_from_tilts(
+    yaw: float, side_tilt: float, fwd_tilt: float, g: float
+) -> tuple[float, float]:
+    """In-plane gravity straight from the three tilt angles (radians)."""
+    return in_plane_gravity(plane_rotation(yaw, side_tilt, fwd_tilt), g)
+
+
+def mass_matrix(p: PendulumParameters, theta2: float) -> np.ndarray:
+    """Symmetric 2x2 mass matrix for the given relative angle."""
+    cos_theta2 = math.cos(theta2)
+    m11 = p.i1 + p.i2 + p.m2 * p.l1 * p.l1 + 2.0 * p.m2 * p.l1 * p.lc2 * cos_theta2
+    m12 = p.i2 + p.m2 * p.l1 * p.lc2 * cos_theta2
+    m22 = p.i2
+    return np.array([[m11, m12], [m12, m22]])
+
+
+def coriolis_vector(
+    p: PendulumParameters, theta2: float, omega1: float, omega2: float
+) -> tuple[float, float]:
+    """Coriolis and centripetal generalized-force vector."""
+    h = -p.m2 * p.l1 * p.lc2 * math.sin(theta2)
+    c1 = h * (2.0 * omega1 * omega2 + omega2 * omega2)
+    c2 = -h * omega1 * omega1
+    return c1, c2
+
+
+def gravity_vector(
+    p: PendulumParameters,
+    theta1: float,
+    theta2: float,
+    g_inplane: tuple[float, float],
+) -> tuple[float, float]:
+    """Gravity generalized-force vector for an in-plane gravity 2-vector.
+
+    For the flat plane ``(0, -g)`` this reduces exactly to the classic
+    scalar form used by the UpstreamDrift reference.
+    """
+    gx, gy = g_inplane
+    t12 = theta1 + theta2
+    a1 = p.m1 * p.lc1 + p.m2 * p.l1
+    a2 = p.m2 * p.lc2
+    g1 = -a1 * (gx * math.cos(theta1) + gy * math.sin(theta1)) - a2 * (
+        gx * math.cos(t12) + gy * math.sin(t12)
+    )
+    g2 = -a2 * (gx * math.cos(t12) + gy * math.sin(t12))
+    return g1, g2
+
+
+def damping_vector(
+    p: PendulumParameters, omega1: float, omega2: float
+) -> tuple[float, float]:
+    """Viscous damping torques."""
+    return p.d1 * omega1, p.d2 * omega2
+
+
+def _invert_mass_matrix(p: PendulumParameters, theta2: float) -> np.ndarray:
+    m = mass_matrix(p, theta2)
+    det = m[0, 0] * m[1, 1] - m[0, 1] * m[1, 0]
+    require(
+        abs(det) > MASS_MATRIX_SINGULAR_TOLERANCE,
+        "mass matrix determinant too close to zero; check pendulum parameters",
+        det,
+    )
+    return np.array([[m[1, 1] / det, -m[0, 1] / det], [-m[1, 0] / det, m[0, 0] / det]])
+
+
+def derivatives(
+    p: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+) -> tuple[float, float, float, float]:
+    """State derivatives ``(dθ1, dθ2, dω1, dω2)`` for unforced dynamics."""
+    c1, c2 = coriolis_vector(p, state.theta2, state.omega1, state.omega2)
+    g1, g2 = gravity_vector(p, state.theta1, state.theta2, g_inplane)
+    d1, d2 = damping_vector(p, state.omega1, state.omega2)
+    inv_m = _invert_mass_matrix(p, state.theta2)
+    rhs1 = -(c1 + g1 + d1)
+    rhs2 = -(c2 + g2 + d2)
+    acc1 = inv_m[0, 0] * rhs1 + inv_m[0, 1] * rhs2
+    acc2 = inv_m[1, 0] * rhs1 + inv_m[1, 1] * rhs2
+    return state.omega1, state.omega2, acc1, acc2
+
+
+def rk4_step(
+    p: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+    dt: float,
+) -> PendulumState:
+    """Advance the state by one classical RK4 step of size ``dt``."""
+    require(math.isfinite(dt) and dt > 0.0, "dt must be finite and > 0", dt)
+    y = (state.theta1, state.theta2, state.omega1, state.omega2)
+
+    def f(v: tuple[float, ...]) -> tuple[float, float, float, float]:
+        return derivatives(
+            p,
+            PendulumState(theta1=v[0], theta2=v[1], omega1=v[2], omega2=v[3]),
+            g_inplane,
+        )
+
+    def add(a: tuple[float, ...], s: float, b: tuple[float, ...]) -> tuple[float, ...]:
+        return tuple(ai + s * bi for ai, bi in zip(a, b, strict=True))
+
+    k1 = f(y)
+    k2 = f(add(y, dt / 2.0, k1))
+    k3 = f(add(y, dt / 2.0, k2))
+    k4 = f(add(y, dt, k3))
+    out = [
+        y[i] + dt / 6.0 * (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]) for i in range(4)
+    ]
+    return PendulumState(theta1=out[0], theta2=out[1], omega1=out[2], omega2=out[3])
+
+
+def total_energy(
+    p: PendulumParameters,
+    state: PendulumState,
+    g_inplane: tuple[float, float],
+) -> float:
+    """Total mechanical energy (kinetic + gravitational potential) [J]."""
+    m = mass_matrix(p, state.theta2)
+    q0, q1 = state.omega1, state.omega2
+    kinetic = 0.5 * (m[0, 0] * q0 * q0 + 2.0 * m[0, 1] * q0 * q1 + m[1, 1] * q1 * q1)
+
+    gx, gy = g_inplane
+    e1x, e1y = math.sin(state.theta1), -math.cos(state.theta1)
+    t12 = state.theta1 + state.theta2
+    e2x, e2y = math.sin(t12), -math.cos(t12)
+    p1 = (p.lc1 * e1x, p.lc1 * e1y)
+    p2 = (p.l1 * e1x + p.lc2 * e2x, p.l1 * e1y + p.lc2 * e2y)
+    potential = -(p.m1 * (gx * p1[0] + gy * p1[1]) + p.m2 * (gx * p2[0] + gy * p2[1]))
+    return float(kinetic + potential)
+
+
+def simulate(
+    p: PendulumParameters,
+    initial: PendulumState,
+    g_inplane: tuple[float, float],
+    dt: float,
+    n_steps: int,
+) -> np.ndarray:
+    """Simulate ``n_steps`` RK4 steps.
+
+    Returns an ``(n_steps + 1, 4)`` array of rows
+    ``[theta1, theta2, omega1, omega2]`` including the initial state.
+    """
+    require(n_steps >= 0, "n_steps must be >= 0", n_steps)
+    out = np.empty((n_steps + 1, 4), dtype=np.float64)
+    out[0] = (initial.theta1, initial.theta2, initial.omega1, initial.omega2)
+    current = initial
+    for i in range(n_steps):
+        current = rk4_step(p, current, g_inplane, dt)
+        out[i + 1] = (current.theta1, current.theta2, current.omega1, current.omega2)
+    return out

--- a/src/shared/python/swing_sim/swing_source.py
+++ b/src/shared/python/swing_sim/swing_source.py
@@ -1,0 +1,193 @@
+"""Swing sources: ``t -> clubhead pose + twist`` abstraction (epic #4103 P1).
+
+:class:`SwingSource` is the protocol every swing generator implements —
+manual deliveries, pendulum models, and (later) the movement optimizer.
+:class:`DoublePendulumSwing` is the first concrete source: a double pendulum
+swinging on an oriented plane, integrated once at construction (one-shot,
+so backend "auto" may fall back to the pure-Python reference when the Rust
+wheel is absent) and sampled by linear interpolation afterwards.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Literal, Protocol, runtime_checkable
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from . import _rust_facade, reference
+from .types import (
+    DEFAULT_GRAVITY_M_S2,
+    PendulumParameters,
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+)
+
+Backend = Literal["auto", "rust", "python"]
+
+
+@runtime_checkable
+class SwingSource(Protocol):
+    """Anything that can be sampled for a clubhead pose + twist over time."""
+
+    @property
+    def duration(self) -> float:
+        """Total duration [s] of the swing."""
+        ...
+
+    def sample(self, t: float) -> SwingSample:
+        """Return the clubhead sample at time ``t`` in ``[0, duration]``."""
+        ...
+
+
+def _local_axis_rotation(angle: float) -> np.ndarray:
+    """Rotation about the plane-local normal axis (local y) by ``angle``."""
+    c, s = math.cos(angle), math.sin(angle)
+    return np.array([[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]])
+
+
+class DoublePendulumSwing:
+    """Double-pendulum swing on an oriented plane, as a :class:`SwingSource`.
+
+    The trajectory is integrated once at construction on a uniform grid of
+    step ``dt`` and sampled by linear interpolation of the joint state.
+
+    Backend policy (strict-Rust posture for hot loops):
+    - ``"rust"``: require the ``swing_core`` wheel; raise ``ImportError``
+      when absent.
+    - ``"python"``: always use the pure-Python reference (parity oracle).
+    - ``"auto"`` (default): use Rust when available, else fall back — this
+      constructor is a one-shot call, so the explicit fallback is allowed.
+    """
+
+    def __init__(
+        self,
+        parameters: PendulumParameters | None = None,
+        plane: PlaneOrientation | None = None,
+        initial_state: PendulumState | None = None,
+        duration: float = 1.5,
+        dt: float = 1e-3,
+        gravity_m_s2: float = DEFAULT_GRAVITY_M_S2,
+        backend: Backend = "auto",
+    ) -> None:
+        require(
+            math.isfinite(duration) and duration > 0.0,
+            "duration must be finite and > 0",
+            duration,
+        )
+        require(math.isfinite(dt) and dt > 0.0, "dt must be finite and > 0", dt)
+        require(dt <= duration, "dt must not exceed duration", dt)
+        require(
+            math.isfinite(gravity_m_s2) and gravity_m_s2 >= 0.0,
+            "gravity_m_s2 must be finite and >= 0",
+            gravity_m_s2,
+        )
+
+        self._parameters = parameters or PendulumParameters.golf_default()
+        self._plane = plane or PlaneOrientation()
+        self._initial_state = initial_state or PendulumState(
+            theta1=math.pi / 2.0, theta2=0.0, omega1=0.0, omega2=0.0
+        )
+        self._dt = float(dt)
+        self._n_steps = int(round(duration / dt))
+        self._duration = self._n_steps * self._dt
+
+        self._plane_r = reference.plane_rotation(
+            self._plane.yaw_rad, self._plane.side_tilt_rad, self._plane.forward_tilt_rad
+        )
+        self._g_inplane = reference.in_plane_gravity(self._plane_r, gravity_m_s2)
+
+        use_rust = backend == "rust" or (
+            backend == "auto" and _rust_facade.rust_available()
+        )
+        if use_rust:
+            self._states = _rust_facade.simulate_rust(
+                self._parameters,
+                self._initial_state,
+                self._g_inplane,
+                self._dt,
+                self._n_steps,
+            )
+            self._backend: Backend = "rust"
+        else:
+            self._states = reference.simulate(
+                self._parameters,
+                self._initial_state,
+                self._g_inplane,
+                self._dt,
+                self._n_steps,
+            )
+            self._backend = "python"
+
+    @property
+    def backend(self) -> Backend:
+        """Backend that produced the trajectory (``"rust"`` or ``"python"``)."""
+        return self._backend
+
+    @property
+    def parameters(self) -> PendulumParameters:
+        """Pendulum parameters used for the integration."""
+        return self._parameters
+
+    @property
+    def plane(self) -> PlaneOrientation:
+        """Swing-plane orientation."""
+        return self._plane
+
+    @property
+    def duration(self) -> float:
+        """Total duration [s] of the integrated swing."""
+        return self._duration
+
+    def _state_at(self, t: float) -> tuple[float, float, float, float]:
+        """Linearly interpolate the joint state at time ``t``."""
+        idx = t / self._dt
+        i0 = min(int(idx), self._n_steps)
+        i1 = min(i0 + 1, self._n_steps)
+        frac = idx - i0
+        row = (1.0 - frac) * self._states[i0] + frac * self._states[i1]
+        return float(row[0]), float(row[1]), float(row[2]), float(row[3])
+
+    def sample(self, t: float) -> SwingSample:
+        """Return the clubhead :class:`SwingSample` at time ``t``.
+
+        Preconditions: ``0 <= t <= duration`` (within float tolerance).
+        """
+        require(math.isfinite(t), "t must be finite", t)
+        require(
+            -1e-9 <= t <= self._duration + 1e-9,
+            "t must be within [0, duration]",
+            t,
+        )
+        t = min(max(t, 0.0), self._duration)
+        theta1, theta2, omega1, omega2 = self._state_at(t)
+
+        p = self._parameters
+        t12 = theta1 + theta2
+        # In-plane clubhead position (local x horizontal, local y up).
+        x = p.l1 * math.sin(theta1) + p.l2 * math.sin(t12)
+        y = -(p.l1 * math.cos(theta1) + p.l2 * math.cos(t12))
+        # In-plane clubhead velocity.
+        vx = p.l1 * math.cos(theta1) * omega1 + p.l2 * math.cos(t12) * (omega1 + omega2)
+        vy = p.l1 * math.sin(theta1) * omega1 + p.l2 * math.sin(t12) * (omega1 + omega2)
+
+        r_plane = self._plane_r
+        x_axis = r_plane[:, 0]
+        normal = r_plane[:, 1]
+        up_axis = r_plane[:, 2]
+
+        position = x * x_axis + y * up_axis
+        rotation = r_plane @ _local_axis_rotation(t12)
+
+        pose = np.eye(4)
+        pose[:3, :3] = rotation
+        pose[:3, 3] = position
+
+        angular = (omega1 + omega2) * normal
+        linear = vx * x_axis + vy * up_axis
+        twist = np.concatenate([angular, linear])
+
+        return SwingSample(t=t, pose=pose, twist=twist)

--- a/src/shared/python/swing_sim/tests/__init__.py
+++ b/src/shared/python/swing_sim/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the shared swing simulation package."""

--- a/src/shared/python/swing_sim/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/tests/test_contract_api.py
@@ -1,0 +1,68 @@
+"""Contract test pinning the public API surface of swing_sim.
+
+Downstream consumers (UpstreamDrift, rate_of_closure UI, web backend)
+import from the curated façade only; this test fails loudly when the
+surface changes so removals are always deliberate.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import shared.python.swing_sim as swing_sim
+
+EXPECTED_PUBLIC_API = {
+    "DEFAULT_GRAVITY_M_S2",
+    "DoublePendulumSwing",
+    "PendulumParameters",
+    "PendulumState",
+    "PlaneOrientation",
+    "SwingSample",
+    "SwingSource",
+    "SwingTrajectory",
+    "__version__",
+    "rust_available",
+}
+
+
+@pytest.mark.contract
+def test_public_api_surface_is_pinned() -> None:
+    assert set(swing_sim.__all__) == EXPECTED_PUBLIC_API
+
+
+@pytest.mark.contract
+def test_all_exports_resolve() -> None:
+    for name in swing_sim.__all__:
+        assert getattr(swing_sim, name) is not None, f"{name} did not resolve"
+
+
+@pytest.mark.contract
+def test_swing_source_protocol_shape() -> None:
+    from shared.python.swing_sim import SwingSource
+
+    assert hasattr(SwingSource, "sample")
+    assert hasattr(SwingSource, "duration")
+
+
+@pytest.mark.contract
+def test_types_are_frozen_dataclasses() -> None:
+    import dataclasses
+
+    from shared.python.swing_sim import (
+        PendulumParameters,
+        PendulumState,
+        PlaneOrientation,
+        SwingSample,
+        SwingTrajectory,
+    )
+
+    for cls in (
+        PlaneOrientation,
+        PendulumParameters,
+        PendulumState,
+        SwingSample,
+        SwingTrajectory,
+    ):
+        assert dataclasses.is_dataclass(cls), f"{cls.__name__} not a dataclass"
+        params = cls.__dataclass_params__
+        assert params.frozen, f"{cls.__name__} must be frozen"

--- a/src/shared/python/swing_sim/tests/test_parity_rust.py
+++ b/src/shared/python/swing_sim/tests/test_parity_rust.py
@@ -1,0 +1,91 @@
+"""Rust <-> Python parity tests for the swing dynamics kernel.
+
+The pure-Python :mod:`shared.python.swing_sim.reference` module is the
+oracle; the ``swing_core`` wheel must reproduce it to floating-point
+accumulation tolerance. Skipped cleanly when the wheel is absent (same
+posture as ``signal_toolkit/tests/test_bilateral_rust_parity.py``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim import reference
+from shared.python.swing_sim.types import (
+    DEFAULT_GRAVITY_M_S2 as G,
+)
+from shared.python.swing_sim.types import (
+    PendulumParameters,
+    PendulumState,
+)
+
+pytest.importorskip(
+    "swing_core",
+    reason="Rust swing_core wheel not installed on this interpreter",
+)
+# Imported after the skip so machines without the wheel can still collect.
+from shared.python.swing_sim import _rust_facade  # noqa: E402
+
+# Both sides evaluate the same formulas in the same order; differences come
+# only from double-precision accumulation across RK4 stages.
+_PARITY_TOL = 1e-9
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_plane_rotation_parity() -> None:
+    for yaw, side, fwd in ((0.0, 0.0, 0.0), (1.2, -0.6, 0.35), (-2.0, 1.1, 2.9)):
+        py_r = reference.plane_rotation(yaw, side, fwd)
+        rust_r = _rust_facade.plane_rotation_rust(yaw, side, fwd)
+        np.testing.assert_allclose(rust_r, py_r, atol=1e-14)
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_in_plane_gravity_parity() -> None:
+    for yaw, side, fwd in ((0.0, 0.0, 0.0), (0.5, 0.9, -0.3), (-2.0, 1.4, 1.1)):
+        py_g = reference.in_plane_gravity_from_tilts(yaw, side, fwd, G)
+        rust_g = _rust_facade.in_plane_gravity_rust(yaw, side, fwd, G)
+        assert rust_g[0] == pytest.approx(py_g[0], abs=1e-14)
+        assert rust_g[1] == pytest.approx(py_g[1], abs=1e-14)
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_single_step_parity() -> None:
+    p = PendulumParameters.golf_default()
+    state = PendulumState(theta1=1.2, theta2=-0.5, omega1=0.3, omega2=-0.1)
+    g = reference.in_plane_gravity_from_tilts(0.4, 0.6, -0.2, G)
+    py_next = reference.rk4_step(p, state, g, 1e-3)
+    rust_next = _rust_facade.step_rust(p, state, g, 1e-3)
+    assert rust_next.theta1 == pytest.approx(py_next.theta1, abs=_PARITY_TOL)
+    assert rust_next.theta2 == pytest.approx(py_next.theta2, abs=_PARITY_TOL)
+    assert rust_next.omega1 == pytest.approx(py_next.omega1, abs=_PARITY_TOL)
+    assert rust_next.omega2 == pytest.approx(py_next.omega2, abs=_PARITY_TOL)
+
+
+@pytest.mark.parity
+def test_trajectory_parity_500_steps() -> None:
+    p = PendulumParameters.golf_default()
+    initial = PendulumState(theta1=1.5, theta2=-0.8, omega1=0.0, omega2=0.0)
+    g = reference.in_plane_gravity_from_tilts(0.3, 0.7, 0.1, G)
+    dt, n_steps = 1e-3, 500
+
+    py_states = reference.simulate(p, initial, g, dt, n_steps)
+    rust_states = _rust_facade.simulate_rust(p, initial, g, dt, n_steps)
+
+    assert rust_states.shape == py_states.shape == (n_steps + 1, 4)
+    max_diff = float(np.abs(py_states - rust_states).max())
+    assert max_diff < _PARITY_TOL, f"trajectory diverged: max diff {max_diff}"
+
+
+@pytest.mark.parity
+@pytest.mark.unit
+def test_total_energy_parity() -> None:
+    p = PendulumParameters.golf_default()
+    state = PendulumState(theta1=0.9, theta2=0.4, omega1=1.1, omega2=-0.6)
+    g = (0.0, -G)
+    py_e = reference.total_energy(p, state, g)
+    rust_e = _rust_facade.total_energy_rust(p, state, g)
+    assert rust_e == pytest.approx(py_e, abs=1e-10)

--- a/src/shared/python/swing_sim/tests/test_reference.py
+++ b/src/shared/python/swing_sim/tests/test_reference.py
@@ -1,0 +1,128 @@
+"""Unit tests for the pure-Python reference dynamics (parity oracle)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim import reference
+from shared.python.swing_sim.types import (
+    DEFAULT_GRAVITY_M_S2 as G,
+)
+from shared.python.swing_sim.types import (
+    PendulumParameters,
+    PendulumState,
+)
+
+
+def _undamped() -> PendulumParameters:
+    p = PendulumParameters.golf_default()
+    return PendulumParameters(
+        m1=p.m1,
+        l1=p.l1,
+        lc1=p.lc1,
+        i1=p.i1,
+        m2=p.m2,
+        l2=p.l2,
+        lc2=p.lc2,
+        i2=p.i2,
+        d1=0.0,
+        d2=0.0,
+    )
+
+
+@pytest.mark.unit
+class TestPlaneRotation:
+    def test_identity_pose(self) -> None:
+        r = reference.plane_rotation(0.0, 0.0, 0.0)
+        np.testing.assert_allclose(r, np.eye(3), atol=1e-15)
+
+    def test_orthonormal_for_generic_tilts(self) -> None:
+        r = reference.plane_rotation(1.2, -0.6, 0.35)
+        np.testing.assert_allclose(r.T @ r, np.eye(3), atol=1e-12)
+        assert np.linalg.det(r) == pytest.approx(1.0, abs=1e-12)
+
+    def test_flat_plane_full_gravity_down(self) -> None:
+        gx, gy = reference.in_plane_gravity_from_tilts(0.0, 0.0, 0.0, G)
+        assert gx == pytest.approx(0.0, abs=1e-12)
+        assert gy == pytest.approx(-G, abs=1e-12)
+
+    def test_pure_yaw_is_invariant(self) -> None:
+        for yaw in (-3.0, -1.2, 0.4, 1.7, 3.1):
+            gx, gy = reference.in_plane_gravity_from_tilts(yaw, 0.0, 0.0, G)
+            assert gx == pytest.approx(0.0, abs=1e-12)
+            assert gy == pytest.approx(-G, abs=1e-12)
+
+    def test_side_tilt_cosine_projection(self) -> None:
+        # Matches UpstreamDrift's scalar projected_gravity = g·cos(inclination).
+        for side in (0.2, 0.6, 1.0):
+            _, gy = reference.in_plane_gravity_from_tilts(0.0, side, 0.0, G)
+            assert gy == pytest.approx(-G * np.cos(side), abs=1e-12)
+
+    def test_projection_never_amplifies(self) -> None:
+        for yaw, side, fwd in ((0.5, 0.9, -0.3), (-2.0, 1.4, 1.1), (3.0, -0.7, 0.6)):
+            gx, gy = reference.in_plane_gravity_from_tilts(yaw, side, fwd, G)
+            assert gx * gx + gy * gy <= G * G + 1e-9
+
+
+@pytest.mark.unit
+class TestDynamics:
+    def test_mass_matrix_symmetric_positive_definite(self) -> None:
+        p = PendulumParameters.golf_default()
+        for theta2 in (-3.0, -1.5, 0.0, 0.8, 1.6, 3.1):
+            m = reference.mass_matrix(p, theta2)
+            assert m[0, 1] == pytest.approx(m[1, 0], abs=1e-15)
+            eigenvalues = np.linalg.eigvalsh(m)
+            assert np.all(eigenvalues > 0.0)
+
+    def test_gravity_vector_flat_plane_matches_scalar_reference(self) -> None:
+        p = PendulumParameters.golf_default()
+        theta1, theta2 = 0.7, -0.4
+        g1, g2 = reference.gravity_vector(p, theta1, theta2, (0.0, -G))
+        expected_g1 = (p.m1 * p.lc1 + p.m2 * p.l1) * G * np.sin(theta1) + (
+            p.m2 * p.lc2 * G * np.sin(theta1 + theta2)
+        )
+        expected_g2 = p.m2 * p.lc2 * G * np.sin(theta1 + theta2)
+        assert g1 == pytest.approx(expected_g1, abs=1e-12)
+        assert g2 == pytest.approx(expected_g2, abs=1e-12)
+
+    def test_undamped_energy_conserved_over_1000_steps(self) -> None:
+        p = _undamped()
+        g = reference.in_plane_gravity_from_tilts(0.4, 0.6, -0.2, G)
+        initial = PendulumState(theta1=1.2, theta2=-0.5, omega1=0.0, omega2=0.0)
+        states = reference.simulate(p, initial, g, 1e-4, 1000)
+        e0 = reference.total_energy(p, initial, g)
+        scale = max(abs(e0), 1.0)
+        for row in states:
+            s = PendulumState(
+                theta1=row[0], theta2=row[1], omega1=row[2], omega2=row[3]
+            )
+            assert abs(reference.total_energy(p, s, g) - e0) / scale < 1e-6
+
+    def test_damping_dissipates_energy(self) -> None:
+        p = PendulumParameters.golf_default()
+        g = (0.0, -G)
+        initial = PendulumState(theta1=1.0, theta2=0.3, omega1=0.5, omega2=-0.2)
+        states = reference.simulate(p, initial, g, 1e-3, 2000)
+        final = PendulumState(
+            theta1=states[-1, 0],
+            theta2=states[-1, 1],
+            omega1=states[-1, 2],
+            omega2=states[-1, 3],
+        )
+        assert reference.total_energy(p, final, g) < reference.total_energy(
+            p, initial, g
+        )
+
+    def test_simulate_shape_and_initial_row(self) -> None:
+        p = PendulumParameters.golf_default()
+        initial = PendulumState(theta1=0.1, theta2=0.0, omega1=0.0, omega2=0.0)
+        states = reference.simulate(p, initial, (0.0, -G), 1e-3, 10)
+        assert states.shape == (11, 4)
+        np.testing.assert_allclose(states[0], (0.1, 0.0, 0.0, 0.0))
+
+    def test_rk4_rejects_nonpositive_dt(self) -> None:
+        p = PendulumParameters.golf_default()
+        s = PendulumState(theta1=0.1, theta2=0.0, omega1=0.0, omega2=0.0)
+        with pytest.raises(ValueError, match="dt"):
+            reference.rk4_step(p, s, (0.0, -G), 0.0)

--- a/src/shared/python/swing_sim/tests/test_swing_source.py
+++ b/src/shared/python/swing_sim/tests/test_swing_source.py
@@ -1,0 +1,99 @@
+"""Unit tests for the SwingSource protocol and DoublePendulumSwing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.swing_source import DoublePendulumSwing, SwingSource
+from shared.python.swing_sim.types import (
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+)
+
+
+def _small_swing(**kwargs: object) -> DoublePendulumSwing:
+    defaults: dict[str, object] = {
+        "duration": 0.1,
+        "dt": 1e-3,
+        "backend": "python",
+    }
+    defaults.update(kwargs)
+    return DoublePendulumSwing(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+class TestDoublePendulumSwing:
+    def test_conforms_to_swing_source_protocol(self) -> None:
+        swing = _small_swing()
+        assert isinstance(swing, SwingSource)
+
+    def test_duration_matches_grid(self) -> None:
+        swing = _small_swing(duration=0.1, dt=1e-3)
+        assert swing.duration == pytest.approx(0.1)
+
+    def test_python_backend_selected_when_forced(self) -> None:
+        assert _small_swing(backend="python").backend == "python"
+
+    def test_sample_returns_valid_swing_sample(self) -> None:
+        swing = _small_swing()
+        sample = swing.sample(0.05)
+        assert isinstance(sample, SwingSample)
+        assert sample.t == pytest.approx(0.05)
+        rotation = sample.pose[:3, :3]
+        np.testing.assert_allclose(rotation.T @ rotation, np.eye(3), atol=1e-9)
+        assert np.all(np.isfinite(sample.twist))
+
+    def test_sample_at_zero_matches_initial_geometry(self) -> None:
+        initial = PendulumState(theta1=np.pi / 2.0, theta2=0.0, omega1=0.0, omega2=0.0)
+        swing = _small_swing(initial_state=initial, plane=PlaneOrientation())
+        sample = swing.sample(0.0)
+        p = swing.parameters
+        # theta1 = pi/2, theta2 = 0: both segments horizontal along +x.
+        expected = np.array([p.l1 + p.l2, 0.0, 0.0])
+        np.testing.assert_allclose(sample.pose[:3, 3], expected, atol=1e-9)
+        # At rest: zero twist.
+        np.testing.assert_allclose(sample.twist, np.zeros(6), atol=1e-12)
+
+    def test_flat_plane_motion_stays_in_plane(self) -> None:
+        swing = _small_swing(plane=PlaneOrientation())
+        for t in (0.0, 0.03, 0.07, 0.1):
+            sample = swing.sample(t)
+            # Identity plane spans world x/z; normal is world y.
+            assert sample.pose[1, 3] == pytest.approx(0.0, abs=1e-12)
+
+    def test_yawed_plane_rotates_positions(self) -> None:
+        flat = _small_swing(plane=PlaneOrientation())
+        yawed = _small_swing(plane=PlaneOrientation(yaw_deg=90.0))
+        p_flat = flat.sample(0.05).pose[:3, 3]
+        p_yawed = yawed.sample(0.05).pose[:3, 3]
+        # Same in-plane dynamics (gravity yaw-invariant), rotated 90° about z.
+        rz90 = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        np.testing.assert_allclose(p_yawed, rz90 @ p_flat, atol=1e-9)
+
+    def test_sample_outside_duration_raises(self) -> None:
+        swing = _small_swing()
+        with pytest.raises(ValueError, match="duration"):
+            swing.sample(swing.duration + 0.1)
+        with pytest.raises(ValueError, match="duration"):
+            swing.sample(-0.1)
+
+    def test_rejects_nonpositive_duration(self) -> None:
+        with pytest.raises(ValueError, match="duration"):
+            _small_swing(duration=0.0)
+
+    def test_rejects_dt_exceeding_duration(self) -> None:
+        with pytest.raises(ValueError, match="dt"):
+            _small_swing(duration=0.01, dt=0.1)
+
+    def test_rust_backend_strict_posture(self) -> None:
+        from shared.python.swing_sim import _rust_facade
+
+        if _rust_facade.rust_available():
+            # Wheel present: rust backend must work and be reported.
+            assert _small_swing(backend="rust").backend == "rust"
+        else:
+            # Wheel absent: forcing rust must raise, never silently degrade.
+            with pytest.raises(ImportError, match="swing_core"):
+                _small_swing(backend="rust")

--- a/src/shared/python/swing_sim/tests/test_types.py
+++ b/src/shared/python/swing_sim/tests/test_types.py
@@ -1,0 +1,165 @@
+"""Unit tests for swing_sim value types (DbC validation)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.types import (
+    PendulumParameters,
+    PendulumState,
+    PlaneOrientation,
+    SwingSample,
+    SwingTrajectory,
+)
+
+
+def _identity_sample(t: float) -> SwingSample:
+    return SwingSample(t=t, pose=np.eye(4), twist=np.zeros(6))
+
+
+@pytest.mark.unit
+class TestPlaneOrientation:
+    def test_default_is_zero_pose(self) -> None:
+        plane = PlaneOrientation()
+        assert plane.yaw_deg == 0.0
+        assert plane.side_tilt_deg == 0.0
+        assert plane.forward_tilt_deg == 0.0
+
+    def test_radian_conversion(self) -> None:
+        plane = PlaneOrientation(yaw_deg=180.0, side_tilt_deg=90.0)
+        assert plane.yaw_rad == pytest.approx(np.pi)
+        assert plane.side_tilt_rad == pytest.approx(np.pi / 2.0)
+        assert plane.forward_tilt_rad == 0.0
+
+    def test_rejects_non_finite(self) -> None:
+        with pytest.raises(ValueError, match="finite"):
+            PlaneOrientation(yaw_deg=float("nan"))
+
+    def test_is_frozen(self) -> None:
+        plane = PlaneOrientation()
+        with pytest.raises(AttributeError):
+            plane.yaw_deg = 1.0  # type: ignore[misc]
+
+
+@pytest.mark.unit
+class TestPendulumParameters:
+    def test_golf_default_is_valid_and_matches_reference_constants(self) -> None:
+        p = PendulumParameters.golf_default()
+        assert p.m1 == pytest.approx(7.5)
+        assert p.l1 == pytest.approx(0.75)
+        assert p.lc1 == pytest.approx(0.3375)
+        assert p.m2 == pytest.approx(0.35)
+        assert p.l2 == pytest.approx(1.0)
+        assert p.lc2 == pytest.approx((0.43 * 0.15 + 0.20) / 0.35)
+        assert p.d1 == pytest.approx(0.4)
+        assert p.d2 == pytest.approx(0.25)
+
+    def test_rejects_nonpositive_mass(self) -> None:
+        p = PendulumParameters.golf_default()
+        with pytest.raises(ValueError, match="m1"):
+            PendulumParameters(
+                m1=0.0,
+                l1=p.l1,
+                lc1=p.lc1,
+                i1=p.i1,
+                m2=p.m2,
+                l2=p.l2,
+                lc2=p.lc2,
+                i2=p.i2,
+            )
+
+    def test_rejects_negative_damping(self) -> None:
+        p = PendulumParameters.golf_default()
+        with pytest.raises(ValueError, match="d1"):
+            PendulumParameters(
+                m1=p.m1,
+                l1=p.l1,
+                lc1=p.lc1,
+                i1=p.i1,
+                m2=p.m2,
+                l2=p.l2,
+                lc2=p.lc2,
+                i2=p.i2,
+                d1=-0.1,
+            )
+
+    def test_rejects_com_beyond_segment(self) -> None:
+        p = PendulumParameters.golf_default()
+        with pytest.raises(ValueError, match="lc1"):
+            PendulumParameters(
+                m1=p.m1,
+                l1=p.l1,
+                lc1=2.0 * p.l1,
+                i1=p.i1,
+                m2=p.m2,
+                l2=p.l2,
+                lc2=p.lc2,
+                i2=p.i2,
+            )
+
+
+@pytest.mark.unit
+class TestPendulumState:
+    def test_valid_construction(self) -> None:
+        s = PendulumState(theta1=1.0, theta2=-0.5, omega1=0.0, omega2=2.0)
+        assert s.theta1 == 1.0
+
+    def test_rejects_non_finite(self) -> None:
+        with pytest.raises(ValueError, match="omega2"):
+            PendulumState(theta1=0.0, theta2=0.0, omega1=0.0, omega2=float("inf"))
+
+
+@pytest.mark.unit
+class TestSwingSample:
+    def test_valid_identity_sample(self) -> None:
+        sample = _identity_sample(0.5)
+        assert sample.t == 0.5
+        assert sample.pose.shape == (4, 4)
+        assert sample.twist.shape == (6,)
+
+    def test_rejects_bad_pose_shape(self) -> None:
+        with pytest.raises(ValueError, match="4x4"):
+            SwingSample(t=0.0, pose=np.eye(3), twist=np.zeros(6))
+
+    def test_rejects_bad_twist_shape(self) -> None:
+        with pytest.raises(ValueError, match="6-vector"):
+            SwingSample(t=0.0, pose=np.eye(4), twist=np.zeros(5))
+
+    def test_rejects_non_orthonormal_rotation(self) -> None:
+        pose = np.eye(4)
+        pose[0, 0] = 2.0
+        with pytest.raises(ValueError, match="orthonormal"):
+            SwingSample(t=0.0, pose=pose, twist=np.zeros(6))
+
+    def test_rejects_bad_bottom_row(self) -> None:
+        pose = np.eye(4)
+        pose[3, 0] = 1.0
+        with pytest.raises(ValueError, match="bottom row"):
+            SwingSample(t=0.0, pose=pose, twist=np.zeros(6))
+
+    def test_rejects_negative_time(self) -> None:
+        with pytest.raises(ValueError, match=">= 0"):
+            _identity_sample(-0.1)
+
+
+@pytest.mark.unit
+class TestSwingTrajectory:
+    def test_duration_and_len(self) -> None:
+        traj = SwingTrajectory(
+            samples=(
+                _identity_sample(0.0),
+                _identity_sample(0.5),
+                _identity_sample(1.0),
+            )
+        )
+        assert traj.duration == pytest.approx(1.0)
+        assert len(traj) == 3
+
+    def test_rejects_empty(self) -> None:
+        with pytest.raises(ValueError, match="samples"):
+            SwingTrajectory(samples=())
+
+    def test_rejects_non_increasing_times(self) -> None:
+        with pytest.raises(ValueError, match="increasing"):
+            SwingTrajectory(samples=(_identity_sample(0.5), _identity_sample(0.5)))

--- a/src/shared/python/swing_sim/types.py
+++ b/src/shared/python/swing_sim/types.py
@@ -1,0 +1,212 @@
+"""Core swing-simulation value types (frozen dataclasses with DbC validation).
+
+All angles on public dataclasses are degrees (UI-friendly); radians are used
+internally by the dynamics. SI units throughout (kg, m, s).
+
+Conventions (mirrors ``rust_core/swing-core/src/swing``):
+- World frame: x forward, y left, z up.
+- Plane pose: three sequential intrinsic tilts — yaw about world-up, then
+  side tilt about the rotated in-plane horizontal axis, then forward/back
+  tilt about the resulting in-plane up axis.
+- ``theta1`` measured from the in-plane downward vertical; ``theta2`` is the
+  lower segment's angle relative to the upper segment.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from shared.python.contracts import require
+
+DEFAULT_GRAVITY_M_S2 = 9.80665
+"""Standard gravitational acceleration [m/s²]."""
+
+# Defaults ported from UpstreamDrift double_pendulum.py (documented there).
+_ARM_LENGTH_M = 0.75
+_ARM_MASS_KG = 7.5
+_ARM_COM_RATIO = 0.45
+_ARM_INERTIA_SCALING = 1.0 / 12.0
+_SHAFT_LENGTH_M = 1.0
+_SHAFT_MASS_KG = 0.15
+_CLUBHEAD_MASS_KG = 0.20
+_SHAFT_COM_RATIO = 0.43
+_DAMPING_SHOULDER = 0.4
+_DAMPING_WRIST = 0.25
+
+
+def _require_finite(name: str, value: float) -> None:
+    require(math.isfinite(value), f"{name} must be finite", value)
+
+
+@dataclass(frozen=True)
+class PlaneOrientation:
+    """Swing-plane pose as three sequential intrinsic tilts (degrees).
+
+    Order (documented, epic #4103): yaw about world-up, then side tilt about
+    the rotated in-plane horizontal axis, then forward/back tilt about the
+    resulting in-plane up axis. The zero pose is a vertical plane feeling
+    full gravity in-plane.
+    """
+
+    yaw_deg: float = 0.0
+    side_tilt_deg: float = 0.0
+    forward_tilt_deg: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in ("yaw_deg", "side_tilt_deg", "forward_tilt_deg"):
+            _require_finite(name, getattr(self, name))
+
+    @property
+    def yaw_rad(self) -> float:
+        """Yaw angle in radians."""
+        return math.radians(self.yaw_deg)
+
+    @property
+    def side_tilt_rad(self) -> float:
+        """Side tilt angle in radians."""
+        return math.radians(self.side_tilt_deg)
+
+    @property
+    def forward_tilt_rad(self) -> float:
+        """Forward/back tilt angle in radians."""
+        return math.radians(self.forward_tilt_deg)
+
+
+@dataclass(frozen=True)
+class PendulumParameters:
+    """Double-pendulum physical parameters (SI units).
+
+    Inertias ``i1``/``i2`` are about the proximal joint (parallel-axis
+    already applied), matching the Rust kernel and the UpstreamDrift
+    reference implementation.
+    """
+
+    m1: float
+    l1: float
+    lc1: float
+    i1: float
+    m2: float
+    l2: float
+    lc2: float
+    i2: float
+    d1: float = _DAMPING_SHOULDER
+    d2: float = _DAMPING_WRIST
+
+    def __post_init__(self) -> None:
+        for name in ("m1", "l1", "lc1", "i1", "m2", "l2", "lc2", "i2"):
+            value = getattr(self, name)
+            _require_finite(name, value)
+            require(value > 0.0, f"{name} must be > 0", value)
+        for name in ("d1", "d2"):
+            value = getattr(self, name)
+            _require_finite(name, value)
+            require(value >= 0.0, f"{name} must be >= 0", value)
+        require(self.lc1 <= self.l1, "lc1 must not exceed l1", self.lc1)
+        require(self.lc2 <= self.l2, "lc2 must not exceed l2", self.lc2)
+
+    @classmethod
+    def golf_default(cls) -> PendulumParameters:
+        """Default golf-swing parameters (UpstreamDrift reference constants).
+
+        Computed from the same segment formulas as the Rust kernel so the
+        two backends agree bit-for-bit.
+        """
+        m1 = _ARM_MASS_KG
+        l1 = _ARM_LENGTH_M
+        lc1 = l1 * _ARM_COM_RATIO
+        i1_com = _ARM_INERTIA_SCALING * m1 * l1 * l1
+        i1 = i1_com + m1 * lc1 * lc1
+
+        l2 = _SHAFT_LENGTH_M
+        ms = _SHAFT_MASS_KG
+        mh = _CLUBHEAD_MASS_KG
+        m2 = ms + mh
+        shaft_com = l2 * _SHAFT_COM_RATIO
+        lc2 = (shaft_com * ms + l2 * mh) / m2
+        shaft_inertia_com = (1.0 / 12.0) * ms * l2 * l2
+        parallel_axis = ms * (shaft_com - lc2) * (shaft_com - lc2) + mh * (l2 - lc2) * (
+            l2 - lc2
+        )
+        i2_com = shaft_inertia_com + parallel_axis
+        i2 = i2_com + m2 * lc2 * lc2
+
+        return cls(m1=m1, l1=l1, lc1=lc1, i1=i1, m2=m2, l2=l2, lc2=lc2, i2=i2)
+
+
+@dataclass(frozen=True)
+class PendulumState:
+    """Planar dynamic state (radians, rad/s)."""
+
+    theta1: float
+    theta2: float
+    omega1: float
+    omega2: float
+
+    def __post_init__(self) -> None:
+        for name in ("theta1", "theta2", "omega1", "omega2"):
+            _require_finite(name, getattr(self, name))
+
+
+@dataclass(frozen=True)
+class SwingSample:
+    """One clubhead sample: time, SE(3) pose, and spatial twist.
+
+    - ``pose``: 4x4 homogeneous transform (world-from-clubhead), rotation in
+      the upper-left 3x3 block, position in the last column.
+    - ``twist``: 6-vector ``[wx, wy, wz, vx, vy, vz]`` — world-frame angular
+      velocity followed by clubhead linear velocity.
+    """
+
+    t: float
+    pose: np.ndarray = field(repr=False)
+    twist: np.ndarray = field(repr=False)
+
+    def __post_init__(self) -> None:
+        _require_finite("t", self.t)
+        require(self.t >= 0.0, "t must be >= 0", self.t)
+        pose = np.asarray(self.pose, dtype=np.float64)
+        twist = np.asarray(self.twist, dtype=np.float64)
+        require(pose.shape == (4, 4), "pose must be a 4x4 matrix", pose.shape)
+        require(twist.shape == (6,), "twist must be a 6-vector", twist.shape)
+        require(bool(np.all(np.isfinite(pose))), "pose must be finite", None)
+        require(bool(np.all(np.isfinite(twist))), "twist must be finite", None)
+        require(
+            bool(np.allclose(pose[3], (0.0, 0.0, 0.0, 1.0), atol=1e-12)),
+            "pose bottom row must be [0, 0, 0, 1]",
+            None,
+        )
+        rotation = pose[:3, :3]
+        require(
+            bool(np.allclose(rotation.T @ rotation, np.eye(3), atol=1e-9)),
+            "pose rotation block must be orthonormal",
+            None,
+        )
+        object.__setattr__(self, "pose", pose)
+        object.__setattr__(self, "twist", twist)
+
+
+@dataclass(frozen=True)
+class SwingTrajectory:
+    """Immutable, time-ordered sequence of :class:`SwingSample`."""
+
+    samples: tuple[SwingSample, ...]
+
+    def __post_init__(self) -> None:
+        require(len(self.samples) > 0, "trajectory must contain samples", None)
+        times = [s.t for s in self.samples]
+        require(
+            all(b > a for a, b in zip(times, times[1:], strict=False)),
+            "sample times must be strictly increasing",
+            None,
+        )
+
+    @property
+    def duration(self) -> float:
+        """Trajectory duration [s] (time of last sample minus first)."""
+        return self.samples[-1].t - self.samples[0].t
+
+    def __len__(self) -> int:
+        return len(self.samples)

--- a/tests/rate_of_closure/test_simulation.py
+++ b/tests/rate_of_closure/test_simulation.py
@@ -1,0 +1,260 @@
+"""Tests for the simulation session package (epic #4103 integration).
+
+Covers: the app-frame swing sources (manual constant twist, double
+pendulum adapter, new triple pendulum), the end-to-end session
+(swing -> impact -> flight in a plausible driver band), the impact-time
+scrubber math (tau shift -> clubhead-ball coincidence), the ISA adapter
+sanity against ``twist_to_screw`` on a constant twist, and the CSV/JSON
+export round-trip.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import warnings
+
+import numpy as np
+import pytest
+
+from rate_of_closure.club import get_club
+from rate_of_closure.model import ImpactScenario
+from rate_of_closure.simulation import (
+    BALL_POSITION_M,
+    SOURCE_KINDS,
+    ManualSwingSource,
+    SimulationConfig,
+    SimulationRun,
+    TriplePendulumParameters,
+    TriplePendulumSwing,
+    delivery_at,
+    make_source,
+    run_simulation,
+    run_to_json_dict,
+    screw_axis_samples,
+    write_csv,
+    write_json,
+)
+from shared.python.swing_sim.types import PlaneOrientation
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+_SCENARIO = ImpactScenario(clubhead_speed_mph=113.0)
+_DRIVER = get_club("Driver 10.5°")
+
+
+# ── Sources ─────────────────────────────────────────────────────────
+
+
+class TestManualSwingSource:
+    def test_square_at_midpoint_with_reference_at_origin(self) -> None:
+        source = ManualSwingSource(_SCENARIO, duration=0.06)
+        sample = source.sample(0.03)
+        assert np.allclose(sample.pose[:3, :3], np.eye(3), atol=1e-12)
+        assert np.allclose(sample.pose[:3, 3], 0.0, atol=1e-12)
+
+    def test_constant_twist_matches_scenario(self) -> None:
+        source = ManualSwingSource(_SCENARIO)
+        s0 = source.sample(0.0)
+        s1 = source.sample(source.duration)
+        assert np.allclose(s0.twist, s1.twist)
+        speed_mps = 113.0 * 0.44704
+        assert np.linalg.norm(s0.twist[3:]) == pytest.approx(speed_mps, rel=1e-9)
+
+    def test_out_of_range_time_rejected(self) -> None:
+        source = ManualSwingSource(_SCENARIO)
+        with pytest.raises(Exception, match="within"):
+            source.sample(source.duration + 1.0)
+
+
+class TestPendulumSources:
+    def test_make_source_covers_every_kind(self) -> None:
+        for kind in SOURCE_KINDS:
+            source = make_source(kind, _SCENARIO, duration=0.5)
+            sample = source.sample(source.duration / 2.0)
+            assert sample.pose.shape == (4, 4)
+            assert sample.twist.shape == (6,)
+
+    def test_unknown_kind_rejected(self) -> None:
+        with pytest.raises(Exception, match="unknown swing source"):
+            make_source("quadruple", _SCENARIO)
+
+    def test_double_pendulum_app_frame_stays_on_tilted_plane(self) -> None:
+        """With zero tilts the swing plane's normal is the app x axis...
+
+        no — the swing frame's plane normal (y) maps to app -z, so a
+        zero-tilt swing stays in the app x-y plane (z = const = 0).
+        """
+        source = make_source("double_pendulum", _SCENARIO, duration=0.5)
+        for t in np.linspace(0.0, source.duration, 11):
+            assert source.sample(float(t)).pose[2, 3] == pytest.approx(0.0, abs=1e-9)
+
+    def test_triple_pendulum_conserves_energy_without_damping(self) -> None:
+        params = TriplePendulumParameters.golf_default()
+        undamped = TriplePendulumParameters(
+            m=params.m,
+            l=params.l,
+            lc=params.lc,
+            i_com=params.i_com,
+            damping=(0.0, 0.0, 0.0),
+        )
+        swing = TriplePendulumSwing(parameters=undamped, duration=1.0, dt=5e-4)
+        from rate_of_closure.simulation.sources import triple_total_energy
+
+        e0 = triple_total_energy(undamped, swing._states[0], swing._g_inplane)
+        e1 = triple_total_energy(undamped, swing._states[-1], swing._g_inplane)
+        # e0 is ~0 J (all links horizontal defines the potential zero),
+        # so compare absolutely against the ~100 J swing energy scale.
+        assert e1 == pytest.approx(e0, abs=1e-6)
+
+    def test_triple_pendulum_reach_bounded_by_total_length(self) -> None:
+        swing = TriplePendulumSwing(duration=0.5)
+        total = sum(swing.parameters.l)
+        for t in np.linspace(0.0, swing.duration, 21):
+            reach = float(np.linalg.norm(swing.sample(float(t)).pose[:3, 3]))
+            assert reach <= total + 1e-9
+
+
+# ── Session ─────────────────────────────────────────────────────────
+
+
+class TestSession:
+    @pytest.fixture(scope="class")
+    def manual_run(self) -> SimulationRun:
+        return run_simulation(SimulationConfig(scenario=_SCENARIO, club=_DRIVER))
+
+    def test_manual_run_produces_plausible_driver_numbers(
+        self, manual_run: SimulationRun
+    ) -> None:
+        launch = manual_run.launch
+        # 113 mph clubhead, 10.5° driver: smash pushes ball speed well
+        # above clubhead speed; typical fitting bands.
+        assert 130.0 < launch["ball_speed_mph"] < 185.0
+        assert 5.0 < launch["launch_angle_deg"] < 20.0
+        assert 1000.0 < launch["spin_rpm"] < 5000.0
+        assert 150.0 < launch["carry_m"] < 320.0
+        assert 10.0 < launch["max_height_m"] < 60.0
+        assert launch["flight_time_s"] > 3.0
+
+    def test_pendulum_run_end_to_end(self) -> None:
+        run = run_simulation(
+            SimulationConfig(
+                scenario=_SCENARIO,
+                club=_DRIVER,
+                source_kind="double_pendulum",
+                plane=PlaneOrientation(side_tilt_deg=-30.0),
+            )
+        )
+        # Auto impact time = maximum clubhead speed; a gravity-driven
+        # double pendulum from horizontal reaches a modest but real
+        # speed, and the ball must leave faster than the clubhead.
+        speed = float(np.linalg.norm(run.delivery.clubhead_velocity))
+        assert speed > 3.0
+        assert run.launch["ball_speed_mph"] > speed * 2.23694
+        assert run.launch["carry_m"] > 0.0
+        assert run.total_duration_s > run.impact_time_s
+
+    def test_triple_pendulum_run_end_to_end(self) -> None:
+        run = run_simulation(
+            SimulationConfig(
+                scenario=_SCENARIO, club=_DRIVER, source_kind="triple_pendulum"
+            )
+        )
+        assert run.launch["ball_speed_mph"] > 0.0
+        assert len(run.flight_positions) > 2
+
+    def test_scrubber_tau_shift_gives_clubhead_ball_coincidence(self) -> None:
+        for tau in (0.010, 0.030, 0.045):
+            run = run_simulation(
+                SimulationConfig(scenario=_SCENARIO, club=_DRIVER, impact_time_s=tau)
+            )
+            assert run.impact_time_s == pytest.approx(tau)
+            index = int(np.argmin(np.abs(run.swing_times - tau)))
+            assert np.allclose(run.swing_positions[index], BALL_POSITION_M, atol=1e-6)
+
+    def test_scrubber_delivery_updates_live(self) -> None:
+        source = make_source("double_pendulum", _SCENARIO, duration=0.8)
+        d1 = delivery_at(source, 0.3, _SCENARIO, _DRIVER)
+        d2 = delivery_at(source, 0.6, _SCENARIO, _DRIVER)
+        assert not np.allclose(d1.clubhead_velocity, d2.clubhead_velocity)
+
+    def test_flight_starts_at_ball_position(self, manual_run: SimulationRun) -> None:
+        assert np.allclose(manual_run.flight_positions[0], BALL_POSITION_M, atol=1e-9)
+
+    def test_bad_flight_model_rejected(self) -> None:
+        with pytest.raises(ValueError, match="not a valid"):
+            SimulationConfig(
+                scenario=_SCENARIO, club=_DRIVER, flight_model="warp_drive"
+            )
+
+
+# ── ISA adapter ─────────────────────────────────────────────────────
+
+
+class TestIsaAdapter:
+    def test_constant_twist_axis_and_rate_match_twist_to_screw(self) -> None:
+        source = ManualSwingSource(_SCENARIO, duration=0.02)
+        dt = 1e-3
+        times = np.arange(0.0, source.duration + dt / 2.0, dt)
+        poses = [source.sample(float(t)).pose for t in times]
+        samples = screw_axis_samples(poses, dt)
+
+        omega = source.sample(0.0).twist[:3]
+        expected_axis = omega / np.linalg.norm(omega)
+        expected_rate = math.degrees(float(np.linalg.norm(omega)))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from rotation_converter.twist_screw import twist_to_screw
+
+        screw = twist_to_screw(source.sample(0.0).twist)
+        assert np.allclose(np.asarray(screw["axis"]), expected_axis, atol=1e-9)
+
+        for entry in samples:
+            assert np.allclose(entry["axis"], expected_axis, atol=1e-6)
+            assert entry["rate_dps"] == pytest.approx(expected_rate, rel=1e-6)
+            assert math.isfinite(entry["r_isa_m"])
+
+    def test_requires_two_poses_and_positive_dt(self) -> None:
+        pose = np.eye(4)
+        with pytest.raises(Exception, match="at least 2"):
+            screw_axis_samples([pose], 1e-3)
+        with pytest.raises(Exception, match="dt"):
+            screw_axis_samples([pose, pose], 0.0)
+
+
+# ── Export ──────────────────────────────────────────────────────────
+
+
+class TestExport:
+    @pytest.fixture(scope="class")
+    def run(self) -> SimulationRun:
+        return run_simulation(SimulationConfig(scenario=_SCENARIO, club=_DRIVER))
+
+    def test_csv_round_trip(self, run: SimulationRun, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        path = tmp_path / "run.csv"
+        write_csv(run, path)
+        with path.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.reader(handle))
+        assert rows[0] == ["phase", "t_s", "x_m", "y_m", "z_m", "speed_mps"]
+        assert len(rows) - 1 == len(run.swing_times) + len(run.flight_times)
+        phases = {row[0] for row in rows[1:]}
+        assert phases == {"swing", "flight"}
+        # Times must be numeric and non-decreasing within each phase.
+        swing_ts = [float(r[1]) for r in rows[1:] if r[0] == "swing"]
+        assert swing_ts == sorted(swing_ts)
+
+    def test_json_round_trip(self, run: SimulationRun, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        path = tmp_path / "run.json"
+        write_json(run, path)
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        assert loaded == run_to_json_dict(run)
+        assert loaded["format"].startswith("rate_of_closure.simulation_run/")
+        assert loaded["parameters"]["club"] == _DRIVER.name
+        assert loaded["launch"]["ball_speed_mph"] == pytest.approx(
+            run.launch["ball_speed_mph"]
+        )
+        assert len(loaded["series"]["rows"]) == len(run.swing_times) + len(
+            run.flight_times
+        )

--- a/tests/rate_of_closure/test_simulation_gui.py
+++ b/tests/rate_of_closure/test_simulation_gui.py
@@ -1,0 +1,182 @@
+"""PyQt6 GUI smoke tests for the Simulation tab (epic #4103).
+
+Headless-safe (Agg-compatible matplotlib embedding, timers stopped).
+Covers: tab presence in the main window, a full run populating launch
+rows / scene / inspector, scrubber-driven reruns, playback controls
+(rate presets, frame stepping, loop), scene toggles, sourced hover
+guidance on every new input, and export-button gating.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt6")
+pytest.importorskip("pytestqt")
+
+from rate_of_closure.derivation import LAUNCH_EXPLANATIONS  # noqa: E402
+from rate_of_closure.model import ImpactScenario  # noqa: E402
+from rate_of_closure.simulation import SimulationRun  # noqa: E402
+from rate_of_closure.ui.pyqt6.main_window import RateOfClosureMainWindow  # noqa: E402
+from rate_of_closure.ui.pyqt6.simulation_tab import (  # noqa: E402
+    LAUNCH_ROWS,
+    SimulationTab,
+)
+from rate_of_closure.ui.pyqt6.simulation_view import RATE_PRESETS  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+@pytest.fixture
+def tab(qtbot):  # type: ignore[no-untyped-def]
+    widget = SimulationTab()
+    qtbot.addWidget(widget)
+    widget.set_scenario(ImpactScenario(clubhead_speed_mph=113.0))
+    yield widget
+    widget.stop()
+
+
+@pytest.fixture
+def ran_tab(tab, qtbot):  # type: ignore[no-untyped-def]
+    with qtbot.waitSignal(tab.runCompleted, timeout=10000):
+        tab.run_now()
+    return tab
+
+
+class TestSimulationTab:
+    def test_main_window_hosts_the_simulation_tab(self, qtbot) -> None:  # type: ignore[no-untyped-def]
+        window = RateOfClosureMainWindow()
+        qtbot.addWidget(window)
+        try:
+            tabs = window.centralWidget().findChildren(SimulationTab)
+            assert tabs, "main window must host the Simulation tab"
+        finally:
+            window._club_view.stop()
+            window._simulation_tab.stop()
+
+    def test_every_launch_row_has_an_explanation(self) -> None:
+        for field, _label, _unit in LAUNCH_ROWS:
+            assert field in LAUNCH_EXPLANATIONS, field
+
+    def test_run_populates_launch_rows(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        assert isinstance(ran_tab.last_run(), SimulationRun)
+        for field, _label, _unit in LAUNCH_ROWS:
+            assert ran_tab._rows[field].value_label.text() != "—", field
+
+    def test_clicking_launch_row_shows_explanation(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        ran_tab._rows["carry_m"].clicked.emit("carry_m")
+        html = ran_tab._explanation.toHtml()
+        assert "Carry Distance" in html
+        assert "flight model" in html
+
+    def test_new_inputs_carry_sourced_guidance(self, tab) -> None:  # type: ignore[no-untyped-def]
+        widgets = [
+            tab._source_combo,
+            tab._club_combo,
+            tab._flight_combo,
+            tab._scrub_slider,
+            *tab._tilt_spins.values(),
+            tab.view()._ball_check,
+            tab.view()._ground_check,
+            tab.view()._screw_check,
+        ]
+        for widget in widgets:
+            assert "Suggested range" in widget.toolTip(), widget
+            assert "Source:" in widget.toolTip(), widget
+
+    def test_scrub_updates_tau_and_reruns(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        first_tau = ran_tab.last_run().impact_time_s
+        ran_tab._scrub_slider.setValue(250)
+        run = ran_tab.last_run()
+        assert run.impact_time_s != pytest.approx(first_tau)
+        assert "mph" in ran_tab._delivery_label.text()
+
+    def test_auto_button_restores_max_speed_tau(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        ran_tab._scrub_slider.setValue(200)
+        shifted = ran_tab.last_run().impact_time_s
+        ran_tab._auto_tau_button.click()
+        assert ran_tab.last_run().impact_time_s != pytest.approx(shifted)
+
+    def test_pendulum_source_runs(self, tab, qtbot) -> None:  # type: ignore[no-untyped-def]
+        tab._source_combo.setCurrentIndex(1)  # double pendulum
+        with qtbot.waitSignal(tab.runCompleted, timeout=10000):
+            run = tab.run_now()
+        assert run is not None
+        assert run.config.source_kind == "double_pendulum"
+
+
+class TestSimulationView:
+    def test_rate_presets_cover_spec_and_round_trip(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        view = ran_tab.view()
+        assert [rate for _name, rate in RATE_PRESETS] == [0.1, 0.25, 0.5, 1.0, 2.0]
+        view.set_playback_rate(0.25)
+        assert view.playback_rate() == pytest.approx(0.25)
+        view.set_playback_rate(1.0)
+        assert view.playback_rate() == pytest.approx(1.0)
+
+    def test_frame_step_moves_by_one_sample(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        view = ran_tab.view()
+        run = ran_tab.last_run()
+        dt = float(run.swing_times[1] - run.swing_times[0])
+        view.set_playback_time(0.010)
+        view.step_frames(1)
+        assert view.playback_time() == pytest.approx(0.010 + dt)
+        view.step_frames(-2)
+        assert view.playback_time() == pytest.approx(0.010 - dt)
+
+    def test_playback_time_clamps_to_timeline(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        view = ran_tab.view()
+        total = ran_tab.last_run().total_duration_s
+        view.set_playback_time(total + 99.0)
+        assert view.playback_time() == pytest.approx(total)
+        view.set_playback_time(-1.0)
+        assert view.playback_time() == pytest.approx(0.0)
+
+    def test_play_pause_and_loop_toggle(self, ran_tab, qtbot) -> None:  # type: ignore[no-untyped-def]
+        view = ran_tab.view()
+        assert not view.is_playing()
+        view._play_button.setChecked(True)
+        assert view.is_playing()
+        view._play_button.setChecked(False)
+        assert not view.is_playing()
+        view.set_looping(True)
+        assert view._loop_check.isChecked()
+
+    def test_scene_toggles_redraw_without_error(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        view = ran_tab.view()
+        for check in (view._ball_check, view._ground_check, view._screw_check):
+            check.setChecked(not check.isChecked())
+        view.set_playback_time(ran_tab.last_run().impact_time_s)
+        # Move into the flight phase too (different extent branch).
+        view.set_playback_time(ran_tab.last_run().total_duration_s * 0.9)
+
+    def test_screw_axis_overlay_appears_during_swing(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        view = ran_tab.view()
+        view._screw_check.setChecked(True)
+        view.set_playback_time(ran_tab.last_run().impact_time_s * 0.5)
+        labels = [line.get_label() for line in view._axes.lines]
+        assert any("screw axis" in str(label) for label in labels)
+
+
+class TestInspector:
+    def test_export_buttons_gate_on_run(self, tab, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        fresh = tab.inspector()
+        assert not fresh._export_csv_button.isEnabled() or fresh.run() is not None
+        inspector = ran_tab.inspector()
+        assert inspector._export_csv_button.isEnabled()
+        assert inspector._export_json_button.isEnabled()
+
+    def test_table_populates_and_sorts(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        run = ran_tab.last_run()
+        table = ran_tab.inspector()._table
+        expected = len(run.swing_times) + len(run.flight_times)
+        assert table.rowCount() == expected
+        table.sortItems(1)  # by time ascending — numeric sort
+        first = float(table.item(0, 1).data(0x0100))  # Qt.UserRole
+        last = float(table.item(table.rowCount() - 1, 1).data(0x0100))
+        assert first <= last
+
+    def test_summary_mentions_club_and_carry(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        text = ran_tab.inspector()._summary_label.text()
+        assert ran_tab.last_run().config.club.name in text
+        assert "Carry" in text


### PR DESCRIPTION
Part of epic #4103 — the PyQt6 app-side integration wave (#4105 recon swing models, #4107 playback/export/guidance, #4108 screw axis, #4110 ball flight; consumes the impact package from #4106/#4114).

## Branch lineage
Merges `origin/feat/swing-sim-flight` (PRs #4113/#4115) **and** `origin/feat/swing-sim-impact` (PR #4114) into the `feat/rate-of-closure-club-model` lineage (PRs #4097/#4112). The trees are disjoint except `SPEC.md`, which was resolved by keeping the dated sections from both sides (all five 2026-08-x sections + all version-history rows).

## What's built

**`src/rate_of_closure/simulation/` package**
- `sources.py` — app-frame swing sources: `ManualSwingSource` (the explorer's `ImpactScenario` as a trivial constant-twist source), the shared `DoublePendulumSwing` behind an `AppFrameSwing` frame adapter (swing frame → AffineDrift app frame), and a NEW planar `TriplePendulumSwing` (absolute-angle n-link EOM, classical RK4, energy-conservation-tested, plane tilts via the shared `plane_rotation`/`in_plane_gravity`). Pendulum sources start on the target side so the downswing carries the clubhead toward +x.
- `session.py` — `SimulationRun` record + `run_simulation`: sample swing → delivery at τ → `swing_sim.impact` rigid-body solve with gear effect (club package's `face_normal_at_offset` bulge/roll callable wired in, club mass/MOI/CG depth from the `ClubSpec`) → `swing_sim.flight` launch derivation + selected literature model. **Impact-time scrubber convention:** the ball is a fixed world position; τ translates the swing so the clubhead at τ meets it (postcondition-checked), with `delivery_at` giving live numbers while dragging.
- `isa.py` — the single thin adapter over `rotation_converter.screw_visualization.extract_screw_axes_from_trajectory` per the #4108 recon: submodule import with the DeprecationWarning confined here, per-step θ divided by dt → deg/s, R_ISA from midpoint-to-axis distance, dense 1 ms sampling, `MIN_RATE_DPS` guard for the θ→0 ill-conditioning.
- `export.py` — phase-tagged CSV time series + JSON summary/params document.

**PyQt6 Simulation tab** (existing explorer tabs untouched)
- Swing-source picker, three plane-tilt inputs, club picker (shared library), flight-model picker, Run button — sourced hover guidance (FIELD_GUIDANCE) on every new input, including the scene checkboxes.
- Scrub slider with live delivery readout + auto (max clubhead speed) reset.
- 3D scene: ball and ground behind independent checkboxes, flight trajectory polyline, toggleable screw-axis overlay annotated with rate/pitch/R_ISA; **theme palette only** (`get_chart_color`), no hard-coded colors in new code.
- Full video playback: play/pause, whole swing+flight timeline scrub, frame step ±, loop, rate presets 0.1×/0.25×/0.5×/**1× real-time**/2×.
- Launch result rows (ball speed, launch angle/azimuth, spin, carry, apex, flight time, landing angle) with explanations in the new `derivation.LAUNCH_EXPLANATIONS`; clickable row widget extracted to `ui/pyqt6/result_row.py` and shared with the main window.
- Sortable run-data inspector + CSV/JSON export.

**Web parity (practical degree)**
- `web/src/model/simulation.ts` + `flight.ts`: double-pendulum RK4 (port of `reference.py`), scalar-MOI rigid-body impact with the 2/7 rolling cap (t×n axis fix carried over), launch derivation, Waterloo/Penner flight on fixed-step RK4 — vitest **parity pins** against the pytest numbers (1e-8-ish for the formula-for-formula ports, 1–2 % bands for scipy-RK45-vs-RK4 flight). Code notes that the swing-core/tools-core **WASM kernels replace this in P7**.
- Simulation tab: source/tilt inputs with sourced guidance, τ scrubber, ball/ground toggles + trajectory polyline on canvas, playback with the same rate presets + loop + frame step, JSON export as a download.
- **Skipped on web (P7 follow-ups, noted in code):** screw-axis overlay, gear effect, triple pendulum, club picker in the sim tab.

## Tests
- `tests/rate_of_closure/test_simulation.py`: source contracts, triple-pendulum energy conservation, session end-to-end plausibility bands (113 mph driver → ball speed 130–185 mph, carry 150–320 m…), scrubber τ-shift → clubhead-ball coincidence, ISA adapter vs `twist_to_screw` on a constant twist, CSV/JSON round-trips.
- `tests/rate_of_closure/test_simulation_gui.py`: tab presence, run population, scrub reruns, playback presets/stepping/loop, scene toggles + screw overlay, sourced guidance on every new input, inspector sorting + export gating.
- `web/src/model/simulation.test.ts`: parity pins + session bands.

## Gates
- `pytest tests/rate_of_closure src/shared/python/swing_sim` — **337 passed**
- `ruff check` + `ruff format --check` — clean; `mypy src/rate_of_closure` — clean
- web `npm test` (62 passed) / `type-check` / `lint` / `build` — all clean
- All new files ≤ 500 LOC

## SPEC
Dated section `2026-08-04 Rate of Closure Simulation Session` + 1.8.0 version-history row; identity bumped to 1.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)