### PR TITLE
feat(rate_of_closure): solver panel — goal-driven optimization UI (#4109 #4110)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,49 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Swing impact-parameter solver (epic #4103, #4109)
+
+- New self-facaded subpackage `src/shared/python/swing_sim/solver/`:
+  goal-driven robust optimization over golf delivery/swing variables.
+  Scaffolding modeled on UpstreamDrift's
+  `src/shared/python/movement_optimizer` (pure cost module, multi-start
+  parallel driver, `ProgressReport`/`cancel_event` plumbing, named tuning
+  constants) with golf-impact semantics replacing the barbell/balance
+  costs.
+- `goals.py`: `ImpactGoal` — optionally weighted targets over any subset
+  of club_path/face_angle/attack_angle/dynamic_loft [deg], ball_speed
+  [mph], launch_angle/launch_azimuth [deg], spin [RPM], spin-axis tilt
+  [deg, + = fade side], carry [m] — and `VariablePartition`, which splits
+  the delivery front-end variables (plus toe/high impact offsets) into
+  optimizer-controlled (bounded) vs user-fixed, with DbC validation
+  (disjointness, finite bounds, unknown names). A swing-source mode swaps
+  in double-pendulum variables (the three sequential plane tilts, the
+  impact-time offset relative to peak clubhead speed, and the damping
+  parameters) and derives clubhead speed/path/attack angle from the
+  sampled pendulum twist.
+- `objective.py`: pure residual builder — candidate variables run
+  delivery → rigid-body impact with physics-based gear effect (→ launch
+  derivation → ball flight only when the goal requires it) and score as
+  `weight * (achieved - target) / scale` with launch-monitor-resolution
+  scales from `tuning.py`. `evaluate_candidate(variables, partition,
+  goal) -> residuals` is the documented seam a later Rust port replaces
+  behind a facade (no Rust added in this PR).
+- `solve.py`: bounded `scipy.optimize.least_squares` (trf) multi-start
+  driver — Latin-hypercube starts across the bounds (start 0 = caller
+  `x0` or midpoint), parallel starts via `concurrent.futures`,
+  thread-safe progress tracking with the movement_optimizer
+  `ProgressReport` shape and stall heuristic, cooperative cancellation
+  via `threading.Event` (`CancelledError`), best-of selection, and a
+  `SolverResult` carrying the solution variables, achieved quantities,
+  per-goal errors, residual norm, eval counts, elapsed time, convergence
+  flag, and all per-start summaries.
+- In-package tests (`unit` / `physics` / `contract` markers):
+  exact-recovery from a cold start, underdetermined and conflicting-goal
+  behaviour, bounds enforcement, cancellation (pre-set and mid-solve),
+  progress-report shape, partition validation errors, and a contract
+  test pinning the `swing_sim.solver` public API. The parent
+  `swing_sim/__init__.py` facade is deliberately untouched.
+
 ### 2026-08-04 Swing simulation ball-flight package (epic #4103, #4107)
 
 - New self-facaded subpackage `src/shared/python/swing_sim/flight/` porting
@@ -1817,6 +1860,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.8.0 | feat(swing_sim, #4109): add the impact-parameter solver subpackage `src/shared/python/swing_sim/solver/` — goal-driven robust optimization (`ImpactGoal` weighted targets over launch-monitor quantities incl. carry; `VariablePartition` free-with-bounds vs fixed delivery/swing variables, with a double-pendulum swing-source mode covering the three plane tilts, impact-time offset, and damping); pure residual builder with the documented Rust-portable `evaluate_candidate` seam; bounded scipy trf multi-start driver (Latin-hypercube starts, parallel via concurrent.futures, movement_optimizer-shaped ProgressReport/cancel_event plumbing, per-start diagnostics in `SolverResult`). Scaffolding modeled on UpstreamDrift's movement_optimizer. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4107): add the ball-flight package `src/shared/python/swing_sim/flight/` — 7 literature flight models (Waterloo/Penner, MacDonald-Hanzely, and five cited constant-coefficient presets) behind `FlightModelRegistry` with scipy RK45 + terminal ground event; public `derive_launch_conditions` (post-impact velocity/spin → launch conditions with exact round-trip); app↔flight frame adapters; graceful Rust fast path over `tools-core`'s canonical `ball_flight.rs` kernel (new `simulate_trajectory`/`analyze_trajectory` pyfunctions, property setters, velocity getters) with parity tests; `FlightSimulatorProtocol` + `simulate()` pipeline seam for the impact stage. |
 | 2026-08-04 | 1.7.0 | feat(swing_sim, #4106): add the impact physics subpackage `src/shared/python/swing_sim/impact/` — rigid-body COR impulse model (2/7 rolling-cap friction spin) + spring-damper + finite-time models, energy-balance validator, and recorder ported self-contained from UpstreamDrift's `physics/impact_model` with three fixes (off-center base impulse no longer drops `impact_offset`; opt-in 3x3 club MOI tensor effective mass `1/m_eff = 1/m + (r x n)^T I^-1 (r x n)`; friction-spin axis sign corrected to `t x n`); new launch-monitor delivery front-end (`delivery.py`, AffineDrift frame, spin-loft + D-plane diagnostics) and physics-based gear effect (`gear_effect.py`, head recoil × CG-depth lever arm, bulge/roll via `face_normal_at_offset` callable seam) replacing the empirical three-constant version. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4104): add the swing simulation foundation — new `rust_core/swing-core` workspace crate (double-pendulum EOM with plane-oriented in-plane gravity, PyO3 wheel `swing_core` + wasm-bindgen bindings) and shared `src/shared/python/swing_sim` package (DbC value types, `SwingSource` protocol, `DoublePendulumSwing`, strict Rust façade with pure-Python parity oracle); wire swing-core into the rust quality gate's wasm build and add the `maturin-swing-core.yml` build/import/parity workflow. |

--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,51 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Rate of Closure solver panel — goal-driven optimization UI (epic #4103, #4109 #4110)
+
+- PyQt6: new "Solver" tab inside the Simulation tab's right-hand tab
+  stack (`ui/pyqt6/solver_panel.py`, editor spec tables in
+  `solver_specs.py`): checkbox-enabled weighted goal targets over every
+  `swing_sim.solver` goal quantity, a per-variable Optimize
+  (min/max bounds) | Fix (value) partition editor with a swing-source
+  mode toggle that swaps the derived delivery variables for the
+  double-pendulum swing variables, a start-count spinner, and Run /
+  Cancel. Every new input carries sourced hover guidance
+  ("Suggested range … Source: …", test-enforced); theming stays with
+  the shared ThemeManager palette (no hard-coded colors).
+- The solve runs on a `QThread` worker (`solver_worker.py`) — the UI
+  never blocks; the solver's `ProgressReport` callback drives the
+  progress bar (evaluation count against the multi-start budget) and a
+  status line with best cost and the stall heuristic; Cancel sets the
+  cooperative `cancel_event`, and in-flight starts unwind at their next
+  residual evaluation.
+- Results view: achieved-vs-goal table with per-goal errors, residual
+  norm + convergence flag + evaluation counts in the summary, and
+  expandable per-start diagnostics (cost, evals, status, message,
+  solution vector). Apply loads the solved variables back into the
+  simulation session and reruns so the optimized swing/impact shows in
+  the 3D scene: both modes land the solved impact offsets in the
+  scenario; delivery mode selects the manual source and sets the
+  scenario clubhead speed; swing-source mode selects the double
+  pendulum, drives the plane-tilt inputs, and shifts tau by the solved
+  impact-time offset. Documented deviation: the session's delivery
+  convention is a square face at the club's loft, so solved face-angle
+  / dynamic-loft values inform the goal table but are not replayed.
+- DbC validation errors (no goals checked, inverted bounds, …) surface
+  as friendly status-line messages, never tracebacks.
+- Web (practical parity): `model/solver.ts` reuses the parity-ported TS
+  physics as the objective — goals limited to what it computes
+  (path/face/AoA/loft, ball speed, launch angles, spin, carry) over the
+  delivery variables, solved with a bounded Nelder-Mead (candidates
+  clamped into bounds) and a small deterministic multi-start; the
+  `SolverPanel` section in the Simulation tab mirrors the goal /
+  partition editors, results table, and an Apply that loads the solved
+  clubhead speed and impact offsets into the scenario. Parity-tested
+  against the pytest-pinned easy case (150 mph ball-speed goal solves
+  to ~45.825 m/s clubhead speed in both implementations). Progress,
+  cancellation, the swing-source mode, and a web-worker/WASM objective
+  land with the P7 kernels (deliberate deferral).
+
 ### 2026-08-04 Swing impact-parameter solver (epic #4103, #4109)
 
 - New self-facaded subpackage `src/shared/python/swing_sim/solver/`:
@@ -1993,6 +2038,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.9.0 | feat(rate_of_closure, #4109 #4110): solver panel — goal-driven optimization UI. PyQt6 Solver tab in the Simulation tab (checkbox-enabled weighted ImpactGoal targets, Optimize-with-bounds / Fix VariablePartition editor with a double-pendulum swing-source mode, start-count spinner, Run/Cancel on a QThread worker with ProgressReport-driven progress bar and cooperative cancel_event, achieved-vs-goal table with per-goal errors / residual norm / convergence / expandable per-start diagnostics, Apply loading solved variables into the simulation session and rerunning the 3D scene; sourced tooltips throughout, DbC errors as friendly status messages). Web: model/solver.ts bounded Nelder-Mead over the TS-physics objective (delivery variables, deterministic multi-start) + SolverPanel section with apply-to-scenario, parity-pinned against the pytest easy case (150 mph ball speed -> ~45.825 m/s clubhead speed); WASM/worker upgrade deferred to P7. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4107): add the ball-flight package `src/shared/python/swing_sim/flight/` — 7 literature flight models (Waterloo/Penner, MacDonald-Hanzely, and five cited constant-coefficient presets) behind `FlightModelRegistry` with scipy RK45 + terminal ground event; public `derive_launch_conditions` (post-impact velocity/spin → launch conditions with exact round-trip); app↔flight frame adapters; graceful Rust fast path over `tools-core`'s canonical `ball_flight.rs` kernel (new `simulate_trajectory`/`analyze_trajectory` pyfunctions, property setters, velocity getters) with parity tests; `FlightSimulatorProtocol` + `simulate()` pipeline seam for the impact stage. |
 | 2026-08-04 | 1.8.0 | feat(rate_of_closure, epic #4103): simulation session integrating swing_sim into the app — app-frame swing sources (manual constant twist, shared double pendulum, new triple pendulum), swing → impact (gear effect + bulge/roll callable) → flight orchestration into one exportable SimulationRun, fixed-ball impact-time scrubber, thin ISA adapter over the rotation converter with a toggleable screw-axis overlay, PyQt6 Simulation tab (sourced-guidance inputs, launch rows with explanations, ball/ground toggles, flight polyline, full video playback with 1×-real-time rate presets, sortable inspector, CSV/JSON export) and a parity-pinned web Simulation tab (pendulum/impact/flight TS port, scrubber, playback, JSON download; WASM supersedes in P7). |
 | 2026-08-04 | 1.8.0 | feat(swing_sim, #4109): add the impact-parameter solver subpackage `src/shared/python/swing_sim/solver/` — goal-driven robust optimization (`ImpactGoal` weighted targets over launch-monitor quantities incl. carry; `VariablePartition` free-with-bounds vs fixed delivery/swing variables, with a double-pendulum swing-source mode covering the three plane tilts, impact-time offset, and damping); pure residual builder with the documented Rust-portable `evaluate_candidate` seam; bounded scipy trf multi-start driver (Latin-hypercube starts, parallel via concurrent.futures, movement_optimizer-shaped ProgressReport/cancel_event plumbing, per-start diagnostics in `SolverResult`). Scaffolding modeled on UpstreamDrift's movement_optimizer. |

--- a/src/rate_of_closure/ui/pyqt6/simulation_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/simulation_tab.py
@@ -17,6 +17,7 @@ builds :class:`SimulationConfig` objects for the session layer.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import math
 
@@ -42,7 +43,7 @@ from PyQt6.QtWidgets import (
 
 from rate_of_closure.club import club_names, get_club
 from rate_of_closure.derivation import LAUNCH_EXPLANATIONS
-from rate_of_closure.model import ImpactScenario
+from rate_of_closure.model import MPH_PER_MPS, ImpactScenario
 from rate_of_closure.simulation import (
     SOURCE_KINDS,
     SimulationConfig,
@@ -54,6 +55,7 @@ from rate_of_closure.simulation import (
 from rate_of_closure.ui.pyqt6.inspector_view import InspectorView
 from rate_of_closure.ui.pyqt6.result_row import ResultRow
 from rate_of_closure.ui.pyqt6.simulation_view import SimulationView
+from rate_of_closure.ui.pyqt6.solver_panel import SolverPanel
 from rate_of_closure.units import FIELD_GUIDANCE
 from shared.python.swing_sim.flight.registry import FlightModelType
 from shared.python.swing_sim.types import PlaneOrientation
@@ -107,6 +109,8 @@ class SimulationTab(QWidget):
 
         self._view = SimulationView()
         self._inspector = InspectorView()
+        self._solver_panel = SolverPanel()
+        self._solver_panel.applyRequested.connect(self.apply_solver_solution)
 
         left = QWidget()
         left_layout = QVBoxLayout(left)
@@ -120,6 +124,7 @@ class SimulationTab(QWidget):
         right = QTabWidget()
         right.addTab(self._view, "Scene")
         right.addTab(self._inspector, "Inspector")
+        right.addTab(self._solver_panel, "Solver")
 
         splitter = QSplitter()
         splitter.addWidget(left)
@@ -289,9 +294,62 @@ class SimulationTab(QWidget):
         """The run-data inspector."""
         return self._inspector
 
+    def solver_panel(self) -> SolverPanel:
+        """The goal-driven Solver panel (worker lifecycle lives on it)."""
+        return self._solver_panel
+
+    def apply_solver_solution(
+        self, result: object, use_swing_source: bool
+    ) -> SimulationRun | None:
+        """Load a SolverResult's variables into the session and rerun.
+
+        Mapping (documented deviation — the session's delivery convention
+        is a square face at the club's loft, so face angle / dynamic loft
+        solutions inform the goal table but are not replayed):
+
+        * both modes: the solved impact offsets land in the scenario;
+        * delivery mode: the manual constant-twist source is selected and
+          the solved clubhead speed becomes the scenario reference speed;
+        * swing-source mode: the double-pendulum source is selected, the
+          solved plane tilts drive the tilt inputs, and the solved
+          impact-time offset shifts tau off the peak-speed instant.
+        """
+        variables: dict[str, float] = result.variables  # type: ignore[attr-defined]
+        updates = {
+            "impact_offset_toe_mm": variables["impact_offset_toe_mm"],
+            "impact_offset_high_mm": variables["impact_offset_high_mm"],
+        }
+        if use_swing_source:
+            self._source_combo.setCurrentIndex(SOURCE_KINDS.index("double_pendulum"))
+            for attr, var in (
+                ("yaw_deg", "swing_yaw_deg"),
+                ("side_tilt_deg", "swing_side_tilt_deg"),
+                ("forward_tilt_deg", "swing_forward_tilt_deg"),
+            ):
+                spin = self._tilt_spins[attr]
+                spin.blockSignals(True)
+                spin.setValue(variables[var])
+                spin.blockSignals(False)
+        else:
+            self._source_combo.setCurrentIndex(SOURCE_KINDS.index("manual"))
+            updates["clubhead_speed_mph"] = (
+                variables["clubhead_speed_mps"] * MPH_PER_MPS
+            )
+        self._scenario = dataclasses.replace(self._scenario, **updates)
+        self._invalidate_source()
+        self._tau = None  # auto: impact at maximum clubhead speed
+        run = self.run_now()
+        offset = variables.get("swing_impact_time_offset_s", 0.0)
+        if run is not None and use_swing_source and abs(offset) > 1e-9:
+            source = self._ensure_source()
+            self._tau = min(max(run.impact_time_s + offset, 0.0), source.duration)
+            run = self.run_now()
+        return run
+
     def stop(self) -> None:
-        """Stop the playback timer (window close and tests)."""
+        """Stop the playback timer and solver worker (close and tests)."""
         self._view.stop()
+        self._solver_panel.stop()
 
     # ── internals ──────────────────────────────────────────────────
     def _ensure_source(self):  # type: ignore[no-untyped-def]

--- a/src/rate_of_closure/ui/pyqt6/solver_panel.py
+++ b/src/rate_of_closure/ui/pyqt6/solver_panel.py
@@ -1,0 +1,466 @@
+"""The Solver panel: goal-driven optimization UI (epic #4103, #4109/#4110).
+
+Lets the user pick launch-monitor goal targets (any subset, weighted),
+partition the delivery / swing variables into optimizer-controlled
+(with bounds) vs fixed, and run the ``swing_sim.solver`` multi-start
+driver on a worker thread (:class:`SolverWorker`) with live progress,
+cooperative cancellation, and a results view: achieved-vs-goal table
+with per-goal errors, residual norm, convergence flag, expandable
+per-start diagnostics, and an Apply button that hands the solved
+variables back to the Simulation tab so the optimized swing/impact
+shows up in the 3D scene immediately.
+
+Validation errors from the solver's DbC layer (unknown names, bad
+bounds, empty goal/free set) surface as friendly messages in the status
+line — never tracebacks.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QAbstractSpinBox,
+    QButtonGroup,
+    QCheckBox,
+    QDoubleSpinBox,
+    QFrame,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QProgressBar,
+    QPushButton,
+    QRadioButton,
+    QScrollArea,
+    QSpinBox,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rate_of_closure.ui.pyqt6.solver_specs import (
+    GOAL_SPECS,
+    VARIABLE_SPECS,
+    GoalSpec,
+    VariableSpec,
+)
+from rate_of_closure.ui.pyqt6.solver_worker import SolverWorker
+from shared.python.contracts import ContractViolationError
+from shared.python.swing_sim.solver.goals import (
+    SWING_DERIVED_VARIABLES,
+    ImpactGoal,
+    VariablePartition,
+)
+from shared.python.swing_sim.solver.solve import ProgressReport, SolverResult
+from shared.python.swing_sim.solver.tuning import DEFAULT_N_STARTS
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["SolverPanel"]
+
+_SWING_MODE_GUIDANCE = (
+    "Suggested range: off to optimize the delivery numbers directly; on "
+    "to optimize double-pendulum swing variables (plane tilts, impact "
+    "timing, joint damping) with clubhead speed/path/attack angle "
+    "derived from the swing. Source: shared swing_sim solver "
+    "documentation (movement_optimizer scaffolding)."
+)
+_STARTS_GUIDANCE = (
+    "Suggested range: 1-12 multi-start seeds (6 default); start 0 is "
+    "the bounds midpoint, the rest a Latin-hypercube sample. More "
+    "starts are more robust to local minima but slower. Source: shared "
+    "swing_sim solver tuning documentation."
+)
+
+
+def _spin(
+    lo: float, hi: float, value: float, decimals: int, suffix: str
+) -> QDoubleSpinBox:
+    """A no-arrow, typed QDoubleSpinBox in the app's input style."""
+    spin = QDoubleSpinBox()
+    spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+    spin.setKeyboardTracking(False)
+    spin.setDecimals(decimals)
+    spin.setRange(lo, hi)
+    spin.setSuffix(suffix)
+    spin.setValue(value)
+    return spin
+
+
+class _GoalRow(QWidget):
+    """One goal quantity: enable checkbox + target + weight entries."""
+
+    def __init__(self, spec: GoalSpec) -> None:
+        super().__init__()
+        self.spec = spec
+        self.enabled = QCheckBox(spec.label)
+        self.enabled.setToolTip(spec.guidance)
+        self.target = _spin(
+            spec.spin_range[0], spec.spin_range[1], spec.default_target, 1, spec.unit
+        )
+        self.target.setToolTip(spec.guidance)
+        self.weight = _spin(0.01, 100.0, 1.0, 2, "")
+        self.weight.setToolTip(
+            "Suggested range: 0.1-10 relative weight (1 default); larger "
+            "weights make the optimizer trade other goals away to hit "
+            "this one. Source: shared swing_sim solver tuning "
+            "documentation (launch-monitor-resolution residual scales)."
+        )
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.enabled, stretch=1)
+        layout.addWidget(self.target)
+        layout.addWidget(QLabel("w"))
+        layout.addWidget(self.weight)
+        for widget in (self.target, self.weight):
+            widget.setEnabled(False)
+        self.enabled.toggled.connect(self.target.setEnabled)
+        self.enabled.toggled.connect(self.weight.setEnabled)
+
+
+class _VariableRow(QWidget):
+    """One variable: radio Optimize (min/max bounds) | Fix (value)."""
+
+    def __init__(self, spec: VariableSpec) -> None:
+        super().__init__()
+        self.spec = spec
+        lo, hi = spec.spin_range
+        self.optimize = QRadioButton("Optimize")
+        self.fix = QRadioButton("Fix")
+        self._group = QButtonGroup(self)
+        self._group.addButton(self.optimize)
+        self._group.addButton(self.fix)
+        # NOTE: not named "lower"/"raise_" — those are QWidget methods.
+        self.low = _spin(lo, hi, spec.default_bounds[0], spec.decimals, spec.unit)
+        self.high = _spin(lo, hi, spec.default_bounds[1], spec.decimals, spec.unit)
+        self.fixed_value = _spin(lo, hi, spec.default_value, spec.decimals, spec.unit)
+        label = QLabel(spec.label)
+        for widget in (label, self.optimize, self.fix, self.low, self.high):
+            widget.setToolTip(spec.guidance)
+        self.fixed_value.setToolTip(spec.guidance)
+
+        layout = QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(label, 0, 0, 1, 4)
+        layout.addWidget(self.optimize, 1, 0)
+        layout.addWidget(self.low, 1, 1)
+        layout.addWidget(self.high, 1, 2)
+        layout.addWidget(self.fix, 1, 3)
+        layout.addWidget(self.fixed_value, 1, 4)
+        self.optimize.toggled.connect(self._sync_enabled)
+        self.fix.setChecked(True)
+        self._sync_enabled()
+
+    def _sync_enabled(self, *_args: object) -> None:
+        free = self.optimize.isChecked()
+        self.low.setEnabled(free)
+        self.high.setEnabled(free)
+        self.fixed_value.setEnabled(not free)
+
+
+class SolverPanel(QWidget):
+    """Goal editor + variable partition + run/cancel + results + apply."""
+
+    #: Emitted with (SolverResult, use_swing_source) when Apply is clicked.
+    applyRequested = pyqtSignal(object, bool)  # noqa: N815 — Qt convention
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._worker: SolverWorker | None = None
+        self._result: SolverResult | None = None
+        self._goal_rows: dict[str, _GoalRow] = {}
+        self._var_rows: dict[str, _VariableRow] = {}
+
+        left = QWidget()
+        left_layout = QVBoxLayout(left)
+        left_layout.addWidget(self._build_goal_box())
+        left_layout.addWidget(self._build_variable_box())
+        left_layout.addWidget(self._build_run_box())
+        left_layout.addStretch(1)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        scroll.setWidget(left)
+        scroll.setMinimumWidth(380)
+
+        splitter = QSplitter()
+        splitter.addWidget(scroll)
+        splitter.addWidget(self._build_results_column())
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(splitter)
+
+        # Sensible demo defaults: target ball speed, free clubhead speed.
+        self._goal_rows["ball_speed_mph"].enabled.setChecked(True)
+        self._var_rows["clubhead_speed_mps"].optimize.setChecked(True)
+        self._sync_mode_rows()
+
+    # ── construction ────────────────────────────────────────────────
+    def _build_goal_box(self) -> QGroupBox:
+        box = QGroupBox("Goals (Check the Targets to Hit)")
+        layout = QVBoxLayout(box)
+        layout.setSpacing(2)
+        for spec in GOAL_SPECS:
+            row = _GoalRow(spec)
+            self._goal_rows[spec.name] = row
+            layout.addWidget(row)
+        return box
+
+    def _build_variable_box(self) -> QGroupBox:
+        box = QGroupBox("Variables (Optimize Within Bounds, or Fix)")
+        layout = QVBoxLayout(box)
+        layout.setSpacing(4)
+        self._swing_check = QCheckBox("Optimize Swing Variables (Double Pendulum)")
+        self._swing_check.setToolTip(_SWING_MODE_GUIDANCE)
+        self._swing_check.toggled.connect(self._sync_mode_rows)
+        layout.addWidget(self._swing_check)
+        for spec in VARIABLE_SPECS:
+            row = _VariableRow(spec)
+            self._var_rows[spec.name] = row
+            layout.addWidget(row)
+        return box
+
+    def _build_run_box(self) -> QGroupBox:
+        box = QGroupBox("Run")
+        layout = QVBoxLayout(box)
+        row = QHBoxLayout()
+        row.addWidget(QLabel("Starts"))
+        self._starts_spin = QSpinBox()
+        self._starts_spin.setRange(1, 64)
+        self._starts_spin.setValue(DEFAULT_N_STARTS)
+        self._starts_spin.setToolTip(_STARTS_GUIDANCE)
+        row.addWidget(self._starts_spin)
+        self._run_button = QPushButton("Run Solver")
+        self._run_button.setToolTip(
+            "Solve for the free-variable values that best achieve the "
+            "checked goals (multi-start least squares on a worker thread)."
+        )
+        self._run_button.clicked.connect(self._on_run)
+        row.addWidget(self._run_button, stretch=1)
+        self._cancel_button = QPushButton("Cancel")
+        self._cancel_button.setEnabled(False)
+        self._cancel_button.setToolTip(
+            "Cooperatively cancel the running solve; in-flight starts "
+            "stop at their next residual evaluation."
+        )
+        self._cancel_button.clicked.connect(self._on_cancel)
+        row.addWidget(self._cancel_button)
+        layout.addLayout(row)
+        self._progress = QProgressBar()
+        self._progress.setRange(0, 1)
+        self._progress.setValue(0)
+        layout.addWidget(self._progress)
+        self._status = QLabel("Ready.")
+        self._status.setWordWrap(True)
+        layout.addWidget(self._status)
+        return box
+
+    def _build_results_column(self) -> QWidget:
+        column = QWidget()
+        layout = QVBoxLayout(column)
+
+        results_box = QGroupBox("Achieved vs Goal")
+        results_layout = QVBoxLayout(results_box)
+        self._table = QTableWidget(0, 4)
+        self._table.setHorizontalHeaderLabels(
+            ["Quantity", "Target", "Achieved", "Error"]
+        )
+        self._table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        results_layout.addWidget(self._table)
+        self._summary = QLabel("No solution yet.")
+        self._summary.setWordWrap(True)
+        results_layout.addWidget(self._summary)
+        layout.addWidget(results_box, stretch=2)
+
+        starts_box = QGroupBox("Per-Start Diagnostics")
+        starts_layout = QVBoxLayout(starts_box)
+        self._starts_tree = QTreeWidget()
+        self._starts_tree.setHeaderLabels(["Start", "Cost", "Evals", "Status"])
+        starts_layout.addWidget(self._starts_tree)
+        layout.addWidget(starts_box, stretch=1)
+
+        self._apply_button = QPushButton("Apply to Simulation")
+        self._apply_button.setEnabled(False)
+        self._apply_button.setToolTip(
+            "Load the solved variables into the Simulation tab (scenario "
+            "speed and impact offsets; swing-plane tilts and impact "
+            "timing in swing mode) and rerun so the optimized swing and "
+            "impact appear in the 3D scene."
+        )
+        self._apply_button.clicked.connect(self._on_apply)
+        layout.addWidget(self._apply_button)
+        return column
+
+    # ── editor -> solver inputs ─────────────────────────────────────
+    def use_swing_source(self) -> bool:
+        """Whether swing-source mode is selected."""
+        return self._swing_check.isChecked()
+
+    def _sync_mode_rows(self, *_args: object) -> None:
+        """Show only the variables valid for the selected mode."""
+        swing = self.use_swing_source()
+        for name, row in self._var_rows.items():
+            if row.spec.swing_only:
+                row.setVisible(swing)
+            elif name in SWING_DERIVED_VARIABLES:
+                row.setVisible(not swing)
+
+    def build_goal(self) -> ImpactGoal:
+        """The ImpactGoal described by the checked rows (DbC-validated)."""
+        targets = {
+            name: (row.target.value(), row.weight.value())
+            for name, row in self._goal_rows.items()
+            if row.enabled.isChecked()
+        }
+        return ImpactGoal.of(**targets)
+
+    def build_partition(self) -> VariablePartition:
+        """The VariablePartition described by the variable rows."""
+        free: dict[str, tuple[float, float]] = {}
+        fixed: dict[str, float] = {}
+        for name, row in self._var_rows.items():
+            if row.isHidden():
+                continue
+            if row.optimize.isChecked():
+                free[name] = (row.low.value(), row.high.value())
+            else:
+                fixed[name] = row.fixed_value.value()
+        return VariablePartition(
+            free=free, fixed=fixed, use_swing_source=self.use_swing_source()
+        )
+
+    # ── run / cancel ────────────────────────────────────────────────
+    def _on_run(self) -> None:
+        if self._worker is not None and self._worker.isRunning():
+            return
+        try:
+            goal = self.build_goal()
+            partition = self.build_partition()
+        except (ContractViolationError, ValueError) as exc:
+            self._status.setText(f"Cannot solve: {exc}")
+            return
+        self._result = None
+        self._apply_button.setEnabled(False)
+        self._run_button.setEnabled(False)
+        self._cancel_button.setEnabled(True)
+        worker = SolverWorker(goal, partition, self._starts_spin.value())
+        worker.progressed.connect(self._on_progress)
+        worker.succeeded.connect(self._on_succeeded)
+        worker.cancelled.connect(self._on_cancelled)
+        worker.failed.connect(self._on_failed)
+        worker.finished.connect(self._on_finished)
+        self._worker = worker
+        self._progress.setRange(0, worker.max_evaluations)
+        self._progress.setValue(0)
+        self._status.setText("Solving…")
+        worker.start()
+
+    def _on_cancel(self) -> None:
+        if self._worker is not None:
+            self._worker.cancel()
+            self._status.setText("Cancelling…")
+
+    def stop(self) -> None:
+        """Cancel and join any running worker (window close and tests)."""
+        if self._worker is not None:
+            self._worker.cancel()
+            self._worker.wait(10_000)
+
+    # ── worker callbacks (GUI thread) ───────────────────────────────
+    def _on_progress(self, report: ProgressReport) -> None:
+        self._progress.setValue(min(report.iteration, self._progress.maximum()))
+        stalled = f" — {report.stall_reason}" if report.is_stalled else ""
+        self._status.setText(
+            f"Evaluations {report.iteration}, best cost "
+            f"{report.best_cost:.3g}, {report.elapsed_s:.1f} s{stalled}"
+        )
+
+    def _on_succeeded(self, result: SolverResult) -> None:
+        self._result = result
+        self._populate_results(result)
+        self._apply_button.setEnabled(True)
+        flag = "converged" if result.converged else "did NOT converge"
+        self._status.setText(
+            f"Done: best start {flag}, residual norm "
+            f"{result.residual_norm:.3g}, {result.n_evals} evaluations in "
+            f"{result.elapsed_s:.1f} s."
+        )
+
+    def _on_cancelled(self) -> None:
+        self._status.setText("Cancelled before any start completed.")
+
+    def _on_failed(self, message: str) -> None:
+        self._status.setText(f"Solver failed: {message}")
+
+    def _on_finished(self) -> None:
+        self._run_button.setEnabled(True)
+        self._cancel_button.setEnabled(False)
+        self._progress.setValue(self._progress.maximum())
+
+    # ── results view ────────────────────────────────────────────────
+    def _populate_results(self, result: SolverResult) -> None:
+        goals = list(result.per_goal_errors)
+        labels = {spec.name: (spec.label, spec.unit) for spec in GOAL_SPECS}
+        rows = self._goal_rows
+        self._table.setRowCount(len(goals))
+        for i, name in enumerate(goals):
+            label, unit = labels[name]
+            target = rows[name].target.value()
+            achieved = result.achieved[name]
+            error = result.per_goal_errors[name]
+            for col, text in enumerate(
+                (
+                    label,
+                    f"{target:+.2f}{unit}",
+                    f"{achieved:+.2f}{unit}",
+                    f"{error:+.3f}{unit}",
+                )
+            ):
+                item = QTableWidgetItem(text)
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+                self._table.setItem(i, col, item)
+        var_text = ", ".join(
+            f"{name} = {result.variables[name]:.3f}" for name in result.free_names
+        )
+        self._summary.setText(
+            f"Solved variables: {var_text or '(none)'}. Residual norm "
+            f"{result.residual_norm:.3g}; "
+            f"{'converged' if result.converged else 'not converged'}."
+        )
+        self._starts_tree.clear()
+        for start in result.starts:
+            status = (
+                "cancelled"
+                if start.cancelled
+                else ("converged" if start.converged else "stopped")
+            )
+            node = QTreeWidgetItem(
+                [
+                    str(start.seed),
+                    f"{start.cost:.4g}",
+                    str(start.n_evals),
+                    status,
+                ]
+            )
+            node.addChild(QTreeWidgetItem([f"message: {start.message}", "", "", ""]))
+            if start.x is not None:
+                solution = ", ".join(f"{v:.4g}" for v in start.x.tolist())
+                node.addChild(QTreeWidgetItem([f"x: [{solution}]", "", "", ""]))
+            self._starts_tree.addTopLevelItem(node)
+
+    # ── apply ───────────────────────────────────────────────────────
+    def result(self) -> SolverResult | None:
+        """The most recent successful SolverResult, if any."""
+        return self._result
+
+    def _on_apply(self) -> None:
+        if self._result is not None:
+            self.applyRequested.emit(self._result, self.use_swing_source())

--- a/src/rate_of_closure/ui/pyqt6/solver_specs.py
+++ b/src/rate_of_closure/ui/pyqt6/solver_specs.py
@@ -1,0 +1,319 @@
+"""Editor specs for the Solver panel (epic #4103, #4109 / #4110).
+
+Declarative tables driving the goal editor and the variable-partition
+editor of :class:`~rate_of_closure.ui.pyqt6.solver_panel.SolverPanel`:
+one row per solver goal quantity and one row per solver variable, each
+with a Title Case label, display unit, spin ranges, defaults, and
+sourced hover guidance in the FIELD_GUIDANCE style ("Suggested range
+... Source: ...").
+
+Names match ``shared.python.swing_sim.solver.goals`` exactly
+(test-enforced): the goal table covers ``GOAL_QUANTITIES`` and the
+variable table covers ``DELIVERY_VARIABLE_DEFAULTS`` plus
+``SWING_VARIABLE_DEFAULTS``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["GOAL_SPECS", "VARIABLE_SPECS", "GoalSpec", "VariableSpec"]
+
+
+@dataclass(frozen=True)
+class GoalSpec:
+    """One goal-quantity row: label, unit, editor ranges, guidance."""
+
+    name: str
+    label: str
+    unit: str
+    default_target: float
+    spin_range: tuple[float, float]
+    guidance: str
+
+
+@dataclass(frozen=True)
+class VariableSpec:
+    """One variable row: label, unit, default value/bounds, guidance."""
+
+    name: str
+    label: str
+    unit: str
+    default_value: float
+    default_bounds: tuple[float, float]
+    spin_range: tuple[float, float]
+    guidance: str
+    decimals: int = 1
+    swing_only: bool = False
+
+
+GOAL_SPECS: tuple[GoalSpec, ...] = (
+    GoalSpec(
+        "club_path_deg",
+        "Club Path",
+        "°",
+        0.0,
+        (-45.0, 45.0),
+        "Suggested range: -8 to +8 deg (positive = in-to-out); tour "
+        "driver means sit within a few degrees of zero. Source: openly "
+        "published tour launch-monitor averages.",
+    ),
+    GoalSpec(
+        "face_angle_deg",
+        "Face Angle",
+        "°",
+        0.0,
+        (-45.0, 45.0),
+        "Suggested range: -5 to +5 deg at impact (positive = open, "
+        "right of target for a right-handed player). Source: standard "
+        "launch-monitor sign conventions and published tour data.",
+    ),
+    GoalSpec(
+        "attack_angle_deg",
+        "Attack Angle",
+        "°",
+        -1.0,
+        (-30.0, 30.0),
+        "Suggested range: -5 to +5 deg for drivers (tour mean near "
+        "-1 deg; distance-optimised swings hit up to +5). Source: "
+        "openly published tour launch-monitor averages.",
+    ),
+    GoalSpec(
+        "dynamic_loft_deg",
+        "Dynamic Loft",
+        "°",
+        12.0,
+        (0.0, 60.0),
+        "Suggested range: 8-16 deg delivered loft for drivers, up to "
+        "the static loft plus shaft lean for irons and wedges. Source: "
+        "published launch-monitor fitting references.",
+    ),
+    GoalSpec(
+        "ball_speed_mph",
+        "Ball Speed",
+        " mph",
+        150.0,
+        (0.0, 250.0),
+        "Suggested range: 120-185 mph driver ball speed (tour average "
+        "near 170; strong amateurs 140-160). Source: openly published "
+        "tour launch-monitor averages.",
+    ),
+    GoalSpec(
+        "launch_angle_deg",
+        "Launch Angle",
+        "°",
+        12.0,
+        (-20.0, 60.0),
+        "Suggested range: 9-16 deg for driver carry optimisation at "
+        "tour speeds; higher for slower ball speeds. Source: published "
+        "launch-optimisation charts from launch-monitor vendors.",
+    ),
+    GoalSpec(
+        "launch_azimuth_deg",
+        "Launch Azimuth",
+        "°",
+        0.0,
+        (-45.0, 45.0),
+        "Suggested range: within +/-5 deg of the target line (positive "
+        "= right of target); the ball starts close to the face "
+        "direction. Source: standard launch-monitor D-plane material.",
+    ),
+    GoalSpec(
+        "spin_rpm",
+        "Total Spin",
+        " rpm",
+        2600.0,
+        (0.0, 20000.0),
+        "Suggested range: 2,000-3,200 rpm for drivers (tour mean near "
+        "2,500), 4,000-7,000 mid irons, up to 10,000+ for wedges. "
+        "Source: openly published tour launch-monitor averages.",
+    ),
+    GoalSpec(
+        "spin_axis_deg",
+        "Spin-Axis Tilt",
+        "°",
+        0.0,
+        (-90.0, 90.0),
+        "Suggested range: within +/-10 deg for reasonably straight "
+        "shots (positive = fade/slice side); +/-20 deg is a strong "
+        "curve. Source: standard launch-monitor D-plane material.",
+    ),
+    GoalSpec(
+        "carry_m",
+        "Carry Distance",
+        " m",
+        230.0,
+        (0.0, 400.0),
+        "Suggested range: 200-290 m driver carry at tour ball speeds; "
+        "scale with ball speed for other clubs. Source: openly "
+        "published tour launch-monitor averages.",
+    ),
+)
+
+VARIABLE_SPECS: tuple[VariableSpec, ...] = (
+    VariableSpec(
+        "clubhead_speed_mps",
+        "Clubhead Speed",
+        " m/s",
+        45.0,
+        (30.0, 60.0),
+        (1.0, 100.0),
+        "Suggested range: 36-58 m/s (80-130 mph) driver clubhead speed "
+        "(tour average near 50.5 m/s). Source: openly published tour "
+        "launch-monitor averages.",
+    ),
+    VariableSpec(
+        "club_path_deg",
+        "Club Path",
+        "°",
+        0.0,
+        (-15.0, 15.0),
+        (-45.0, 45.0),
+        "Suggested range: -8 to +8 deg (positive = in-to-out). Source: "
+        "openly published tour launch-monitor averages.",
+    ),
+    VariableSpec(
+        "face_angle_deg",
+        "Face Angle",
+        "°",
+        0.0,
+        (-15.0, 15.0),
+        (-45.0, 45.0),
+        "Suggested range: -5 to +5 deg at impact (positive = open). "
+        "Source: standard launch-monitor sign conventions and published "
+        "tour data.",
+    ),
+    VariableSpec(
+        "attack_angle_deg",
+        "Attack Angle",
+        "°",
+        0.0,
+        (-10.0, 10.0),
+        (-30.0, 30.0),
+        "Suggested range: -5 to +5 deg for drivers (tour mean near "
+        "-1 deg). Source: openly published tour launch-monitor "
+        "averages.",
+    ),
+    VariableSpec(
+        "dynamic_loft_deg",
+        "Dynamic Loft",
+        "°",
+        10.5,
+        (5.0, 25.0),
+        (0.0, 60.0),
+        "Suggested range: 8-16 deg delivered loft for drivers; the "
+        "10.5 deg default mirrors the desktop default driver. Source: "
+        "published launch-monitor fitting references.",
+    ),
+    VariableSpec(
+        "lie_deg",
+        "Residual Lie Rotation",
+        "°",
+        0.0,
+        (-10.0, 10.0),
+        (-45.0, 45.0),
+        "Suggested range: within +/-5 deg of square; 0 keeps the "
+        "impact offsets aligned with the face's toe/high axes. Source: "
+        "AffineDrift launch-monitor frame conventions.",
+    ),
+    VariableSpec(
+        "impact_offset_toe_mm",
+        "Impact Toward Toe",
+        " mm",
+        0.0,
+        (-20.0, 20.0),
+        (-40.0, 40.0),
+        "Suggested range: within +/-15 mm of face center for "
+        "reasonable strikes; gear-effect studies use up to +/-20 mm. "
+        "Source: published robot-test impact maps.",
+    ),
+    VariableSpec(
+        "impact_offset_high_mm",
+        "Impact Above Center",
+        " mm",
+        0.0,
+        (-15.0, 15.0),
+        (-40.0, 40.0),
+        "Suggested range: within +/-10 mm of face center vertically. "
+        "Source: published robot-test impact maps.",
+    ),
+    VariableSpec(
+        "swing_yaw_deg",
+        "Swing-Plane Yaw",
+        "°",
+        0.0,
+        (-30.0, 30.0),
+        (-90.0, 90.0),
+        "Suggested range: within +/-20 deg; rotates the whole swing "
+        "plane about vertical, steering the delivered path. Source: "
+        "3-D motion-capture swing-plane studies collected in the "
+        "AffineDrift dossier.",
+        swing_only=True,
+    ),
+    VariableSpec(
+        "swing_side_tilt_deg",
+        "Swing-Plane Side Tilt",
+        "°",
+        -45.0,
+        (-70.0, -20.0),
+        (-89.0, 89.0),
+        "Suggested range: -30 to -60 deg for driver swings (0 = "
+        "vertical cartwheel plane; the tour driver plane leans roughly "
+        "45 deg). Source: 3-D motion-capture swing-plane studies "
+        "collected in the AffineDrift dossier.",
+        swing_only=True,
+    ),
+    VariableSpec(
+        "swing_forward_tilt_deg",
+        "Swing-Plane Forward Tilt",
+        "°",
+        0.0,
+        (-30.0, 30.0),
+        (-89.0, 89.0),
+        "Suggested range: within +/-15 deg; tips the plane toward or "
+        "away from the target, trading attack angle against low-point "
+        "position. Source: 3-D motion-capture swing-plane studies "
+        "collected in the AffineDrift dossier.",
+        swing_only=True,
+    ),
+    VariableSpec(
+        "swing_impact_time_offset_s",
+        "Impact-Time Offset",
+        " s",
+        0.0,
+        (-0.05, 0.05),
+        (-0.5, 0.5),
+        "Suggested range: within +/-0.05 s of the peak-clubhead-speed "
+        "instant; early impacts arrive on a descending, in-to-out arc, "
+        "late ones the reverse. Source: pendulum swing-model timing in "
+        "the shared swing_sim package.",
+        decimals=4,
+        swing_only=True,
+    ),
+    VariableSpec(
+        "swing_damping_shoulder",
+        "Shoulder Damping",
+        " N·m·s",
+        0.4,
+        (0.0, 2.0),
+        (0.0, 10.0),
+        "Suggested range: 0-2 N·m·s viscous damping on the shoulder "
+        "joint (0.4 is the shared golf default). Source: double-"
+        "pendulum golf-swing literature parameters used by swing_sim.",
+        decimals=2,
+        swing_only=True,
+    ),
+    VariableSpec(
+        "swing_damping_wrist",
+        "Wrist Damping",
+        " N·m·s",
+        0.25,
+        (0.0, 2.0),
+        (0.0, 10.0),
+        "Suggested range: 0-2 N·m·s viscous damping on the wrist hinge "
+        "(0.25 is the shared golf default). Source: double-pendulum "
+        "golf-swing literature parameters used by swing_sim.",
+        decimals=2,
+        swing_only=True,
+    ),
+)

--- a/src/rate_of_closure/ui/pyqt6/solver_worker.py
+++ b/src/rate_of_closure/ui/pyqt6/solver_worker.py
@@ -1,0 +1,87 @@
+"""QThread worker running the impact-parameter solver off the UI thread.
+
+Epic #4103, #4109/#4110. The Solver panel never blocks the GUI: the
+multi-start ``swing_sim.solver.solve`` call runs inside this
+:class:`QThread`, progress reports cross back as queued signals, and
+cancellation is cooperative via the solver's ``cancel_event`` seam
+(``threading.Event``) — the same plumbing the movement_optimizer UIs
+use.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from PyQt6.QtCore import QThread, pyqtSignal
+
+from shared.python.swing_sim.solver.goals import ImpactGoal, VariablePartition
+from shared.python.swing_sim.solver.solve import CancelledError, solve
+from shared.python.swing_sim.solver.tuning import DEFAULT_MAX_NFEV_PER_START
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["SolverWorker"]
+
+
+class SolverWorker(QThread):
+    """One solver run: construct, ``start()``, listen, optionally ``cancel()``.
+
+    Signals (all delivered on the GUI thread via queued connections):
+        progressed(object): A ``ProgressReport`` snapshot.
+        succeeded(object): The final ``SolverResult``.
+        cancelled(): The run was cancelled before any start completed.
+        failed(str): The solver raised; the message is user-presentable.
+    """
+
+    progressed = pyqtSignal(object)  # noqa: N815 — Qt signal convention
+    succeeded = pyqtSignal(object)  # noqa: N815
+    cancelled = pyqtSignal()  # noqa: N815
+    failed = pyqtSignal(str)  # noqa: N815
+
+    def __init__(
+        self,
+        goal: ImpactGoal,
+        partition: VariablePartition,
+        n_starts: int,
+        max_nfev_per_start: int = DEFAULT_MAX_NFEV_PER_START,
+    ) -> None:
+        super().__init__()
+        self._goal = goal
+        self._partition = partition
+        self._n_starts = int(n_starts)
+        self._max_nfev = int(max_nfev_per_start)
+        self._cancel_event = threading.Event()
+
+    @property
+    def cancel_event(self) -> threading.Event:
+        """The cooperative cancellation event wired into the solver."""
+        return self._cancel_event
+
+    @property
+    def max_evaluations(self) -> int:
+        """Upper bound on residual evaluations (drives the progress bar)."""
+        return self._n_starts * self._max_nfev
+
+    def cancel(self) -> None:
+        """Request cooperative cancellation (in-flight starts unwind)."""
+        self._cancel_event.set()
+
+    def run(self) -> None:  # pragma: no cover — exercised via signals in tests
+        """Thread body: run the solver, translate outcomes into signals."""
+        try:
+            result = solve(
+                self._goal,
+                self._partition,
+                n_starts=self._n_starts,
+                max_nfev_per_start=self._max_nfev,
+                progress_cb=self.progressed.emit,
+                cancel_event=self._cancel_event,
+            )
+        except CancelledError:
+            self.cancelled.emit()
+        except Exception as exc:  # noqa: BLE001 — surface solver failures
+            logger.warning("solver run failed: %s", exc)
+            self.failed.emit(str(exc))
+        else:
+            self.succeeded.emit(result)

--- a/src/rate_of_closure/web/src/App.tsx
+++ b/src/rate_of_closure/web/src/App.tsx
@@ -239,7 +239,13 @@ export default function App() {
       {tab === TABS[2] ? (
         // Static loft mirrors the desktop default driver; the full club
         // picker joins the web simulation with the P7 WASM port.
-        <SimulationPanel scenario={scenario} loftDeg={10.5} />
+        <SimulationPanel
+          scenario={scenario}
+          loftDeg={10.5}
+          onScenarioChange={(updates) =>
+            setScenario((s) => ({ ...s, ...updates }))
+          }
+        />
       ) : tab === TABS[1] ? (
         <Derivation scenario={scenario} />
       ) : (

--- a/src/rate_of_closure/web/src/components/SimulationPanel.tsx
+++ b/src/rate_of_closure/web/src/components/SimulationPanel.tsx
@@ -23,6 +23,7 @@ import {
 } from "../model/simulation";
 import { FIELD_GUIDANCE } from "../model/units";
 import { type ImpactScenario } from "../model/impact";
+import { SolverPanel } from "./SolverPanel";
 
 const RATE_PRESETS: Array<{ label: string; rate: number }> = [
   { label: "0.1×", rate: 0.1 },
@@ -46,9 +47,10 @@ const LAUNCH_ROWS: Array<{ key: keyof SimulationRunTs["launch"]; label: string; 
 interface Props {
   scenario: ImpactScenario;
   loftDeg: number;
+  onScenarioChange: (updates: Partial<ImpactScenario>) => void;
 }
 
-export function SimulationPanel({ scenario, loftDeg }: Props) {
+export function SimulationPanel({ scenario, loftDeg, onScenarioChange }: Props) {
   const [sourceKind, setSourceKind] = useState<WebSourceKind>("manual");
   const [tilts, setTilts] = useState({ yaw: 0, side: -45, forward: 0 });
   const [tauMs, setTauMs] = useState<number | null>(null);
@@ -368,6 +370,8 @@ export function SimulationPanel({ scenario, loftDeg }: Props) {
             WASM kernels in P7.
           </p>
         </div>
+
+        <SolverPanel onApply={onScenarioChange} />
       </section>
 
       <section className="space-y-3">

--- a/src/rate_of_closure/web/src/components/SolverPanel.tsx
+++ b/src/rate_of_closure/web/src/components/SolverPanel.tsx
@@ -1,0 +1,398 @@
+/**
+ * Solver section for the web Simulation tab (epic #4103, #4109/#4110).
+ *
+ * Practical counterpart of the PyQt6 Solver panel: checkbox-enabled
+ * weighted goal targets, a per-variable Optimize-with-bounds / Fix
+ * partition over the delivery variables, a synchronous bounded
+ * Nelder-Mead run through the parity-ported TS physics
+ * (model/solver.ts), an achieved-vs-goal results table with per-goal
+ * errors / residual norm / convergence, and an Apply button that loads
+ * the solved clubhead speed and impact offsets into the scenario so the
+ * simulation reruns with them. Validation problems surface as friendly
+ * messages. The WASM + web-worker upgrade (progress, cancel, swing-
+ * source mode) lands with the P7 kernels.
+ */
+
+import { useState } from "react";
+
+import { type ImpactScenario } from "../model/impact";
+import { MPH_PER_MPS } from "../model/simulation";
+import {
+  solveGoals,
+  type SolverGoalKey,
+  type SolverGoalTs,
+  type SolverResultTs,
+  type SolverVariableKey,
+  type VariablePartitionTs,
+  VARIABLE_DEFAULTS,
+} from "../model/solver";
+import { FIELD_GUIDANCE } from "../model/units";
+
+interface GoalRowSpec {
+  key: SolverGoalKey;
+  label: string;
+  unit: string;
+  target: number;
+}
+
+const GOAL_ROWS: GoalRowSpec[] = [
+  { key: "clubPathDeg", label: "Club Path", unit: "°", target: 0 },
+  { key: "faceAngleDeg", label: "Face Angle", unit: "°", target: 0 },
+  { key: "attackAngleDeg", label: "Attack Angle", unit: "°", target: -1 },
+  { key: "dynamicLoftDeg", label: "Dynamic Loft", unit: "°", target: 12 },
+  { key: "ballSpeedMph", label: "Ball Speed", unit: "mph", target: 150 },
+  { key: "launchAngleDeg", label: "Launch Angle", unit: "°", target: 12 },
+  { key: "launchAzimuthDeg", label: "Launch Azimuth", unit: "°", target: 0 },
+  { key: "spinRpm", label: "Total Spin", unit: "rpm", target: 2600 },
+  { key: "carryM", label: "Carry Distance", unit: "m", target: 230 },
+];
+
+interface VarRowSpec {
+  key: SolverVariableKey;
+  label: string;
+  unit: string;
+  bounds: [number, number];
+  guidanceKey: string;
+}
+
+const VAR_ROWS: VarRowSpec[] = [
+  {
+    key: "clubheadSpeedMps",
+    label: "Clubhead Speed",
+    unit: "m/s",
+    bounds: [30, 60],
+    guidanceKey: "clubheadSpeedMph",
+  },
+  {
+    key: "clubPathDeg",
+    label: "Club Path",
+    unit: "°",
+    bounds: [-15, 15],
+    guidanceKey: "solverClubPath",
+  },
+  {
+    key: "faceAngleDeg",
+    label: "Face Angle",
+    unit: "°",
+    bounds: [-15, 15],
+    guidanceKey: "solverFaceAngle",
+  },
+  {
+    key: "attackAngleDeg",
+    label: "Attack Angle",
+    unit: "°",
+    bounds: [-10, 10],
+    guidanceKey: "solverAttackAngle",
+  },
+  {
+    key: "dynamicLoftDeg",
+    label: "Dynamic Loft",
+    unit: "°",
+    bounds: [5, 25],
+    guidanceKey: "clubLoftDeg",
+  },
+  {
+    key: "impactOffsetToeMm",
+    label: "Impact Toward Toe",
+    unit: "mm",
+    bounds: [-20, 20],
+    guidanceKey: "impactOffsetToeMm",
+  },
+  {
+    key: "impactOffsetHighMm",
+    label: "Impact Above Center",
+    unit: "mm",
+    bounds: [-15, 15],
+    guidanceKey: "impactOffsetHighMm",
+  },
+];
+
+/** Solver-only guidance (FIELD_GUIDANCE covers the shared fields). */
+const SOLVER_GUIDANCE: Record<string, string> = {
+  solverClubPath:
+    "Suggested range: -8 to +8 deg (positive = in-to-out). Source: " +
+    "openly published tour launch-monitor averages.",
+  solverFaceAngle:
+    "Suggested range: -5 to +5 deg at impact (positive = open). Source: " +
+    "standard launch-monitor sign conventions and published tour data.",
+  solverAttackAngle:
+    "Suggested range: -5 to +5 deg for drivers (tour mean near -1 deg). " +
+    "Source: openly published tour launch-monitor averages.",
+};
+
+const guidance = (key: string): string =>
+  FIELD_GUIDANCE[key] ?? SOLVER_GUIDANCE[key] ?? "";
+
+interface GoalState {
+  enabled: boolean;
+  target: number;
+  weight: number;
+}
+
+interface VarState {
+  optimize: boolean;
+  lo: number;
+  hi: number;
+  value: number;
+}
+
+interface Props {
+  onApply: (updates: Partial<ImpactScenario>) => void;
+}
+
+const inputClass =
+  "no-spinner w-20 rounded border border-slate-700 bg-slate-800 px-2 " +
+  "py-1 text-slate-100 focus:border-blue-500 focus:outline-none " +
+  "disabled:opacity-40";
+
+export function SolverPanel({ onApply }: Props) {
+  const [goals, setGoals] = useState<Record<string, GoalState>>(() =>
+    Object.fromEntries(
+      GOAL_ROWS.map((row) => [
+        row.key,
+        {
+          enabled: row.key === "ballSpeedMph",
+          target: row.target,
+          weight: 1,
+        },
+      ]),
+    ),
+  );
+  const [vars, setVars] = useState<Record<string, VarState>>(() =>
+    Object.fromEntries(
+      VAR_ROWS.map((row) => [
+        row.key,
+        {
+          optimize: row.key === "clubheadSpeedMps",
+          lo: row.bounds[0],
+          hi: row.bounds[1],
+          value: VARIABLE_DEFAULTS[row.key],
+        },
+      ]),
+    ),
+  );
+  const [result, setResult] = useState<SolverResultTs | null>(null);
+  const [message, setMessage] = useState<string>("");
+
+  const setGoal = (key: string, patch: Partial<GoalState>) =>
+    setGoals((g) => ({ ...g, [key]: { ...g[key], ...patch } }));
+  const setVar = (key: string, patch: Partial<VarState>) =>
+    setVars((v) => ({ ...v, [key]: { ...v[key], ...patch } }));
+
+  const runSolver = () => {
+    const goal: SolverGoalTs = {};
+    for (const row of GOAL_ROWS) {
+      const state = goals[row.key];
+      if (state.enabled) {
+        goal[row.key] = { target: state.target, weight: state.weight };
+      }
+    }
+    const partition: VariablePartitionTs = { free: {}, fixed: {} };
+    for (const row of VAR_ROWS) {
+      const state = vars[row.key];
+      if (state.optimize) partition.free[row.key] = [state.lo, state.hi];
+      else partition.fixed[row.key] = state.value;
+    }
+    try {
+      const solved = solveGoals(goal, partition);
+      setResult(solved);
+      setMessage(
+        `${solved.converged ? "Converged" : "Did NOT converge"} — residual ` +
+          `norm ${solved.residualNorm.toExponential(2)}, ${solved.nEvals} ` +
+          "evaluations.",
+      );
+    } catch (error) {
+      setResult(null);
+      setMessage(`Cannot solve: ${(error as Error).message}`);
+    }
+  };
+
+  const applySolution = () => {
+    if (!result) return;
+    onApply({
+      clubheadSpeedMph: result.variables.clubheadSpeedMps * MPH_PER_MPS,
+      impactOffsetToeMm: result.variables.impactOffsetToeMm,
+      impactOffsetHighMm: result.variables.impactOffsetHighMm,
+    });
+    setMessage(
+      "Applied: scenario clubhead speed and impact offsets updated — " +
+        "run the simulation to see the optimized impact.",
+    );
+  };
+
+  const numberField = (
+    value: number,
+    disabled: boolean,
+    title: string,
+    onChange: (value: number) => void,
+  ) => (
+    <input
+      type="number"
+      inputMode="decimal"
+      value={value}
+      disabled={disabled}
+      title={title}
+      aria-disabled={disabled}
+      onChange={(e) => {
+        const parsed = Number(e.target.value);
+        if (Number.isFinite(parsed)) onChange(parsed);
+      }}
+      className={inputClass}
+    />
+  );
+
+  return (
+    <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5 shadow-lg shadow-black/20 backdrop-blur">
+      <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+        Solver — Goal-Driven Optimization
+      </h2>
+
+      <h3 className="mb-2 text-xs font-semibold uppercase text-slate-500">
+        Goals (Check the Targets to Hit)
+      </h3>
+      <div className="mb-4 grid gap-1">
+        {GOAL_ROWS.map((row) => {
+          const state = goals[row.key];
+          return (
+            <label
+              key={row.key}
+              className="flex items-center gap-2 text-sm text-slate-300"
+            >
+              <input
+                type="checkbox"
+                checked={state.enabled}
+                onChange={(e) => setGoal(row.key, { enabled: e.target.checked })}
+              />
+              <span className="flex-1">
+                {row.label}{" "}
+                <span className="text-slate-500">({row.unit})</span>
+              </span>
+              {numberField(state.target, !state.enabled, `Target ${row.unit}`, (v) =>
+                setGoal(row.key, { target: v }),
+              )}
+              <span className="text-slate-500">w</span>
+              {numberField(state.weight, !state.enabled, "Relative weight", (v) =>
+                setGoal(row.key, { weight: v }),
+              )}
+            </label>
+          );
+        })}
+      </div>
+
+      <h3 className="mb-2 text-xs font-semibold uppercase text-slate-500">
+        Variables (Optimize Within Bounds, or Fix)
+      </h3>
+      <div className="mb-4 grid gap-2">
+        {VAR_ROWS.map((row) => {
+          const state = vars[row.key];
+          return (
+            <div
+              key={row.key}
+              title={guidance(row.guidanceKey)}
+              className="flex flex-wrap items-center gap-2 text-sm text-slate-300"
+            >
+              <span className="w-40">
+                {row.label}{" "}
+                <span className="text-slate-500">({row.unit})</span>
+              </span>
+              <label className="flex items-center gap-1">
+                <input
+                  type="radio"
+                  name={`solver-var-${row.key}`}
+                  checked={state.optimize}
+                  onChange={() => setVar(row.key, { optimize: true })}
+                />
+                Optimize
+              </label>
+              {numberField(state.lo, !state.optimize, "Lower bound", (v) =>
+                setVar(row.key, { lo: v }),
+              )}
+              {numberField(state.hi, !state.optimize, "Upper bound", (v) =>
+                setVar(row.key, { hi: v }),
+              )}
+              <label className="flex items-center gap-1">
+                <input
+                  type="radio"
+                  name={`solver-var-${row.key}`}
+                  checked={!state.optimize}
+                  onChange={() => setVar(row.key, { optimize: false })}
+                />
+                Fix
+              </label>
+              {numberField(state.value, state.optimize, "Fixed value", (v) =>
+                setVar(row.key, { value: v }),
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mb-3 flex gap-2">
+        <button
+          type="button"
+          onClick={runSolver}
+          className="flex-1 rounded-lg border border-sky-400/60 bg-sky-500/10 px-3 py-2 text-sm font-semibold text-sky-300 transition-all hover:bg-sky-500/20"
+        >
+          Run Solver
+        </button>
+        <button
+          type="button"
+          onClick={applySolution}
+          disabled={!result}
+          className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-300 hover:border-slate-500 disabled:opacity-40"
+        >
+          Apply to Scenario
+        </button>
+      </div>
+
+      {message && (
+        <p aria-live="polite" className="mb-3 text-xs text-slate-400">
+          {message}
+        </p>
+      )}
+
+      {result && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="text-xs uppercase text-slate-500">
+                <th className="py-1 pr-2">Quantity</th>
+                <th className="py-1 pr-2">Target</th>
+                <th className="py-1 pr-2">Achieved</th>
+                <th className="py-1">Error</th>
+              </tr>
+            </thead>
+            <tbody>
+              {GOAL_ROWS.filter((row) => goals[row.key].enabled).map((row) => (
+                <tr key={row.key} className="border-t border-slate-800/70">
+                  <td className="py-1 pr-2 text-slate-400">{row.label}</td>
+                  <td className="py-1 pr-2 tabular-nums">
+                    {goals[row.key].target.toFixed(1)} {row.unit}
+                  </td>
+                  <td className="py-1 pr-2 tabular-nums">
+                    {(result.achieved[row.key] ?? NaN).toFixed(1)} {row.unit}
+                  </td>
+                  <td className="py-1 tabular-nums">
+                    {(result.perGoalErrors[row.key] ?? NaN).toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="mt-2 text-xs text-slate-500">
+            Solved:{" "}
+            {VAR_ROWS.filter((row) => vars[row.key].optimize)
+              .map(
+                (row) =>
+                  `${row.label} = ${result.variables[row.key].toFixed(2)} ${row.unit}`,
+              )
+              .join(", ")}
+            . Goals are limited to what the parity-ported TS physics
+            computes; the swing-source mode, progress reporting, and
+            cancellation arrive with the WASM worker in P7.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/rate_of_closure/web/src/model/solver.test.ts
+++ b/src/rate_of_closure/web/src/model/solver.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Solver tests — the easy case is pinned against the pytest suite
+ * (tests/rate_of_closure/test_solver_gui.py, TestWorker): a 150 mph
+ * ball-speed goal over a free clubhead speed in [30, 70] m/s solves to
+ * ~45.825 m/s in the Python swing_sim solver; the TS solver must land
+ * on the same solution through the parity-ported physics.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  achievedQuantities,
+  assembleVariables,
+  solveGoals,
+  validateInputs,
+  VARIABLE_DEFAULTS,
+} from "./solver";
+
+const easyGoal = { ballSpeedMph: { target: 150.0, weight: 1.0 } };
+const easyPartition = {
+  free: { clubheadSpeedMps: [30.0, 70.0] as [number, number] },
+  fixed: {},
+};
+
+describe("solveGoals — pinned parity easy case", () => {
+  it("recovers the pytest-pinned clubhead speed for 150 mph ball speed", () => {
+    const result = solveGoals(easyGoal, easyPartition);
+    expect(result.converged).toBe(true);
+    // Python swing_sim solver pins 45.825 m/s (test_solver_gui.py).
+    expect(result.variables.clubheadSpeedMps).toBeCloseTo(45.825, 1);
+    expect(result.achieved.ballSpeedMph!).toBeCloseTo(150.0, 2);
+    expect(result.perGoalErrors.ballSpeedMph!).toBeCloseTo(0.0, 2);
+    expect(result.residualNorm).toBeLessThan(1e-2);
+  });
+
+  it("respects bounds when the goal is unreachable", () => {
+    const result = solveGoals(easyGoal, {
+      free: { clubheadSpeedMps: [30.0, 40.0] },
+      fixed: {},
+    });
+    expect(result.variables.clubheadSpeedMps).toBeLessThanOrEqual(40.0);
+    expect(result.variables.clubheadSpeedMps).toBeCloseTo(40.0, 3);
+    expect(result.achieved.ballSpeedMph!).toBeLessThan(150.0);
+  });
+
+  it("solves a two-variable goal (launch angle via loft, speed)", () => {
+    const result = solveGoals(
+      {
+        ballSpeedMph: { target: 150.0, weight: 1.0 },
+        launchAngleDeg: { target: 12.0, weight: 1.0 },
+      },
+      {
+        free: {
+          clubheadSpeedMps: [30.0, 70.0],
+          dynamicLoftDeg: [5.0, 25.0],
+        },
+        fixed: {},
+      },
+    );
+    expect(result.achieved.ballSpeedMph!).toBeCloseTo(150.0, 1);
+    expect(result.achieved.launchAngleDeg!).toBeCloseTo(12.0, 1);
+  });
+
+  it("delivery-level goals pass straight through", () => {
+    const achieved = achievedQuantities(
+      { ...VARIABLE_DEFAULTS, clubPathDeg: 3.0 },
+      { clubPathDeg: { target: 3.0, weight: 1.0 } },
+    );
+    expect(achieved.clubPathDeg).toBeCloseTo(3.0, 9);
+    expect(achieved.ballSpeedMph).toBeUndefined();
+  });
+
+  it("assembles defaults + fixed + free in the documented order", () => {
+    const variables = assembleVariables(
+      [50.0],
+      ["clubheadSpeedMps"],
+      { free: { clubheadSpeedMps: [30, 70] }, fixed: { faceAngleDeg: 2.0 } },
+    );
+    expect(variables.clubheadSpeedMps).toBe(50.0);
+    expect(variables.faceAngleDeg).toBe(2.0);
+    expect(variables.dynamicLoftDeg).toBe(VARIABLE_DEFAULTS.dynamicLoftDeg);
+  });
+});
+
+describe("validateInputs — DbC parity", () => {
+  it("rejects an empty goal", () => {
+    expect(() => validateInputs({}, easyPartition)).toThrow(/at least one goal/);
+  });
+
+  it("rejects an empty free set", () => {
+    expect(() =>
+      validateInputs(easyGoal, { free: {}, fixed: {} }),
+    ).toThrow(/at least one variable/);
+  });
+
+  it("rejects inverted bounds", () => {
+    expect(() =>
+      validateInputs(easyGoal, {
+        free: { clubheadSpeedMps: [70.0, 30.0] },
+        fixed: {},
+      }),
+    ).toThrow(/lower < upper/);
+  });
+
+  it("rejects overlapping free and fixed variables", () => {
+    expect(() =>
+      validateInputs(easyGoal, {
+        free: { clubheadSpeedMps: [30.0, 70.0] },
+        fixed: { clubheadSpeedMps: 45.0 },
+      }),
+    ).toThrow(/both free and fixed/);
+  });
+
+  it("rejects non-positive weights", () => {
+    expect(() =>
+      validateInputs(
+        { ballSpeedMph: { target: 150.0, weight: 0.0 } },
+        easyPartition,
+      ),
+    ).toThrow(/weight/);
+  });
+});

--- a/src/rate_of_closure/web/src/model/solver.ts
+++ b/src/rate_of_closure/web/src/model/solver.ts
@@ -1,0 +1,344 @@
+/**
+ * Impact-parameter solver for the web clone (epic #4103, #4109/#4110).
+ *
+ * Practical TypeScript counterpart of shared/python/swing_sim/solver:
+ * goals limited to what the ported TS physics computes (club path / face
+ * / attack angle / dynamic loft at the delivery level; ball speed,
+ * launch angles, and spin through solveImpact + deriveLaunch; carry
+ * through the Waterloo/Penner flight port), the same
+ * launch-monitor-resolution residual scales, and the same free-with-
+ * bounds vs fixed variable partition over the delivery variables.
+ *
+ * The optimizer is a bounded Nelder-Mead over the free variables
+ * (candidates clamped into the bounds before evaluation) with a small
+ * deterministic multi-start — simple and honest for <= 7 smooth
+ * variables. No swing-source mode on web, and no worker thread yet:
+ * solves are quick at these sizes, and the WASM + web-worker upgrade
+ * lands with the P7 kernels (see model/simulation.ts).
+ *
+ * Parity: solver.test.ts pins the same easy case as the pytest suite
+ * (tests/rate_of_closure/test_solver_gui.py) — 150 mph ball speed from
+ * a free clubhead speed solves to ~45.825 m/s in both implementations.
+ */
+
+import { deriveLaunch, simulateFlight } from "./flight";
+import { MPH_PER_MPS, solveImpact, toFlightFrame } from "./simulation";
+
+export const SOLVER_GOAL_KEYS = [
+  "clubPathDeg",
+  "faceAngleDeg",
+  "attackAngleDeg",
+  "dynamicLoftDeg",
+  "ballSpeedMph",
+  "launchAngleDeg",
+  "launchAzimuthDeg",
+  "spinRpm",
+  "carryM",
+] as const;
+export type SolverGoalKey = (typeof SOLVER_GOAL_KEYS)[number];
+
+export const SOLVER_VARIABLE_KEYS = [
+  "clubheadSpeedMps",
+  "clubPathDeg",
+  "faceAngleDeg",
+  "attackAngleDeg",
+  "dynamicLoftDeg",
+  "impactOffsetToeMm",
+  "impactOffsetHighMm",
+] as const;
+export type SolverVariableKey = (typeof SOLVER_VARIABLE_KEYS)[number];
+
+/** Defaults used for variables that are neither free nor fixed. */
+export const VARIABLE_DEFAULTS: Record<SolverVariableKey, number> = {
+  clubheadSpeedMps: 45.0,
+  clubPathDeg: 0.0,
+  faceAngleDeg: 0.0,
+  attackAngleDeg: 0.0,
+  dynamicLoftDeg: 10.5,
+  impactOffsetToeMm: 0.0,
+  impactOffsetHighMm: 0.0,
+};
+
+/** Same launch-monitor-resolution scales as swing_sim/solver/tuning.py. */
+const RESIDUAL_SCALES: Record<SolverGoalKey, number> = {
+  clubPathDeg: 0.5,
+  faceAngleDeg: 0.5,
+  attackAngleDeg: 0.5,
+  dynamicLoftDeg: 0.5,
+  ballSpeedMph: 1.0,
+  launchAngleDeg: 0.5,
+  launchAzimuthDeg: 0.5,
+  spinRpm: 100.0,
+  carryM: 1.0,
+};
+
+export interface GoalTermTs {
+  target: number;
+  weight: number;
+}
+
+export type SolverGoalTs = Partial<Record<SolverGoalKey, GoalTermTs>>;
+
+export interface VariablePartitionTs {
+  free: Partial<Record<SolverVariableKey, [number, number]>>;
+  fixed: Partial<Record<SolverVariableKey, number>>;
+}
+
+export interface SolverResultTs {
+  variables: Record<SolverVariableKey, number>;
+  achieved: Partial<Record<SolverGoalKey, number>>;
+  perGoalErrors: Partial<Record<SolverGoalKey, number>>;
+  residualNorm: number;
+  cost: number;
+  converged: boolean;
+  nEvals: number;
+}
+
+const MAX_ANGLE_DEG = 89.0;
+const clampAngle = (v: number): number =>
+  Math.max(-MAX_ANGLE_DEG, Math.min(MAX_ANGLE_DEG, v));
+
+/** DbC-style validation mirroring VariablePartition/ImpactGoal. */
+export function validateInputs(
+  goal: SolverGoalTs,
+  partition: VariablePartitionTs,
+): void {
+  const goalKeys = Object.keys(goal) as SolverGoalKey[];
+  if (goalKeys.length === 0) {
+    throw new Error("at least one goal quantity must be targeted");
+  }
+  for (const key of goalKeys) {
+    const term = goal[key];
+    if (!SOLVER_GOAL_KEYS.includes(key)) {
+      throw new Error(`unknown goal quantity ${key}`);
+    }
+    if (!term || !Number.isFinite(term.target) || !(term.weight > 0)) {
+      throw new Error(`goal ${key} needs a finite target and a weight > 0`);
+    }
+  }
+  const freeKeys = Object.keys(partition.free) as SolverVariableKey[];
+  const fixedKeys = Object.keys(partition.fixed) as SolverVariableKey[];
+  for (const key of [...freeKeys, ...fixedKeys]) {
+    if (!SOLVER_VARIABLE_KEYS.includes(key)) {
+      throw new Error(`unknown variable ${key}`);
+    }
+  }
+  for (const key of freeKeys) {
+    if (fixedKeys.includes(key)) {
+      throw new Error(`variable ${key} cannot be both free and fixed`);
+    }
+    const [lo, hi] = partition.free[key]!;
+    if (!Number.isFinite(lo) || !Number.isFinite(hi) || !(lo < hi)) {
+      throw new Error(`bounds for ${key} must be finite with lower < upper`);
+    }
+  }
+  for (const key of fixedKeys) {
+    if (!Number.isFinite(partition.fixed[key]!)) {
+      throw new Error(`fixed value for ${key} must be finite`);
+    }
+  }
+  if (freeKeys.length === 0) {
+    throw new Error("at least one variable must be optimized");
+  }
+}
+
+/** Full variable record from a free-variable vector (defaults filled). */
+export function assembleVariables(
+  x: number[],
+  freeKeys: SolverVariableKey[],
+  partition: VariablePartitionTs,
+): Record<SolverVariableKey, number> {
+  const variables = { ...VARIABLE_DEFAULTS, ...partition.fixed };
+  freeKeys.forEach((key, i) => {
+    variables[key] = x[i];
+  });
+  return variables;
+}
+
+/** Run delivery -> impact (-> flight) and report achieved quantities. */
+export function achievedQuantities(
+  variables: Record<SolverVariableKey, number>,
+  goal: SolverGoalTs,
+): Partial<Record<SolverGoalKey, number>> {
+  const achieved: Partial<Record<SolverGoalKey, number>> = {
+    clubPathDeg: clampAngle(variables.clubPathDeg),
+    faceAngleDeg: clampAngle(variables.faceAngleDeg),
+    attackAngleDeg: clampAngle(variables.attackAngleDeg),
+    dynamicLoftDeg: clampAngle(variables.dynamicLoftDeg),
+  };
+  const needsLaunch =
+    goal.ballSpeedMph !== undefined ||
+    goal.launchAngleDeg !== undefined ||
+    goal.launchAzimuthDeg !== undefined ||
+    goal.spinRpm !== undefined ||
+    goal.carryM !== undefined;
+  if (!needsLaunch) return achieved;
+
+  const impact = solveImpact({
+    clubheadSpeedMps: Math.max(variables.clubheadSpeedMps, 1e-3),
+    clubPathDeg: achieved.clubPathDeg!,
+    faceAngleDeg: achieved.faceAngleDeg!,
+    attackAngleDeg: achieved.attackAngleDeg!,
+    dynamicLoftDeg: achieved.dynamicLoftDeg!,
+    impactOffsetToeMm: variables.impactOffsetToeMm,
+    impactOffsetHighMm: variables.impactOffsetHighMm,
+  });
+  const launch = deriveLaunch(
+    toFlightFrame(impact.ballVelocity),
+    toFlightFrame(impact.ballAngularVelocity),
+  );
+  achieved.ballSpeedMph = launch.ballSpeedMps * MPH_PER_MPS;
+  achieved.launchAngleDeg = (launch.launchAngleRad * 180.0) / Math.PI;
+  // Flight-frame azimuth is + toward +y (left); goals use + = right.
+  achieved.launchAzimuthDeg = (-launch.azimuthRad * 180.0) / Math.PI;
+  achieved.spinRpm = launch.spinRpm;
+  if (goal.carryM !== undefined) {
+    achieved.carryM = simulateFlight(launch).carryM;
+  }
+  return achieved;
+}
+
+/** Scalar cost: sum of squared weighted, scaled per-goal residuals. */
+function costOf(
+  x: number[],
+  freeKeys: SolverVariableKey[],
+  partition: VariablePartitionTs,
+  goal: SolverGoalTs,
+): number {
+  const achieved = achievedQuantities(
+    assembleVariables(x, freeKeys, partition),
+    goal,
+  );
+  let cost = 0.0;
+  for (const key of Object.keys(goal) as SolverGoalKey[]) {
+    const term = goal[key]!;
+    const r =
+      (term.weight * (achieved[key]! - term.target)) / RESIDUAL_SCALES[key];
+    cost += r * r;
+  }
+  return 0.5 * cost;
+}
+
+interface NmOptions {
+  maxEvals: number;
+  tol: number;
+}
+
+/** Bounded Nelder-Mead: candidates are clamped into the bounds. */
+function nelderMead(
+  f: (x: number[]) => number,
+  x0: number[],
+  lo: number[],
+  hi: number[],
+  options: NmOptions,
+): { x: number[]; cost: number; nEvals: number; converged: boolean } {
+  const n = x0.length;
+  const clamp = (x: number[]): number[] =>
+    x.map((v, i) => Math.max(lo[i], Math.min(hi[i], v)));
+  let nEvals = 0;
+  const evalAt = (x: number[]): number => {
+    nEvals += 1;
+    return f(clamp(x));
+  };
+  // Initial simplex: x0 plus 5%-of-range steps along each axis.
+  let simplex = [clamp(x0), ...x0.map((_, i) => {
+    const step = 0.05 * (hi[i] - lo[i]);
+    const vertex = [...x0];
+    vertex[i] = vertex[i] + step <= hi[i] ? vertex[i] + step : vertex[i] - step;
+    return clamp(vertex);
+  })].map((x) => ({ x, cost: evalAt(x) }));
+
+  let converged = false;
+  while (nEvals < options.maxEvals) {
+    simplex.sort((a, b) => a.cost - b.cost);
+    if (
+      Math.abs(simplex[n].cost - simplex[0].cost) <
+      options.tol * (1.0 + Math.abs(simplex[0].cost))
+    ) {
+      converged = true;
+      break;
+    }
+    const centroid = new Array<number>(n).fill(0);
+    for (let i = 0; i < n; i += 1) {
+      for (let j = 0; j < n; j += 1) centroid[j] += simplex[i].x[j] / n;
+    }
+    const worst = simplex[n];
+    const move = (factor: number): number[] =>
+      centroid.map((c, j) => c + factor * (worst.x[j] - c));
+    const reflected = move(-1.0);
+    const reflectedCost = evalAt(reflected);
+    if (reflectedCost < simplex[0].cost) {
+      const expanded = move(-2.0);
+      const expandedCost = evalAt(expanded);
+      simplex[n] =
+        expandedCost < reflectedCost
+          ? { x: expanded, cost: expandedCost }
+          : { x: reflected, cost: reflectedCost };
+    } else if (reflectedCost < simplex[n - 1].cost) {
+      simplex[n] = { x: reflected, cost: reflectedCost };
+    } else {
+      const contracted = move(0.5);
+      const contractedCost = evalAt(contracted);
+      if (contractedCost < worst.cost) {
+        simplex[n] = { x: contracted, cost: contractedCost };
+      } else {
+        // Shrink toward the best vertex.
+        simplex = simplex.map((v, i) =>
+          i === 0
+            ? v
+            : (() => {
+                const x = v.x.map(
+                  (value, j) => simplex[0].x[j] + 0.5 * (value - simplex[0].x[j]),
+                );
+                return { x, cost: evalAt(x) };
+              })(),
+        );
+      }
+    }
+  }
+  simplex.sort((a, b) => a.cost - b.cost);
+  return { x: clamp(simplex[0].x), cost: simplex[0].cost, nEvals, converged };
+}
+
+/** Deterministic multi-start fractions (midpoint first, no RNG). */
+const START_FRACTIONS = [0.5, 0.25, 0.75];
+
+/** Solve for the free-variable values that best achieve the goal. */
+export function solveGoals(
+  goal: SolverGoalTs,
+  partition: VariablePartitionTs,
+  maxEvalsPerStart = 400,
+): SolverResultTs {
+  validateInputs(goal, partition);
+  const freeKeys = Object.keys(partition.free) as SolverVariableKey[];
+  const lo = freeKeys.map((key) => partition.free[key]![0]);
+  const hi = freeKeys.map((key) => partition.free[key]![1]);
+  const f = (x: number[]): number => costOf(x, freeKeys, partition, goal);
+
+  let best: ReturnType<typeof nelderMead> | null = null;
+  let totalEvals = 0;
+  for (const fraction of START_FRACTIONS) {
+    const x0 = lo.map((l, i) => l + fraction * (hi[i] - l));
+    const run = nelderMead(f, x0, lo, hi, {
+      maxEvals: maxEvalsPerStart,
+      tol: 1e-12,
+    });
+    totalEvals += run.nEvals;
+    if (best === null || run.cost < best.cost) best = run;
+  }
+  const variables = assembleVariables(best!.x, freeKeys, partition);
+  const achieved = achievedQuantities(variables, goal);
+  const perGoalErrors: Partial<Record<SolverGoalKey, number>> = {};
+  for (const key of Object.keys(goal) as SolverGoalKey[]) {
+    perGoalErrors[key] = achieved[key]! - goal[key]!.target;
+  }
+  return {
+    variables,
+    achieved,
+    perGoalErrors,
+    residualNorm: Math.sqrt(2.0 * best!.cost),
+    cost: best!.cost,
+    converged: best!.converged,
+    nEvals: totalEvals,
+  };
+}

--- a/src/shared/python/swing_sim/solver/__init__.py
+++ b/src/shared/python/swing_sim/solver/__init__.py
@@ -1,0 +1,69 @@
+"""Impact-parameter solver subpackage of ``swing_sim`` (epic #4103, #4109).
+
+Goal-driven robust optimization over golf delivery/swing variables:
+declare target launch-monitor numbers (:class:`ImpactGoal`), choose which
+variables the optimizer controls (:class:`VariablePartition`), and
+:func:`solve` finds the bounded least-squares best fit with parallel
+multi-start (Latin hypercube), progress reporting, and cancellation.
+
+Scaffolding modeled on UpstreamDrift's
+``src/shared/python/movement_optimizer`` (pure cost module, multi-start
+parallel driver, ProgressReport/cancel_event plumbing, named tuning
+constants), with golf-impact semantics replacing the barbell/balance
+costs. The inner evaluation is the pure function
+:func:`evaluate_candidate` — the documented seam a later Rust port
+replaces behind a facade.
+
+Self-facaded: downstream code imports from
+``shared.python.swing_sim.solver`` only. The parent
+``swing_sim/__init__.py`` facade is wired during epic integration; do not
+add solver exports there from this subpackage.
+"""
+
+from __future__ import annotations
+
+from .goals import (
+    DELIVERY_VARIABLE_DEFAULTS,
+    GOAL_QUANTITIES,
+    SWING_DERIVED_VARIABLES,
+    SWING_VARIABLE_DEFAULTS,
+    GoalTerm,
+    ImpactGoal,
+    VariablePartition,
+)
+from .objective import (
+    EvaluationConfig,
+    achieved_quantities,
+    evaluate_candidate,
+    residuals,
+)
+from .solve import (
+    CancelledError,
+    ProgressCallback,
+    ProgressReport,
+    SolverResult,
+    StartSummary,
+    detect_stall,
+    solve,
+)
+
+__all__ = [
+    "DELIVERY_VARIABLE_DEFAULTS",
+    "GOAL_QUANTITIES",
+    "SWING_DERIVED_VARIABLES",
+    "SWING_VARIABLE_DEFAULTS",
+    "CancelledError",
+    "EvaluationConfig",
+    "GoalTerm",
+    "ImpactGoal",
+    "ProgressCallback",
+    "ProgressReport",
+    "SolverResult",
+    "StartSummary",
+    "VariablePartition",
+    "achieved_quantities",
+    "detect_stall",
+    "evaluate_candidate",
+    "residuals",
+    "solve",
+]

--- a/src/shared/python/swing_sim/solver/goals.py
+++ b/src/shared/python/swing_sim/solver/goals.py
@@ -1,0 +1,316 @@
+"""Goal and variable-partition types for the impact-parameter solver.
+
+Epic #4103, issue #4109. Scaffolding modeled on UpstreamDrift's
+``movement_optimizer`` (typed goal/constraint dataclasses feeding a pure
+objective; see ``trajectory/optimizer_constraints.py``), with golf-impact
+semantics: goals target launch-monitor quantities, and the optimizer
+controls a user-chosen partition of delivery / swing variables.
+
+Goal quantities (all optional, each with an optional weight)
+------------------------------------------------------------
+============================ ======= =====================================
+name                         unit    sign convention
+============================ ======= =====================================
+``club_path_deg``            deg     + = in-to-out
+``face_angle_deg``           deg     + = open (right of target, RH player)
+``attack_angle_deg``         deg     + = hitting up
+``dynamic_loft_deg``         deg     + = lofted upward
+``ball_speed_mph``           mph     >= 0
+``launch_angle_deg``         deg     + = above horizontal
+``launch_azimuth_deg``       deg     + = right of the target line
+``spin_rpm``                 RPM     total spin magnitude, >= 0
+``spin_axis_deg``            deg     + = fade/slice side (tilt vs backspin)
+``carry_m``                  m       carry distance, >= 0
+============================ ======= =====================================
+
+Variables (delivery mode)
+-------------------------
+The delivery front-end parameters of
+:class:`shared.python.swing_sim.impact.delivery.DeliveryParameters`:
+``clubhead_speed_mps``, ``club_path_deg``, ``face_angle_deg``,
+``attack_angle_deg``, ``dynamic_loft_deg``, ``lie_deg``, plus the impact
+offsets ``impact_offset_toe_mm`` / ``impact_offset_high_mm``.
+
+Variables (swing-source mode, ``use_swing_source=True``)
+--------------------------------------------------------
+The clubhead delivery (speed / path / attack angle) is *derived* from a
+:class:`shared.python.swing_sim.swing_source.DoublePendulumSwing` sampled
+near peak clubhead speed, so those three names are rejected; instead the
+pendulum variables become available: the three sequential swing-plane
+tilts ``swing_yaw_deg`` / ``swing_side_tilt_deg`` /
+``swing_forward_tilt_deg``, the impact-time offset
+``swing_impact_time_offset_s`` (relative to the peak-speed instant), and
+the pendulum damping parameters ``swing_damping_shoulder`` /
+``swing_damping_wrist``. Face orientation and impact offsets remain
+delivery variables in both modes.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field, fields
+from types import MappingProxyType
+
+import numpy as np
+
+from shared.python.contracts import require
+
+GOAL_QUANTITIES: tuple[str, ...] = (
+    "club_path_deg",
+    "face_angle_deg",
+    "attack_angle_deg",
+    "dynamic_loft_deg",
+    "ball_speed_mph",
+    "launch_angle_deg",
+    "launch_azimuth_deg",
+    "spin_rpm",
+    "spin_axis_deg",
+    "carry_m",
+)
+"""Canonical, ordered goal-quantity names (defines residual ordering)."""
+
+DELIVERY_VARIABLE_DEFAULTS: Mapping[str, float] = MappingProxyType(
+    {
+        "clubhead_speed_mps": 45.0,
+        "club_path_deg": 0.0,
+        "face_angle_deg": 0.0,
+        "attack_angle_deg": 0.0,
+        "dynamic_loft_deg": 10.5,
+        "lie_deg": 0.0,
+        "impact_offset_toe_mm": 0.0,
+        "impact_offset_high_mm": 0.0,
+    }
+)
+"""Delivery variables and their defaults when neither free nor fixed."""
+
+SWING_VARIABLE_DEFAULTS: Mapping[str, float] = MappingProxyType(
+    {
+        "swing_yaw_deg": 0.0,
+        "swing_side_tilt_deg": 0.0,
+        "swing_forward_tilt_deg": 0.0,
+        "swing_impact_time_offset_s": 0.0,
+        "swing_damping_shoulder": 0.4,
+        "swing_damping_wrist": 0.25,
+    }
+)
+"""Swing-source variables (pendulum + plane tilts) and their defaults."""
+
+SWING_DERIVED_VARIABLES: tuple[str, ...] = (
+    "clubhead_speed_mps",
+    "club_path_deg",
+    "attack_angle_deg",
+)
+"""Delivery variables derived from the swing sample in swing-source mode."""
+
+
+@dataclass(frozen=True)
+class GoalTerm:
+    """One goal target with a positive weight (dimensionless multiplier)."""
+
+    target: float
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        require(math.isfinite(self.target), "target must be finite", self.target)
+        require(
+            math.isfinite(self.weight) and self.weight > 0.0,
+            "weight must be finite and > 0",
+            self.weight,
+        )
+
+
+def _as_term(value: GoalTerm | float | tuple[float, float]) -> GoalTerm:
+    """Coerce ``float`` / ``(target, weight)`` / :class:`GoalTerm` inputs."""
+    if isinstance(value, GoalTerm):
+        return value
+    if isinstance(value, tuple):
+        target, weight = value
+        return GoalTerm(float(target), float(weight))
+    return GoalTerm(float(value))
+
+
+@dataclass(frozen=True)
+class ImpactGoal:
+    """Targets over any subset of the goal quantities, each optionally weighted.
+
+    Build directly with :class:`GoalTerm` fields, or via :meth:`of` which
+    also accepts plain floats and ``(target, weight)`` tuples::
+
+        goal = ImpactGoal.of(ball_speed_mph=163.0, spin_rpm=(2600.0, 0.5))
+
+    Invariant: at least one quantity is targeted.
+    """
+
+    club_path_deg: GoalTerm | None = None
+    face_angle_deg: GoalTerm | None = None
+    attack_angle_deg: GoalTerm | None = None
+    dynamic_loft_deg: GoalTerm | None = None
+    ball_speed_mph: GoalTerm | None = None
+    launch_angle_deg: GoalTerm | None = None
+    launch_azimuth_deg: GoalTerm | None = None
+    spin_rpm: GoalTerm | None = None
+    spin_axis_deg: GoalTerm | None = None
+    carry_m: GoalTerm | None = None
+
+    def __post_init__(self) -> None:
+        require(
+            any(getattr(self, name) is not None for name in GOAL_QUANTITIES),
+            "ImpactGoal must target at least one quantity",
+            None,
+        )
+        for spec in fields(self):
+            value = getattr(self, spec.name)
+            require(
+                value is None or isinstance(value, GoalTerm),
+                f"{spec.name} must be a GoalTerm or None (use ImpactGoal.of)",
+                value,
+            )
+
+    @classmethod
+    def of(cls, **targets: GoalTerm | float | tuple[float, float]) -> ImpactGoal:
+        """Build a goal from floats, ``(target, weight)`` tuples, or terms."""
+        unknown = set(targets) - set(GOAL_QUANTITIES)
+        require(not unknown, "unknown goal quantities", sorted(unknown))
+        return cls(**{name: _as_term(value) for name, value in targets.items()})
+
+    def items(self) -> tuple[tuple[str, GoalTerm], ...]:
+        """Targeted ``(quantity, term)`` pairs in canonical order."""
+        return tuple(
+            (name, term)
+            for name in GOAL_QUANTITIES
+            if (term := getattr(self, name)) is not None
+        )
+
+    @property
+    def needs_flight(self) -> bool:
+        """True when a ball-flight simulation is required (carry goals)."""
+        return self.carry_m is not None
+
+    @property
+    def needs_launch(self) -> bool:
+        """True when the impact -> launch derivation is required."""
+        return any(
+            getattr(self, name) is not None
+            for name in (
+                "ball_speed_mph",
+                "launch_angle_deg",
+                "launch_azimuth_deg",
+                "spin_rpm",
+                "spin_axis_deg",
+                "carry_m",
+            )
+        )
+
+
+@dataclass(frozen=True)
+class VariablePartition:
+    """Which variables the optimizer controls (with bounds) vs user-fixed.
+
+    Attributes:
+        free: Mapping of variable name -> ``(lower, upper)`` bounds. These
+            are the optimizer's decision variables.
+        fixed: Mapping of variable name -> value held constant.
+        use_swing_source: When True, candidate evaluation runs a
+            double-pendulum swing source and derives clubhead speed /
+            path / attack angle from it (see module docstring); the
+            ``swing_*`` variables become available and the derived
+            delivery names are rejected.
+
+    Variables in neither mapping take the documented defaults.
+
+    Invariants (DbC, validated at construction):
+        - every name is a known variable for the selected mode;
+        - ``free`` and ``fixed`` are disjoint;
+        - bounds are finite with ``lower < upper``; fixed values finite;
+        - in swing-source mode no derived delivery variable appears; in
+          delivery mode no ``swing_*`` variable appears.
+    """
+
+    free: Mapping[str, tuple[float, float]]
+    fixed: Mapping[str, float] = field(default_factory=dict)
+    use_swing_source: bool = False
+
+    def __post_init__(self) -> None:
+        known = set(DELIVERY_VARIABLE_DEFAULTS)
+        if self.use_swing_source:
+            known = (known - set(SWING_DERIVED_VARIABLES)) | set(
+                SWING_VARIABLE_DEFAULTS
+            )
+        free = dict(self.free)
+        fixed = dict(self.fixed)
+        unknown = (set(free) | set(fixed)) - known
+        require(
+            not unknown,
+            "unknown variables for this mode (swing-derived delivery names "
+            "are rejected when use_swing_source=True, swing_* names when "
+            "False)",
+            sorted(unknown),
+        )
+        overlap = set(free) & set(fixed)
+        require(
+            not overlap,
+            "variables cannot be both free and fixed",
+            sorted(overlap),
+        )
+        for name, bounds in free.items():
+            lo, hi = float(bounds[0]), float(bounds[1])
+            require(
+                math.isfinite(lo) and math.isfinite(hi) and lo < hi,
+                f"bounds for {name!r} must be finite with lower < upper",
+                (lo, hi),
+            )
+            free[name] = (lo, hi)
+        for name, value in fixed.items():
+            require(
+                math.isfinite(float(value)),
+                f"fixed value for {name!r} must be finite",
+                value,
+            )
+            fixed[name] = float(value)
+        object.__setattr__(self, "free", MappingProxyType(free))
+        object.__setattr__(self, "fixed", MappingProxyType(fixed))
+
+    @property
+    def free_names(self) -> tuple[str, ...]:
+        """Free-variable names in insertion order (defines vector layout)."""
+        return tuple(self.free)
+
+    def bounds_arrays(self) -> tuple[np.ndarray, np.ndarray]:
+        """Lower/upper bound vectors aligned with :attr:`free_names`."""
+        require(len(self.free) > 0, "partition has no free variables", None)
+        lo = np.array([self.free[name][0] for name in self.free_names])
+        hi = np.array([self.free[name][1] for name in self.free_names])
+        return lo, hi
+
+    def assemble(self, x: np.ndarray) -> dict[str, float]:
+        """Full variable dict from a free-variable vector (defaults filled).
+
+        Preconditions: ``x`` is finite with one entry per free variable.
+        """
+        arr = np.asarray(x, dtype=float)
+        require(
+            arr.shape == (len(self.free),),
+            "x must have one entry per free variable",
+            arr.shape,
+        )
+        require(bool(np.all(np.isfinite(arr))), "x must be finite", arr)
+        variables: dict[str, float] = dict(DELIVERY_VARIABLE_DEFAULTS)
+        if self.use_swing_source:
+            for name in SWING_DERIVED_VARIABLES:
+                variables.pop(name)
+            variables.update(SWING_VARIABLE_DEFAULTS)
+        variables.update(self.fixed)
+        variables.update(zip(self.free_names, arr.tolist(), strict=True))
+        return variables
+
+
+__all__ = [
+    "DELIVERY_VARIABLE_DEFAULTS",
+    "GOAL_QUANTITIES",
+    "SWING_DERIVED_VARIABLES",
+    "SWING_VARIABLE_DEFAULTS",
+    "GoalTerm",
+    "ImpactGoal",
+    "VariablePartition",
+]

--- a/src/shared/python/swing_sim/solver/objective.py
+++ b/src/shared/python/swing_sim/solver/objective.py
@@ -1,0 +1,314 @@
+"""Residual-vector builder for the impact-parameter solver (#4103, #4109).
+
+Scaffolding modeled on UpstreamDrift's
+``movement_optimizer/trajectory/optimizer_cost.py`` (pure, free functions
+computing objective terms so the driver stays orchestration-only), with
+golf-impact semantics: a candidate variable vector runs the
+delivery -> impact pipeline (and ball flight when carry goals are present)
+and is scored as weighted residuals against an
+:class:`~shared.python.swing_sim.solver.goals.ImpactGoal`.
+
+Rust seam (documented, do NOT remove)
+-------------------------------------
+:func:`evaluate_candidate` is deliberately a single **pure function**
+``(variables, partition, goal[, config]) -> residuals`` with plain-float
+inputs and a plain ``numpy`` output: a later Rust port of the inner
+delivery -> impact evaluation can replace it wholesale behind a facade
+(swap the function, keep the signature), exactly like
+``swing_sim._rust_facade`` swaps the pendulum integrator. Nothing in
+:mod:`.solve` may reach around this function into the impact internals.
+
+Units and frames
+----------------
+Variables and goal quantities are the launch-monitor units documented in
+:mod:`.goals` (deg / m/s / mph / RPM / m). Internally the delivery and
+impact stages work in the AffineDrift app frame (x target, y up, z right);
+the launch derivation and flight run in the flight frame (x forward,
+y left, z up) via :mod:`shared.python.swing_sim.flight.frames`. Achieved
+``launch_azimuth_deg`` is negated from the flight-frame azimuth so that
+positive means right of the target line, matching the face/path sign
+convention. ``spin_axis_deg`` uses the delivery D-plane convention:
+positive = fade/slice side.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import math
+from collections.abc import Mapping
+
+import numpy as np
+
+from shared.python.contracts import require
+
+from ..flight import derive_launch_conditions, simulate, to_flight_frame
+from ..impact import (
+    DeliveryParameters,
+    ImpactModelType,
+    ImpactSolverAPI,
+    derive_delivery,
+)
+from ..swing_source import DoublePendulumSwing
+from ..types import PendulumParameters, PendulumState, PlaneOrientation
+from .goals import ImpactGoal, VariablePartition
+from .tuning import (
+    DEFAULT_FLIGHT_DT_S,
+    DEFAULT_FLIGHT_MAX_TIME_S,
+    DEFAULT_FLIGHT_MODEL,
+    DEFAULT_SWING_DT_S,
+    DEFAULT_SWING_DURATION_S,
+    MIN_CLUBHEAD_SPEED_MPS,
+    MPH_TO_MPS,
+    SCALE_ANGLE_DEG,
+    SCALE_BALL_SPEED_MPH,
+    SCALE_CARRY_M,
+    SCALE_SPIN_AXIS_DEG,
+    SCALE_SPIN_RPM,
+    SWING_TIME_SEARCH_SAMPLES,
+)
+
+_RESIDUAL_SCALES: Mapping[str, float] = {
+    "club_path_deg": SCALE_ANGLE_DEG,
+    "face_angle_deg": SCALE_ANGLE_DEG,
+    "attack_angle_deg": SCALE_ANGLE_DEG,
+    "dynamic_loft_deg": SCALE_ANGLE_DEG,
+    "ball_speed_mph": SCALE_BALL_SPEED_MPH,
+    "launch_angle_deg": SCALE_ANGLE_DEG,
+    "launch_azimuth_deg": SCALE_ANGLE_DEG,
+    "spin_rpm": SCALE_SPIN_RPM,
+    "spin_axis_deg": SCALE_SPIN_AXIS_DEG,
+    "carry_m": SCALE_CARRY_M,
+}
+
+_MAX_DELIVERY_ANGLE_DEG = 89.0
+_EPS = 1e-12
+
+
+@dataclasses.dataclass(frozen=True)
+class EvaluationConfig:
+    """Knobs for candidate evaluation (kept off the hot signature).
+
+    Attributes:
+        flight_model: Registry flight-model name for carry goals.
+        flight_max_time_s: Maximum simulated flight time [s].
+        flight_dt_s: Flight sampling interval [s].
+        swing_duration_s: Integrated swing duration [s] per pendulum
+            candidate (swing-source mode).
+        swing_dt_s: Pendulum RK4 step [s] (swing-source mode).
+    """
+
+    flight_model: str = DEFAULT_FLIGHT_MODEL
+    flight_max_time_s: float = DEFAULT_FLIGHT_MAX_TIME_S
+    flight_dt_s: float = DEFAULT_FLIGHT_DT_S
+    swing_duration_s: float = DEFAULT_SWING_DURATION_S
+    swing_dt_s: float = DEFAULT_SWING_DT_S
+
+    def __post_init__(self) -> None:
+        for name in (
+            "flight_max_time_s",
+            "flight_dt_s",
+            "swing_duration_s",
+            "swing_dt_s",
+        ):
+            value = getattr(self, name)
+            require(
+                math.isfinite(value) and value > 0.0,
+                f"{name} must be finite and > 0",
+                value,
+            )
+
+
+def _clamp_angle(value: float) -> float:
+    """Clamp an angle [deg] into the delivery contract's open range."""
+    return min(max(value, -_MAX_DELIVERY_ANGLE_DEG), _MAX_DELIVERY_ANGLE_DEG)
+
+
+def _derive_from_swing(
+    variables: Mapping[str, float], config: EvaluationConfig
+) -> tuple[float, float, float]:
+    """Swing-source mode: pendulum swing -> (speed [m/s], path, AoA [deg]).
+
+    Builds a :class:`DoublePendulumSwing` on the candidate's tilted plane
+    (pure-Python backend: candidates run in worker threads and must not
+    depend on wheel availability), locates the peak-clubhead-speed instant
+    on a coarse grid, applies the candidate's impact-time offset, and
+    converts the sampled world-frame twist (x fwd / y left / z up) to the
+    app frame to read off speed, club path, and attack angle.
+    """
+    plane = PlaneOrientation(
+        yaw_deg=variables["swing_yaw_deg"],
+        side_tilt_deg=variables["swing_side_tilt_deg"],
+        forward_tilt_deg=variables["swing_forward_tilt_deg"],
+    )
+    defaults = PendulumParameters.golf_default()
+    parameters = dataclasses.replace(
+        defaults,
+        d1=max(variables["swing_damping_shoulder"], 0.0),
+        d2=max(variables["swing_damping_wrist"], 0.0),
+    )
+    # Start at theta1 = -pi/2 (arm horizontal on the backswing side) so
+    # the gravity-driven downswing travels toward +x (the target line);
+    # the package default of +pi/2 swings away from the target.
+    initial_state = PendulumState(
+        theta1=-math.pi / 2.0, theta2=0.0, omega1=0.0, omega2=0.0
+    )
+    swing = DoublePendulumSwing(
+        parameters=parameters,
+        plane=plane,
+        initial_state=initial_state,
+        duration=config.swing_duration_s,
+        dt=config.swing_dt_s,
+        backend="python",
+    )
+    times = np.linspace(0.0, swing.duration, SWING_TIME_SEARCH_SAMPLES)
+    speeds = [float(np.linalg.norm(swing.sample(float(t)).twist[3:])) for t in times]
+    t_peak = float(times[int(np.argmax(speeds))])
+    t_impact = min(
+        max(t_peak + variables["swing_impact_time_offset_s"], 0.0),
+        swing.duration,
+    )
+    v_world = swing.sample(t_impact).twist[3:]
+    # Swing world frame == flight frame (x fwd, y left, z up) -> app frame.
+    v_app = np.array([v_world[0], v_world[2], -v_world[1]])
+    speed = max(float(np.linalg.norm(v_app)), MIN_CLUBHEAD_SPEED_MPS)
+    aoa_deg = math.degrees(math.asin(float(np.clip(v_app[1] / speed, -1.0, 1.0))))
+    path_deg = math.degrees(math.atan2(float(v_app[2]), float(v_app[0])))
+    return speed, _clamp_angle(path_deg), _clamp_angle(aoa_deg)
+
+
+def _spin_axis_tilt_deg(spin_vector: np.ndarray) -> float:
+    """Signed D-plane spin-axis tilt [deg] from an app-frame spin vector.
+
+    Same convention as ``delivery.derive_delivery``: pure backspin is the
+    +z (right) axis; positive tilt = fade/slice side. Zero spin reports 0.
+    """
+    magnitude = float(np.linalg.norm(spin_vector))
+    if magnitude < _EPS:
+        return 0.0
+    axis = spin_vector / magnitude
+    horizontal = math.hypot(float(axis[0]), float(axis[2]))
+    return math.degrees(math.atan2(-float(axis[1]), horizontal))
+
+
+def achieved_quantities(
+    variables: Mapping[str, float],
+    partition: VariablePartition,
+    goal: ImpactGoal,
+    config: EvaluationConfig | None = None,
+) -> dict[str, float]:
+    """Run delivery -> impact (-> flight) and report achieved quantities.
+
+    Pure function of its inputs (no recorder state, no globals mutated).
+    Returns the delivery-level quantities always, launch-level quantities
+    when the goal needs them, and ``carry_m`` when the goal needs flight.
+
+    Args:
+        variables: Full variable mapping (from
+            :meth:`VariablePartition.assemble`), launch-monitor units.
+        partition: The variable partition (selects swing-source mode).
+        goal: The goal (selects how deep the pipeline must run).
+        config: Optional evaluation knobs.
+
+    Returns:
+        Mapping of goal-quantity name -> achieved value (documented units).
+    """
+    cfg = config or EvaluationConfig()
+
+    if partition.use_swing_source:
+        speed, path_deg, aoa_deg = _derive_from_swing(variables, cfg)
+    else:
+        speed = variables["clubhead_speed_mps"]
+        path_deg = variables["club_path_deg"]
+        aoa_deg = variables["attack_angle_deg"]
+
+    params = DeliveryParameters(
+        clubhead_speed_mps=speed,
+        club_path_deg=path_deg,
+        face_angle_deg=_clamp_angle(variables["face_angle_deg"]),
+        attack_angle_deg=aoa_deg,
+        dynamic_loft_deg=_clamp_angle(variables["dynamic_loft_deg"]),
+        lie_deg=_clamp_angle(variables["lie_deg"]),
+        impact_offset_toe_mm=variables["impact_offset_toe_mm"],
+        impact_offset_high_mm=variables["impact_offset_high_mm"],
+    )
+
+    achieved: dict[str, float] = {
+        "club_path_deg": params.club_path_deg,
+        "face_angle_deg": params.face_angle_deg,
+        "attack_angle_deg": params.attack_angle_deg,
+        "dynamic_loft_deg": params.dynamic_loft_deg,
+    }
+    if not goal.needs_launch:
+        return achieved
+
+    derived = derive_delivery(params)
+    api = ImpactSolverAPI(model_type=ImpactModelType.RIGID_BODY)
+    post = api.solve_with_gear_effect(
+        timestamp=0.0,
+        clubhead_velocity=derived.clubhead_velocity,
+        clubhead_orientation=derived.face_normal,
+        impact_offset=derived.impact_offset,
+        record=False,
+    )
+
+    launch = derive_launch_conditions(
+        to_flight_frame(post.ball_velocity),
+        to_flight_frame(post.ball_angular_velocity),
+    )
+    achieved["ball_speed_mph"] = launch.ball_speed / MPH_TO_MPS
+    achieved["launch_angle_deg"] = math.degrees(launch.launch_angle)
+    # Flight azimuth is + toward +y (left); goals use + = right of target.
+    achieved["launch_azimuth_deg"] = -math.degrees(launch.azimuth_angle)
+    achieved["spin_rpm"] = launch.spin_rate
+    achieved["spin_axis_deg"] = _spin_axis_tilt_deg(post.ball_angular_velocity)
+
+    if goal.needs_flight:
+        result = simulate(
+            launch,
+            model_name=cfg.flight_model,
+            max_time=cfg.flight_max_time_s,
+            dt=cfg.flight_dt_s,
+        )
+        achieved["carry_m"] = result.carry_distance
+    return achieved
+
+
+def evaluate_candidate(
+    variables: Mapping[str, float],
+    partition: VariablePartition,
+    goal: ImpactGoal,
+    config: EvaluationConfig | None = None,
+) -> np.ndarray:
+    """Weighted residual vector for a full candidate variable mapping.
+
+    This is the Rust-portable seam (see module docstring): pure function,
+    plain-float inputs, ``(n_goals,)`` float output ordered like
+    :meth:`ImpactGoal.items`. Each residual is
+    ``weight * (achieved - target) / scale`` with the per-quantity scales
+    from :mod:`.tuning`.
+    """
+    achieved = achieved_quantities(variables, partition, goal, config)
+    return np.array(
+        [
+            term.weight * (achieved[name] - term.target) / _RESIDUAL_SCALES[name]
+            for name, term in goal.items()
+        ]
+    )
+
+
+def residuals(
+    x: np.ndarray,
+    partition: VariablePartition,
+    goal: ImpactGoal,
+    config: EvaluationConfig | None = None,
+) -> np.ndarray:
+    """Residual vector for a free-variable vector (driver entry point)."""
+    return evaluate_candidate(partition.assemble(x), partition, goal, config)
+
+
+__all__ = [
+    "EvaluationConfig",
+    "achieved_quantities",
+    "evaluate_candidate",
+    "residuals",
+]

--- a/src/shared/python/swing_sim/solver/solve.py
+++ b/src/shared/python/swing_sim/solver/solve.py
@@ -1,0 +1,402 @@
+"""Robust multi-start driver for the impact-parameter solver (#4103, #4109).
+
+Scaffolding modeled on UpstreamDrift's ``movement_optimizer``:
+
+- :class:`ProgressReport` / :class:`CancelledError` copy the shapes of
+  ``movement_optimizer/trajectory/result.py`` so UIs can share plumbing;
+- the multi-start dispatch/collect/select structure mirrors
+  ``trajectory/optimizer_parallel.py`` (``concurrent.futures`` pool,
+  drain loop honouring the cancel event, best-of selection);
+- the progress tracker mirrors ``trajectory/optimizer_progress.py``
+  (thread-safe recording, periodic emission, stall heuristic).
+
+Golf-impact semantics replace the barbell/balance machinery: each start is
+a bounded ``scipy.optimize.least_squares`` (trf) run over the free
+variables of a :class:`~shared.python.swing_sim.solver.goals.VariablePartition`,
+scoring :func:`~shared.python.swing_sim.solver.objective.residuals`
+against an :class:`~shared.python.swing_sim.solver.goals.ImpactGoal`.
+Starts are a Latin-hypercube sample of the bounds (start 0 is the caller's
+``x0`` or the bounds midpoint).
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from collections.abc import Callable
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass, field
+
+import numpy as np
+from scipy.optimize import least_squares
+from scipy.stats import qmc
+
+from shared.python.contracts import require
+
+from .goals import ImpactGoal, VariablePartition
+from .objective import EvaluationConfig, achieved_quantities, residuals
+from .tuning import (
+    DEFAULT_FTOL,
+    DEFAULT_GTOL,
+    DEFAULT_MAX_NFEV_PER_START,
+    DEFAULT_N_STARTS,
+    DEFAULT_XTOL,
+    PROGRESS_EMIT_EVERY,
+    STALL_THRESHOLD,
+    STALL_WINDOW,
+)
+
+
+class CancelledError(Exception):
+    """Raised when the caller cancels solving via ``cancel_event``.
+
+    Same shape as ``movement_optimizer.trajectory.result.CancelledError``.
+    """
+
+
+@dataclass
+class ProgressReport:
+    """Snapshot of solver state emitted to a progress callback.
+
+    Field-for-field copy of
+    ``movement_optimizer.trajectory.result.ProgressReport`` so existing
+    progress UIs plug in unchanged; ``cost`` is half the squared residual
+    norm (the scipy least-squares cost).
+    """
+
+    iteration: int
+    cost: float
+    best_cost: float
+    improvement_pct: float
+    elapsed_s: float
+    cost_history: list[float] = field(default_factory=list)
+    is_stalled: bool = False
+    stall_reason: str = ""
+
+
+ProgressCallback = Callable[[ProgressReport], None]
+
+
+def detect_stall(history: list[float]) -> tuple[bool, str]:
+    """Stall heuristic ported from ``optimizer_progress.detect_stall``."""
+    if len(history) < STALL_WINDOW:
+        return False, ""
+    old_cost, new_cost = history[-STALL_WINDOW], history[-1]
+    if old_cost == 0:
+        return False, ""
+    if abs(old_cost - new_cost) / abs(old_cost) < STALL_THRESHOLD:
+        return True, (
+            f"Cost changed < {STALL_THRESHOLD * 100:.2f}% over last "
+            f"{STALL_WINDOW} evals ({old_cost:.3g} -> {new_cost:.3g})"
+        )
+    return False, ""
+
+
+class _ProgressTracker:
+    """Thread-safe eval recording + periodic emission (movement_optimizer)."""
+
+    def __init__(self, progress_cb: ProgressCallback | None) -> None:
+        self._cb = progress_cb
+        self._lock = threading.Lock()
+        self._iter = 0
+        self._best = float("inf")
+        self._history: list[float] = []
+        self._start = time.monotonic()
+
+    def record(self, cost: float) -> None:
+        with self._lock:
+            self._iter += 1
+            self._history.append(cost)
+            self._best = min(self._best, cost)
+            if self._cb is not None and self._iter % PROGRESS_EMIT_EVERY == 0:
+                self._emit(cost)
+
+    def _emit(self, cost: float) -> None:
+        if len(self._history) >= 2 * PROGRESS_EMIT_EVERY:
+            prev = self._history[-2 * PROGRESS_EMIT_EVERY]
+            improvement = (prev - cost) / abs(prev) * 100 if prev != 0 else 0.0
+        else:
+            improvement = 0.0
+        is_stalled, reason = detect_stall(self._history)
+        assert self._cb is not None
+        self._cb(
+            ProgressReport(
+                iteration=self._iter,
+                cost=cost,
+                best_cost=self._best,
+                improvement_pct=improvement,
+                elapsed_s=time.monotonic() - self._start,
+                cost_history=self._history[-200:],
+                is_stalled=is_stalled,
+                stall_reason=reason,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class StartSummary:
+    """Diagnostics for one multi-start seed."""
+
+    seed: int
+    x0: np.ndarray
+    x: np.ndarray | None
+    cost: float
+    n_evals: int
+    converged: bool
+    message: str
+    cancelled: bool = False
+
+
+@dataclass(frozen=True)
+class SolverResult:
+    """Best-of-all-starts solution plus diagnostics.
+
+    Attributes:
+        variables: Full solved variable mapping (free solution + fixed +
+            defaults), launch-monitor units per :mod:`.goals`.
+        free_names: Free-variable ordering matching ``x``.
+        x: Solved free-variable vector.
+        achieved: Achieved quantities at the solution (delivery-level
+            always; launch/flight-level when the goal required them).
+        per_goal_errors: ``quantity -> achieved - target`` at the solution.
+        residual_norm: 2-norm of the weighted residual vector.
+        cost: Scipy least-squares cost (``0.5 * residual_norm**2``).
+        converged: True when the best start terminated successfully.
+        n_evals: Total residual evaluations across all starts.
+        elapsed_s: Wall-clock seconds spent in :func:`solve`.
+        starts: Per-start summaries (diagnostics for all seeds).
+    """
+
+    variables: dict[str, float]
+    free_names: tuple[str, ...]
+    x: np.ndarray
+    achieved: dict[str, float]
+    per_goal_errors: dict[str, float]
+    residual_norm: float
+    cost: float
+    converged: bool
+    n_evals: int
+    elapsed_s: float
+    starts: tuple[StartSummary, ...]
+
+
+class _StartCancelled(Exception):
+    """Internal: unwinds a scipy start when the cancel event fires."""
+
+
+def _build_starts(
+    lo: np.ndarray,
+    hi: np.ndarray,
+    n_starts: int,
+    seed: int,
+    x0: np.ndarray | None,
+) -> list[np.ndarray]:
+    """Start 0 = ``x0`` or bounds midpoint; rest = Latin hypercube."""
+    first = (
+        np.clip(np.asarray(x0, dtype=float), lo, hi)
+        if x0 is not None
+        else 0.5 * (lo + hi)
+    )
+    starts = [first]
+    if n_starts > 1:
+        sampler = qmc.LatinHypercube(d=lo.size, seed=seed)
+        unit = sampler.random(n=n_starts - 1)
+        starts.extend(lo + unit_row * (hi - lo) for unit_row in unit)
+    return starts
+
+
+def _run_single_start(
+    seed_idx: int,
+    x_start: np.ndarray,
+    lo: np.ndarray,
+    hi: np.ndarray,
+    partition: VariablePartition,
+    goal: ImpactGoal,
+    config: EvaluationConfig | None,
+    tracker: _ProgressTracker,
+    cancel_event: threading.Event,
+    max_nfev: int,
+) -> StartSummary:
+    """One bounded trf run; cancellation unwinds via :class:`_StartCancelled`."""
+    n_evals = 0
+
+    def fun(x: np.ndarray) -> np.ndarray:
+        nonlocal n_evals
+        if cancel_event.is_set():
+            raise _StartCancelled
+        res = residuals(x, partition, goal, config)
+        n_evals += 1
+        tracker.record(0.5 * float(res @ res))
+        return res
+
+    try:
+        res = least_squares(
+            fun,
+            x_start,
+            bounds=(lo, hi),
+            method="trf",
+            xtol=DEFAULT_XTOL,
+            ftol=DEFAULT_FTOL,
+            gtol=DEFAULT_GTOL,
+            max_nfev=max_nfev,
+        )
+    except _StartCancelled:
+        return StartSummary(
+            seed=seed_idx,
+            x0=x_start,
+            x=None,
+            cost=float("inf"),
+            n_evals=n_evals,
+            converged=False,
+            message="cancelled",
+            cancelled=True,
+        )
+    return StartSummary(
+        seed=seed_idx,
+        x0=x_start,
+        x=np.asarray(res.x, dtype=float),
+        cost=float(res.cost),
+        n_evals=n_evals,
+        converged=bool(res.success),
+        message=str(res.message),
+    )
+
+
+def _collect(
+    pending: set[Future[StartSummary]],
+    cancel_event: threading.Event,
+) -> list[StartSummary]:
+    """Drain futures, honouring cancellation (optimizer_parallel shape)."""
+    summaries: list[StartSummary] = []
+    while pending:
+        if cancel_event.is_set():
+            for f in pending:
+                f.cancel()
+            # Workers observe the event via their residual wrapper; any
+            # still-running start returns a cancelled summary.
+            done, _ = wait(pending, timeout=None)
+            summaries.extend(f.result() for f in done if not f.cancelled())
+            break
+        done, pending = wait(pending, timeout=0.2, return_when=FIRST_COMPLETED)
+        summaries.extend(f.result() for f in done)
+    return summaries
+
+
+def solve(
+    goal: ImpactGoal,
+    partition: VariablePartition,
+    config: EvaluationConfig | None = None,
+    n_starts: int = DEFAULT_N_STARTS,
+    seed: int = 0,
+    x0: np.ndarray | None = None,
+    max_nfev_per_start: int = DEFAULT_MAX_NFEV_PER_START,
+    n_workers: int | None = None,
+    progress_cb: ProgressCallback | None = None,
+    cancel_event: threading.Event | None = None,
+) -> SolverResult:
+    """Solve for the variable values that best achieve the goal.
+
+    Args:
+        goal: Targeted quantities with weights.
+        partition: Free variables (with bounds) vs fixed values.
+        config: Optional evaluation knobs (flight model, swing grid).
+        n_starts: Multi-start count (>= 1); start 0 is ``x0`` or the
+            bounds midpoint, the rest a seeded Latin-hypercube sample.
+        seed: RNG seed for the Latin-hypercube starts.
+        x0: Optional initial free-variable vector for start 0.
+        max_nfev_per_start: Residual-evaluation cap per start.
+        n_workers: Thread-pool size (default ``min(n_starts, 4)``).
+        progress_cb: Optional callback receiving :class:`ProgressReport`.
+        cancel_event: Optional event; setting it aborts pending and
+            in-flight starts.
+
+    Returns:
+        :class:`SolverResult` for the lowest-cost completed start.
+
+    Raises:
+        CancelledError: If cancelled before any start completed.
+        ValueError / ContractViolationError: On invalid inputs (empty free
+            set is rejected by ``partition.bounds_arrays``).
+    """
+    require(n_starts >= 1, "n_starts must be >= 1", n_starts)
+    require(max_nfev_per_start >= 1, "max_nfev_per_start must be >= 1", None)
+    require(seed >= 0, "seed must be >= 0", seed)
+    lo, hi = partition.bounds_arrays()
+    if x0 is not None:
+        arr = np.asarray(x0, dtype=float)
+        require(arr.shape == lo.shape, "x0 must match the free set", arr.shape)
+        require(bool(np.all(np.isfinite(arr))), "x0 must be finite", arr)
+
+    event = cancel_event or threading.Event()
+    if event.is_set():
+        raise CancelledError("Solve cancelled before start")
+
+    t0 = time.monotonic()
+    tracker = _ProgressTracker(progress_cb)
+    starts = _build_starts(lo, hi, n_starts, seed, x0)
+    workers = n_workers if n_workers is not None else min(n_starts, 4)
+    require(workers >= 1, "n_workers must be >= 1", workers)
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        pending = {
+            pool.submit(
+                _run_single_start,
+                i,
+                x_start,
+                lo,
+                hi,
+                partition,
+                goal,
+                config,
+                tracker,
+                event,
+                max_nfev_per_start,
+            )
+            for i, x_start in enumerate(starts)
+        }
+        summaries = _collect(pending, event)
+
+    summaries.sort(key=lambda s: s.seed)
+    completed = [s for s in summaries if s.x is not None]
+    if not completed:
+        raise CancelledError("All solver starts were cancelled")
+
+    best = min(completed, key=lambda s: s.cost)
+    assert best.x is not None
+    solution = partition.assemble(best.x)
+    achieved = achieved_quantities(solution, partition, goal, config)
+    per_goal = {name: achieved[name] - term.target for name, term in goal.items()}
+    res_vec = residuals(best.x, partition, goal, config)
+    residual_norm = float(np.linalg.norm(res_vec))
+    require(
+        math.isclose(0.5 * residual_norm**2, best.cost, rel_tol=1e-6, abs_tol=1e-9),
+        "postcondition: re-evaluated cost must match the best start "
+        "(objective must be deterministic)",
+        (0.5 * residual_norm**2, best.cost),
+    )
+
+    return SolverResult(
+        variables=solution,
+        free_names=partition.free_names,
+        x=best.x,
+        achieved=achieved,
+        per_goal_errors=per_goal,
+        residual_norm=residual_norm,
+        cost=best.cost,
+        converged=best.converged,
+        n_evals=sum(s.n_evals for s in summaries),
+        elapsed_s=time.monotonic() - t0,
+        starts=tuple(summaries),
+    )
+
+
+__all__ = [
+    "CancelledError",
+    "ProgressCallback",
+    "ProgressReport",
+    "SolverResult",
+    "StartSummary",
+    "detect_stall",
+    "solve",
+]

--- a/src/shared/python/swing_sim/solver/tests/__init__.py
+++ b/src/shared/python/swing_sim/solver/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the swing_sim impact-parameter solver (epic #4103, #4109)."""

--- a/src/shared/python/swing_sim/solver/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/solver/tests/test_contract_api.py
@@ -1,0 +1,126 @@
+"""Contract test pinning the public API surface of swing_sim.solver.
+
+Downstream consumers (UI integration wave, web backend, UpstreamDrift)
+import from the subpackage facade only; this test fails loudly when the
+surface changes so removals are always deliberate.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import shared.python.swing_sim.solver as solver
+
+EXPECTED_PUBLIC_API = {
+    "DELIVERY_VARIABLE_DEFAULTS",
+    "GOAL_QUANTITIES",
+    "SWING_DERIVED_VARIABLES",
+    "SWING_VARIABLE_DEFAULTS",
+    "CancelledError",
+    "EvaluationConfig",
+    "GoalTerm",
+    "ImpactGoal",
+    "ProgressCallback",
+    "ProgressReport",
+    "SolverResult",
+    "StartSummary",
+    "VariablePartition",
+    "achieved_quantities",
+    "detect_stall",
+    "evaluate_candidate",
+    "residuals",
+    "solve",
+}
+
+pytestmark = pytest.mark.contract
+
+
+def test_public_api_is_pinned() -> None:
+    assert set(solver.__all__) == EXPECTED_PUBLIC_API
+
+
+def test_facade_exports_resolve() -> None:
+    for name in EXPECTED_PUBLIC_API:
+        assert getattr(solver, name) is not None
+
+
+def test_goal_quantities_are_pinned() -> None:
+    assert solver.GOAL_QUANTITIES == (
+        "club_path_deg",
+        "face_angle_deg",
+        "attack_angle_deg",
+        "dynamic_loft_deg",
+        "ball_speed_mph",
+        "launch_angle_deg",
+        "launch_azimuth_deg",
+        "spin_rpm",
+        "spin_axis_deg",
+        "carry_m",
+    )
+
+
+def test_variable_registries_are_pinned() -> None:
+    assert set(solver.DELIVERY_VARIABLE_DEFAULTS) == {
+        "clubhead_speed_mps",
+        "club_path_deg",
+        "face_angle_deg",
+        "attack_angle_deg",
+        "dynamic_loft_deg",
+        "lie_deg",
+        "impact_offset_toe_mm",
+        "impact_offset_high_mm",
+    }
+    assert set(solver.SWING_VARIABLE_DEFAULTS) == {
+        "swing_yaw_deg",
+        "swing_side_tilt_deg",
+        "swing_forward_tilt_deg",
+        "swing_impact_time_offset_s",
+        "swing_damping_shoulder",
+        "swing_damping_wrist",
+    }
+    assert solver.SWING_DERIVED_VARIABLES == (
+        "clubhead_speed_mps",
+        "club_path_deg",
+        "attack_angle_deg",
+    )
+
+
+def test_progress_report_matches_movement_optimizer_shape() -> None:
+    """Field-for-field copy of movement_optimizer's ProgressReport."""
+    names = [f.name for f in dataclasses.fields(solver.ProgressReport)]
+    assert names == [
+        "iteration",
+        "cost",
+        "best_cost",
+        "improvement_pct",
+        "elapsed_s",
+        "cost_history",
+        "is_stalled",
+        "stall_reason",
+    ]
+
+
+def test_solver_result_diagnostic_fields_are_pinned() -> None:
+    names = {f.name for f in dataclasses.fields(solver.SolverResult)}
+    assert names == {
+        "variables",
+        "free_names",
+        "x",
+        "achieved",
+        "per_goal_errors",
+        "residual_norm",
+        "cost",
+        "converged",
+        "n_evals",
+        "elapsed_s",
+        "starts",
+    }
+
+
+def test_parent_facade_untouched() -> None:
+    """The parent swing_sim facade must not re-export solver names yet."""
+    import shared.python.swing_sim as swing_sim
+
+    assert "solve" not in getattr(swing_sim, "__all__", ())

--- a/src/shared/python/swing_sim/solver/tests/test_goals.py
+++ b/src/shared/python/swing_sim/solver/tests/test_goals.py
@@ -1,0 +1,147 @@
+"""Unit tests for goal and variable-partition types (DbC validation)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.contracts import ContractViolationError
+from shared.python.swing_sim.solver import (
+    DELIVERY_VARIABLE_DEFAULTS,
+    GOAL_QUANTITIES,
+    SWING_VARIABLE_DEFAULTS,
+    GoalTerm,
+    ImpactGoal,
+    VariablePartition,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestGoalTerm:
+    def test_defaults_weight_to_one(self) -> None:
+        assert GoalTerm(10.0).weight == 1.0
+
+    @pytest.mark.parametrize("weight", [0.0, -1.0, float("nan"), float("inf")])
+    def test_rejects_bad_weight(self, weight: float) -> None:
+        with pytest.raises(ContractViolationError):
+            GoalTerm(10.0, weight)
+
+    def test_rejects_non_finite_target(self) -> None:
+        with pytest.raises(ContractViolationError):
+            GoalTerm(float("nan"))
+
+
+class TestImpactGoal:
+    def test_requires_at_least_one_target(self) -> None:
+        with pytest.raises(ContractViolationError):
+            ImpactGoal()
+
+    def test_of_accepts_floats_tuples_and_terms(self) -> None:
+        goal = ImpactGoal.of(
+            ball_speed_mph=150.0,
+            spin_rpm=(2600.0, 0.5),
+            carry_m=GoalTerm(230.0, 2.0),
+        )
+        items = dict(goal.items())
+        assert items["ball_speed_mph"] == GoalTerm(150.0)
+        assert items["spin_rpm"] == GoalTerm(2600.0, 0.5)
+        assert items["carry_m"] == GoalTerm(230.0, 2.0)
+
+    def test_of_rejects_unknown_quantity(self) -> None:
+        with pytest.raises(ContractViolationError):
+            ImpactGoal.of(smash_factor=1.5)
+
+    def test_rejects_raw_float_field(self) -> None:
+        with pytest.raises(ContractViolationError):
+            ImpactGoal(ball_speed_mph=150.0)  # type: ignore[arg-type]
+
+    def test_items_follow_canonical_order(self) -> None:
+        goal = ImpactGoal.of(carry_m=200.0, club_path_deg=2.0, spin_rpm=2500.0)
+        names = [name for name, _ in goal.items()]
+        assert names == sorted(names, key=GOAL_QUANTITIES.index)
+
+    def test_needs_flags(self) -> None:
+        assert not ImpactGoal.of(club_path_deg=1.0).needs_launch
+        assert ImpactGoal.of(ball_speed_mph=140.0).needs_launch
+        assert not ImpactGoal.of(ball_speed_mph=140.0).needs_flight
+        assert ImpactGoal.of(carry_m=200.0).needs_flight
+        assert ImpactGoal.of(carry_m=200.0).needs_launch
+
+
+class TestVariablePartition:
+    def test_free_and_fixed_must_be_disjoint(self) -> None:
+        with pytest.raises(ContractViolationError):
+            VariablePartition(
+                free={"face_angle_deg": (-5.0, 5.0)},
+                fixed={"face_angle_deg": 1.0},
+            )
+
+    def test_unknown_variable_rejected(self) -> None:
+        with pytest.raises(ContractViolationError):
+            VariablePartition(free={"smash_factor": (1.0, 2.0)})
+
+    def test_swing_names_rejected_in_delivery_mode(self) -> None:
+        with pytest.raises(ContractViolationError):
+            VariablePartition(free={"swing_yaw_deg": (-10.0, 10.0)})
+
+    def test_derived_delivery_names_rejected_in_swing_mode(self) -> None:
+        with pytest.raises(ContractViolationError):
+            VariablePartition(
+                free={"clubhead_speed_mps": (30.0, 50.0)},
+                use_swing_source=True,
+            )
+
+    def test_swing_mode_accepts_swing_and_face_variables(self) -> None:
+        partition = VariablePartition(
+            free={"swing_yaw_deg": (-10.0, 10.0)},
+            fixed={"dynamic_loft_deg": 12.0},
+            use_swing_source=True,
+        )
+        assert partition.free_names == ("swing_yaw_deg",)
+
+    @pytest.mark.parametrize(
+        "bounds", [(1.0, 1.0), (2.0, 1.0), (float("nan"), 1.0), (0.0, float("inf"))]
+    )
+    def test_bad_bounds_rejected(self, bounds: tuple[float, float]) -> None:
+        with pytest.raises(ContractViolationError):
+            VariablePartition(free={"face_angle_deg": bounds})
+
+    def test_non_finite_fixed_rejected(self) -> None:
+        with pytest.raises(ContractViolationError):
+            VariablePartition(
+                free={"face_angle_deg": (-5.0, 5.0)},
+                fixed={"lie_deg": float("nan")},
+            )
+
+    def test_empty_free_set_rejected_at_bounds(self) -> None:
+        partition = VariablePartition(free={}, fixed={"face_angle_deg": 1.0})
+        with pytest.raises(ContractViolationError):
+            partition.bounds_arrays()
+
+    def test_assemble_fills_defaults_fixed_and_free(self) -> None:
+        partition = VariablePartition(
+            free={"clubhead_speed_mps": (30.0, 50.0)},
+            fixed={"face_angle_deg": 2.0},
+        )
+        variables = partition.assemble(np.array([41.0]))
+        assert variables["clubhead_speed_mps"] == 41.0
+        assert variables["face_angle_deg"] == 2.0
+        assert variables["lie_deg"] == DELIVERY_VARIABLE_DEFAULTS["lie_deg"]
+
+    def test_assemble_swing_mode_swaps_variable_sets(self) -> None:
+        partition = VariablePartition(
+            free={"swing_impact_time_offset_s": (-0.05, 0.05)},
+            use_swing_source=True,
+        )
+        variables = partition.assemble(np.array([0.01]))
+        assert "clubhead_speed_mps" not in variables
+        assert variables["swing_impact_time_offset_s"] == 0.01
+        assert variables["swing_yaw_deg"] == SWING_VARIABLE_DEFAULTS["swing_yaw_deg"]
+
+    def test_assemble_rejects_wrong_shape_and_non_finite(self) -> None:
+        partition = VariablePartition(free={"face_angle_deg": (-5.0, 5.0)})
+        with pytest.raises(ContractViolationError):
+            partition.assemble(np.array([1.0, 2.0]))
+        with pytest.raises(ContractViolationError):
+            partition.assemble(np.array([float("nan")]))

--- a/src/shared/python/swing_sim/solver/tests/test_objective.py
+++ b/src/shared/python/swing_sim/solver/tests/test_objective.py
@@ -1,0 +1,169 @@
+"""Unit/physics tests for the pure candidate-evaluation objective."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from shared.python.swing_sim.solver import (
+    EvaluationConfig,
+    ImpactGoal,
+    VariablePartition,
+    achieved_quantities,
+    evaluate_candidate,
+    residuals,
+)
+
+FAST_SWING = EvaluationConfig(swing_duration_s=0.8, swing_dt_s=5e-3)
+
+
+def _delivery_partition() -> VariablePartition:
+    return VariablePartition(
+        free={
+            "clubhead_speed_mps": (30.0, 55.0),
+            "dynamic_loft_deg": (5.0, 20.0),
+        }
+    )
+
+
+@pytest.mark.unit
+class TestEvaluateCandidate:
+    def test_zero_residuals_at_generating_variables(self) -> None:
+        """Goal built from a candidate's own outputs scores ~zero."""
+        partition = _delivery_partition()
+        variables = partition.assemble(np.array([44.0, 12.0]))
+        achieved = achieved_quantities(
+            variables,
+            partition,
+            ImpactGoal.of(ball_speed_mph=1.0, spin_rpm=1.0),
+        )
+        goal = ImpactGoal.of(
+            ball_speed_mph=achieved["ball_speed_mph"],
+            spin_rpm=achieved["spin_rpm"],
+        )
+        res = evaluate_candidate(variables, partition, goal)
+        assert res.shape == (2,)
+        np.testing.assert_allclose(res, 0.0, atol=1e-9)
+
+    def test_pure_function_deterministic_and_non_mutating(self) -> None:
+        partition = _delivery_partition()
+        variables = partition.assemble(np.array([44.0, 12.0]))
+        snapshot = dict(variables)
+        goal = ImpactGoal.of(ball_speed_mph=150.0, launch_angle_deg=13.0)
+        first = evaluate_candidate(variables, partition, goal)
+        second = evaluate_candidate(variables, partition, goal)
+        np.testing.assert_array_equal(first, second)
+        assert variables == snapshot
+
+    def test_residual_ordering_matches_goal_items(self) -> None:
+        partition = _delivery_partition()
+        goal = ImpactGoal.of(spin_rpm=99999.0, club_path_deg=0.0)
+        res = residuals(np.array([44.0, 12.0]), partition, goal)
+        # Canonical order: club_path_deg (exact -> 0) before spin_rpm.
+        assert res[0] == pytest.approx(0.0, abs=1e-12)
+        assert res[1] < 0.0
+
+    def test_weight_and_scale_applied(self) -> None:
+        partition = _delivery_partition()
+        variables = partition.assemble(np.array([44.0, 12.0]))
+        achieved = achieved_quantities(
+            variables, partition, ImpactGoal.of(ball_speed_mph=1.0)
+        )
+        target = achieved["ball_speed_mph"] - 3.0  # 3 mph high, scale 1 mph
+        base = evaluate_candidate(
+            variables, partition, ImpactGoal.of(ball_speed_mph=target)
+        )
+        double = evaluate_candidate(
+            variables, partition, ImpactGoal.of(ball_speed_mph=(target, 2.0))
+        )
+        assert base[0] == pytest.approx(3.0)
+        assert double[0] == pytest.approx(6.0)
+
+    def test_delivery_only_goal_skips_impact(self) -> None:
+        partition = _delivery_partition()
+        variables = partition.assemble(np.array([44.0, 12.0]))
+        achieved = achieved_quantities(
+            variables, partition, ImpactGoal.of(dynamic_loft_deg=10.0)
+        )
+        assert "ball_speed_mph" not in achieved
+        assert achieved["dynamic_loft_deg"] == 12.0
+
+
+@pytest.mark.physics
+class TestPhysicsSignatures:
+    def test_more_speed_more_ball_speed(self) -> None:
+        partition = _delivery_partition()
+        goal = ImpactGoal.of(ball_speed_mph=1.0)
+        slow = achieved_quantities(
+            partition.assemble(np.array([38.0, 12.0])), partition, goal
+        )
+        fast = achieved_quantities(
+            partition.assemble(np.array([50.0, 12.0])), partition, goal
+        )
+        assert fast["ball_speed_mph"] > slow["ball_speed_mph"]
+
+    def test_open_face_launches_right_with_fade_axis(self) -> None:
+        partition = VariablePartition(
+            free={"face_angle_deg": (-10.0, 10.0)},
+            fixed={"clubhead_speed_mps": 45.0, "dynamic_loft_deg": 12.0},
+        )
+        goal = ImpactGoal.of(launch_azimuth_deg=0.0, spin_axis_deg=0.0)
+        open_face = achieved_quantities(
+            partition.assemble(np.array([4.0])), partition, goal
+        )
+        square = achieved_quantities(
+            partition.assemble(np.array([0.0])), partition, goal
+        )
+        assert open_face["launch_azimuth_deg"] > square["launch_azimuth_deg"]
+        # Face open to a straight path tilts spin to the fade side (+).
+        assert open_face["spin_axis_deg"] > square["spin_axis_deg"]
+
+    def test_more_loft_more_launch_and_spin(self) -> None:
+        partition = _delivery_partition()
+        goal = ImpactGoal.of(launch_angle_deg=0.0, spin_rpm=0.0)
+        low = achieved_quantities(
+            partition.assemble(np.array([44.0, 8.0])), partition, goal
+        )
+        high = achieved_quantities(
+            partition.assemble(np.array([44.0, 16.0])), partition, goal
+        )
+        assert high["launch_angle_deg"] > low["launch_angle_deg"]
+        assert high["spin_rpm"] > low["spin_rpm"]
+
+    def test_carry_reported_when_goal_needs_flight(self) -> None:
+        partition = _delivery_partition()
+        achieved = achieved_quantities(
+            partition.assemble(np.array([44.0, 12.0])),
+            partition,
+            ImpactGoal.of(carry_m=200.0),
+        )
+        assert 20.0 < achieved["carry_m"] < 400.0
+
+    def test_swing_mode_derives_target_directed_delivery(self) -> None:
+        partition = VariablePartition(
+            free={"swing_impact_time_offset_s": (-0.05, 0.05)},
+            fixed={"dynamic_loft_deg": 12.0},
+            use_swing_source=True,
+        )
+        goal = ImpactGoal.of(club_path_deg=0.0, attack_angle_deg=0.0)
+        achieved = achieved_quantities(
+            partition.assemble(np.array([0.0])), partition, goal, FAST_SWING
+        )
+        # Gravity-driven pendulum: modest speed, roughly target-line path.
+        assert abs(achieved["club_path_deg"]) < 10.0
+        assert abs(achieved["attack_angle_deg"]) < 45.0
+
+    def test_swing_yaw_tilts_club_path(self) -> None:
+        base_part = VariablePartition(
+            free={"swing_yaw_deg": (-15.0, 15.0)},
+            fixed={"dynamic_loft_deg": 12.0},
+            use_swing_source=True,
+        )
+        goal = ImpactGoal.of(club_path_deg=0.0)
+        yawed = achieved_quantities(
+            base_part.assemble(np.array([8.0])), base_part, goal, FAST_SWING
+        )
+        square = achieved_quantities(
+            base_part.assemble(np.array([0.0])), base_part, goal, FAST_SWING
+        )
+        assert yawed["club_path_deg"] != pytest.approx(square["club_path_deg"], abs=1.0)

--- a/src/shared/python/swing_sim/solver/tests/test_solve.py
+++ b/src/shared/python/swing_sim/solver/tests/test_solve.py
@@ -1,0 +1,188 @@
+"""Physics/behaviour tests for the robust multi-start solve driver."""
+
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+import pytest
+
+from shared.python.contracts import ContractViolationError
+from shared.python.swing_sim.solver import (
+    CancelledError,
+    ImpactGoal,
+    ProgressReport,
+    VariablePartition,
+    achieved_quantities,
+    solve,
+)
+
+pytestmark = pytest.mark.physics
+
+
+def _recovery_setup() -> tuple[VariablePartition, dict[str, float], ImpactGoal]:
+    """Known variables -> outputs -> goal targeting those outputs."""
+    partition = VariablePartition(
+        free={
+            "clubhead_speed_mps": (30.0, 55.0),
+            "dynamic_loft_deg": (5.0, 20.0),
+            "face_angle_deg": (-8.0, 8.0),
+        }
+    )
+    truth = partition.assemble(np.array([46.0, 13.5, 1.5]))
+    probe = ImpactGoal.of(ball_speed_mph=1.0)
+    achieved = achieved_quantities(truth, partition, probe)
+    goal = ImpactGoal.of(
+        ball_speed_mph=achieved["ball_speed_mph"],
+        launch_angle_deg=achieved["launch_angle_deg"],
+        launch_azimuth_deg=achieved["launch_azimuth_deg"],
+    )
+    return partition, truth, goal
+
+
+class TestExactRecovery:
+    def test_recovers_generating_variables_from_cold_start(self) -> None:
+        partition, truth, goal = _recovery_setup()
+        result = solve(goal, partition, n_starts=4, seed=1)
+        assert result.converged
+        assert result.residual_norm < 1e-6
+        assert result.variables["clubhead_speed_mps"] == pytest.approx(
+            truth["clubhead_speed_mps"], abs=1e-2
+        )
+        assert result.variables["dynamic_loft_deg"] == pytest.approx(
+            truth["dynamic_loft_deg"], abs=1e-2
+        )
+        assert result.variables["face_angle_deg"] == pytest.approx(
+            truth["face_angle_deg"], abs=1e-2
+        )
+        for error in result.per_goal_errors.values():
+            assert abs(error) < 1e-4
+
+    def test_result_diagnostics_are_complete(self) -> None:
+        partition, _, goal = _recovery_setup()
+        result = solve(goal, partition, n_starts=3, seed=2)
+        assert result.free_names == partition.free_names
+        assert result.x.shape == (3,)
+        assert len(result.starts) == 3
+        assert {s.seed for s in result.starts} == {0, 1, 2}
+        assert result.n_evals == sum(s.n_evals for s in result.starts)
+        assert result.n_evals > 0
+        assert result.elapsed_s >= 0.0
+        assert result.cost == pytest.approx(
+            0.5 * result.residual_norm**2, rel=1e-6, abs=1e-9
+        )
+
+
+class TestUnderdeterminedAndConflicting:
+    def test_underdetermined_returns_valid_flat_residual_solution(self) -> None:
+        """Two free variables, one goal: any exact solution is acceptable."""
+        partition = VariablePartition(
+            free={
+                "clubhead_speed_mps": (30.0, 55.0),
+                "dynamic_loft_deg": (5.0, 20.0),
+            }
+        )
+        goal = ImpactGoal.of(ball_speed_mph=150.0)
+        result = solve(goal, partition, n_starts=3, seed=3)
+        assert result.residual_norm < 1e-6
+        lo, hi = partition.bounds_arrays()
+        assert np.all(result.x >= lo) and np.all(result.x <= hi)
+        assert result.achieved["ball_speed_mph"] == pytest.approx(150.0, abs=1e-3)
+
+    def test_conflicting_goals_report_honest_nonzero_residual(self) -> None:
+        """Face controls both azimuth and face-angle goals set in conflict."""
+        partition = VariablePartition(
+            free={"face_angle_deg": (-8.0, 8.0)},
+            fixed={"clubhead_speed_mps": 45.0, "dynamic_loft_deg": 12.0},
+        )
+        goal = ImpactGoal.of(face_angle_deg=5.0, launch_azimuth_deg=-5.0)
+        result = solve(goal, partition, n_starts=3, seed=4)
+        assert result.residual_norm > 1.0  # genuinely unattainable
+        errors = result.per_goal_errors
+        # Best compromise: both goals miss in opposite directions.
+        assert errors["face_angle_deg"] < 0.0
+        assert errors["launch_azimuth_deg"] > 0.0
+        # The compromise face sits strictly between the two pulls.
+        assert -5.0 < result.variables["face_angle_deg"] < 5.0
+
+
+class TestBoundsAndValidation:
+    def test_solution_respects_bounds_under_unreachable_goal(self) -> None:
+        partition = VariablePartition(
+            free={"clubhead_speed_mps": (30.0, 40.0)},
+            fixed={"dynamic_loft_deg": 12.0},
+        )
+        goal = ImpactGoal.of(ball_speed_mph=250.0)
+        result = solve(goal, partition, n_starts=2, seed=5)
+        assert result.x[0] == pytest.approx(40.0, abs=1e-6)
+        assert result.residual_norm > 0.0
+
+    def test_empty_free_set_raises(self) -> None:
+        partition = VariablePartition(free={}, fixed={"face_angle_deg": 0.0})
+        with pytest.raises(ContractViolationError):
+            solve(ImpactGoal.of(ball_speed_mph=150.0), partition)
+
+    def test_goal_variable_cannot_be_free_and_fixed(self) -> None:
+        with pytest.raises(ContractViolationError):
+            VariablePartition(
+                free={"dynamic_loft_deg": (5.0, 20.0)},
+                fixed={"dynamic_loft_deg": 12.0},
+            )
+
+    def test_bad_x0_rejected(self) -> None:
+        partition = VariablePartition(free={"face_angle_deg": (-5.0, 5.0)})
+        goal = ImpactGoal.of(face_angle_deg=1.0)
+        with pytest.raises(ContractViolationError):
+            solve(goal, partition, x0=np.array([1.0, 2.0]))
+
+
+class TestCancellationAndProgress:
+    def test_pre_set_cancel_event_raises(self) -> None:
+        partition = VariablePartition(free={"face_angle_deg": (-5.0, 5.0)})
+        goal = ImpactGoal.of(face_angle_deg=1.0)
+        event = threading.Event()
+        event.set()
+        with pytest.raises(CancelledError):
+            solve(goal, partition, cancel_event=event)
+
+    def test_cancel_during_solve_is_honoured(self) -> None:
+        partition = VariablePartition(
+            free={
+                "clubhead_speed_mps": (30.0, 55.0),
+                "dynamic_loft_deg": (5.0, 20.0),
+            }
+        )
+        goal = ImpactGoal.of(ball_speed_mph=150.0, launch_angle_deg=13.0)
+        event = threading.Event()
+        calls = {"n": 0}
+
+        def cancelling_cb(report: ProgressReport) -> None:
+            calls["n"] += 1
+            event.set()
+
+        try:
+            result = solve(
+                goal,
+                partition,
+                n_starts=6,
+                progress_cb=cancelling_cb,
+                cancel_event=event,
+                n_workers=1,
+            )
+        except CancelledError:
+            return  # cancelled before any start completed: valid outcome
+        # Otherwise at least one start was cut short by the event.
+        assert calls["n"] >= 1
+        assert any(s.cancelled for s in result.starts)
+
+    def test_progress_reports_have_movement_optimizer_shape(self) -> None:
+        partition, _, goal = _recovery_setup()
+        reports: list[ProgressReport] = []
+        solve(goal, partition, n_starts=3, seed=6, progress_cb=reports.append)
+        assert reports, "expected at least one progress report"
+        report = reports[-1]
+        assert report.iteration > 0
+        assert report.best_cost <= report.cost or report.best_cost >= 0.0
+        assert report.elapsed_s >= 0.0
+        assert isinstance(report.cost_history, list)
+        assert isinstance(report.is_stalled, bool)

--- a/src/shared/python/swing_sim/solver/tuning.py
+++ b/src/shared/python/swing_sim/solver/tuning.py
@@ -1,0 +1,93 @@
+"""Tuning parameters for the impact-parameter solver (epic #4103, #4109).
+
+Scaffolding modeled on UpstreamDrift's
+``movement_optimizer/trajectory/tuning.py`` (named, documented constants
+instead of magic numbers inside the driver), with golf-impact semantics.
+
+All values below are **tuning parameters**: the residual scales normalise
+heterogeneous goal units (degrees, mph, RPM, metres) so a default-weighted
+goal contributes comparably to the least-squares cost per "one perceptible
+unit" of error; the multi-start counts balance robustness against runtime.
+They are not derived from first principles.
+
+Rationale:
+
+- Residual scales: 1 unit of each scale is roughly the smallest difference
+  a launch monitor reports (0.5 deg, 1 mph, 100 RPM, 1 m of carry), so the
+  optimizer trades goals off at launch-monitor resolution by default.
+- ``DEFAULT_N_STARTS``: the delivery->impact map is smooth and mostly
+  monotone in each variable, so a handful of Latin-hypercube starts is
+  enough to escape the rare fold (e.g. loft/speed trade-offs).
+- ``DEFAULT_MAX_NFEV_PER_START``: trf on <= ~12 variables converges in a
+  few dozen evaluations; the cap only guards against pathological goals.
+"""
+
+from __future__ import annotations
+
+# -- Unit conversions (exact definitions) ----------------------------------
+MPH_TO_MPS: float = 0.44704
+"""Miles per hour to metres per second (exact, 1 mph = 0.44704 m/s)."""
+
+# -- Residual scales per goal quantity (see module docstring) --------------
+SCALE_ANGLE_DEG: float = 0.5
+"""Residual scale for angular goals [deg]: path/face/AoA/loft/launch/azimuth."""
+
+SCALE_BALL_SPEED_MPH: float = 1.0
+"""Residual scale for ball-speed goals [mph]."""
+
+SCALE_SPIN_RPM: float = 100.0
+"""Residual scale for total-spin goals [RPM]."""
+
+SCALE_SPIN_AXIS_DEG: float = 1.0
+"""Residual scale for spin-axis tilt goals [deg]."""
+
+SCALE_CARRY_M: float = 1.0
+"""Residual scale for carry-distance goals [m]."""
+
+# -- Multi-start driver -----------------------------------------------------
+DEFAULT_N_STARTS: int = 6
+"""Default number of multi-start seeds (start 0 = midpoint/x0 baseline)."""
+
+DEFAULT_MAX_NFEV_PER_START: int = 200
+"""Default cap on residual evaluations per ``scipy`` least-squares start."""
+
+DEFAULT_XTOL: float = 1e-10
+"""``scipy.optimize.least_squares`` step tolerance."""
+
+DEFAULT_FTOL: float = 1e-10
+"""``scipy.optimize.least_squares`` cost-reduction tolerance."""
+
+DEFAULT_GTOL: float = 1e-10
+"""``scipy.optimize.least_squares`` gradient tolerance."""
+
+PROGRESS_EMIT_EVERY: int = 20
+"""Emit a ProgressReport to the callback every N recorded evaluations."""
+
+STALL_WINDOW: int = 80
+"""Evaluations examined by the stall heuristic (movement_optimizer value)."""
+
+STALL_THRESHOLD: float = 1e-4
+"""Relative cost change below which the stall heuristic fires."""
+
+# -- Swing-source evaluation (pendulum candidates) --------------------------
+DEFAULT_SWING_DURATION_S: float = 1.0
+"""Integrated swing duration [s] per pendulum candidate evaluation."""
+
+DEFAULT_SWING_DT_S: float = 2e-3
+"""RK4 step [s] for pendulum candidate evaluations (pure-Python path)."""
+
+SWING_TIME_SEARCH_SAMPLES: int = 64
+"""Grid samples used to locate the peak-clubhead-speed nominal impact time."""
+
+MIN_CLUBHEAD_SPEED_MPS: float = 1e-3
+"""Floor applied to swing-derived clubhead speed [m/s] (delivery requires > 0)."""
+
+# -- Flight evaluation (carry goals) ----------------------------------------
+DEFAULT_FLIGHT_MODEL: str = "waterloo_penner"
+"""Registry flight model used when carry goals are present."""
+
+DEFAULT_FLIGHT_MAX_TIME_S: float = 12.0
+"""Maximum simulated flight time [s]."""
+
+DEFAULT_FLIGHT_DT_S: float = 0.02
+"""Flight trajectory sampling interval [s]."""

--- a/tests/rate_of_closure/test_solver_gui.py
+++ b/tests/rate_of_closure/test_solver_gui.py
@@ -1,0 +1,240 @@
+"""PyQt6 GUI smoke tests for the Solver panel (epic #4103, #4109/#4110).
+
+Headless-safe. Covers: spec tables matching the solver package's
+variable/goal names, sourced hover guidance on every new input, a full
+worker-thread solve populating the results view, clean cancellation
+(pre-set and mid-run), the apply round-trip landing solved variables in
+the simulation session, and DbC validation errors surfacing as friendly
+status messages instead of tracebacks.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PyQt6")
+pytest.importorskip("pytestqt")
+
+from rate_of_closure.model import MPH_PER_MPS, ImpactScenario  # noqa: E402
+from rate_of_closure.ui.pyqt6.simulation_tab import SimulationTab  # noqa: E402
+from rate_of_closure.ui.pyqt6.solver_panel import SolverPanel  # noqa: E402
+from rate_of_closure.ui.pyqt6.solver_specs import (  # noqa: E402
+    GOAL_SPECS,
+    VARIABLE_SPECS,
+)
+from rate_of_closure.ui.pyqt6.solver_worker import SolverWorker  # noqa: E402
+from shared.python.swing_sim.solver.goals import (  # noqa: E402
+    DELIVERY_VARIABLE_DEFAULTS,
+    GOAL_QUANTITIES,
+    SWING_VARIABLE_DEFAULTS,
+    ImpactGoal,
+    VariablePartition,
+)
+from shared.python.swing_sim.solver.solve import SolverResult  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+def _easy_goal_and_partition() -> tuple[ImpactGoal, VariablePartition]:
+    """The pinned easy case: hit 150 mph ball speed with clubhead speed."""
+    goal = ImpactGoal.of(ball_speed_mph=150.0)
+    partition = VariablePartition(free={"clubhead_speed_mps": (30.0, 70.0)})
+    return goal, partition
+
+
+def _configure_easy_case(panel: SolverPanel) -> None:
+    """Drive the editors to the pinned easy case (defaults already close)."""
+    for name, row in panel._goal_rows.items():
+        row.enabled.setChecked(name == "ball_speed_mph")
+    panel._goal_rows["ball_speed_mph"].target.setValue(150.0)
+    for name, row in panel._var_rows.items():
+        row.optimize.setChecked(name == "clubhead_speed_mps")
+        row.fix.setChecked(name != "clubhead_speed_mps")
+    panel._var_rows["clubhead_speed_mps"].low.setValue(30.0)
+    panel._var_rows["clubhead_speed_mps"].high.setValue(70.0)
+    panel._starts_spin.setValue(2)
+
+
+@pytest.fixture
+def panel(qtbot):  # type: ignore[no-untyped-def]
+    widget = SolverPanel()
+    qtbot.addWidget(widget)
+    yield widget
+    widget.stop()
+
+
+@pytest.fixture
+def tab(qtbot):  # type: ignore[no-untyped-def]
+    widget = SimulationTab()
+    qtbot.addWidget(widget)
+    widget.set_scenario(ImpactScenario(clubhead_speed_mph=113.0))
+    yield widget
+    widget.stop()
+
+
+class TestSpecs:
+    def test_goal_specs_cover_the_solver_quantities_exactly(self) -> None:
+        assert tuple(spec.name for spec in GOAL_SPECS) == GOAL_QUANTITIES
+
+    def test_variable_specs_cover_both_modes_exactly(self) -> None:
+        names = {spec.name for spec in VARIABLE_SPECS}
+        assert names == set(DELIVERY_VARIABLE_DEFAULTS) | set(SWING_VARIABLE_DEFAULTS)
+        swing_only = {spec.name for spec in VARIABLE_SPECS if spec.swing_only}
+        assert swing_only == set(SWING_VARIABLE_DEFAULTS)
+
+    def test_every_input_carries_sourced_guidance(self, panel) -> None:  # type: ignore[no-untyped-def]
+        widgets = [panel._swing_check, panel._starts_spin]
+        for row in panel._goal_rows.values():
+            widgets += [row.enabled, row.target, row.weight]
+        for row in panel._var_rows.values():
+            widgets += [row.optimize, row.low, row.high, row.fixed_value]
+        for widget in widgets:
+            assert "Suggested range" in widget.toolTip(), widget
+            assert "Source:" in widget.toolTip(), widget
+
+
+class TestEditors:
+    def test_mode_toggle_swaps_derived_for_swing_rows(self, panel) -> None:  # type: ignore[no-untyped-def]
+        panel._swing_check.setChecked(True)
+        partition = panel.build_partition()
+        assert partition.use_swing_source
+        names = set(partition.free) | set(partition.fixed)
+        assert "swing_side_tilt_deg" in names
+        assert "clubhead_speed_mps" not in names
+        panel._swing_check.setChecked(False)
+        partition = panel.build_partition()
+        names = set(partition.free) | set(partition.fixed)
+        assert "clubhead_speed_mps" in names
+        assert "swing_side_tilt_deg" not in names
+
+    def test_no_goals_checked_surfaces_a_friendly_message(self, panel) -> None:  # type: ignore[no-untyped-def]
+        for row in panel._goal_rows.values():
+            row.enabled.setChecked(False)
+        panel._on_run()
+        assert panel._status.text().startswith("Cannot solve:")
+        assert panel._run_button.isEnabled()
+
+    def test_inverted_bounds_surface_a_friendly_message(self, panel) -> None:  # type: ignore[no-untyped-def]
+        _configure_easy_case(panel)
+        row = panel._var_rows["clubhead_speed_mps"]
+        row.low.setValue(60.0)
+        row.high.setValue(40.0)
+        panel._on_run()
+        assert panel._status.text().startswith("Cannot solve:")
+        assert panel._run_button.isEnabled()
+
+
+class TestWorker:
+    def test_worker_completes_and_reports_the_pinned_solution(self, qtbot) -> None:  # type: ignore[no-untyped-def]
+        goal, partition = _easy_goal_and_partition()
+        worker = SolverWorker(goal, partition, n_starts=2)
+        with qtbot.waitSignal(worker.succeeded, timeout=60000) as blocker:
+            worker.start()
+        worker.wait(10_000)
+        result = blocker.args[0]
+        assert result.converged
+        # Pinned solution (matches the web parity test): ~45.82 m/s.
+        assert result.variables["clubhead_speed_mps"] == pytest.approx(45.825, abs=0.05)
+        assert result.achieved["ball_speed_mph"] == pytest.approx(150.0, abs=0.1)
+
+    def test_preset_cancel_event_cancels_cleanly(self, qtbot) -> None:  # type: ignore[no-untyped-def]
+        goal, partition = _easy_goal_and_partition()
+        worker = SolverWorker(goal, partition, n_starts=4)
+        worker.cancel()
+        with qtbot.waitSignal(worker.cancelled, timeout=30000):
+            worker.start()
+        worker.wait(10_000)
+        assert worker.cancel_event.is_set()
+
+    def test_midrun_cancel_finishes_without_error(self, qtbot) -> None:  # type: ignore[no-untyped-def]
+        goal = ImpactGoal.of(carry_m=230.0)  # flight per eval: slower run
+        partition = VariablePartition(free={"clubhead_speed_mps": (30.0, 70.0)})
+        worker = SolverWorker(goal, partition, n_starts=8)
+        outcomes: list[str] = []
+        worker.succeeded.connect(lambda _r: outcomes.append("succeeded"))
+        worker.cancelled.connect(lambda: outcomes.append("cancelled"))
+        worker.failed.connect(lambda _m: outcomes.append("failed"))
+        with qtbot.waitSignal(worker.finished, timeout=120000):
+            worker.start()
+            worker.cancel()
+        worker.wait(10_000)
+        assert worker.cancel_event.is_set()
+        assert outcomes in (["succeeded"], ["cancelled"])
+
+
+class TestPanelRun:
+    def test_panel_run_populates_results_and_enables_apply(self, panel, qtbot) -> None:  # type: ignore[no-untyped-def]
+        _configure_easy_case(panel)
+        assert not panel._apply_button.isEnabled()
+        panel._on_run()
+        assert panel._worker is not None
+        with qtbot.waitSignal(panel._worker.succeeded, timeout=60000):
+            pass
+        panel._worker.wait(10_000)
+        qtbot.waitUntil(panel._apply_button.isEnabled, timeout=10000)
+        assert panel._table.rowCount() == 1
+        assert panel._table.item(0, 0).text() == "Ball Speed"
+        assert "Solved variables" in panel._summary.text()
+        assert panel._starts_tree.topLevelItemCount() == 2
+        assert "converged" in panel._status.text()
+
+
+class TestApply:
+    def test_delivery_apply_round_trip_lands_in_the_session(self, tab, qtbot) -> None:  # type: ignore[no-untyped-def]
+        panel = tab.solver_panel()
+        _configure_easy_case(panel)
+        panel._var_rows["impact_offset_toe_mm"].fixed_value.setValue(4.0)
+        panel._on_run()
+        with qtbot.waitSignal(panel._worker.succeeded, timeout=60000):
+            pass
+        panel._worker.wait(10_000)
+        qtbot.waitUntil(panel._apply_button.isEnabled, timeout=10000)
+        result = panel.result()
+        with qtbot.waitSignal(tab.runCompleted, timeout=30000):
+            panel._apply_button.click()
+        config = tab.config()
+        assert config.source_kind == "manual"
+        assert config.scenario.clubhead_speed_mph == pytest.approx(
+            result.variables["clubhead_speed_mps"] * MPH_PER_MPS
+        )
+        assert config.scenario.impact_offset_toe_mm == pytest.approx(4.0)
+        assert tab.last_run() is not None
+
+    def test_swing_apply_selects_pendulum_and_drives_tilts(self, tab, qtbot) -> None:  # type: ignore[no-untyped-def]
+        variables = {
+            "face_angle_deg": 0.0,
+            "dynamic_loft_deg": 10.5,
+            "lie_deg": 0.0,
+            "impact_offset_toe_mm": 2.0,
+            "impact_offset_high_mm": -1.0,
+            "swing_yaw_deg": 5.0,
+            "swing_side_tilt_deg": -40.0,
+            "swing_forward_tilt_deg": -3.0,
+            "swing_impact_time_offset_s": 0.01,
+            "swing_damping_shoulder": 0.4,
+            "swing_damping_wrist": 0.25,
+        }
+        result = SolverResult(
+            variables=variables,
+            free_names=("swing_side_tilt_deg",),
+            x=np.array([-40.0]),
+            achieved={},
+            per_goal_errors={},
+            residual_norm=0.0,
+            cost=0.0,
+            converged=True,
+            n_evals=1,
+            elapsed_s=0.0,
+            starts=(),
+        )
+        with qtbot.waitSignal(tab.runCompleted, timeout=60000):
+            run = tab.apply_solver_solution(result, True)
+        assert run is not None
+        assert tab.source_kind() == "double_pendulum"
+        assert tab.plane().yaw_deg == pytest.approx(5.0)
+        assert tab.plane().side_tilt_deg == pytest.approx(-40.0)
+        config = tab.config()
+        assert config.scenario.impact_offset_toe_mm == pytest.approx(2.0)
+        # The solved impact-time offset shifted tau off the auto instant.
+        assert config.impact_time_s is not None


### PR DESCRIPTION
## Summary

Wires the impact-parameter solver (PR #4116, `src/shared/python/swing_sim/solver/`) into the Rate of Closure app UI (Tools epic #4103, issues #4109 / #4110). Branched from `feat/rate-of-closure-simulation` with `origin/feat/swing-sim-solver` merged in (SPEC.md conflict resolved keeping all sections).

### PyQt6 — Solver tab (Simulation tab, right-hand stack)

- **Goal editor**: checkbox-enable any subset of the 10 `ImpactGoal` quantities, each with target + weight entries; sourced hover guidance on every input ("Suggested range … Source: …", test-enforced).
- **Variable partition editor**: per variable, radio *Optimize* (min/max bounds) | *Fix* (value); a swing-source toggle swaps the derived delivery variables (speed/path/AoA) for the double-pendulum swing variables, matching the solver package's mode rules.
- **Run/Cancel** on a `QThread` worker (`solver_worker.py`) — UI never blocks; the solver's `ProgressReport` callback drives the progress bar (evals against the multi-start budget) plus a status line with best cost and the stall heuristic; Cancel sets the cooperative `cancel_event`.
- **Results**: achieved-vs-goal table with per-goal errors, residual norm / convergence / eval counts, expandable per-start diagnostics (cost, evals, status, message, solution vector).
- **Apply**: loads the solved variables into the simulation session and reruns so the optimized swing/impact shows in the 3D scene — both modes land the impact offsets in the scenario; delivery mode selects the manual source + scenario clubhead speed; swing mode selects the double pendulum, drives the plane tilts, and shifts tau by the solved impact-time offset.
- DbC validation errors surface as friendly status messages, never tracebacks. Theming stays with the shared ThemeManager palette (no hard-coded colors).

### Web (practical parity)

- `model/solver.ts`: bounded Nelder-Mead over the free delivery variables (candidates clamped into bounds, deterministic multi-start) using the existing parity-ported TS physics as the objective; goals limited to what it computes (path/face/AoA/loft, ball speed, launch angles, spin, carry).
- `components/SolverPanel.tsx`: Solver section in the Simulation tab — goal/partition editors, results table, Apply-to-scenario.
- Parity-pinned against the pytest easy case: 150 mph ball-speed goal solves to ~45.825 m/s clubhead speed in both implementations.
- Progress/cancel, swing-source mode, and the web-worker/WASM objective land with the P7 kernels (noted in SPEC + UI copy).

### Tests

- `tests/rate_of_closure/test_solver_gui.py` (12 tests, headless-safe): worker completes with the pinned solution, cancels cleanly (pre-set and mid-run), panel run populates results + enables Apply, delivery apply round-trips into the session config, swing apply selects the pendulum and drives the tilts, editor validation surfaces friendly messages, spec tables cover the solver package names exactly, sourced guidance on every input.
- `src/rate_of_closure/web/src/model/solver.test.ts` (10 tests): pinned parity case, bounds enforcement, two-variable goal, DbC validation parity.

### Gates

- pytest `tests/rate_of_closure` + `src/shared/python/swing_sim`: **404 passed**
- ruff check + format: clean; mypy (new/changed modules): clean
- web: `npm test` 72 passed (7 files), `type-check`, `lint`, `build`: clean
- all new files ≤ 500 LOC

### Documented deviations

- The simulation session delivers a square face at the club's loft, so solved face-angle / dynamic-loft values inform the goal table but are not replayed by Apply (SPEC-documented).
- Web solver is synchronous (fast at ≤7 variables) — worker-thread + progress/cancel deferred to P7 with the WASM kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)