### PR TITLE
feat(rate_of_closure): scale-separated strike/swing/flight viewers, standalone flight explorer, small-window layout fixes (V2, #4120)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -35,6 +35,67 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Rate of Closure scale-separated viewers + standalone Flight Explorer (epic #4120, V2)
+
+- Three purpose-built, scale-separated viewers replace the single
+  mixed-scale scene in the Simulation tab's display area (sub-tabs
+  Strike / Swing / Flight, each with its own display-parameter
+  checklist whose state persists for the session):
+  - `ui/pyqt6/strike_view.py` — impact-zone view at FACE scale
+    (millimetres, hard-capped at ±120 mm — `STRIKE_MAX_EXTENT_MM`;
+    never shows flight): superellipse face outline sized from the
+    club's mass envelope, bulge/roll sagitta contours when the face is
+    curved, impact-offset marker plus a strike-history scatter, the
+    delivered club-path / face-normal / attack-angle vectors projected
+    into the face plane, and a club-info annotation.
+  - Swing view (`simulation_view.py`) — the existing 3D scene scoped
+    to SWING scale: the flight polyline is removed from the default
+    display and the scene extent stays at the swing envelope; a new
+    'Show Ball Flight' checkbox (default OFF, with guidance warning
+    that the flight envelope dwarfs the swing) opts back into the old
+    expand-to-flight behaviour.
+  - `ui/pyqt6/flight_view.py` — dedicated FLIGHT-scale viewer: side
+    profile (height vs carry) + top-down (lateral vs carry) 2D panels
+    plus the 3D polyline, landing point and apex annotated, reusable
+    with a bare trajectory (no swing) via `set_trajectory`.
+- Standalone Ball-Flight Explorer: new top-level PyQt6 tab
+  (`ui/pyqt6/flight_explorer_tab.py`) over a pure logic layer
+  (`simulation/flight_explorer.py`): direct entry of launch conditions
+  (ball speed with mph / m/s unit drop-down, launch angle, azimuth,
+  spin rpm, spin-axis tilt — app signs: + = right of target / fade
+  side) OR impact-delivery parameters run through
+  `swing_sim.impact.delivery` + the rigid-body impact model, a model
+  picker across all 7 literature flight models, rendering in the
+  flight viewer, and clickable result rows (carry, apex, flight time,
+  landing angle, lateral — `lateral_m` explanation added to
+  `LAUNCH_EXPLANATIONS`). No swing required.
+- Small-window layout defect fixed: window minimum lowered to
+  1024×700 (registration updated), every control column scrolls
+  (`QScrollArea`), typed entries carry minimum widths (≥ 84 px spins),
+  result-row labels tooltip their full text and values keep a minimum
+  width; `tests/rate_of_closure/test_layout_minsize.py` resizes the
+  window to 1024×700 headlessly, walks every (nested) tab, and asserts
+  every visible QLineEdit/QDoubleSpinBox is ≥ 64 px wide with no
+  zero-height visible widgets.
+- Web practical parity: Strike / Swing / Flight segmented views in the
+  Simulation panel (strike-zone canvas with face outline + offset
+  marker + delivery vectors; side + top-down flight profile canvases
+  with landing annotations), a 'Show Ball Flight' toggle separated
+  from the swing canvas scale, and a standalone Flight Explorer tab
+  (`model/flightExplorer.ts` + `components/FlightExplorerPanel.tsx`)
+  parity-banded against the pytest pinned case (167 mph / 10.9° /
+  2,686 rpm → carry ≈ 247.5 m under Waterloo/Penner); responsive
+  min-widths (`min-w-*`, truncation with title attributes). The
+  7-model picker and delivery mode stay Python-side until P7 WASM.
+- Tests: viewer scale invariants (strike extents never exceed face
+  scale; the flight toggle changes the swing-view limits and restores
+  them), flight-explorer end-to-end pins in both entry modes, sign
+  conventions (+ azimuth / fade tilt land right), all-7-model runs, TS
+  parity pins, GUI smoke for every new tab, sourced tooltips
+  test-enforced on every new control. Non-goals here: the Closure
+  Sweep plotting suite (V1, separate branch), the Monte Carlo
+  variation engine (V3), and the help system (V4).
+
 ### 2026-08-04 Rate of Closure solver panel — goal-driven optimization UI (epic #4103, #4109 #4110)
 
 - PyQt6: new "Solver" tab inside the Simulation tab's right-hand tab
@@ -2038,6 +2099,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.10.0 | feat(rate_of_closure, #4120 V2): scale-separated viewers + standalone Flight Explorer + small-window layout fixes. PyQt6: Strike/Swing/Flight display sub-tabs in the Simulation tab — new face-scale StrikeView (superellipse face outline sized from the club mass envelope, bulge/roll sagitta contours, impact marker + strike-history scatter, path/face/AoA vectors in the face plane, club info; extents hard-capped at ±120 mm), swing view scoped to swing scale with the flight polyline behind a default-OFF 'Show Ball Flight' checkbox (guidance warns flight dwarfs the swing), new flight-scale FlightView (side + top-down profiles + 3D polyline, landing/apex annotated); new top-level Flight Explorer tab over `simulation/flight_explorer.py` (direct launch entry with unit drop-down or impact-delivery entry through swing_sim.impact + rigid-body solve, 7-model picker, result rows with explanations incl. new lateral_m); window minimum lowered to 1024×700 with scrolling control columns, ≥84 px entry minimums, and a headless small-window layout test. Web: Strike/Swing/Flight segmented views (strike + flight profile canvases), separated Show-Ball-Flight toggle, standalone Flight Explorer panel parity-banded against the pytest pinned case (167 mph / 10.9° / 2686 rpm → ~247.5 m carry); responsive min-widths with title-attribute truncation. |
 | 2026-08-04 | 1.9.0 | feat(rate_of_closure, #4109 #4110): solver panel — goal-driven optimization UI. PyQt6 Solver tab in the Simulation tab (checkbox-enabled weighted ImpactGoal targets, Optimize-with-bounds / Fix VariablePartition editor with a double-pendulum swing-source mode, start-count spinner, Run/Cancel on a QThread worker with ProgressReport-driven progress bar and cooperative cancel_event, achieved-vs-goal table with per-goal errors / residual norm / convergence / expandable per-start diagnostics, Apply loading solved variables into the simulation session and rerunning the 3D scene; sourced tooltips throughout, DbC errors as friendly status messages). Web: model/solver.ts bounded Nelder-Mead over the TS-physics objective (delivery variables, deterministic multi-start) + SolverPanel section with apply-to-scenario, parity-pinned against the pytest easy case (150 mph ball speed -> ~45.825 m/s clubhead speed); WASM/worker upgrade deferred to P7. |
 | 2026-08-04 | 1.6.0 | feat(swing_sim, #4107): add the ball-flight package `src/shared/python/swing_sim/flight/` — 7 literature flight models (Waterloo/Penner, MacDonald-Hanzely, and five cited constant-coefficient presets) behind `FlightModelRegistry` with scipy RK45 + terminal ground event; public `derive_launch_conditions` (post-impact velocity/spin → launch conditions with exact round-trip); app↔flight frame adapters; graceful Rust fast path over `tools-core`'s canonical `ball_flight.rs` kernel (new `simulate_trajectory`/`analyze_trajectory` pyfunctions, property setters, velocity getters) with parity tests; `FlightSimulatorProtocol` + `simulate()` pipeline seam for the impact stage. |
 | 2026-08-04 | 1.8.0 | feat(rate_of_closure, epic #4103): simulation session integrating swing_sim into the app — app-frame swing sources (manual constant twist, shared double pendulum, new triple pendulum), swing → impact (gear effect + bulge/roll callable) → flight orchestration into one exportable SimulationRun, fixed-ball impact-time scrubber, thin ISA adapter over the rotation converter with a toggleable screw-axis overlay, PyQt6 Simulation tab (sourced-guidance inputs, launch rows with explanations, ball/ground toggles, flight polyline, full video playback with 1×-real-time rate presets, sortable inspector, CSV/JSON export) and a parity-pinned web Simulation tab (pendulum/impact/flight TS port, scrubber, playback, JSON download; WASM supersedes in P7). |

--- a/src/rate_of_closure/derivation.py
+++ b/src/rate_of_closure/derivation.py
@@ -205,6 +205,13 @@ LAUNCH_EXPLANATIONS: dict[str, str] = {
         "Descent angle below horizontal at the terminal ground event; "
         "steeper landings stop faster (driver band roughly 35-45 deg)."
     ),
+    "lateral_m": (
+        "Sideways landing offset from the target line (+ = right of "
+        "target for a right-handed player): the integrated effect of "
+        "launch azimuth plus spin-axis-tilt curvature (the D-plane's "
+        "Magnus component), reported the way launch monitors report "
+        "carry offline."
+    ),
 }
 
 

--- a/src/rate_of_closure/gui_registration.py
+++ b/src/rate_of_closure/gui_registration.py
@@ -21,7 +21,7 @@ GUI_INFO = {
         "class": "RateOfClosureMainWindow",
         "dependencies": ["PyQt6", "matplotlib", "numpy"],
         "settings_app": "RateOfClosure",
-        "min_size": [1200, 780],
+        "min_size": [1024, 700],
     },
     "web": {
         "port": 5193,

--- a/src/rate_of_closure/simulation/__init__.py
+++ b/src/rate_of_closure/simulation/__init__.py
@@ -16,6 +16,13 @@ Orchestrates a full swing -> impact -> flight run:
 from __future__ import annotations
 
 from .export import run_to_json_dict, write_csv, write_json
+from .flight_explorer import (
+    EXPLORER_METRIC_KEYS,
+    FlightExploration,
+    explore_flight,
+    launch_from_delivery,
+    launch_from_direct,
+)
 from .isa import screw_axis_samples
 from .session import (
     BALL_POSITION_M,
@@ -35,14 +42,19 @@ from .sources import (
 
 __all__ = [
     "BALL_POSITION_M",
+    "EXPLORER_METRIC_KEYS",
     "SOURCE_KINDS",
     "AppFrameSwing",
+    "FlightExploration",
     "ManualSwingSource",
     "SimulationConfig",
     "SimulationRun",
     "TriplePendulumParameters",
     "TriplePendulumSwing",
     "delivery_at",
+    "explore_flight",
+    "launch_from_delivery",
+    "launch_from_direct",
     "make_source",
     "run_simulation",
     "run_to_json_dict",

--- a/src/rate_of_closure/simulation/flight_explorer.py
+++ b/src/rate_of_closure/simulation/flight_explorer.py
@@ -1,0 +1,194 @@
+"""Standalone ball-flight exploration: launch entry -> flight, no swing.
+
+Logic layer of the V2 Flight Explorer (epic #4120): build
+:class:`~shared.python.swing_sim.flight.types.LaunchConditions` either
+directly from launch-monitor ball numbers (ball speed, launch angle,
+azimuth, spin, spin-axis tilt) or from club delivery numbers run through
+``swing_sim.impact.delivery`` and the rigid-body impact model, then
+integrate the flight with any of the 7 literature models in
+``swing_sim.flight`` and return an app-frame trajectory + metrics.
+
+Sign conventions match the simulation session (app frame: x target,
+y up, z right): azimuth and lateral are + right of target; spin-axis
+tilt is + fade-side (curves right), matching the D-plane diagnostics in
+``swing_sim.impact.delivery``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from rate_of_closure._contracts import ensure, require
+from rate_of_closure.model import MPH_PER_MPS
+from rate_of_closure.simulation.session import BALL_POSITION_M
+from shared.python.swing_sim.flight import (
+    LaunchConditions,
+    derive_launch_conditions,
+    from_flight_frame,
+    to_flight_frame,
+)
+from shared.python.swing_sim.flight import simulate as flight_simulate
+from shared.python.swing_sim.impact import (
+    DeliveryParameters,
+    ImpactModelType,
+    ImpactSolverAPI,
+    derive_delivery,
+)
+
+__all__ = [
+    "EXPLORER_METRIC_KEYS",
+    "FlightExploration",
+    "explore_flight",
+    "launch_from_delivery",
+    "launch_from_direct",
+]
+
+#: Metric keys every exploration reports, in display order.
+EXPLORER_METRIC_KEYS: tuple[str, ...] = (
+    "ball_speed_mph",
+    "launch_angle_deg",
+    "launch_azimuth_deg",
+    "spin_rpm",
+    "carry_m",
+    "max_height_m",
+    "flight_time_s",
+    "landing_angle_deg",
+    "lateral_m",
+)
+
+
+@dataclass(frozen=True)
+class FlightExploration:
+    """One standalone flight run (app frame).
+
+    Attributes:
+        launch: The flight-frame launch conditions used.
+        model_name: The flight-model registry name used.
+        times: (N,) trajectory sample times [s].
+        positions: (N, 3) app-frame ball positions from the tee.
+        metrics: Launch + flight summary keyed by
+            :data:`EXPLORER_METRIC_KEYS`.
+    """
+
+    launch: LaunchConditions
+    model_name: str
+    times: np.ndarray
+    positions: np.ndarray
+    metrics: dict[str, float]
+
+
+def launch_from_direct(
+    ball_speed_mph: float,
+    launch_angle_deg: float,
+    azimuth_deg: float,
+    spin_rpm: float,
+    spin_axis_tilt_deg: float,
+) -> LaunchConditions:
+    """Launch conditions from launch-monitor ball numbers (app signs).
+
+    Args:
+        ball_speed_mph: Ball speed [mph], > 0.
+        launch_angle_deg: Launch angle above horizontal [deg].
+        azimuth_deg: Launch direction [deg]; + = right of target.
+        spin_rpm: Total spin rate [rpm], >= 0.
+        spin_axis_tilt_deg: Spin-axis tilt [deg]; + = fade-side (curves
+            right for a right-handed player), matching the D-plane tilt
+            reported by ``swing_sim.impact.delivery``.
+
+    Returns:
+        Flight-frame :class:`LaunchConditions`.
+    """
+    require(
+        math.isfinite(ball_speed_mph) and ball_speed_mph > 0.0,
+        "ball_speed_mph must be finite and > 0",
+        ball_speed_mph,
+    )
+    # App azimuth + = right; flight-frame azimuth + = left (+y): flip.
+    # Fade-side tilt (+) needs a downward (-z flight) sidespin component,
+    # which the legacy spin_axis_angle decomposition produces for a
+    # negative angle — hence both signs flip here.
+    return LaunchConditions.from_imperial(
+        ball_speed_mph=ball_speed_mph,
+        launch_angle_deg=launch_angle_deg,
+        spin_rate_rpm=spin_rpm,
+        azimuth_angle_deg=-azimuth_deg,
+        spin_axis_angle_deg=-spin_axis_tilt_deg,
+    )
+
+
+def launch_from_delivery(params: DeliveryParameters) -> LaunchConditions:
+    """Launch conditions from club delivery numbers via the impact model.
+
+    Runs the delivery front-end (:func:`derive_delivery`) and the
+    rigid-body COR impact solve — the same physics chain as the
+    simulation session, minus the swing and the club-specific
+    bulge/roll gear-effect callable (no club is selected here).
+
+    Args:
+        params: Launch-monitor-style delivery parameters.
+
+    Returns:
+        Flight-frame :class:`LaunchConditions` for the struck ball.
+    """
+    derived = derive_delivery(params)
+    solver = ImpactSolverAPI(ImpactModelType.RIGID_BODY)
+    post = solver.solve_impact(
+        timestamp=0.0,
+        clubhead_velocity=derived.clubhead_velocity,
+        clubhead_orientation=derived.face_normal,
+        impact_offset=derived.impact_offset,
+        record=False,
+    )
+    return derive_launch_conditions(
+        to_flight_frame(post.ball_velocity),
+        to_flight_frame(post.ball_angular_velocity),
+    )
+
+
+def explore_flight(
+    launch: LaunchConditions, model_name: str = "waterloo_penner"
+) -> FlightExploration:
+    """Integrate one standalone flight and package app-frame results.
+
+    Args:
+        launch: Flight-frame launch conditions.
+        model_name: A ``FlightModelType`` value string (one of the 7
+            literature models).
+
+    Returns:
+        A complete :class:`FlightExploration`.
+    """
+    flight = flight_simulate(launch, model_name=model_name)
+    times = np.array([p.time for p in flight.trajectory])
+    positions = (
+        from_flight_frame(flight.to_position_array()) + BALL_POSITION_M
+        if len(flight.trajectory)
+        else np.zeros((0, 3))
+    )
+    metrics = {
+        "ball_speed_mph": launch.ball_speed * MPH_PER_MPS,
+        "launch_angle_deg": math.degrees(launch.launch_angle),
+        # Flight azimuth + = left; app convention + = right of target.
+        "launch_azimuth_deg": -math.degrees(launch.azimuth_angle),
+        "spin_rpm": launch.spin_rate,
+        "carry_m": float(flight.carry_distance),
+        "max_height_m": float(flight.max_height),
+        "flight_time_s": float(flight.flight_time),
+        "landing_angle_deg": float(flight.landing_angle),
+        # Flight lateral + = left (+y flight); app lateral + = right.
+        "lateral_m": -float(flight.lateral_deviation),
+    }
+    ensure(
+        set(metrics) == set(EXPLORER_METRIC_KEYS),
+        "exploration metrics must cover EXPLORER_METRIC_KEYS exactly",
+    )
+    return FlightExploration(
+        launch=launch,
+        model_name=model_name,
+        times=times,
+        positions=np.asarray(positions),
+        metrics=metrics,
+    )

--- a/src/rate_of_closure/ui/pyqt6/controls_panel.py
+++ b/src/rate_of_closure/ui/pyqt6/controls_panel.py
@@ -127,6 +127,7 @@ class ControlsPanel(QWidget):
         self._loft_spin.setRange(0.0, 70.0)
         self._loft_spin.setSuffix(" deg")
         self._loft_spin.setToolTip(FIELD_GUIDANCE["club_loft_deg"])
+        self._loft_spin.setMinimumWidth(84)  # readable at small windows
         form.addRow("Loft", self._loft_spin)
 
         self._curvature_check = QCheckBox("Curved Face (Bulge && Roll)")
@@ -146,6 +147,7 @@ class ControlsPanel(QWidget):
             spin.setRange(100.0, 2000.0)
             spin.setSuffix(" mm")
             spin.setToolTip(FIELD_GUIDANCE[key])
+            spin.setMinimumWidth(84)  # readable at small windows
             form.addRow(label, spin)
 
         self._generate_button = QPushButton("Generate Representative Head")
@@ -187,6 +189,7 @@ class ControlsPanel(QWidget):
             spin.setKeyboardTracking(False)
             spin.setDecimals(decimals)
             spin.setToolTip(FIELD_GUIDANCE[name])
+            spin.setMinimumWidth(84)  # readable at small windows
             self._configure_spin_range(spin, name)
             spin.valueChanged.connect(self._on_value_changed)
             self._spins[name] = spin

--- a/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
@@ -1,0 +1,345 @@
+"""Standalone Ball-Flight Explorer tab — launch entry to flight, no swing.
+
+Epic #4120 (V2): type launch conditions directly (ball speed with a
+unit drop-down, launch angle, azimuth, spin, spin-axis tilt) OR club
+delivery numbers run through ``swing_sim.impact.delivery`` and the
+rigid-body impact model, pick any of the 7 literature flight models,
+and render the result in the dedicated flight-scale
+:class:`~rate_of_closure.ui.pyqt6.flight_view.FlightView` with result
+rows (carry, apex, flight time, landing angle, lateral) that click
+through to explanations. Every control carries sourced hover guidance.
+
+The physics lives in :mod:`rate_of_closure.simulation.flight_explorer`;
+this widget is presentation only.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from PyQt6.QtWidgets import (
+    QAbstractSpinBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QFrame,
+    QGroupBox,
+    QHBoxLayout,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QSplitter,
+    QStackedWidget,
+    QTextBrowser,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rate_of_closure.derivation import LAUNCH_EXPLANATIONS
+from rate_of_closure.model import MPH_PER_MPS
+from rate_of_closure.simulation import (
+    FlightExploration,
+    explore_flight,
+    launch_from_delivery,
+    launch_from_direct,
+)
+from rate_of_closure.ui.pyqt6.flight_view import FlightView
+from rate_of_closure.ui.pyqt6.result_row import ResultRow
+from rate_of_closure.units import FIELD_GUIDANCE
+from shared.python.swing_sim.flight.registry import FlightModelType
+from shared.python.swing_sim.impact import DeliveryParameters
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["EXPLORER_ROWS", "FlightExplorerTab"]
+
+#: Entry modes, in combo order.
+_MODES: tuple[str, ...] = ("Direct Launch Conditions", "Impact Delivery")
+
+#: Speed display units: label -> factor from displayed to m/s.
+_SPEED_UNITS: dict[str, float] = {"mph": 1.0 / MPH_PER_MPS, "m/s": 1.0}
+
+#: (metric key, Title Case label, unit suffix) result rows in display
+#: order. Every key must have an entry in LAUNCH_EXPLANATIONS
+#: (test-enforced).
+EXPLORER_ROWS: tuple[tuple[str, str, str], ...] = (
+    ("carry_m", "Carry Distance", " m"),
+    ("max_height_m", "Apex Height", " m"),
+    ("flight_time_s", "Flight Time", " s"),
+    ("landing_angle_deg", "Landing Angle", "°"),
+    ("lateral_m", "Lateral Landing Offset", " m"),
+)
+
+#: Direct-mode fields: (attr, label, guidance key, low, high, default,
+#: decimals, suffix).
+_DIRECT_FIELDS: tuple[tuple[str, str, str, float, float, float, int, str], ...] = (
+    ("launch_angle_deg", "Launch Angle", "fx_launch_angle", -89.0, 89.0, 10.9, 1, "°"),
+    ("azimuth_deg", "Launch Azimuth", "fx_azimuth", -45.0, 45.0, 0.0, 1, "°"),
+    ("spin_rpm", "Total Spin", "fx_spin_rpm", 0.0, 15000.0, 2686.0, 0, " rpm"),
+    (
+        "spin_axis_tilt_deg",
+        "Spin-Axis Tilt",
+        "fx_spin_axis_tilt",
+        -60.0,
+        60.0,
+        0.0,
+        1,
+        "°",
+    ),
+)
+
+#: Delivery-mode fields: same tuple shape as _DIRECT_FIELDS.
+_DELIVERY_FIELDS: tuple[tuple[str, str, str, float, float, float, int, str], ...] = (
+    ("club_path_deg", "Club Path", "fx_club_path", -45.0, 45.0, 0.0, 1, "°"),
+    ("face_angle_deg", "Face Angle", "fx_face_angle", -45.0, 45.0, 0.0, 1, "°"),
+    ("attack_angle_deg", "Attack Angle", "fx_attack_angle", -20.0, 20.0, -1.0, 1, "°"),
+    ("dynamic_loft_deg", "Dynamic Loft", "fx_dynamic_loft", 0.0, 70.0, 12.0, 1, "°"),
+    (
+        "impact_offset_toe_mm",
+        "Impact Toward Toe",
+        "impact_offset_toe_mm",
+        -30.0,
+        30.0,
+        0.0,
+        1,
+        " mm",
+    ),
+    (
+        "impact_offset_high_mm",
+        "Impact Above Center",
+        "impact_offset_high_mm",
+        -30.0,
+        30.0,
+        0.0,
+        1,
+        " mm",
+    ),
+)
+
+
+def _make_spin(
+    low: float, high: float, default: float, decimals: int, suffix: str, tooltip: str
+) -> QDoubleSpinBox:
+    """A typed entry spin box in the explorer's house style."""
+    spin = QDoubleSpinBox()
+    spin.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+    spin.setKeyboardTracking(False)
+    spin.setDecimals(decimals)
+    spin.setRange(low, high)
+    spin.setValue(default)
+    spin.setSuffix(suffix)
+    spin.setToolTip(tooltip)
+    spin.setMinimumWidth(84)  # stays readable at small windows
+    return spin
+
+
+class FlightExplorerTab(QWidget):
+    """Standalone flight explorer: launch entry, model picker, viewer."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._exploration: FlightExploration | None = None
+        self._rows: dict[str, ResultRow] = {}
+        self._direct_spins: dict[str, QDoubleSpinBox] = {}
+        self._delivery_spins: dict[str, QDoubleSpinBox] = {}
+        self._flight_view = FlightView()
+
+        left_content = QWidget()
+        left_layout = QVBoxLayout(left_content)
+        left_layout.addWidget(self._build_entry_box())
+        left_layout.addWidget(self._build_results_box())
+        left_layout.addWidget(self._build_explanation_box())
+        left_layout.addStretch(1)
+        left = QScrollArea()
+        left.setWidgetResizable(True)
+        left.setFrameShape(QFrame.Shape.NoFrame)
+        left.setWidget(left_content)
+        left.setMinimumWidth(300)
+
+        splitter = QSplitter()
+        splitter.addWidget(left)
+        splitter.addWidget(self._flight_view)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(splitter)
+
+        self._show_explanation(EXPLORER_ROWS[0][0])
+
+    # ── construction ────────────────────────────────────────────────
+    def _build_entry_box(self) -> QGroupBox:
+        box = QGroupBox("Launch Entry (No Swing Required)")
+        layout = QVBoxLayout(box)
+        form = QFormLayout()
+
+        self._mode_combo = QComboBox()
+        self._mode_combo.addItems(list(_MODES))
+        self._mode_combo.setToolTip(FIELD_GUIDANCE["fx_mode"])
+        form.addRow("Entry Mode", self._mode_combo)
+
+        speed_row = QHBoxLayout()
+        self._speed_spin = _make_spin(
+            1.0, 250.0, 167.0, 1, "", FIELD_GUIDANCE["fx_ball_speed"]
+        )
+        self._speed_unit_combo = QComboBox()
+        self._speed_unit_combo.addItems(list(_SPEED_UNITS))
+        self._speed_unit_combo.setToolTip(FIELD_GUIDANCE["fx_speed_unit"])
+        self._speed_unit_combo.currentTextChanged.connect(self._on_speed_unit)
+        self._speed_unit = "mph"
+        speed_row.addWidget(self._speed_spin, stretch=1)
+        speed_row.addWidget(self._speed_unit_combo)
+        form.addRow("Speed", speed_row)
+        layout.addLayout(form)
+
+        self._stack = QStackedWidget()
+        self._stack.addWidget(self._build_fields_page(_DIRECT_FIELDS, "direct"))
+        self._stack.addWidget(self._build_fields_page(_DELIVERY_FIELDS, "delivery"))
+        self._mode_combo.currentIndexChanged.connect(self._on_mode_changed)
+        layout.addWidget(self._stack)
+
+        model_form = QFormLayout()
+        self._model_combo = QComboBox()
+        self._model_combo.addItems([m.value for m in FlightModelType])
+        self._model_combo.setCurrentText("waterloo_penner")
+        self._model_combo.setToolTip(FIELD_GUIDANCE["flight_model"])
+        model_form.addRow("Flight Model", self._model_combo)
+        layout.addLayout(model_form)
+
+        self._run_button = QPushButton("Run Flight")
+        self._run_button.setToolTip(
+            "Build launch conditions from the entries (running the "
+            "impact model first in Impact Delivery mode) and integrate "
+            "the ball flight with the selected literature model."
+        )
+        self._run_button.clicked.connect(self.run_now)
+        layout.addWidget(self._run_button)
+        return box
+
+    def _build_fields_page(
+        self,
+        fields: tuple[tuple[str, str, str, float, float, float, int, str], ...],
+        kind: str,
+    ) -> QWidget:
+        page = QWidget()
+        form = QFormLayout(page)
+        form.setContentsMargins(0, 0, 0, 0)
+        target = self._direct_spins if kind == "direct" else self._delivery_spins
+        for attr, label, guidance_key, low, high, default, decimals, suffix in fields:
+            spin = _make_spin(
+                low, high, default, decimals, suffix, FIELD_GUIDANCE[guidance_key]
+            )
+            target[attr] = spin
+            form.addRow(label, spin)
+        return page
+
+    def _build_results_box(self) -> QGroupBox:
+        box = QGroupBox("Flight Numbers")
+        layout = QVBoxLayout(box)
+        layout.setSpacing(4)
+        for key, label, _unit in EXPLORER_ROWS:
+            row = ResultRow(key, label)
+            row.clicked.connect(self._show_explanation)
+            self._rows[key] = row
+            layout.addWidget(row)
+        return box
+
+    def _build_explanation_box(self) -> QGroupBox:
+        box = QGroupBox("What This Number Means")
+        layout = QVBoxLayout(box)
+        self._explanation = QTextBrowser()
+        self._explanation.setOpenExternalLinks(False)
+        self._explanation.setMinimumHeight(90)
+        self._explanation.setMaximumHeight(150)
+        layout.addWidget(self._explanation)
+        return box
+
+    # ── public API ──────────────────────────────────────────────────
+    def speed_mps(self) -> float:
+        """The entered speed converted to m/s."""
+        return self._speed_spin.value() * _SPEED_UNITS[self._speed_unit]
+
+    def mode(self) -> str:
+        """The selected entry mode label."""
+        return _MODES[self._mode_combo.currentIndex()]
+
+    def flight_view(self) -> FlightView:
+        """The embedded flight-scale viewer."""
+        return self._flight_view
+
+    def last_exploration(self) -> FlightExploration | None:
+        """The most recent successful exploration, if any."""
+        return self._exploration
+
+    def run_now(self) -> FlightExploration | None:
+        """Build launch conditions, run the flight, populate the views."""
+        try:
+            if self.mode() == _MODES[0]:
+                launch = launch_from_direct(
+                    ball_speed_mph=self.speed_mps() * MPH_PER_MPS,
+                    launch_angle_deg=self._direct_spins["launch_angle_deg"].value(),
+                    azimuth_deg=self._direct_spins["azimuth_deg"].value(),
+                    spin_rpm=self._direct_spins["spin_rpm"].value(),
+                    spin_axis_tilt_deg=self._direct_spins["spin_axis_tilt_deg"].value(),
+                )
+            else:
+                launch = launch_from_delivery(
+                    DeliveryParameters(
+                        clubhead_speed_mps=self.speed_mps(),
+                        club_path_deg=self._delivery_spins["club_path_deg"].value(),
+                        face_angle_deg=self._delivery_spins["face_angle_deg"].value(),
+                        attack_angle_deg=self._delivery_spins[
+                            "attack_angle_deg"
+                        ].value(),
+                        dynamic_loft_deg=self._delivery_spins[
+                            "dynamic_loft_deg"
+                        ].value(),
+                        impact_offset_toe_mm=self._delivery_spins[
+                            "impact_offset_toe_mm"
+                        ].value(),
+                        impact_offset_high_mm=self._delivery_spins[
+                            "impact_offset_high_mm"
+                        ].value(),
+                    )
+                )
+            exploration = explore_flight(launch, self._model_combo.currentText())
+        except Exception as exc:  # noqa: BLE001 — surface physics failures
+            logger.warning("flight exploration failed: %s", exc)
+            QMessageBox.warning(self, "Flight Failed", str(exc))
+            return None
+        self._exploration = exploration
+        self._flight_view.set_trajectory(exploration.positions)
+        for key, _label, unit in EXPLORER_ROWS:
+            value = exploration.metrics[key]
+            text = f"{value:+.1f}{unit}" if math.isfinite(value) else "—"
+            self._rows[key].value_label.setText(text)
+        return exploration
+
+    # ── internals ──────────────────────────────────────────────────
+    def _on_mode_changed(self, index: int) -> None:
+        self._stack.setCurrentIndex(index)
+        label = "Ball Speed" if index == 0 else "Clubhead Speed"
+        tooltip = (
+            FIELD_GUIDANCE["fx_ball_speed"]
+            if index == 0
+            else FIELD_GUIDANCE["clubhead_speed_mph"]
+        )
+        self._speed_spin.setToolTip(tooltip)
+        self._run_button.setText("Run Flight" if index == 0 else "Run Impact + Flight")
+        logger.debug("flight-explorer mode -> %s (%s)", self.mode(), label)
+
+    def _on_speed_unit(self, unit: str) -> None:
+        previous = self._speed_unit
+        if unit == previous:
+            return
+        mps = self._speed_spin.value() * _SPEED_UNITS[previous]
+        self._speed_unit = unit
+        self._speed_spin.blockSignals(True)
+        self._speed_spin.setValue(mps / _SPEED_UNITS[unit])
+        self._speed_spin.blockSignals(False)
+
+    def _show_explanation(self, key: str) -> None:
+        labels = {row_key: label for row_key, label, _unit in EXPLORER_ROWS}
+        text = LAUNCH_EXPLANATIONS.get(key, "")
+        self._explanation.setHtml(f"<b>{labels.get(key, key)}</b><br/>{text}")

--- a/src/rate_of_closure/ui/pyqt6/flight_view.py
+++ b/src/rate_of_closure/ui/pyqt6/flight_view.py
@@ -1,0 +1,238 @@
+"""Dedicated ball-flight viewer — flight-scale display (tens of metres).
+
+One of the three scale-separated viewers (epic #4120, V2): a side
+profile (height vs carry), a top-down view (lateral vs carry), and the
+3D trajectory polyline, all auto-scaled to the flight regime, with the
+landing point annotated. Each panel and annotation has its own display
+checkbox with sourced guidance. The view accepts either a full
+:class:`~rate_of_closure.simulation.SimulationRun` or a bare
+trajectory, so the standalone Flight Explorer reuses it with no swing.
+
+Colors come from the shared UpstreamDrift theme palette
+(``get_chart_color``); no app colors are hard-coded.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+from PyQt6.QtWidgets import QCheckBox, QHBoxLayout, QVBoxLayout, QWidget
+
+from rate_of_closure.simulation import SimulationRun
+from rate_of_closure.units import FIELD_GUIDANCE
+
+try:  # Theme palette (optional in standalone/vendored use).
+    from shared.python.theme.matplotlib_style import get_chart_color
+except ImportError:  # pragma: no cover - theme package always ships in-repo
+
+    def get_chart_color(index: int) -> str:
+        """Matplotlib cycle colors as a theme-neutral fallback."""
+        return f"C{index % 10}"
+
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["FlightView"]
+
+#: Minimum plotted extents so degenerate flights stay readable.
+_MIN_CARRY_M = 10.0
+_MIN_HEIGHT_M = 5.0
+_MIN_LATERAL_M = 5.0
+
+#: (checkbox attribute, label, FIELD_GUIDANCE key, default) per display
+#: parameter, in bar order.
+_DISPLAY_PARAMS: tuple[tuple[str, str, str, bool], ...] = (
+    ("side", "Side Profile", "flight_side_visible", True),
+    ("top", "Top-Down", "flight_top_visible", True),
+    ("three_d", "3D Trajectory", "flight_3d_visible", True),
+    ("landing", "Landing Point", "flight_landing_visible", True),
+    ("apex", "Apex", "flight_apex_visible", True),
+)
+
+
+class FlightView(QWidget):
+    """Flight-scale trajectory viewer: side + top-down 2D panels + 3D."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._figure = Figure(figsize=(7, 5), tight_layout=True)
+        self._canvas = FigureCanvas(self._figure)
+
+        self._positions: np.ndarray = np.zeros((0, 3))
+        self._checks: dict[str, QCheckBox] = {}
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(self._build_param_bar())
+        layout.addWidget(self._canvas)
+        self._draw()
+
+    def _build_param_bar(self) -> QHBoxLayout:
+        bar = QHBoxLayout()
+        bar.setContentsMargins(4, 4, 4, 0)
+        for attr, label, guidance_key, default in _DISPLAY_PARAMS:
+            check = QCheckBox(label)
+            check.setChecked(default)
+            check.setToolTip(FIELD_GUIDANCE[guidance_key])
+            check.toggled.connect(lambda _checked: self._draw())
+            self._checks[attr] = check
+            bar.addWidget(check)
+        bar.addStretch(1)
+        return bar
+
+    # ── public API ──────────────────────────────────────────────────
+    def set_run(self, run: SimulationRun | None) -> None:
+        """Adopt the flight trajectory of a full simulation run."""
+        self.set_trajectory(None if run is None else run.flight_positions)
+
+    def set_trajectory(self, positions: np.ndarray | None) -> None:
+        """Adopt an (N, 3) app-frame trajectory (or clear with ``None``).
+
+        App frame: x downrange along the target line [m], y up [m],
+        z right of target [m].
+        """
+        self._positions = (
+            np.zeros((0, 3)) if positions is None else np.asarray(positions, float)
+        )
+        self._draw()
+
+    def trajectory(self) -> np.ndarray:
+        """The (N, 3) app-frame trajectory currently rendered."""
+        return self._positions
+
+    def display_check(self, name: str) -> QCheckBox:
+        """The display-parameter checkbox for ``name`` (test seam)."""
+        return self._checks[name]
+
+    def extents_m(self) -> tuple[float, float, float]:
+        """(carry, height, lateral) plot extents [m] — flight regime."""
+        pos = self._positions
+        if not len(pos):
+            return (_MIN_CARRY_M, _MIN_HEIGHT_M, _MIN_LATERAL_M)
+        return (
+            max(_MIN_CARRY_M, float(np.max(pos[:, 0])) * 1.05),
+            max(_MIN_HEIGHT_M, float(np.max(pos[:, 1])) * 1.2),
+            max(_MIN_LATERAL_M, float(np.max(np.abs(pos[:, 2]))) * 1.3),
+        )
+
+    # ── drawing ─────────────────────────────────────────────────────
+    def _annotate_landing(self, axes, x: float, y: float, text: str) -> None:  # type: ignore[no-untyped-def]
+        axes.scatter([x], [y], s=45, color=get_chart_color(4), zorder=5)
+        axes.annotate(
+            text,
+            xy=(x, y),
+            xytext=(-8, 10),
+            textcoords="offset points",
+            fontsize=7,
+            ha="right",
+            color=get_chart_color(4),
+        )
+
+    def _draw_side(self, axes, pos: np.ndarray, extents) -> None:  # type: ignore[no-untyped-def]
+        carry_ext, height_ext, _ = extents
+        axes.plot(pos[:, 0], pos[:, 1], color=get_chart_color(2), lw=1.6)
+        axes.axhline(0.0, color=get_chart_color(7), lw=0.6, alpha=0.6)
+        if self._checks["apex"].isChecked():
+            apex_index = int(np.argmax(pos[:, 1]))
+            axes.scatter(
+                [pos[apex_index, 0]],
+                [pos[apex_index, 1]],
+                s=30,
+                color=get_chart_color(3),
+                zorder=5,
+            )
+            axes.annotate(
+                f"apex {pos[apex_index, 1]:.1f} m",
+                xy=(pos[apex_index, 0], pos[apex_index, 1]),
+                xytext=(4, 4),
+                textcoords="offset points",
+                fontsize=7,
+                color=get_chart_color(3),
+            )
+        if self._checks["landing"].isChecked():
+            self._annotate_landing(
+                axes, pos[-1, 0], pos[-1, 1], f"carry {pos[-1, 0]:.1f} m"
+            )
+        axes.set_xlim(0.0, carry_ext)
+        axes.set_ylim(0.0, height_ext)
+        axes.set_xlabel("carry [m]", fontsize=8)
+        axes.set_ylabel("height [m]", fontsize=8)
+        axes.set_title("Side profile", fontsize=9)
+        axes.tick_params(labelsize=7)
+
+    def _draw_top(self, axes, pos: np.ndarray, extents) -> None:  # type: ignore[no-untyped-def]
+        carry_ext, _, lateral_ext = extents
+        axes.plot(pos[:, 0], pos[:, 2], color=get_chart_color(2), lw=1.6)
+        axes.axhline(0.0, color=get_chart_color(7), lw=0.6, alpha=0.6)
+        if self._checks["landing"].isChecked():
+            self._annotate_landing(
+                axes, pos[-1, 0], pos[-1, 2], f"lateral {pos[-1, 2]:+.1f} m"
+            )
+        axes.set_xlim(0.0, carry_ext)
+        axes.set_ylim(-lateral_ext, lateral_ext)
+        axes.set_xlabel("carry [m]", fontsize=8)
+        axes.set_ylabel("right (+) [m]", fontsize=8)
+        axes.set_title("Top-down", fontsize=9)
+        axes.tick_params(labelsize=7)
+
+    def _draw_3d(self, axes, pos: np.ndarray, extents) -> None:  # type: ignore[no-untyped-def]
+        carry_ext, height_ext, lateral_ext = extents
+        # Display axes: (z right, x downrange, y up) like the swing view.
+        axes.plot(pos[:, 2], pos[:, 0], pos[:, 1], color=get_chart_color(2), lw=1.6)
+        if self._checks["landing"].isChecked():
+            axes.scatter(
+                [pos[-1, 2]],
+                [pos[-1, 0]],
+                [pos[-1, 1]],
+                s=40,
+                color=get_chart_color(4),
+            )
+        axes.set_xlim(-lateral_ext, lateral_ext)
+        axes.set_ylim(0.0, carry_ext)
+        axes.set_zlim(0.0, height_ext)
+        axes.set_xlabel("z — right [m]", fontsize=7)
+        axes.set_ylabel("x — target [m]", fontsize=7)
+        axes.set_zlabel("y — up [m]", fontsize=7)
+        axes.set_title("3D trajectory", fontsize=9)
+        axes.tick_params(labelsize=6)
+
+    def _draw(self) -> None:
+        self._figure.clear()
+        pos = self._positions
+        panels = [
+            name
+            for name in ("side", "top", "three_d")
+            if self._checks[name].isChecked()
+        ]
+        if not len(pos) or not panels:
+            axes = self._figure.add_subplot(111)
+            axes.set_xticks([])
+            axes.set_yticks([])
+            axes.set_title(
+                "Run a flight to populate the view"
+                if not len(pos)
+                else "Enable a panel to display the flight"
+            )
+            self._canvas.draw_idle()
+            return
+
+        want_3d = "three_d" in panels
+        left = [name for name in panels if name != "three_d"]
+        grid = self._figure.add_gridspec(
+            max(len(left), 1), 2 if want_3d and left else 1
+        )
+        extents = self.extents_m()
+        for row, name in enumerate(left):
+            axes = self._figure.add_subplot(grid[row, 0])
+            if name == "side":
+                self._draw_side(axes, pos, extents)
+            else:
+                self._draw_top(axes, pos, extents)
+        if want_3d:
+            spec = grid[:, 1] if left else grid[:, 0]
+            axes_3d = self._figure.add_subplot(spec, projection="3d")
+            self._draw_3d(axes_3d, pos, extents)
+        self._canvas.draw_idle()

--- a/src/rate_of_closure/ui/pyqt6/main_window.py
+++ b/src/rate_of_closure/ui/pyqt6/main_window.py
@@ -38,6 +38,7 @@ from rate_of_closure.model import ImpactScenario, closure_metrics, solve
 from rate_of_closure.ui.pyqt6.club_view import Club3DView, SweepView
 from rate_of_closure.ui.pyqt6.controls_panel import ControlsPanel
 from rate_of_closure.ui.pyqt6.derivation_view import DerivationView
+from rate_of_closure.ui.pyqt6.flight_explorer_tab import FlightExplorerTab
 from rate_of_closure.ui.pyqt6.result_row import ResultRow as _ResultRow
 from rate_of_closure.ui.pyqt6.simulation_tab import SimulationTab
 from rate_of_closure.units import convert_from_canonical
@@ -118,7 +119,9 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Rate of Closure Impact Explorer")
-        self.setMinimumSize(1240, 800)
+        # Small-window support (#4120): layouts scroll and elide below
+        # this size instead of crushing entries into unreadability.
+        self.setMinimumSize(1024, 700)
 
         self._controls = ControlsPanel()
         self._rows: dict[str, _ResultRow] = {}
@@ -126,6 +129,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         self._sweep_view = SweepView()
         self._derivation_view = DerivationView()
         self._simulation_tab = SimulationTab()
+        self._flight_explorer_tab = FlightExplorerTab()
 
         left_content = QWidget()
         left_layout = QVBoxLayout(left_content)
@@ -142,13 +146,14 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         left.setWidgetResizable(True)
         left.setFrameShape(QFrame.Shape.NoFrame)
         left.setWidget(left_content)
-        left.setMinimumWidth(390)
+        left.setMinimumWidth(320)
 
         tabs = QTabWidget()
         tabs.addTab(self._club_view, "3D Clubhead")
         tabs.addTab(self._sweep_view, "Closure Sweep")
         tabs.addTab(self._derivation_view, "Derivation && Traceability")
         tabs.addTab(self._simulation_tab, "Simulation")
+        tabs.addTab(self._flight_explorer_tab, "Flight Explorer")
 
         splitter = QSplitter()
         splitter.addWidget(left)

--- a/src/rate_of_closure/ui/pyqt6/result_row.py
+++ b/src/rate_of_closure/ui/pyqt6/result_row.py
@@ -32,12 +32,17 @@ class ResultRow(QFrame):
         row = QHBoxLayout(self)
         row.setContentsMargins(10, 6, 10, 6)
         name = QLabel(label)
+        # Small-window robustness (#4120): long labels may be clipped by
+        # the layout, so the full text always rides on the tooltip, and
+        # the value keeps a readable minimum width.
+        name.setToolTip(label)
         row.addWidget(name)
         row.addStretch(1)
         self.value_label = QLabel("—")
         font = self.value_label.font()
         font.setBold(True)
         self.value_label.setFont(font)
+        self.value_label.setMinimumWidth(64)
         row.addWidget(self.value_label)
 
     def mousePressEvent(self, event) -> None:  # type: ignore[no-untyped-def]  # noqa: N802

--- a/src/rate_of_closure/ui/pyqt6/simulation_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/simulation_tab.py
@@ -28,11 +28,13 @@ from PyQt6.QtWidgets import (
     QComboBox,
     QDoubleSpinBox,
     QFormLayout,
+    QFrame,
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QMessageBox,
     QPushButton,
+    QScrollArea,
     QSlider,
     QSplitter,
     QTabWidget,
@@ -52,10 +54,12 @@ from rate_of_closure.simulation import (
     make_source,
     run_simulation,
 )
+from rate_of_closure.ui.pyqt6.flight_view import FlightView
 from rate_of_closure.ui.pyqt6.inspector_view import InspectorView
 from rate_of_closure.ui.pyqt6.result_row import ResultRow
 from rate_of_closure.ui.pyqt6.simulation_view import SimulationView
 from rate_of_closure.ui.pyqt6.solver_panel import SolverPanel
+from rate_of_closure.ui.pyqt6.strike_view import StrikeView
 from rate_of_closure.units import FIELD_GUIDANCE
 from shared.python.swing_sim.flight.registry import FlightModelType
 from shared.python.swing_sim.types import PlaneOrientation
@@ -108,23 +112,38 @@ class SimulationTab(QWidget):
         self._rows: dict[str, ResultRow] = {}
 
         self._view = SimulationView()
+        self._strike_view = StrikeView()
+        self._flight_view = FlightView()
         self._inspector = InspectorView()
         self._solver_panel = SolverPanel()
         self._solver_panel.applyRequested.connect(self.apply_solver_solution)
 
-        left = QWidget()
-        left_layout = QVBoxLayout(left)
+        left_content = QWidget()
+        left_layout = QVBoxLayout(left_content)
         left_layout.addWidget(self._build_setup_box())
         left_layout.addWidget(self._build_scrub_box())
         left_layout.addWidget(self._build_launch_box())
         left_layout.addWidget(self._build_explanation_box())
         left_layout.addStretch(1)
-        left.setMinimumWidth(320)
+        # Small-window robustness (#4120): the control column scrolls
+        # instead of crushing its entry widgets below readability.
+        left = QScrollArea()
+        left.setWidgetResizable(True)
+        left.setFrameShape(QFrame.Shape.NoFrame)
+        left.setWidget(left_content)
+        left.setMinimumWidth(300)
 
+        # Scale-separated viewers as sub-tabs of the display area
+        # (epic #4120 V2): strike (face scale), swing (metres), flight
+        # (tens of metres) — each with its own display checklist whose
+        # state persists for the session (plain widget state).
         right = QTabWidget()
-        right.addTab(self._view, "Scene")
+        right.addTab(self._strike_view, "Strike")
+        right.addTab(self._view, "Swing")
+        right.addTab(self._flight_view, "Flight")
         right.addTab(self._inspector, "Inspector")
         right.addTab(self._solver_panel, "Solver")
+        right.setCurrentWidget(self._view)
 
         splitter = QSplitter()
         splitter.addWidget(left)
@@ -156,6 +175,7 @@ class SimulationTab(QWidget):
             spin.setDecimals(1)
             spin.setRange(-90.0, 90.0)
             spin.setSuffix(" deg")
+            spin.setMinimumWidth(84)  # stays readable at small windows
             spin.setToolTip(FIELD_GUIDANCE[guidance_key])
             spin.valueChanged.connect(self._invalidate_source)
             self._tilt_spins[attr] = spin
@@ -273,6 +293,8 @@ class SimulationTab(QWidget):
         self._tau = run.impact_time_s
         self._sync_scrub_slider(run.impact_time_s)
         self._view.set_run(run)
+        self._strike_view.set_run(run)
+        self._flight_view.set_run(run)
         self._inspector.set_run(run)
         for field, _label, unit in LAUNCH_ROWS:
             value = run.launch[field]
@@ -287,8 +309,16 @@ class SimulationTab(QWidget):
         return self._run
 
     def view(self) -> SimulationView:
-        """The 3D scene (playback controls live on it)."""
+        """The swing-scale 3D scene (playback controls live on it)."""
         return self._view
+
+    def strike_view(self) -> StrikeView:
+        """The face-scale impact-zone viewer."""
+        return self._strike_view
+
+    def flight_view(self) -> FlightView:
+        """The flight-scale trajectory viewer."""
+        return self._flight_view
 
     def inspector(self) -> InspectorView:
         """The run-data inspector."""

--- a/src/rate_of_closure/ui/pyqt6/simulation_view.py
+++ b/src/rate_of_closure/ui/pyqt6/simulation_view.py
@@ -1,10 +1,15 @@
-"""3D scene + full video playback controls for the simulation session.
+"""Swing-scale 3D scene + full video playback controls (the Swing view).
 
-Renders one :class:`~rate_of_closure.simulation.session.SimulationRun`:
-the swing path with the clubhead marker at the playback instant, the
-fixed ball (own checkbox), the ground plane (own checkbox), the flight
-trajectory polyline, and a toggleable instantaneous-screw-axis overlay
-computed through the one thin ISA adapter (recon #4108).
+Renders one :class:`~rate_of_closure.simulation.session.SimulationRun`
+at SWING scale (epic #4120, V2): the swing path with the clubhead
+marker at the playback instant, the fixed ball (own checkbox), the
+ground plane (own checkbox), and a toggleable instantaneous-screw-axis
+overlay computed through the one thin ISA adapter (recon #4108). The
+flight polyline is OFF by default — a 'Show Ball Flight' checkbox
+expands the scene to flight scale, with guidance warning that the
+flight envelope dwarfs the swing; the dedicated
+:class:`~rate_of_closure.ui.pyqt6.flight_view.FlightView` is the
+flight-scale display.
 
 Playback is a full video bar — play/pause, a scrub slider over the
 whole swing + flight timeline, frame step +/-, a loop toggle, and rate
@@ -153,7 +158,21 @@ class SimulationView(QWidget):
         self._screw_check = QCheckBox("Screw Axis")
         self._screw_check.setChecked(False)
         self._screw_check.setToolTip(FIELD_GUIDANCE["screw_axis_visible"])
-        for check in (self._ball_check, self._ground_check, self._screw_check):
+        # Scale separation (epic #4120): flight display is opt-in here
+        # because its envelope dwarfs the swing envelope.
+        self._flight_check = QCheckBox("Show Ball Flight")
+        self._flight_check.setChecked(False)
+        self._flight_check.setToolTip(
+            "Warning: turning this on expands the scene to flight scale "
+            "(100+ m), which dwarfs the ~3 m swing. "
+            + FIELD_GUIDANCE["swing_flight_toggle"]
+        )
+        for check in (
+            self._ball_check,
+            self._ground_check,
+            self._screw_check,
+            self._flight_check,
+        ):
             check.toggled.connect(lambda _checked: self._draw())
             bar.addWidget(check)
         bar.addStretch(1)
@@ -207,6 +226,19 @@ class SimulationView(QWidget):
     def set_looping(self, looping: bool) -> None:
         """Set the loop toggle."""
         self._loop_check.setChecked(looping)
+
+    def flight_shown(self) -> bool:
+        """Whether the flight-scale 'Show Ball Flight' toggle is on."""
+        return self._flight_check.isChecked()
+
+    def set_flight_shown(self, shown: bool) -> None:
+        """Set the 'Show Ball Flight' toggle (default off: swing scale)."""
+        self._flight_check.setChecked(shown)
+
+    def scene_extent_m(self) -> float:
+        """Current axis half-extent [m] — the scale-invariant seam."""
+        x0, x1 = self._axes.get_xlim()
+        return abs(float(x1) - float(x0)) / 2.0
 
     def stop(self) -> None:
         """Stop the playback timer (window close and tests)."""
@@ -339,9 +371,11 @@ class SimulationView(QWidget):
         )
         index = min(index, len(run.swing_times) - 1)
 
-        # Scene extent: the swing envelope, or the flight envelope once
-        # the playback instant is past impact.
-        if in_flight and len(run.flight_positions):
+        # Scene extent: the swing envelope. Only the opt-in 'Show Ball
+        # Flight' toggle expands to the flight envelope past impact —
+        # flight scale dwarfs the swing (epic #4120 scale separation).
+        show_flight = self._flight_check.isChecked() and bool(len(run.flight_positions))
+        if in_flight and show_flight:
             extent = max(5.0, float(np.max(np.abs(run.flight_positions))) * 1.05)
         else:
             extent = max(
@@ -376,8 +410,8 @@ class SimulationView(QWidget):
         head = self._display(run.swing_positions[index])
         axes.scatter(*head, color=get_chart_color(1), s=45, zorder=5)
 
-        # Flight trajectory: traversed portion once past impact.
-        if len(run.flight_positions):
+        # Flight trajectory: opt-in only (see the toggle's guidance).
+        if show_flight:
             flight_t = self._time - run.impact_time_s
             n_flight = int(np.searchsorted(run.flight_times, flight_t, side="right"))
             traj = self._display(run.flight_positions)
@@ -407,7 +441,7 @@ class SimulationView(QWidget):
 
         axes.set_xlim(-extent, extent)
         axes.set_ylim(-extent, extent)
-        axes.set_zlim(0.0 if in_flight else -extent * 0.4, extent)
+        axes.set_zlim(0.0 if (in_flight and show_flight) else -extent * 0.4, extent)
         axes.view_init(elev=elev, azim=azim)
         axes.set_xlabel("z — right of target [m]")
         axes.set_ylabel("x — target line [m]")

--- a/src/rate_of_closure/ui/pyqt6/solver_panel.py
+++ b/src/rate_of_closure/ui/pyqt6/solver_panel.py
@@ -90,6 +90,7 @@ def _spin(
     spin.setRange(lo, hi)
     spin.setSuffix(suffix)
     spin.setValue(value)
+    spin.setMinimumWidth(84)  # readable at small windows (#4120)
     return spin
 
 
@@ -237,6 +238,7 @@ class SolverPanel(QWidget):
         self._starts_spin.setRange(1, 64)
         self._starts_spin.setValue(DEFAULT_N_STARTS)
         self._starts_spin.setToolTip(_STARTS_GUIDANCE)
+        self._starts_spin.setMinimumWidth(64)  # readable at small windows
         row.addWidget(self._starts_spin)
         self._run_button = QPushButton("Run Solver")
         self._run_button.setToolTip(

--- a/src/rate_of_closure/ui/pyqt6/strike_view.py
+++ b/src/rate_of_closure/ui/pyqt6/strike_view.py
@@ -1,0 +1,305 @@
+"""Impact-zone (strike) viewer — face-scale display, never flight scale.
+
+One of the three scale-separated viewers (epic #4120, V2): a 2D
+face-plane view of one simulation run at face scale (millimetres). It
+draws the club-face outline (with bulge/roll curvature contours when
+the club has a curved face), the impact-offset marker plus a scatter of
+previous strikes, the delivery vectors (club path, face normal, and
+attack angle projected into the face plane), and a club-info
+annotation. Every display parameter has its own checkbox with sourced
+guidance, and the axis extents are hard-capped at
+:data:`STRIKE_MAX_EXTENT_MM` — ball flight never appears here.
+
+Colors come from the shared UpstreamDrift theme palette
+(``get_chart_color``); no app colors are hard-coded.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+import numpy as np
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+from PyQt6.QtWidgets import QCheckBox, QHBoxLayout, QVBoxLayout, QWidget
+
+from rate_of_closure.club import (
+    REFERENCE_HEAD_MASS_KG,
+    ClubSpec,
+    face_sagitta,
+)
+from rate_of_closure.club.parametric_head import BASE_SECTIONS
+from rate_of_closure.simulation import SimulationRun
+from rate_of_closure.units import FIELD_GUIDANCE
+
+try:  # Theme palette (optional in standalone/vendored use).
+    from shared.python.theme.matplotlib_style import get_chart_color
+except ImportError:  # pragma: no cover - theme package always ships in-repo
+
+    def get_chart_color(index: int) -> str:
+        """Matplotlib cycle colors as a theme-neutral fallback."""
+        return f"C{index % 10}"
+
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["STRIKE_MAX_EXTENT_MM", "StrikeView"]
+
+#: Hard cap on the face-plane half-extent [mm]: the strike view is a
+#: face-scale display (~120 mm across a driver face) and never zooms
+#: out to swing or flight scale.
+STRIKE_MAX_EXTENT_MM = 120.0
+
+#: Margin factor around the face outline.
+_EXTENT_MARGIN = 1.35
+
+#: Superellipse exponent for the face outline (matches the parametric
+#: head's face-plate cross-section rounding).
+_FACE_EXPONENT = 2.5
+
+#: Delivery arrows are drawn at this fraction of the axis extent.
+_ARROW_FRACTION = 0.55
+
+#: Maximum strike-history points kept.
+_MAX_HISTORY = 50
+
+#: (checkbox attribute, label, FIELD_GUIDANCE key, default) per display
+#: parameter, in bar order.
+_DISPLAY_PARAMS: tuple[tuple[str, str, str, bool], ...] = (
+    ("curvature", "Curvature", "strike_curvature_visible", True),
+    ("vectors", "Delivery Vectors", "strike_vectors_visible", True),
+    ("history", "Strike History", "strike_history_visible", True),
+    ("club_info", "Club Info", "strike_club_info_visible", True),
+)
+
+
+def face_half_extents_mm(club: ClubSpec) -> tuple[float, float]:
+    """(half-width, half-height) of the club's face plate, millimetres.
+
+    Derived from the parametric head's face-plate cross-section scaled
+    by the club's constant-density mass factor — the same envelope the
+    3D head mesh uses.
+    """
+    scale = float((club.head_mass_kg / REFERENCE_HEAD_MASS_KG) ** (1.0 / 3.0))
+    _x, half_h, half_w = BASE_SECTIONS[0]
+    return half_w * scale * 1000.0, half_h * scale * 1000.0
+
+
+class StrikeView(QWidget):
+    """Face-plane strike view of one simulation run, face scale only."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._figure = Figure(figsize=(5, 5), tight_layout=True)
+        self._canvas = FigureCanvas(self._figure)
+        self._axes = self._figure.add_subplot(111)
+
+        self._run: SimulationRun | None = None
+        self._history: list[tuple[float, float]] = []
+        self._checks: dict[str, QCheckBox] = {}
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addLayout(self._build_param_bar())
+        layout.addWidget(self._canvas)
+        self._draw()
+
+    def _build_param_bar(self) -> QHBoxLayout:
+        bar = QHBoxLayout()
+        bar.setContentsMargins(4, 4, 4, 0)
+        for attr, label, guidance_key, default in _DISPLAY_PARAMS:
+            check = QCheckBox(label)
+            check.setChecked(default)
+            check.setToolTip(FIELD_GUIDANCE[guidance_key])
+            check.toggled.connect(lambda _checked: self._draw())
+            self._checks[attr] = check
+            bar.addWidget(check)
+        bar.addStretch(1)
+        return bar
+
+    # ── public API ──────────────────────────────────────────────────
+    def set_run(self, run: SimulationRun | None) -> None:
+        """Adopt a run (or clear with ``None``); records strike history."""
+        self._run = run
+        if run is not None:
+            strike = (
+                run.config.scenario.impact_offset_toe_mm,
+                run.config.scenario.impact_offset_high_mm,
+            )
+            self._history.append(strike)
+            del self._history[:-_MAX_HISTORY]
+        self._draw()
+
+    def run(self) -> SimulationRun | None:
+        """The run currently rendered, if any."""
+        return self._run
+
+    def strike_history(self) -> list[tuple[float, float]]:
+        """Recorded (toe, high) strike offsets [mm], oldest first."""
+        return list(self._history)
+
+    def clear_history(self) -> None:
+        """Drop the strike-history scatter."""
+        self._history.clear()
+        self._draw()
+
+    def display_check(self, name: str) -> QCheckBox:
+        """The display-parameter checkbox for ``name`` (test seam)."""
+        return self._checks[name]
+
+    def extents_mm(self) -> tuple[float, float]:
+        """Current axis half-extents (x, y) [mm] — the scale invariant."""
+        x0, x1 = self._axes.get_xlim()
+        y0, y1 = self._axes.get_ylim()
+        return (abs(x1 - x0) / 2.0, abs(y1 - y0) / 2.0)
+
+    # ── drawing ─────────────────────────────────────────────────────
+    def _face_outline(self, half_w: float, half_h: float) -> np.ndarray:
+        theta = np.linspace(0.0, 2.0 * np.pi, 120)
+        exponent = 2.0 / _FACE_EXPONENT
+        x = half_w * np.sign(np.cos(theta)) * np.abs(np.cos(theta)) ** exponent
+        y = half_h * np.sign(np.sin(theta)) * np.abs(np.sin(theta)) ** exponent
+        return np.column_stack([x, y])
+
+    def _draw_curvature(self, club: ClubSpec, half_w: float, half_h: float) -> None:
+        if not club.has_curved_face:
+            return
+        toe = np.linspace(-half_w, half_w, 41)
+        high = np.linspace(-half_h, half_h, 41)
+        grid_toe, grid_high = np.meshgrid(toe, high)
+        sag = np.vectorize(
+            lambda t, h: face_sagitta(club, t * 1e-3, h * 1e-3) * 1000.0
+        )(grid_toe, grid_high)
+        contours = self._axes.contour(
+            grid_toe,
+            grid_high,
+            sag,
+            levels=5,
+            colors=get_chart_color(7),
+            linewidths=0.6,
+            alpha=0.7,
+        )
+        self._axes.clabel(contours, inline=True, fontsize=6, fmt="%.1f mm")
+
+    def _draw_vectors(self, run: SimulationRun, extent: float) -> None:
+        velocity = run.delivery.clubhead_velocity
+        speed = float(np.linalg.norm(velocity))
+        if speed <= 0.0:
+            return
+        path_deg = math.degrees(math.atan2(float(velocity[2]), float(velocity[0])))
+        aoa_deg = math.degrees(
+            math.atan2(
+                float(velocity[1]),
+                math.hypot(float(velocity[0]), float(velocity[2])),
+            )
+        )
+        toe_mm = run.config.scenario.impact_offset_toe_mm
+        high_mm = run.config.scenario.impact_offset_high_mm
+        length = extent * _ARROW_FRACTION
+        # Face-plane projection: horizontal axis = toe (+z app),
+        # vertical axis = up the face (+y app).
+        arrows = (
+            # (dx, dy, color index, label)
+            (
+                math.sin(math.radians(path_deg)) * length,
+                math.sin(math.radians(aoa_deg)) * length,
+                0,
+                f"club path {path_deg:+.1f}° / AoA {aoa_deg:+.1f}°",
+            ),
+            (
+                float(run.delivery.face_normal[2]) * length,
+                float(run.delivery.face_normal[1]) * length,
+                3,
+                f"face normal (loft {run.config.club.loft_deg:.1f}°)",
+            ),
+        )
+        for dx, dy, color_index, label in arrows:
+            self._axes.annotate(
+                "",
+                xy=(toe_mm + dx, high_mm + dy),
+                xytext=(toe_mm, high_mm),
+                arrowprops={
+                    "arrowstyle": "-|>",
+                    "color": get_chart_color(color_index),
+                    "lw": 1.6,
+                },
+            )
+            self._axes.plot(
+                [], [], color=get_chart_color(color_index), lw=1.6, label=label
+            )
+
+    def _club_info_text(self, club: ClubSpec) -> str:
+        if club.face_bulge_radius_m is not None and club.face_roll_radius_m is not None:
+            curvature = (
+                f"bulge {club.face_bulge_radius_m * 1000.0:.0f} mm / "
+                f"roll {club.face_roll_radius_m * 1000.0:.0f} mm"
+            )
+        else:
+            curvature = "flat face"
+        return (
+            f"{club.name} — loft {club.loft_deg:.1f}°, "
+            f"{club.head_mass_kg * 1000.0:.0f} g, {curvature}"
+        )
+
+    def _draw(self) -> None:
+        axes = self._axes
+        axes.clear()
+        run = self._run
+        if run is None:
+            axes.set_title("Run a simulation to populate the strike view")
+            axes.set_xticks([])
+            axes.set_yticks([])
+            self._canvas.draw_idle()
+            return
+
+        club = run.config.club
+        half_w, half_h = face_half_extents_mm(club)
+        extent = min(max(half_w, half_h) * _EXTENT_MARGIN, STRIKE_MAX_EXTENT_MM)
+
+        outline = self._face_outline(half_w, half_h)
+        axes.plot(
+            outline[:, 0],
+            outline[:, 1],
+            color=get_chart_color(1),
+            lw=1.5,
+            label="face outline",
+        )
+        axes.axhline(0.0, color=get_chart_color(7), lw=0.5, alpha=0.5)
+        axes.axvline(0.0, color=get_chart_color(7), lw=0.5, alpha=0.5)
+
+        if self._checks["curvature"].isChecked():
+            self._draw_curvature(club, half_w, half_h)
+        if self._checks["history"].isChecked() and len(self._history) > 1:
+            past = np.array(self._history[:-1])
+            axes.scatter(
+                past[:, 0],
+                past[:, 1],
+                s=18,
+                color=get_chart_color(2),
+                alpha=0.45,
+                label="previous strikes",
+            )
+        if self._checks["vectors"].isChecked():
+            self._draw_vectors(run, extent)
+
+        toe_mm = run.config.scenario.impact_offset_toe_mm
+        high_mm = run.config.scenario.impact_offset_high_mm
+        axes.scatter(
+            [toe_mm],
+            [high_mm],
+            s=70,
+            color=get_chart_color(4),
+            zorder=5,
+            label=f"impact ({toe_mm:+.1f}, {high_mm:+.1f}) mm",
+        )
+
+        if self._checks["club_info"].isChecked():
+            axes.set_title(self._club_info_text(club), fontsize=9)
+        axes.set_xlim(-extent, extent)
+        axes.set_ylim(-extent, extent)
+        axes.set_aspect("equal")
+        axes.set_xlabel("toe (+) / heel (−) [mm]")
+        axes.set_ylabel("above (+) / below (−) center [mm]")
+        axes.legend(loc="lower left", fontsize=7)
+        self._canvas.draw_idle()

--- a/src/rate_of_closure/units.py
+++ b/src/rate_of_closure/units.py
@@ -195,4 +195,110 @@ FIELD_GUIDANCE: dict[str, str] = {
         "screw axis near the playback instant. Source: the AffineDrift "
         "closure-rate derivation (omega/v = 1/R_ISA)."
     ),
+    "swing_flight_toggle": (
+        "Off by default: the flight envelope (100+ m) dwarfs the "
+        "swing envelope (~3 m), collapsing the swing to a dot when both "
+        "share one scale. Turn on only to see the full trajectory in "
+        "context. Source: typical driver carry (Penner 2003) vs. club "
+        "length (published manufacturer specs)."
+    ),
+    "strike_curvature_visible": (
+        "Suggested range: on for curved-face clubs to contour the "
+        "bulge/roll set-back across the face (sagitta, mm). Source: "
+        "typical published fitting references (10-13 in driver bulge)."
+    ),
+    "strike_vectors_visible": (
+        "Suggested range: on to draw the delivered club path, face "
+        "normal, and attack-angle directions projected into the face "
+        "plane. Source: standard launch-monitor D-plane presentation "
+        "(TrackMan literature; Jorgensen, The Physics of Golf)."
+    ),
+    "strike_history_visible": (
+        "Suggested range: on to keep a scatter of previous impact "
+        "locations for dispersion context. Source: published robot-test "
+        "impact maps (strike dispersion within +/-15 mm of center)."
+    ),
+    "strike_club_info_visible": (
+        "Suggested range: on to annotate the selected club's name, "
+        "loft, and face curvature radii. Source: typical published "
+        "manufacturer spec sheets."
+    ),
+    "flight_side_visible": (
+        "Suggested range: on for the side profile (height vs carry) — "
+        "the classic trajectory presentation. Source: launch-monitor "
+        "trajectory displays; Penner (2003)."
+    ),
+    "flight_top_visible": (
+        "Suggested range: on for the top-down view (lateral vs carry) "
+        "showing curvature and dispersion. Source: launch-monitor "
+        "dispersion displays; TrackMan D-plane literature."
+    ),
+    "flight_3d_visible": (
+        "Suggested range: on for the 3-D trajectory polyline at flight "
+        "scale. Source: standard 3-D golf-scene convention."
+    ),
+    "flight_landing_visible": (
+        "Suggested range: on to annotate the landing point with carry "
+        "and lateral numbers. Source: launch-monitor carry/offline "
+        "reporting convention."
+    ),
+    "flight_apex_visible": (
+        "Suggested range: on to mark the apex (maximum height). "
+        "Source: launch-monitor apex reporting convention."
+    ),
+    "fx_mode": (
+        "Suggested range: Direct Launch to type launch-monitor ball "
+        "numbers; Impact Delivery to type club delivery numbers and run "
+        "them through the impact model first. Source: launch-monitor "
+        "convention of ball data vs. club data (TrackMan literature)."
+    ),
+    "fx_ball_speed": (
+        "Suggested range: 120-190 mph ball speed (tour driver average "
+        "near 167 mph; strong amateurs 140-160). Source: openly "
+        "published tour launch-monitor averages."
+    ),
+    "fx_launch_angle": (
+        "Suggested range: 8-16 deg launch for drivers (tour average "
+        "near 10.9 deg); higher for irons and wedges. Source: openly "
+        "published tour launch-monitor averages."
+    ),
+    "fx_azimuth": (
+        "Suggested range: within +/-10 deg of the target line; + = "
+        "right of target. Source: standard launch-monitor sign "
+        "convention (launch direction)."
+    ),
+    "fx_spin_rpm": (
+        "Suggested range: 2,000-3,500 rpm total spin for drivers (tour "
+        "average near 2,686 rpm); 4,000-10,000+ for irons and wedges. "
+        "Source: openly published tour launch-monitor averages."
+    ),
+    "fx_spin_axis_tilt": (
+        "Suggested range: within +/-20 deg spin-axis tilt; + = "
+        "fade/slice side (curves right for a right-handed player), - = "
+        "draw/hook side. Source: TrackMan D-plane literature."
+    ),
+    "fx_speed_unit": (
+        "Suggested range: mph for launch-monitor style entry, m/s for "
+        "SI work; the model always computes in SI. Source: launch-"
+        "monitor display convention."
+    ),
+    "fx_club_path": (
+        "Suggested range: within +/-8 deg club path; + = in-to-out. "
+        "Source: openly published tour launch-monitor averages."
+    ),
+    "fx_face_angle": (
+        "Suggested range: within +/-5 deg face angle; + = open (right "
+        "of target). Source: openly published tour launch-monitor "
+        "averages."
+    ),
+    "fx_attack_angle": (
+        "Suggested range: -5 to +5 deg attack angle for drivers (+ = "
+        "hitting up); negative for irons. Source: openly published tour "
+        "launch-monitor averages."
+    ),
+    "fx_dynamic_loft": (
+        "Suggested range: 8-16 deg dynamic loft for drivers, up to "
+        "45+ deg for wedges. Source: openly published tour launch-"
+        "monitor averages."
+    ),
 }

--- a/src/rate_of_closure/web/src/App.tsx
+++ b/src/rate_of_closure/web/src/App.tsx
@@ -12,6 +12,7 @@
 import { useMemo, useState } from "react";
 
 import { ClubCanvas } from "./components/ClubCanvas";
+import { FlightExplorerPanel } from "./components/FlightExplorerPanel";
 import { SimulationPanel } from "./components/SimulationPanel";
 import { ClubPanel } from "./components/ClubPanel";
 import { Derivation } from "./components/Derivation";
@@ -121,7 +122,12 @@ const UNIT_LABELS: Record<Quantity, string> = {
   length: "Length",
 };
 
-const TABS = ["Explorer", "Derivation & Traceability", "Simulation"] as const;
+const TABS = [
+  "Explorer",
+  "Derivation & Traceability",
+  "Simulation",
+  "Flight Explorer",
+] as const;
 
 export default function App() {
   const [scenario, setScenario] = useState<ImpactScenario>(DEFAULT_SCENARIO);
@@ -236,7 +242,9 @@ export default function App() {
         ))}
       </nav>
 
-      {tab === TABS[2] ? (
+      {tab === TABS[3] ? (
+        <FlightExplorerPanel />
+      ) : tab === TABS[2] ? (
         // Static loft mirrors the desktop default driver; the full club
         // picker joins the web simulation with the P7 WASM port.
         <SimulationPanel

--- a/src/rate_of_closure/web/src/components/FlightCanvases.tsx
+++ b/src/rate_of_closure/web/src/components/FlightCanvases.tsx
@@ -1,0 +1,122 @@
+/**
+ * Flight-scale profile canvases (epic #4120, V2 web parity).
+ *
+ * Side profile (height vs carry) and top-down (lateral vs carry)
+ * canvases for an app-frame trajectory, auto-scaled to the flight
+ * regime with the landing point annotated — the web twin of the PyQt6
+ * FlightView's 2D panels.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { type FlightPoint } from "../model/flight";
+
+interface Props {
+  /** App-frame trajectory (x downrange, y up, z right), tee-origin. */
+  points: FlightPoint[];
+  emptyText?: string;
+}
+
+const MIN_CARRY_M = 10.0;
+const MIN_HEIGHT_M = 5.0;
+const MIN_LATERAL_M = 5.0;
+const MARGIN = 34;
+
+function drawPanel(
+  canvas: HTMLCanvasElement,
+  points: FlightPoint[],
+  vertical: "height" | "lateral",
+  emptyText: string,
+): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const { width, height } = canvas;
+  ctx.clearRect(0, 0, width, height);
+  if (points.length < 2) {
+    ctx.fillStyle = "#64748b";
+    ctx.font = "13px sans-serif";
+    ctx.fillText(emptyText, 14, 24);
+    return;
+  }
+
+  const carryExt = Math.max(MIN_CARRY_M, ...points.map((p) => p.position[0])) * 1.05;
+  const value = (p: FlightPoint) =>
+    vertical === "height" ? p.position[1] : p.position[2];
+  const vertExt =
+    vertical === "height"
+      ? Math.max(MIN_HEIGHT_M, ...points.map((p) => p.position[1])) * 1.2
+      : Math.max(MIN_LATERAL_M, ...points.map((p) => Math.abs(p.position[2]))) * 1.3;
+  const zeroY = vertical === "height" ? height - MARGIN : height / 2;
+  const spanY = vertical === "height" ? height - 2 * MARGIN : height / 2 - MARGIN;
+  const px = (x: number) => MARGIN + (x / carryExt) * (width - 2 * MARGIN);
+  const py = (v: number) => zeroY - (v / vertExt) * spanY;
+
+  // Ground / target line.
+  ctx.strokeStyle = "#475569";
+  ctx.beginPath();
+  ctx.moveTo(0, py(0));
+  ctx.lineTo(width, py(0));
+  ctx.stroke();
+
+  // Trajectory polyline.
+  ctx.strokeStyle = "#34d399";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  points.forEach((p, i) => {
+    if (i === 0) ctx.moveTo(px(p.position[0]), py(value(p)));
+    else ctx.lineTo(px(p.position[0]), py(value(p)));
+  });
+  ctx.stroke();
+  ctx.lineWidth = 1;
+
+  // Landing annotation.
+  const last = points[points.length - 1];
+  ctx.fillStyle = "#facc15";
+  ctx.beginPath();
+  ctx.arc(px(last.position[0]), py(value(last)), 4, 0, 2 * Math.PI);
+  ctx.fill();
+  ctx.fillStyle = "#94a3b8";
+  ctx.font = "11px sans-serif";
+  const label =
+    vertical === "height"
+      ? `carry ${last.position[0].toFixed(1)} m`
+      : `lateral ${last.position[2] >= 0 ? "+" : ""}${last.position[2].toFixed(1)} m`;
+  ctx.textAlign = "right";
+  ctx.fillText(label, px(last.position[0]) - 8, py(value(last)) - 8);
+  ctx.textAlign = "left";
+  ctx.fillText(
+    vertical === "height" ? "Side profile (height vs carry)" : "Top-down (right + vs carry)",
+    10,
+    16,
+  );
+}
+
+export function FlightCanvases({ points, emptyText }: Props) {
+  const sideRef = useRef<HTMLCanvasElement | null>(null);
+  const topRef = useRef<HTMLCanvasElement | null>(null);
+  const placeholder = emptyText ?? "Run a flight to populate the view.";
+
+  useEffect(() => {
+    if (sideRef.current) drawPanel(sideRef.current, points, "height", placeholder);
+    if (topRef.current) drawPanel(topRef.current, points, "lateral", placeholder);
+  }, [points, placeholder]);
+
+  return (
+    <div className="grid min-w-0 gap-3">
+      <canvas
+        ref={sideRef}
+        width={860}
+        height={260}
+        className="w-full min-w-0 rounded-lg border border-slate-800 bg-slate-950/60"
+        aria-label="Flight side profile (height vs carry)"
+      />
+      <canvas
+        ref={topRef}
+        width={860}
+        height={220}
+        className="w-full min-w-0 rounded-lg border border-slate-800 bg-slate-950/60"
+        aria-label="Flight top-down view (lateral vs carry)"
+      />
+    </div>
+  );
+}

--- a/src/rate_of_closure/web/src/components/FlightExplorerPanel.tsx
+++ b/src/rate_of_closure/web/src/components/FlightExplorerPanel.tsx
@@ -1,0 +1,200 @@
+/**
+ * Standalone Ball-Flight Explorer section (epic #4120, V2 web parity).
+ *
+ * Direct entry of launch conditions (ball speed with a unit drop-down,
+ * launch angle, azimuth, spin, spin-axis tilt — sourced hover guidance
+ * on every control) integrated with the Waterloo/Penner model and
+ * rendered in the flight profile canvases with result rows. No swing
+ * required. The 7-model picker and delivery mode stay Python-side
+ * until the P7 WASM kernels land.
+ */
+
+import { useState } from "react";
+
+import { FlightCanvases } from "./FlightCanvases";
+import {
+  directLaunch,
+  exploreFlight,
+  type FlightExplorationTs,
+} from "../model/flightExplorer";
+import { FIELD_GUIDANCE } from "../model/units";
+
+const SPEED_UNITS: Record<string, number> = { mph: 1.0, "m/s": 2.236936292054402 };
+
+const RESULT_ROWS: Array<{
+  key: keyof FlightExplorationTs["metrics"];
+  label: string;
+  unit: string;
+}> = [
+  { key: "carryM", label: "Carry Distance", unit: "m" },
+  { key: "maxHeightM", label: "Apex Height", unit: "m" },
+  { key: "flightTimeS", label: "Flight Time", unit: "s" },
+  { key: "landingAngleDeg", label: "Landing Angle", unit: "°" },
+  { key: "lateralM", label: "Lateral Landing Offset", unit: "m" },
+];
+
+interface FieldSpec {
+  key: "launchAngleDeg" | "azimuthDeg" | "spinRpm" | "spinAxisTiltDeg";
+  label: string;
+  unit: string;
+  guidance: string;
+}
+
+const FIELDS: FieldSpec[] = [
+  { key: "launchAngleDeg", label: "Launch Angle", unit: "deg", guidance: "fxLaunchAngle" },
+  { key: "azimuthDeg", label: "Launch Azimuth", unit: "deg", guidance: "fxAzimuth" },
+  { key: "spinRpm", label: "Total Spin", unit: "rpm", guidance: "fxSpinRpm" },
+  { key: "spinAxisTiltDeg", label: "Spin-Axis Tilt", unit: "deg", guidance: "fxSpinAxisTilt" },
+];
+
+export function FlightExplorerPanel() {
+  const [speed, setSpeed] = useState(167.0);
+  const [speedUnit, setSpeedUnit] = useState("mph");
+  const [fields, setFields] = useState({
+    launchAngleDeg: 10.9,
+    azimuthDeg: 0.0,
+    spinRpm: 2686.0,
+    spinAxisTiltDeg: 0.0,
+  });
+  const [result, setResult] = useState<FlightExplorationTs | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = () => {
+    try {
+      const exploration = exploreFlight(
+        directLaunch({
+          ballSpeedMph: speed * (SPEED_UNITS[speedUnit] / SPEED_UNITS.mph),
+          ...fields,
+        }),
+      );
+      setResult(exploration);
+      setError(null);
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+    }
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[340px_1fr]">
+      <section aria-label="Flight explorer inputs" className="min-w-0 space-y-4">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5 shadow-lg shadow-black/20 backdrop-blur">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Launch Entry (No Swing Required)
+          </h2>
+          <label className="mb-2 block text-sm" title={FIELD_GUIDANCE.fxBallSpeed}>
+            <span className="mb-1 flex justify-between text-slate-300">
+              <span className="truncate" title="Ball Speed">
+                Ball Speed
+              </span>
+            </span>
+            <span className="flex min-w-0 gap-2">
+              <input
+                type="number"
+                inputMode="decimal"
+                value={speed}
+                title={FIELD_GUIDANCE.fxBallSpeed}
+                onChange={(e) => {
+                  const parsed = Number(e.target.value);
+                  if (Number.isFinite(parsed)) setSpeed(parsed);
+                }}
+                className="no-spinner w-full min-w-16 rounded border border-slate-700 bg-slate-800 px-2 py-1.5 text-slate-100 focus:border-blue-500 focus:outline-none"
+              />
+              <select
+                value={speedUnit}
+                title={FIELD_GUIDANCE.fxSpeedUnit}
+                onChange={(e) => {
+                  const next = e.target.value;
+                  // Convert the displayed value in place (canonical mph).
+                  const mph = speed * (SPEED_UNITS[speedUnit] / SPEED_UNITS.mph);
+                  setSpeed(Number((mph * (SPEED_UNITS.mph / SPEED_UNITS[next])).toFixed(2)));
+                  setSpeedUnit(next);
+                }}
+                className="min-w-16 rounded border border-slate-700 bg-slate-800 px-2 py-1.5 text-slate-100"
+                aria-label="Ball speed unit"
+              >
+                {Object.keys(SPEED_UNITS).map((unit) => (
+                  <option key={unit} value={unit}>
+                    {unit}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+          {FIELDS.map(({ key, label, unit, guidance }) => (
+            <label key={key} className="mb-2 block text-sm" title={FIELD_GUIDANCE[guidance]}>
+              <span className="mb-1 flex justify-between text-slate-300">
+                <span className="truncate" title={label}>
+                  {label}
+                </span>
+                <span className="text-slate-500">{unit}</span>
+              </span>
+              <input
+                type="number"
+                inputMode="decimal"
+                value={fields[key]}
+                title={FIELD_GUIDANCE[guidance]}
+                onChange={(e) => {
+                  const parsed = Number(e.target.value);
+                  if (Number.isFinite(parsed)) {
+                    setFields((f) => ({ ...f, [key]: parsed }));
+                  }
+                }}
+                className="no-spinner w-full min-w-16 rounded border border-slate-700 bg-slate-800 px-2 py-1.5 text-slate-100 focus:border-blue-500 focus:outline-none"
+              />
+            </label>
+          ))}
+          <button
+            type="button"
+            onClick={run}
+            className="mt-1 w-full rounded-lg border border-sky-400/60 bg-sky-500/10 px-3 py-2 text-sm font-semibold text-sky-300 transition-all hover:bg-sky-500/20"
+          >
+            Run Flight
+          </button>
+          {error && (
+            <p className="mt-2 text-xs text-rose-400" role="alert">
+              {error}
+            </p>
+          )}
+          <p className="mt-3 text-xs text-slate-500">
+            Waterloo/Penner flight physics, parity-banded against the
+            Python explorer (which adds the full 7-model literature picker
+            and an impact-delivery entry mode; both arrive here with the
+            P7 WASM kernels).
+          </p>
+        </div>
+
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5 shadow-lg shadow-black/20 backdrop-blur">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Flight Numbers
+          </h2>
+          <div className="grid gap-2">
+            {RESULT_ROWS.map(({ key, label, unit }) => (
+              <div
+                key={key}
+                className="flex min-w-0 items-center justify-between rounded-lg border border-slate-800/80 bg-slate-900/50 px-3 py-2 text-sm"
+              >
+                <span className="truncate text-slate-400" title={label}>
+                  {label}
+                </span>
+                <span className="ml-2 min-w-16 text-right font-semibold tabular-nums text-slate-100">
+                  {result
+                    ? `${result.metrics[key] >= 0 ? "+" : ""}${result.metrics[key].toFixed(1)} ${unit}`
+                    : "—"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="min-w-0 space-y-3">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-4 shadow-lg shadow-black/20 backdrop-blur">
+          <FlightCanvases
+            points={result?.points ?? []}
+            emptyText="Enter launch conditions and press Run Flight."
+          />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/rate_of_closure/web/src/components/SimulationPanel.tsx
+++ b/src/rate_of_closure/web/src/components/SimulationPanel.tsx
@@ -15,7 +15,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
-  BALL_POSITION,
   runSimulation,
   type SimulationInput,
   type SimulationRunTs,
@@ -23,7 +22,14 @@ import {
 } from "../model/simulation";
 import { FIELD_GUIDANCE } from "../model/units";
 import { type ImpactScenario } from "../model/impact";
+import { FlightCanvases } from "./FlightCanvases";
 import { SolverPanel } from "./SolverPanel";
+import { StrikeCanvas } from "./StrikeCanvas";
+import { drawSwingScene } from "./swingSceneDraw";
+
+/** Scale-separated display views (epic #4120): face / swing / flight. */
+const VIEWS = ["Strike", "Swing", "Flight"] as const;
+type ViewName = (typeof VIEWS)[number];
 
 const RATE_PRESETS: Array<{ label: string; rate: number }> = [
   { label: "0.1×", rate: 0.1 },
@@ -61,7 +67,27 @@ export function SimulationPanel({ scenario, loftDeg, onScenarioChange }: Props) 
   const [time, setTime] = useState(0);
   const [showBall, setShowBall] = useState(true);
   const [showGround, setShowGround] = useState(true);
+  // Scale separation (#4120): flight display in the swing view is
+  // opt-in — its envelope dwarfs the swing envelope.
+  const [showFlight, setShowFlight] = useState(false);
+  const [view, setView] = useState<ViewName>("Swing");
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // Delivered path / attack angle at impact, for the strike view.
+  const deliveryAngles = useMemo(() => {
+    if (!run) return null;
+    const dt = run.swing[1].t - run.swing[0].t;
+    const index = Math.min(
+      run.swing.length - 1,
+      Math.round(run.impactTimeS / dt),
+    );
+    const v = run.swing[index].velocity;
+    const degOf = (r: number) => (r * 180.0) / Math.PI;
+    return {
+      pathDeg: degOf(Math.atan2(v[2], v[0])),
+      aoaDeg: degOf(Math.atan2(v[1], Math.hypot(v[0], v[2]))),
+    };
+  }, [run]);
 
   const input: SimulationInput = useMemo(
     () => ({
@@ -110,106 +136,12 @@ export function SimulationPanel({ scenario, loftDeg, onScenarioChange }: Props) 
     return () => cancelAnimationFrame(raf);
   }, [playing, run, rate, loop]);
 
-  // Scene drawing: side-on orthographic projection (x right, y up).
+  // Scene drawing: swing-scale renderer (see swingSceneDraw.ts).
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    const { width, height } = canvas;
-    ctx.clearRect(0, 0, width, height);
-    if (!run) {
-      ctx.fillStyle = "#64748b";
-      ctx.font = "14px sans-serif";
-      ctx.fillText("Run a simulation to populate the scene.", 16, 28);
-      return;
-    }
-
-    const swingEnd = run.swing[run.swing.length - 1].t;
-    const inFlight = time > run.impactTimeS;
-    // Extent: swing envelope near impact, flight envelope once airborne.
-    const extentX = inFlight
-      ? Math.max(10, ...run.flight.map((p) => Math.abs(p.position[0]))) * 1.05
-      : Math.max(1.5, ...run.swing.map((p) => Math.abs(p.position[0]))) * 1.15;
-    const extentY = inFlight
-      ? Math.max(5, ...run.flight.map((p) => p.position[1])) * 1.3
-      : Math.max(1.5, ...run.swing.map((p) => Math.abs(p.position[1]))) * 1.15;
-    const originX = inFlight ? 30 : width / 2;
-    const scaleX = (width - 60) / (inFlight ? extentX : 2 * extentX);
-    const scaleY = (height - 40) / (inFlight ? extentY : 2 * extentY);
-    const s = Math.min(scaleX, scaleY);
-    const groundY = inFlight ? height - 24 : height / 2 + extentY * s * 0.5;
-    const px = (x: number) => originX + x * s;
-    const py = (y: number) => groundY - y * s;
-
-    if (showGround) {
-      ctx.strokeStyle = "#475569";
-      ctx.beginPath();
-      ctx.moveTo(0, py(0));
-      ctx.lineTo(width, py(0));
-      ctx.stroke();
-    }
-    if (showBall) {
-      ctx.fillStyle = "#facc15";
-      ctx.beginPath();
-      ctx.arc(px(BALL_POSITION[0]), py(BALL_POSITION[1]), 4, 0, 2 * Math.PI);
-      ctx.fill();
-    }
-
-    // Swing path (faint full arc + traversed portion + head marker).
-    const drawPath = (
-      points: Array<{ position: [number, number, number] }>,
-      color: string,
-      widthPx: number,
-    ) => {
-      if (points.length < 2) return;
-      ctx.strokeStyle = color;
-      ctx.lineWidth = widthPx;
-      ctx.beginPath();
-      points.forEach((point, index) => {
-        const cx = px(point.position[0]);
-        const cy = py(point.position[1]);
-        if (index === 0) ctx.moveTo(cx, cy);
-        else ctx.lineTo(cx, cy);
-      });
-      ctx.stroke();
-      ctx.lineWidth = 1;
-    };
-    drawPath(run.swing, "rgba(56,189,248,0.25)", 1);
-    const swingIndex = Math.min(
-      run.swing.length - 1,
-      Math.round((Math.min(time, swingEnd) / swingEnd) * (run.swing.length - 1)),
-    );
-    drawPath(run.swing.slice(0, swingIndex + 1), "#38bdf8", 2);
-    const head = run.swing[swingIndex].position;
-    ctx.fillStyle = "#f472b6";
-    ctx.beginPath();
-    ctx.arc(px(head[0]), py(head[1]), 4, 0, 2 * Math.PI);
-    ctx.fill();
-
-    // Flight trajectory polyline (faint + traversed).
-    drawPath(run.flight, "rgba(52,211,153,0.25)", 1);
-    if (inFlight) {
-      const flightT = time - run.impactTimeS;
-      const upto = run.flight.filter((p) => p.time <= flightT);
-      drawPath(upto, "#34d399", 2);
-      if (upto.length) {
-        const ball = upto[upto.length - 1].position;
-        ctx.fillStyle = "#facc15";
-        ctx.beginPath();
-        ctx.arc(px(ball[0]), py(ball[1]), 3, 0, 2 * Math.PI);
-        ctx.fill();
-      }
-    }
-
-    ctx.fillStyle = "#94a3b8";
-    ctx.font = "12px sans-serif";
-    ctx.fillText(
-      `t = ${time.toFixed(3)} s (${inFlight ? "flight" : "swing"}) — impact at ${run.impactTimeS.toFixed(3)} s`,
-      12,
-      16,
-    );
-  }, [run, time, showBall, showGround]);
+    drawSwingScene(canvas, run, { time, showBall, showGround, showFlight });
+  }, [run, time, showBall, showGround, showFlight, view]);
 
   const exportJson = () => {
     if (!run) return;
@@ -374,8 +306,48 @@ export function SimulationPanel({ scenario, loftDeg, onScenarioChange }: Props) 
         <SolverPanel onApply={onScenarioChange} />
       </section>
 
-      <section className="space-y-3">
+      <section className="min-w-0 space-y-3">
         <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-4 shadow-lg shadow-black/20 backdrop-blur">
+          <div
+            className="mb-3 flex gap-2"
+            role="tablist"
+            aria-label="Display views (scale-separated)"
+          >
+            {VIEWS.map((name) => (
+              <button
+                key={name}
+                type="button"
+                role="tab"
+                aria-selected={view === name}
+                onClick={() => setView(name)}
+                className={
+                  "rounded-full border px-4 py-1 text-sm font-medium transition-all " +
+                  (view === name
+                    ? "border-sky-400/60 bg-sky-500/10 text-sky-300"
+                    : "border-slate-700/80 bg-slate-900/60 text-slate-300 hover:border-slate-500")
+                }
+              >
+                {name}
+              </button>
+            ))}
+          </div>
+          {view === "Strike" && (
+            <StrikeCanvas
+              toeMm={scenario.impactOffsetToeMm}
+              highMm={scenario.impactOffsetHighMm}
+              loftDeg={loftDeg}
+              pathDeg={deliveryAngles?.pathDeg}
+              aoaDeg={deliveryAngles?.aoaDeg}
+            />
+          )}
+          {view === "Flight" && (
+            <FlightCanvases
+              points={run?.flight ?? []}
+              emptyText="Run a simulation to populate the flight view."
+            />
+          )}
+          {view === "Swing" && (
+            <>
           <div className="mb-2 flex flex-wrap items-center gap-2 text-sm">
             <button
               type="button"
@@ -459,14 +431,30 @@ export function SimulationPanel({ scenario, loftDeg, onScenarioChange }: Props) 
               />
               Ground
             </label>
+            <label
+              className="flex items-center gap-1 text-amber-300/90"
+              title={
+                "Warning: expands the scene to flight scale, dwarfing " +
+                "the swing. " + FIELD_GUIDANCE.swingFlightToggle
+              }
+            >
+              <input
+                type="checkbox"
+                checked={showFlight}
+                onChange={(e) => setShowFlight(e.target.checked)}
+              />
+              Show Ball Flight
+            </label>
           </div>
           <canvas
             ref={canvasRef}
             width={860}
             height={480}
-            className="w-full rounded-lg border border-slate-800 bg-slate-950/60"
-            aria-label="Simulation scene (side view)"
+            className="w-full min-w-0 rounded-lg border border-slate-800 bg-slate-950/60"
+            aria-label="Simulation scene (side view, swing scale)"
           />
+            </>
+          )}
         </div>
       </section>
     </div>

--- a/src/rate_of_closure/web/src/components/StrikeCanvas.tsx
+++ b/src/rate_of_closure/web/src/components/StrikeCanvas.tsx
@@ -1,0 +1,138 @@
+/**
+ * Strike-zone canvas (epic #4120, V2 web parity).
+ *
+ * Face-scale (millimetre) view: driver face outline, impact-offset
+ * marker, and the delivered path / face-normal / attack-angle vectors
+ * projected into the face plane — the web twin of the PyQt6
+ * StrikeView. Never shows swing or flight scale content.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { FIELD_GUIDANCE } from "../model/units";
+
+interface Props {
+  toeMm: number;
+  highMm: number;
+  loftDeg: number;
+  /** Delivered club path [deg, + in-to-out]; undefined until a run. */
+  pathDeg?: number;
+  /** Delivered attack angle [deg, + up]; undefined until a run. */
+  aoaDeg?: number;
+}
+
+/** Driver face half-extents [mm] (200 g reference envelope). */
+const HALF_W_MM = 58;
+const HALF_H_MM = 28;
+const EXTENT_MM = Math.max(HALF_W_MM, HALF_H_MM) * 1.35;
+const ARROW_MM = EXTENT_MM * 0.55;
+
+export function StrikeCanvas({ toeMm, highMm, loftDeg, pathDeg, aoaDeg }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return;
+    const { width, height } = canvas;
+    ctx.clearRect(0, 0, width, height);
+    const scale = Math.min(width, height) / (2 * EXTENT_MM);
+    const px = (mm: number) => width / 2 + mm * scale;
+    const py = (mm: number) => height / 2 - mm * scale;
+
+    // Center cross-hairs.
+    ctx.strokeStyle = "#334155";
+    ctx.beginPath();
+    ctx.moveTo(px(-EXTENT_MM), py(0));
+    ctx.lineTo(px(EXTENT_MM), py(0));
+    ctx.moveTo(px(0), py(-EXTENT_MM));
+    ctx.lineTo(px(0), py(EXTENT_MM));
+    ctx.stroke();
+
+    // Superellipse face outline (exponent 2.5, like the desktop view).
+    ctx.strokeStyle = "#f472b6";
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    for (let i = 0; i <= 120; i += 1) {
+      const t = (i / 120) * 2 * Math.PI;
+      const e = 2 / 2.5;
+      const x = HALF_W_MM * Math.sign(Math.cos(t)) * Math.abs(Math.cos(t)) ** e;
+      const y = HALF_H_MM * Math.sign(Math.sin(t)) * Math.abs(Math.sin(t)) ** e;
+      if (i === 0) ctx.moveTo(px(x), py(y));
+      else ctx.lineTo(px(x), py(y));
+    }
+    ctx.closePath();
+    ctx.stroke();
+    ctx.lineWidth = 1;
+
+    const arrow = (dxMm: number, dyMm: number, color: string, label: string, row: number) => {
+      const x0 = px(toeMm);
+      const y0 = py(highMm);
+      const x1 = px(toeMm + dxMm);
+      const y1 = py(highMm + dyMm);
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1.6;
+      ctx.beginPath();
+      ctx.moveTo(x0, y0);
+      ctx.lineTo(x1, y1);
+      ctx.stroke();
+      const angle = Math.atan2(y1 - y0, x1 - x0);
+      ctx.beginPath();
+      ctx.moveTo(x1, y1);
+      ctx.lineTo(x1 - 7 * Math.cos(angle - 0.4), y1 - 7 * Math.sin(angle - 0.4));
+      ctx.lineTo(x1 - 7 * Math.cos(angle + 0.4), y1 - 7 * Math.sin(angle + 0.4));
+      ctx.closePath();
+      ctx.fillStyle = color;
+      ctx.fill();
+      ctx.lineWidth = 1;
+      ctx.font = "11px sans-serif";
+      ctx.fillText(label, 10, height - 12 - row * 15);
+    };
+
+    // Delivery vectors projected into the face plane (toe -> x, up -> y).
+    if (pathDeg !== undefined && aoaDeg !== undefined) {
+      arrow(
+        Math.sin((pathDeg * Math.PI) / 180) * ARROW_MM,
+        Math.sin((aoaDeg * Math.PI) / 180) * ARROW_MM,
+        "#38bdf8",
+        `club path ${pathDeg >= 0 ? "+" : ""}${pathDeg.toFixed(1)}° / AoA ${
+          aoaDeg >= 0 ? "+" : ""
+        }${aoaDeg.toFixed(1)}°`,
+        1,
+      );
+    }
+    arrow(
+      0,
+      Math.sin((loftDeg * Math.PI) / 180) * ARROW_MM,
+      "#a78bfa",
+      `face normal (loft ${loftDeg.toFixed(1)}°)`,
+      0,
+    );
+
+    // Impact marker.
+    ctx.fillStyle = "#facc15";
+    ctx.beginPath();
+    ctx.arc(px(toeMm), py(highMm), 5, 0, 2 * Math.PI);
+    ctx.fill();
+    ctx.fillStyle = "#94a3b8";
+    ctx.font = "12px sans-serif";
+    ctx.fillText(
+      `impact (${toeMm >= 0 ? "+" : ""}${toeMm.toFixed(1)}, ${
+        highMm >= 0 ? "+" : ""
+      }${highMm.toFixed(1)}) mm — face scale, ±${EXTENT_MM.toFixed(0)} mm`,
+      10,
+      16,
+    );
+  }, [toeMm, highMm, loftDeg, pathDeg, aoaDeg]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={860}
+      height={480}
+      title={FIELD_GUIDANCE.strikeVectorsVisible}
+      className="w-full min-w-0 rounded-lg border border-slate-800 bg-slate-950/60"
+      aria-label="Strike zone (face plane, millimetres)"
+    />
+  );
+}

--- a/src/rate_of_closure/web/src/components/swingSceneDraw.ts
+++ b/src/rate_of_closure/web/src/components/swingSceneDraw.ts
@@ -1,0 +1,121 @@
+/**
+ * Swing-scale scene renderer for the web Simulation panel (#4120 V2).
+ *
+ * Extracted from SimulationPanel so the panel stays under the repo's
+ * 500-LOC limit. Side-on orthographic projection (x right, y up); the
+ * scene holds SWING scale unless `showFlight` opts into the flight
+ * envelope past impact (scale separation — flight dwarfs the swing).
+ */
+
+import { BALL_POSITION, type SimulationRunTs } from "../model/simulation";
+
+export interface SwingSceneOptions {
+  time: number;
+  showBall: boolean;
+  showGround: boolean;
+  /** Opt-in flight display; off keeps the scene at swing scale. */
+  showFlight: boolean;
+}
+
+export function drawSwingScene(
+  canvas: HTMLCanvasElement,
+  run: SimulationRunTs | null,
+  { time, showBall, showGround, showFlight }: SwingSceneOptions,
+): void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  const { width, height } = canvas;
+  ctx.clearRect(0, 0, width, height);
+  if (!run) {
+    ctx.fillStyle = "#64748b";
+    ctx.font = "14px sans-serif";
+    ctx.fillText("Run a simulation to populate the scene.", 16, 28);
+    return;
+  }
+
+  const swingEnd = run.swing[run.swing.length - 1].t;
+  // Scale separation (#4120): the scene stays at swing scale unless
+  // the opt-in 'Show Ball Flight' toggle expands it past impact.
+  const inFlight = time > run.impactTimeS && showFlight;
+  const extentX = inFlight
+    ? Math.max(10, ...run.flight.map((p) => Math.abs(p.position[0]))) * 1.05
+    : Math.max(1.5, ...run.swing.map((p) => Math.abs(p.position[0]))) * 1.15;
+  const extentY = inFlight
+    ? Math.max(5, ...run.flight.map((p) => p.position[1])) * 1.3
+    : Math.max(1.5, ...run.swing.map((p) => Math.abs(p.position[1]))) * 1.15;
+  const originX = inFlight ? 30 : width / 2;
+  const scaleX = (width - 60) / (inFlight ? extentX : 2 * extentX);
+  const scaleY = (height - 40) / (inFlight ? extentY : 2 * extentY);
+  const s = Math.min(scaleX, scaleY);
+  const groundY = inFlight ? height - 24 : height / 2 + extentY * s * 0.5;
+  const px = (x: number) => originX + x * s;
+  const py = (y: number) => groundY - y * s;
+
+  if (showGround) {
+    ctx.strokeStyle = "#475569";
+    ctx.beginPath();
+    ctx.moveTo(0, py(0));
+    ctx.lineTo(width, py(0));
+    ctx.stroke();
+  }
+  if (showBall) {
+    ctx.fillStyle = "#facc15";
+    ctx.beginPath();
+    ctx.arc(px(BALL_POSITION[0]), py(BALL_POSITION[1]), 4, 0, 2 * Math.PI);
+    ctx.fill();
+  }
+
+  // Swing path (faint full arc + traversed portion + head marker).
+  const drawPath = (
+    points: Array<{ position: [number, number, number] }>,
+    color: string,
+    widthPx: number,
+  ) => {
+    if (points.length < 2) return;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = widthPx;
+    ctx.beginPath();
+    points.forEach((point, index) => {
+      const cx = px(point.position[0]);
+      const cy = py(point.position[1]);
+      if (index === 0) ctx.moveTo(cx, cy);
+      else ctx.lineTo(cx, cy);
+    });
+    ctx.stroke();
+    ctx.lineWidth = 1;
+  };
+  drawPath(run.swing, "rgba(56,189,248,0.25)", 1);
+  const swingIndex = Math.min(
+    run.swing.length - 1,
+    Math.round((Math.min(time, swingEnd) / swingEnd) * (run.swing.length - 1)),
+  );
+  drawPath(run.swing.slice(0, swingIndex + 1), "#38bdf8", 2);
+  const head = run.swing[swingIndex].position;
+  ctx.fillStyle = "#f472b6";
+  ctx.beginPath();
+  ctx.arc(px(head[0]), py(head[1]), 4, 0, 2 * Math.PI);
+  ctx.fill();
+
+  // Flight trajectory polyline: opt-in only (scale separation).
+  if (showFlight) drawPath(run.flight, "rgba(52,211,153,0.25)", 1);
+  if (inFlight) {
+    const flightT = time - run.impactTimeS;
+    const upto = run.flight.filter((p) => p.time <= flightT);
+    drawPath(upto, "#34d399", 2);
+    if (upto.length) {
+      const ball = upto[upto.length - 1].position;
+      ctx.fillStyle = "#facc15";
+      ctx.beginPath();
+      ctx.arc(px(ball[0]), py(ball[1]), 3, 0, 2 * Math.PI);
+      ctx.fill();
+    }
+  }
+
+  ctx.fillStyle = "#94a3b8";
+  ctx.font = "12px sans-serif";
+  ctx.fillText(
+    `t = ${time.toFixed(3)} s (${inFlight ? "flight" : "swing"}) — impact at ${run.impactTimeS.toFixed(3)} s`,
+    12,
+    16,
+  );
+}

--- a/src/rate_of_closure/web/src/model/flightExplorer.test.ts
+++ b/src/rate_of_closure/web/src/model/flightExplorer.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Parity pins for the standalone flight explorer (epic #4120, V2).
+ *
+ * The pinned tour-driver case mirrors
+ * `tests/rate_of_closure/test_flight_explorer.py::TestLaunchFromDirect
+ * ::test_pinned_tour_driver_case`; bands cover fixed-step RK4 (here)
+ * vs scipy RK45 (Python), like the existing simulation parity tests.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { directLaunch, exploreFlight } from "./flightExplorer";
+import { BALL_POSITION } from "./simulation";
+
+const PINNED = {
+  ballSpeedMph: 167.0,
+  launchAngleDeg: 10.9,
+  azimuthDeg: 0.0,
+  spinRpm: 2686.0,
+  spinAxisTiltDeg: 0.0,
+};
+
+describe("directLaunch", () => {
+  it("converts app-sign entries into flight-frame launch conditions", () => {
+    const launch = directLaunch(PINNED);
+    expect(launch.ballSpeedMps).toBeCloseTo(74.65568, 4);
+    expect(launch.launchAngleRad).toBeCloseTo((10.9 * Math.PI) / 180, 12);
+    expect(launch.azimuthRad).toBeCloseTo(0.0, 12);
+    // Pure backspin: -y axis in the flight frame.
+    expect(launch.spinAxis[0]).toBeCloseTo(0.0, 12);
+    expect(launch.spinAxis[1]).toBeCloseTo(-1.0, 12);
+    expect(launch.spinAxis[2]).toBeCloseTo(0.0, 12);
+  });
+
+  it("rejects non-positive ball speed", () => {
+    expect(() => directLaunch({ ...PINNED, ballSpeedMph: 0 })).toThrow();
+  });
+});
+
+describe("exploreFlight", () => {
+  it("bands the pinned tour-driver case vs the Python pins", () => {
+    // Python (scipy RK45, waterloo_penner): carry 247.484 m, apex
+    // 28.226 m, time 6.278 s, landing 35.120 deg, lateral 0.0 m.
+    const { metrics } = exploreFlight(directLaunch(PINNED));
+    expect(metrics.carryM).toBeGreaterThan(247.484 * 0.99);
+    expect(metrics.carryM).toBeLessThan(247.484 * 1.01);
+    expect(metrics.maxHeightM).toBeGreaterThan(28.226 * 0.98);
+    expect(metrics.maxHeightM).toBeLessThan(28.226 * 1.02);
+    expect(metrics.flightTimeS).toBeGreaterThan(6.278 * 0.99);
+    expect(metrics.flightTimeS).toBeLessThan(6.278 * 1.01);
+    expect(metrics.landingAngleDeg).toBeGreaterThan(35.12 - 1.0);
+    expect(metrics.landingAngleDeg).toBeLessThan(35.12 + 1.0);
+    expect(Math.abs(metrics.lateralM)).toBeLessThan(0.5);
+  });
+
+  it("keeps app sign conventions: + azimuth and + tilt land right", () => {
+    const right = exploreFlight(
+      directLaunch({ ...PINNED, azimuthDeg: 5.0 }),
+    ).metrics;
+    const fade = exploreFlight(
+      directLaunch({ ...PINNED, spinAxisTiltDeg: 10.0 }),
+    ).metrics;
+    const draw = exploreFlight(
+      directLaunch({ ...PINNED, spinAxisTiltDeg: -10.0 }),
+    ).metrics;
+    expect(right.lateralM).toBeGreaterThan(1.0);
+    expect(right.launchAzimuthDeg).toBeCloseTo(5.0, 8);
+    expect(fade.lateralM).toBeGreaterThan(1.0);
+    expect(draw.lateralM).toBeLessThan(-1.0);
+  });
+
+  it("returns an app-frame trajectory from the tee", () => {
+    const { points } = exploreFlight(directLaunch(PINNED));
+    expect(points.length).toBeGreaterThan(10);
+    expect(points[0].position[0]).toBeCloseTo(BALL_POSITION[0], 6);
+    expect(points[0].position[1]).toBeCloseTo(BALL_POSITION[1], 6);
+    const last = points[points.length - 1];
+    expect(last.position[0]).toBeGreaterThan(100.0);
+    expect(last.position[1]).toBeLessThan(1.0); // back at the ground
+  });
+});

--- a/src/rate_of_closure/web/src/model/flightExplorer.ts
+++ b/src/rate_of_closure/web/src/model/flightExplorer.ts
@@ -1,0 +1,100 @@
+/**
+ * Standalone flight-explorer logic for the web clone (epic #4120, V2).
+ *
+ * TypeScript twin of `rate_of_closure/simulation/flight_explorer.py`,
+ * parity-banded by `flightExplorer.test.ts` against the pytest pinned
+ * case: build flight-frame launch conditions from launch-monitor ball
+ * numbers (app signs: azimuth and lateral + = right of target, spin
+ * axis tilt + = fade side) and integrate with the Waterloo/Penner
+ * model. The full 7-model picker stays Python-side until the P7 WASM
+ * kernels land.
+ */
+
+import { simulateFlight, type FlightPoint, type Launch } from "./flight";
+import {
+  BALL_POSITION,
+  MPH_PER_MPS,
+  add,
+  fromFlightFrame,
+  type Vec3,
+} from "./simulation";
+
+const rad = (d: number): number => (d * Math.PI) / 180.0;
+const deg = (r: number): number => (r * 180.0) / Math.PI;
+
+export interface DirectLaunchInput {
+  ballSpeedMph: number;
+  launchAngleDeg: number;
+  azimuthDeg: number; // + = right of target (app convention)
+  spinRpm: number;
+  spinAxisTiltDeg: number; // + = fade side (curves right)
+}
+
+/** Twin of `launch_from_direct` (app signs -> flight frame). */
+export function directLaunch(input: DirectLaunchInput): Launch {
+  if (!(input.ballSpeedMph > 0)) {
+    throw new Error("ballSpeedMph must be > 0");
+  }
+  // App azimuth + = right; flight-frame azimuth + = left: flip. The
+  // fade-side tilt (+) needs a downward (-z flight) sidespin component,
+  // so the legacy spin-axis-angle decomposition gets the flipped angle
+  // too (same derivation as the Python twin).
+  const azimuthRad = -rad(input.azimuthDeg);
+  const axisAngle = -rad(input.spinAxisTiltDeg);
+  const backspin = Math.cos(axisAngle);
+  const sidespin = Math.sin(axisAngle);
+  const spinAxis: Vec3 = [
+    sidespin * Math.sin(azimuthRad),
+    -backspin,
+    sidespin * Math.cos(azimuthRad),
+  ];
+  return {
+    ballSpeedMps: input.ballSpeedMph / MPH_PER_MPS,
+    launchAngleRad: rad(input.launchAngleDeg),
+    azimuthRad,
+    spinRpm: input.spinRpm,
+    spinAxis,
+  };
+}
+
+export interface FlightExplorationTs {
+  /** App-frame trajectory from the tee (x target, y up, z right). */
+  points: FlightPoint[];
+  metrics: {
+    ballSpeedMph: number;
+    launchAngleDeg: number;
+    launchAzimuthDeg: number; // + = right of target
+    spinRpm: number;
+    carryM: number;
+    maxHeightM: number;
+    flightTimeS: number;
+    landingAngleDeg: number;
+    lateralM: number; // + = right of target
+  };
+}
+
+/** Twin of `explore_flight` (Waterloo/Penner only on web). */
+export function exploreFlight(launch: Launch): FlightExplorationTs {
+  const result = simulateFlight(launch);
+  const points = result.trajectory.map((point) => ({
+    ...point,
+    position: add(fromFlightFrame(point.position), BALL_POSITION),
+    velocity: fromFlightFrame(point.velocity),
+  }));
+  return {
+    points,
+    metrics: {
+      ballSpeedMph: launch.ballSpeedMps * MPH_PER_MPS,
+      launchAngleDeg: deg(launch.launchAngleRad),
+      // Flight azimuth + = left; app convention + = right of target.
+      launchAzimuthDeg: -deg(launch.azimuthRad),
+      spinRpm: launch.spinRpm,
+      carryM: result.carryM,
+      maxHeightM: result.maxHeightM,
+      flightTimeS: result.flightTimeS,
+      landingAngleDeg: result.landingAngleDeg,
+      // Flight lateral + = left; app lateral + = right.
+      lateralM: -result.lateralM,
+    },
+  };
+}

--- a/src/rate_of_closure/web/src/model/units.ts
+++ b/src/rate_of_closure/web/src/model/units.ts
@@ -134,4 +134,39 @@ export const FIELD_GUIDANCE: Record<string, string> = {
   groundVisible:
     "Suggested range: on to show the ground line for spatial reference. " +
     "Source: standard golf-scene convention.",
+  swingFlightToggle:
+    "Off by default: the flight envelope (100+ m) dwarfs the swing " +
+    "envelope (~3 m), collapsing the swing to a dot when both share one " +
+    "scale. Turn on only to see the full trajectory in context. Source: " +
+    "typical driver carry (Penner 2003) vs. club length (published " +
+    "manufacturer specs).",
+  strikeVectorsVisible:
+    "Delivered club path, face normal, and attack-angle directions " +
+    "projected into the face plane. Source: standard launch-monitor " +
+    "D-plane presentation (TrackMan literature; Jorgensen, The Physics " +
+    "of Golf).",
+  fxBallSpeed:
+    "Suggested range: 120-190 mph ball speed (tour driver average near " +
+    "167 mph; strong amateurs 140-160). Source: openly published tour " +
+    "launch-monitor averages.",
+  fxLaunchAngle:
+    "Suggested range: 8-16 deg launch for drivers (tour average near " +
+    "10.9 deg); higher for irons and wedges. Source: openly published " +
+    "tour launch-monitor averages.",
+  fxAzimuth:
+    "Suggested range: within +/-10 deg of the target line; + = right of " +
+    "target. Source: standard launch-monitor sign convention (launch " +
+    "direction).",
+  fxSpinRpm:
+    "Suggested range: 2,000-3,500 rpm total spin for drivers (tour " +
+    "average near 2,686 rpm); 4,000-10,000+ for irons and wedges. " +
+    "Source: openly published tour launch-monitor averages.",
+  fxSpinAxisTilt:
+    "Suggested range: within +/-20 deg spin-axis tilt; + = fade/slice " +
+    "side (curves right for a right-handed player), - = draw/hook side. " +
+    "Source: TrackMan D-plane literature.",
+  fxSpeedUnit:
+    "Suggested range: mph for launch-monitor style entry, m/s for SI " +
+    "work; the model always computes in SI. Source: launch-monitor " +
+    "display convention.",
 };

--- a/tests/rate_of_closure/test_flight_explorer.py
+++ b/tests/rate_of_closure/test_flight_explorer.py
@@ -1,0 +1,128 @@
+"""Tests for the standalone flight-explorer logic (epic #4120, V2).
+
+Pure-physics layer: launch building from direct ball numbers and from
+club delivery numbers, flight integration across the 7 literature
+models, app-frame sign conventions (+ = right of target), and the
+pinned end-to-end case that the TypeScript twin bands against
+(``web/src/model/flightExplorer.test.ts``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rate_of_closure.simulation import (
+    BALL_POSITION_M,
+    EXPLORER_METRIC_KEYS,
+    explore_flight,
+    launch_from_delivery,
+    launch_from_direct,
+)
+from shared.python.swing_sim.flight.registry import FlightModelType
+from shared.python.swing_sim.impact import DeliveryParameters
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+#: The pinned tour-driver direct case, mirrored by the TS parity test.
+PINNED_DIRECT = {
+    "ball_speed_mph": 167.0,
+    "launch_angle_deg": 10.9,
+    "azimuth_deg": 0.0,
+    "spin_rpm": 2686.0,
+    "spin_axis_tilt_deg": 0.0,
+}
+#: Expected metrics for PINNED_DIRECT under waterloo_penner (scipy RK45).
+PINNED_METRICS = {
+    "carry_m": 247.484,
+    "max_height_m": 28.226,
+    "flight_time_s": 6.278,
+    "landing_angle_deg": 35.120,
+    "lateral_m": 0.0,
+}
+
+
+class TestLaunchFromDirect:
+    def test_pinned_tour_driver_case(self) -> None:
+        exploration = explore_flight(
+            launch_from_direct(**PINNED_DIRECT), "waterloo_penner"
+        )
+        for key, expected in PINNED_METRICS.items():
+            assert exploration.metrics[key] == pytest.approx(expected, abs=0.05), key
+
+    def test_entered_numbers_round_trip_into_metrics(self) -> None:
+        exploration = explore_flight(launch_from_direct(150.0, 14.0, -3.0, 3100.0, 0.0))
+        assert exploration.metrics["ball_speed_mph"] == pytest.approx(150.0)
+        assert exploration.metrics["launch_angle_deg"] == pytest.approx(14.0)
+        assert exploration.metrics["launch_azimuth_deg"] == pytest.approx(-3.0)
+        assert exploration.metrics["spin_rpm"] == pytest.approx(3100.0)
+
+    def test_positive_azimuth_lands_right_of_target(self) -> None:
+        right = explore_flight(launch_from_direct(150.0, 12.0, 5.0, 2700.0, 0.0))
+        left = explore_flight(launch_from_direct(150.0, 12.0, -5.0, 2700.0, 0.0))
+        assert right.metrics["lateral_m"] > 1.0
+        assert left.metrics["lateral_m"] < -1.0
+
+    def test_fade_tilt_curves_right_and_draw_tilt_left(self) -> None:
+        fade = explore_flight(launch_from_direct(150.0, 12.0, 0.0, 2700.0, 10.0))
+        draw = explore_flight(launch_from_direct(150.0, 12.0, 0.0, 2700.0, -10.0))
+        assert fade.metrics["lateral_m"] > 1.0
+        assert draw.metrics["lateral_m"] < -1.0
+
+    def test_rejects_nonpositive_ball_speed(self) -> None:
+        with pytest.raises(Exception, match="ball_speed"):
+            launch_from_direct(0.0, 12.0, 0.0, 2500.0, 0.0)
+
+
+class TestLaunchFromDelivery:
+    def test_square_driver_delivery_pins(self) -> None:
+        launch = launch_from_delivery(
+            DeliveryParameters(
+                clubhead_speed_mps=50.0,
+                attack_angle_deg=-1.0,
+                dynamic_loft_deg=12.0,
+            )
+        )
+        exploration = explore_flight(launch, "waterloo_penner")
+        assert exploration.metrics["ball_speed_mph"] == pytest.approx(162.187, abs=0.05)
+        assert exploration.metrics["spin_rpm"] == pytest.approx(3595.9, abs=1.0)
+        assert exploration.metrics["carry_m"] == pytest.approx(240.65, abs=0.5)
+
+    def test_open_face_produces_fade_side_lateral(self) -> None:
+        launch = launch_from_delivery(
+            DeliveryParameters(
+                clubhead_speed_mps=50.0, face_angle_deg=3.0, dynamic_loft_deg=12.0
+            )
+        )
+        exploration = explore_flight(launch)
+        # An open face starts the ball right and adds fade-side spin.
+        assert exploration.metrics["launch_azimuth_deg"] > 0.5
+        assert exploration.metrics["lateral_m"] > 1.0
+
+
+class TestExploreFlight:
+    def test_all_seven_literature_models_run(self) -> None:
+        launch = launch_from_direct(150.0, 12.0, 0.0, 2700.0, 0.0)
+        for model in FlightModelType:
+            exploration = explore_flight(launch, model.value)
+            assert exploration.model_name == model.value
+            assert exploration.metrics["carry_m"] > 50.0, model.value
+
+    def test_metrics_cover_the_declared_keys_exactly(self) -> None:
+        exploration = explore_flight(launch_from_direct(150.0, 12.0, 0.0, 2700.0, 0.0))
+        assert set(exploration.metrics) == set(EXPLORER_METRIC_KEYS)
+
+    def test_trajectory_is_app_frame_from_the_tee(self) -> None:
+        exploration = explore_flight(launch_from_direct(150.0, 12.0, 0.0, 2700.0, 0.0))
+        positions = exploration.positions
+        assert positions.ndim == 2 and positions.shape[1] == 3
+        assert len(positions) == len(exploration.times)
+        assert np.allclose(positions[0], BALL_POSITION_M, atol=1e-6)
+        # Downrange (x) grows, and the last sample is back at the ground.
+        assert positions[-1, 0] > 100.0
+        assert positions[-1, 1] == pytest.approx(BALL_POSITION_M[1], abs=0.5)
+
+    def test_unknown_model_name_raises(self) -> None:
+        launch = launch_from_direct(150.0, 12.0, 0.0, 2700.0, 0.0)
+        with pytest.raises(ValueError):
+            explore_flight(launch, "no_such_model")

--- a/tests/rate_of_closure/test_layout_minsize.py
+++ b/tests/rate_of_closure/test_layout_minsize.py
@@ -1,0 +1,100 @@
+"""Small-window layout regression test (#4120 V2 defect fix).
+
+Reported defect: entry boxes and value labels became unreadable at
+small window sizes. The window now supports 1024x700 (scrolling control
+columns, minimum entry widths, tooltip-backed labels); this headless
+test resizes the main window to that floor, walks every tab (including
+nested display sub-tabs), and asserts that every visible QLineEdit /
+QDoubleSpinBox keeps a readable width and that no visible entry widget
+collapses to zero height.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt6")
+pytest.importorskip("pytestqt")
+
+from PyQt6.QtWidgets import (  # noqa: E402
+    QAbstractSpinBox,
+    QLineEdit,
+    QTabWidget,
+)
+
+from rate_of_closure.ui.pyqt6.main_window import RateOfClosureMainWindow  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+#: Verified window floor (width, height) — matches gui_registration.
+SMALL_WINDOW = (1024, 700)
+
+#: Readable minimum width [px] for a typed entry at the window floor.
+MIN_ENTRY_WIDTH_PX = 64
+
+
+@pytest.fixture
+def small_window(qtbot):  # type: ignore[no-untyped-def]
+    window = RateOfClosureMainWindow()
+    qtbot.addWidget(window)
+    window.resize(*SMALL_WINDOW)
+    window.show()
+    qtbot.waitExposed(window)
+    yield window
+    window._club_view.stop()
+    window._simulation_tab.stop()
+
+
+def _visible_entries(window):  # type: ignore[no-untyped-def]
+    """All visible entry widgets (spin boxes and their line edits)."""
+    entries = [w for w in window.findChildren(QAbstractSpinBox) if w.isVisible()]
+    entries += [w for w in window.findChildren(QLineEdit) if w.isVisible()]
+    return entries
+
+
+def _walk_tabs(window, qtbot):  # type: ignore[no-untyped-def]
+    """Yield after activating every page of every (nested) tab widget."""
+    for tabs in window.findChildren(QTabWidget):
+        for index in range(tabs.count()):
+            tabs.setCurrentIndex(index)
+            qtbot.wait(10)
+            yield f"{type(tabs.widget(index)).__name__}[{index}]"
+
+
+class TestSmallWindowLayout:
+    def test_window_minimum_matches_the_supported_floor(self, small_window) -> None:  # type: ignore[no-untyped-def]
+        assert small_window.minimumWidth() <= SMALL_WINDOW[0]
+        assert small_window.minimumHeight() <= SMALL_WINDOW[1]
+        assert small_window.width() == SMALL_WINDOW[0]
+        assert small_window.height() == SMALL_WINDOW[1]
+
+    def test_every_visible_entry_stays_readable_on_every_tab(
+        self, small_window, qtbot
+    ) -> None:  # type: ignore[no-untyped-def]
+        checked = 0
+        for page in _walk_tabs(small_window, qtbot):
+            for entry in _visible_entries(small_window):
+                assert entry.width() >= MIN_ENTRY_WIDTH_PX, (
+                    f"{type(entry).__name__} is {entry.width()}px wide on "
+                    f"{page} — unreadable below {MIN_ENTRY_WIDTH_PX}px"
+                )
+                assert entry.height() > 0, (
+                    f"{type(entry).__name__} collapsed to zero height on {page}"
+                )
+                checked += 1
+        assert checked > 20, "the walk must actually visit entry widgets"
+
+    def test_no_visible_zero_height_widgets_in_control_columns(
+        self, small_window, qtbot
+    ) -> None:  # type: ignore[no-untyped-def]
+        from PyQt6.QtWidgets import QComboBox, QLabel, QPushButton
+
+        for page in _walk_tabs(small_window, qtbot):
+            for cls in (QComboBox, QPushButton, QLabel):
+                for widget in small_window.findChildren(cls):
+                    if widget.isVisible():
+                        assert widget.height() > 0, (
+                            f"{type(widget).__name__} "
+                            f"({widget.objectName() or widget}) has zero "
+                            f"height on {page}"
+                        )

--- a/tests/rate_of_closure/test_viewers_gui.py
+++ b/tests/rate_of_closure/test_viewers_gui.py
@@ -1,0 +1,215 @@
+"""GUI tests for the scale-separated viewers + Flight Explorer (#4120 V2).
+
+Headless-safe. Covers: the Strike/Swing/Flight sub-tabs inside the
+Simulation tab's display area, the strike view's face-scale invariant
+(extents never exceed :data:`STRIKE_MAX_EXTENT_MM`), the swing view's
+'Show Ball Flight' toggle (default OFF; toggling changes the scene
+limits), the dedicated flight view's panels + flight-regime extents,
+sourced tooltips on every new control, and the standalone Flight
+Explorer tab end-to-end in both entry modes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt6")
+pytest.importorskip("pytestqt")
+
+from rate_of_closure.derivation import LAUNCH_EXPLANATIONS  # noqa: E402
+from rate_of_closure.model import ImpactScenario  # noqa: E402
+from rate_of_closure.ui.pyqt6.flight_explorer_tab import (  # noqa: E402
+    EXPLORER_ROWS,
+    FlightExplorerTab,
+)
+from rate_of_closure.ui.pyqt6.flight_view import FlightView  # noqa: E402
+from rate_of_closure.ui.pyqt6.main_window import RateOfClosureMainWindow  # noqa: E402
+from rate_of_closure.ui.pyqt6.simulation_tab import SimulationTab  # noqa: E402
+from rate_of_closure.ui.pyqt6.strike_view import (  # noqa: E402
+    STRIKE_MAX_EXTENT_MM,
+    StrikeView,
+    face_half_extents_mm,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+@pytest.fixture
+def ran_tab(qtbot):  # type: ignore[no-untyped-def]
+    tab = SimulationTab()
+    qtbot.addWidget(tab)
+    tab.set_scenario(
+        ImpactScenario(
+            clubhead_speed_mph=113.0,
+            impact_offset_toe_mm=6.0,
+            impact_offset_high_mm=3.0,
+        )
+    )
+    with qtbot.waitSignal(tab.runCompleted, timeout=15000):
+        tab.run_now()
+    yield tab
+    tab.stop()
+
+
+class TestSimulationSubTabs:
+    def test_display_area_hosts_strike_swing_flight_sub_tabs(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        from PyQt6.QtWidgets import QTabWidget
+
+        assert isinstance(ran_tab.strike_view(), StrikeView)
+        assert isinstance(ran_tab.flight_view(), FlightView)
+        tab_widgets = ran_tab.findChildren(QTabWidget)
+        texts = {
+            widget.tabText(i) for widget in tab_widgets for i in range(widget.count())
+        }
+        assert {"Strike", "Swing", "Flight", "Inspector", "Solver"} <= texts
+
+    def test_run_populates_all_three_viewers(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        assert ran_tab.strike_view().run() is not None
+        assert len(ran_tab.flight_view().trajectory()) > 2
+        assert ran_tab.view().run() is not None
+
+
+class TestStrikeViewScale:
+    def test_extents_never_exceed_face_scale(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        strike = ran_tab.strike_view()
+        half_x, half_y = strike.extents_mm()
+        assert half_x <= STRIKE_MAX_EXTENT_MM
+        assert half_y <= STRIKE_MAX_EXTENT_MM
+        run = strike.run()
+        assert run is not None
+        half_w, half_h = face_half_extents_mm(run.config.club)
+        assert half_x <= max(half_w, half_h) * 1.5
+
+    def test_strike_history_accumulates(self, ran_tab, qtbot) -> None:  # type: ignore[no-untyped-def]
+        strike = ran_tab.strike_view()
+        before = len(strike.strike_history())
+        with qtbot.waitSignal(ran_tab.runCompleted, timeout=15000):
+            ran_tab.run_now()
+        assert len(strike.strike_history()) == before + 1
+        strike.clear_history()
+        assert strike.strike_history() == []
+
+    def test_display_checklist_toggles_redraw(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        strike = ran_tab.strike_view()
+        for name in ("curvature", "vectors", "history", "club_info"):
+            check = strike.display_check(name)
+            check.setChecked(not check.isChecked())
+            check.setChecked(not check.isChecked())
+
+    def test_every_display_control_has_sourced_guidance(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        strike = ran_tab.strike_view()
+        for name in ("curvature", "vectors", "history", "club_info"):
+            assert "Source:" in strike.display_check(name).toolTip(), name
+
+
+class TestSwingViewFlightToggle:
+    def test_flight_display_defaults_off(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        assert ran_tab.view().flight_shown() is False
+
+    def test_toggle_expands_and_restores_scene_limits(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        view = ran_tab.view()
+        run = view.run()
+        assert run is not None
+        view.set_playback_time(run.total_duration_s)  # deep in the flight
+        swing_extent = view.scene_extent_m()
+        assert swing_extent < 10.0, "swing scale must stay metres-sized"
+        view.set_flight_shown(True)
+        flight_extent = view.scene_extent_m()
+        assert flight_extent > swing_extent * 5.0
+        view.set_flight_shown(False)
+        assert view.scene_extent_m() == pytest.approx(swing_extent)
+
+    def test_toggle_carries_a_scale_warning_tooltip(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        tooltip = ran_tab.view()._flight_check.toolTip()
+        assert "dwarfs" in tooltip
+        assert "Source:" in tooltip
+
+
+class TestFlightView:
+    def test_extents_track_the_flight_regime(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        flight = ran_tab.flight_view()
+        carry_ext, height_ext, lateral_ext = flight.extents_m()
+        trajectory = flight.trajectory()
+        assert carry_ext >= float(trajectory[:, 0].max())
+        assert height_ext >= float(trajectory[:, 1].max())
+        assert lateral_ext >= float(abs(trajectory[:, 2]).max())
+        assert carry_ext > 50.0, "a 113 mph driver flight is flight-scale"
+
+    def test_display_checklist_and_guidance(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        flight = ran_tab.flight_view()
+        for name in ("side", "top", "three_d", "landing", "apex"):
+            check = flight.display_check(name)
+            assert "Source:" in check.toolTip(), name
+            check.setChecked(not check.isChecked())
+            check.setChecked(not check.isChecked())
+
+    def test_all_panels_off_shows_placeholder_without_crashing(self, ran_tab) -> None:  # type: ignore[no-untyped-def]
+        flight = ran_tab.flight_view()
+        for name in ("side", "top", "three_d"):
+            flight.display_check(name).setChecked(False)
+        for name in ("side", "top", "three_d"):
+            flight.display_check(name).setChecked(True)
+
+
+class TestFlightExplorerTab:
+    @pytest.fixture
+    def explorer(self, qtbot):  # type: ignore[no-untyped-def]
+        tab = FlightExplorerTab()
+        qtbot.addWidget(tab)
+        return tab
+
+    def test_main_window_hosts_the_flight_explorer_tab(self, qtbot) -> None:  # type: ignore[no-untyped-def]
+        window = RateOfClosureMainWindow()
+        qtbot.addWidget(window)
+        try:
+            tabs = window.centralWidget().findChildren(FlightExplorerTab)
+            assert tabs, "main window must host the Flight Explorer tab"
+        finally:
+            window._club_view.stop()
+            window._simulation_tab.stop()
+
+    def test_every_result_row_has_an_explanation(self) -> None:
+        for key, _label, _unit in EXPLORER_ROWS:
+            assert key in LAUNCH_EXPLANATIONS, key
+
+    def test_direct_mode_end_to_end_matches_the_pinned_case(self, explorer) -> None:  # type: ignore[no-untyped-def]
+        exploration = explorer.run_now()
+        assert exploration is not None
+        # Defaults are the pinned tour-driver case (167 mph / 10.9 deg /
+        # 2686 rpm, waterloo_penner) from test_flight_explorer.py.
+        assert exploration.metrics["carry_m"] == pytest.approx(247.484, abs=0.05)
+        assert "247.5 m" in explorer._rows["carry_m"].value_label.text().replace(
+            "+", ""
+        )
+        assert len(explorer.flight_view().trajectory()) > 2
+
+    def test_delivery_mode_end_to_end(self, explorer) -> None:  # type: ignore[no-untyped-def]
+        explorer._mode_combo.setCurrentIndex(1)
+        explorer._speed_spin.setValue(112.0)  # mph clubhead speed
+        exploration = explorer.run_now()
+        assert exploration is not None
+        assert exploration.metrics["carry_m"] > 100.0
+        assert exploration.metrics["ball_speed_mph"] > 112.0  # smash > 1
+
+    def test_speed_unit_dropdown_converts_in_place(self, explorer) -> None:  # type: ignore[no-untyped-def]
+        explorer._speed_spin.setValue(167.0)
+        mps_before = explorer.speed_mps()
+        explorer._speed_unit_combo.setCurrentText("m/s")
+        assert explorer._speed_spin.value() == pytest.approx(74.66, abs=0.05)
+        assert explorer.speed_mps() == pytest.approx(mps_before, abs=0.05)
+
+    def test_model_picker_covers_all_seven_models(self, explorer) -> None:  # type: ignore[no-untyped-def]
+        assert explorer._model_combo.count() == 7
+
+    def test_every_new_control_has_sourced_guidance(self, explorer) -> None:  # type: ignore[no-untyped-def]
+        controls = [
+            explorer._mode_combo,
+            explorer._speed_spin,
+            explorer._speed_unit_combo,
+            explorer._model_combo,
+            *explorer._direct_spins.values(),
+            *explorer._delivery_spins.values(),
+        ]
+        for control in controls:
+            assert "Source:" in control.toolTip(), control
+        assert explorer._run_button.toolTip()


### PR DESCRIPTION
Phase V2 of the Investigation & Variation Suite epic #4120, stacked on the consolidated platform branch (#4119).

## What's here

### Three scale-separated viewers (Simulation tab display sub-tabs)
- **Strike** (`ui/pyqt6/strike_view.py`, new): impact-zone view at FACE scale — superellipse face outline sized from the club's mass envelope, bulge/roll sagitta contours when curvature is on, impact-offset marker + strike-history scatter, delivered path / face-normal / AoA vectors projected into the face plane, club-info annotation. Extents hard-capped at `STRIKE_MAX_EXTENT_MM` (±120 mm) — never includes flight.
- **Swing** (`simulation_view.py`): the existing Club3DView-based 3D scene scoped to swing scale — the flight polyline is REMOVED from the default display; a new **'Show Ball Flight' checkbox (default OFF)** expands to flight scale with guidance warning it dwarfs the ~3 m swing.
- **Flight** (`ui/pyqt6/flight_view.py`, new): dedicated flight-scale viewer — side profile (height vs carry) + top-down (lateral vs carry) 2D panels plus the 3D polyline, landing point and apex annotated; accepts a bare trajectory so the explorer reuses it.
- Each viewer has its own display-parameter checklist (plain widget state, persists for the session) with sourced tooltips on every control.

### Standalone Ball-Flight Explorer (new top-level tab)
- Pure logic in `simulation/flight_explorer.py`: direct launch entry (ball speed with mph / m/s drop-down, launch angle, azimuth, spin rpm, spin-axis tilt — app signs: + = right of target / fade side) OR impact-delivery parameters through `swing_sim.impact.delivery` + the rigid-body solve; model picker across all **7 literature flight models**; result rows (carry, apex, time, landing angle, lateral) with click-through explanations (`lateral_m` added to `LAUNCH_EXPLANATIONS`). No swing required.

### Small-window layout defect fix
- Window minimum lowered to **1024×700** (gui_registration updated); every control column scrolls; typed entries carry ≥84 px minimums (controls panel, simulation tab, solver panel, explorer); result-row labels tooltip their full text and values keep a minimum width.
- `tests/rate_of_closure/test_layout_minsize.py` resizes the window to 1024×700 headlessly, walks every nested tab, and asserts every visible QLineEdit/QDoubleSpinBox is ≥64 px wide with no zero-height visible widgets.

### Web practical parity
- Strike / Swing / Flight segmented views in the Simulation panel (`StrikeCanvas.tsx`, `FlightCanvases.tsx`; swing scene extracted to `swingSceneDraw.ts` for the 500-LOC limit), 'Show Ball Flight' toggle separated from the swing canvas scale, standalone **Flight Explorer** tab (`model/flightExplorer.ts` + `FlightExplorerPanel.tsx`), responsive `min-w-*` + truncation with `title` attributes.
- TS parity pin mirrors the pytest pinned case: 167 mph / 10.9° / 2686 rpm → carry ≈ 247.5 m (Waterloo/Penner), banded RK4-vs-RK45 like the existing parity tests.

## Gates
- `pytest tests/rate_of_closure src/shared/python/swing_sim` — **437 passed** (33 new tests: scale invariants, explorer end-to-end pins in both modes, sign conventions, all-7-model runs, layout min-size, GUI smoke, tooltip enforcement)
- `ruff check` / `ruff format` — clean; `mypy` on all touched files — clean
- web: `npm test` **77 passed** (5 new parity tests), `type-check`, `lint`, `build` — all clean
- Verified live in the browser: Flight Explorer renders the pinned numbers (carry +247.5 m), all three segmented views switch correctly, no console errors.

## Scope notes
- Closure Sweep tab untouched; no plotting/ package (V1 plotting is a sibling branch); Monte Carlo variation engine deferred to V3 (the standalone tab is single-shot parameter → flight only).
- SPEC.md dated section + §12 changelog row (1.10.0) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)