### PR TITLE
feat(swing_sim,rate_of_closure): putting vertical — impact, skid/roll model, green sim, Putting tab (H3, #4125)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -26,8 +26,8 @@
 | **Owner**               | D-sorganization                            |
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
-| **Current Version**     | 1.11.0                                     |
-| **Spec Version**        | 1.11.0                                     |
+| **Current Version**     | 1.12.0                                     |
+| **Spec Version**        | 1.12.0                                     |
 | **Last Spec Update**    | 2026-08-04                                 |
 
 ## 2. Purpose & Mission
@@ -35,6 +35,54 @@
 Comprehensive monorepo housing 45+ utility tools for data processing, scientific computing, process engineering, and automation. This is the central tooling hub for the D-sorganization fleet, providing modular engineering calculation tools with PyQt6 GUIs, FastAPI web services, Rust numerical kernels, and a unified launcher with plugin architecture for extensibility.
 
 ## 3. Goals & Non-Goals
+### 2026-08-04 Putting vertical — impact, skid/roll, green sim, Putting tab (epic #4125, H3)
+
+- Physics: new self-façaded subpackage
+  `src/shared/python/swing_sim/putting/` (parent `swing_sim/__init__.py`
+  untouched, same policy as `impact`/`variation`), all derivations from
+  first principles in the module docstrings.
+  (a) `impact.py`: putter-ball impact — 1-D COR impulse along the
+  lofted face normal (putter-face COR 0.78, typical published value)
+  plus the 2/7 rolling-cap tangential transfer giving launch angle and
+  the initial backspin "slide" state; pendulum backstroke→speed proxy
+  `v = A·sqrt(g/L)`; H3-local `MINIMAL_PUTTERS` clearly marked for H1
+  club-library reconciliation.
+  (b) `roll.py`: skid phase closed forms (`dv/dt = -μ_k g`,
+  `dω/dt = (5/2)μ_k g/r`, pure roll at `v = ωr` ⇒
+  `v_roll = (5v₀+2ω₀r)/7`); stimpmeter green speed derived from the
+  USGA geometry (36 in ramp, 20° release, V-groove inertia ⇒ release
+  speed ≈ 1.83 m/s) inverted to `μ_r = v²/(2gS)` — the stimp → μ_r →
+  roll-out chain round-trips exactly (test-enforced).
+  (c) `green.py`: uniform planar slope (grade % + downhill aspect),
+  deterministic fixed-step RK4 (2 ms) with a SLIDING/ROLLING mode
+  machine; break, skid/roll split, and a geometric lip-capture bound
+  (ball must fall half a diameter crossing the hole mouth ⇒
+  `v_capture = R·sqrt(g/2r) ≈ 0.82 m/s`; Holmes 1991 cited for the
+  full-chord ~1.6 m/s variant).
+- App: 'Putting' tab in both UIs. PyQt6
+  `ui/pyqt6/putting_tab.py` (putter picker preferring the H1 library
+  putter via `rate_of_closure/putting.py`, clubhead-speed or
+  backstroke pace input, stimp/grade/aspect/distance controls with
+  sourced tooltips, clickable result rows → explanations with glossary
+  links, matplotlib top-down green with phase-coded path + downhill
+  arrow over a speed-vs-distance plot with the capture bound). Web
+  `web/src/model/putting.ts` mirror (same constants, same RK4) with
+  `components/PuttingPanel.tsx` (SVG green view adapting UpstreamDrift
+  `PuttingGreen.tsx` concepts, credited) — parity pins in
+  `putting.test.ts` mirror `tests/rate_of_closure/test_putting.py`
+  value-for-value.
+- Additive registrations: `plotting/putting_catalog.py` (PuttResult-
+  scoped variable registry, pinned SimulationRun catalog untouched);
+  5 new glossary terms (stimp, skid, pure_roll, capture_speed, break)
+  in new `glossary_entries_putting.py` + TS mirror + regenerated
+  parity fixture; `helptext.py`/`helptext.ts` Putting entries;
+  `FIELD_TO_TERM` putt-field mappings.
+- Tests: skid→roll continuity (v = ωr), stimp round-trip, slope
+  mirror symmetry, capture-bound behaviour (dying putt drops, slammed
+  putt runs past), flat-green speed monotonicity, determinism,
+  Python↔TS parity pins on reference putts, GUI smoke + tooltip and
+  help sweeps extended to the new tab.
+
 ### 2026-08-04 Rate of Closure glossary, help system & full-model derivations (epic #4120, phase V4)
 
 - Selected-value clarity: clicking any result/metric/launch row applies
@@ -2282,6 +2330,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-04 | 1.12.0 | feat(swing_sim, rate_of_closure, #4125 H3): putting vertical — new self-façaded `shared/python/swing_sim/putting/` package (putter-ball COR impulse with the 2/7 rolling-cap backspin derivation, first-principles skid→pure-roll model with the USGA stimpmeter geometry derived to ~1.83 m/s release speed and inverted to rolling resistance `μ=v²/(2gS)` with an exact round-trip, planar sloped-green RK4 with break and the geometric lip-capture bound `R·sqrt(g/2r)`≈0.82 m/s, Holmes 1991 cited); 'Putting' tab in both UIs (library-putter picker with minimal-spec fallback marked for H1 reconciliation, speed/backstroke pace input, stimp/grade/aspect controls, clickable result rows with glossary-linked explanations, phase-coded top-down green + speed-vs-distance plot with the capture bound); additive putting plot catalog, 5 new glossary terms with regenerated TS parity fixture, per-tab help in both UIs; Python↔TS parity pins on reference putts; UpstreamDrift putting assets surveyed and credited (stimp-as-friction concept, COR 0.78, SVG green-view concepts). |
 | 2026-08-04 | 1.11.0 | feat(rate_of_closure, #4120 V4): investigation-suite polish — persistent selected-row highlight (palette-derived, both UIs) with the row name leading every explanation panel; 60-term sourced DbC glossary with searchable PyQt6 tab / web section, explanation-panel deep links, and a fixture-pinned TS mirror; Derivation & Traceability renamed Calculation Description; sectioned full-model derivations (closure chain + impact impulse/COR/MOI-tensor/2-7 cap/D-plane/gear effect + flight EOM with the active literature model's cited coefficient law + pendulum Lagrangian with live plane-tilt gravity) rendering conditionally per configuration in mathtext/KaTeX; per-tab cold-user help (PyQt6 '?' corner button, web collapsible How-to sections) contract-tested >300 chars; hover-hint completeness sweeps test-enforced across every interactive widget/element of both UIs. |
 | 2026-08-04 | 1.10.0 | feat(swing_sim, rate_of_closure, #4120 V3): shared variation/Monte-Carlo engine — `shared/python/swing_sim/variation/` (namespaced variable registry, NoiseSpec/VariationPlan JSON schema, seeded parallel N-run engine with solver-shaped progress/cancel, dispersion + one-at-a-time sensitivity + Spearman + 2-sigma landing ellipse, CSV/JSON dataset IO), the PyQt6 "Variation" tab in the Rate of Closure explorer, and the web mirror (seeded mulberry32 engine, capped <=500 runs, shared plan schema, statistical parity fixture vs the Python engine). Prior-art survey of UpstreamDrift Monte-Carlo/perturbation/movement_optimizer machinery credited in module docstrings. |
 | 2026-08-04 | 1.10.0 | feat(rate_of_closure, #4120 V1): investigative plotting suite — `plotting/` package (40-variable DbC data catalog with pinned keys, frozen JSON-round-trip PlotSpec `rate_of_closure.plot_spec/1`, one compute/render pipeline with full-simulation sweeps and themed palette, built-in advanced plots: migrated closure sweep, delivery-vs-τ, launch-vs-toe/high offset maps, swing time series, side/top-down flight profiles); PyQt6 Plots tab replacing the Closure Sweep tab (plot list add/duplicate/remove, 3-step Custom Plot wizard with live preview, navigation toolbar, PNG/SVG/CSV/JSON + save/load definition exports, tooltips everywhere); web parity via plotcatalog.ts (key list pinned against the pytest-exported fixture), plotspec.ts (shared schema + pipeline), and a Plots tab with built-in picker, simplified custom builder, canvas rendering, PNG/CSV/JSON downloads, and definition import/export interoperable with the desktop app. |

--- a/src/rate_of_closure/glossary.py
+++ b/src/rate_of_closure/glossary.py
@@ -19,12 +19,15 @@ from __future__ import annotations
 from ._contracts import ensure
 from .glossary_entries_a_l import ENTRIES as _ENTRIES_A_L
 from .glossary_entries_l_z import ENTRIES as _ENTRIES_L_Z
+from .glossary_entries_putting import ENTRIES as _ENTRIES_PUTTING
 from .glossary_types import GlossaryEntry
 
 __all__ = ["FIELD_TO_TERM", "GLOSSARY", "GlossaryEntry", "search_terms"]
 
 #: Every term used across the app, keyed snake_case. Sorted by key.
-GLOSSARY: dict[str, GlossaryEntry] = dict(sorted((_ENTRIES_A_L | _ENTRIES_L_Z).items()))
+GLOSSARY: dict[str, GlossaryEntry] = dict(
+    sorted((_ENTRIES_A_L | _ENTRIES_L_Z | _ENTRIES_PUTTING).items())
+)
 
 
 #: Explanation field -> the glossary term it pre-selects, for every
@@ -58,6 +61,14 @@ FIELD_TO_TERM: dict[str, str] = {
     "flight_time_s": "flight_time",
     "landing_angle_deg": "landing_angle",
     "lateral_m": "lateral_offset",
+    # PUTT_EXPLANATIONS fields (#4125 H3)
+    "putt_rollout_m": "stimp",
+    "putt_skid_m": "skid",
+    "putt_skid_pct": "skid",
+    "putt_time_s": "pure_roll",
+    "putt_break_m": "break",
+    "putt_speed_at_hole_mps": "capture_speed",
+    "putt_margin": "capture_speed",
 }
 
 

--- a/src/rate_of_closure/glossary_entries_putting.py
+++ b/src/rate_of_closure/glossary_entries_putting.py
@@ -1,0 +1,63 @@
+"""Glossary entry data for the Putting tab (#4125 H3) — see glossary.py.
+
+Additive split module (same 500-LOC-budget pattern as the other
+``glossary_entries_*`` modules); the public surface lives in
+:mod:`rate_of_closure.glossary`, which merges and validates the dicts.
+"""
+
+from __future__ import annotations
+
+from ._contracts import require
+from .glossary_types import GlossaryEntry
+
+__all__ = ["ENTRIES"]
+
+
+def _entry(term: str, definition: str) -> GlossaryEntry:
+    require(bool(term.strip()), "glossary term must be non-empty", term)
+    require(
+        len(definition.strip()) >= 60,
+        "glossary definitions must be substantive",
+        term,
+    )
+    return GlossaryEntry(term=term, definition=definition)
+
+
+ENTRIES: dict[str, GlossaryEntry] = {
+    "break": _entry(
+        "Break",
+        "The lateral drift of a putt off its starting line, driven by the "
+        "in-plane component of gravity on a sloped green. Most of the break "
+        "accumulates late in the putt, when the ball is slowest "
+        "(swing_sim.putting.green derivation).",
+    ),
+    "capture_speed": _entry(
+        "Capture Speed",
+        "The fastest a ball can cross the hole and still drop: it must fall "
+        "half its diameter while traversing the opening, giving roughly "
+        "0.8-1.6 m/s depending on the crossing chord (geometric derivation "
+        "in swing_sim.putting.green; Holmes, Am. J. Phys. 59, 1991).",
+    ),
+    "pure_roll": _entry(
+        "Pure Roll",
+        "The rolling state where the ball's contact point is momentarily at "
+        "rest — forward speed equals surface spin speed (v = ωr). From here "
+        "only rolling resistance, set by the green speed, slows the ball "
+        "(swing_sim.putting.roll derivation).",
+    ),
+    "skid": _entry(
+        "Skid Phase",
+        "The opening stretch of a putt where the ball slides rather than "
+        "rolls: struck with backspin, it is decelerated and spun up by "
+        "sliding friction until v = ωr. With no initial spin the classic "
+        "result is pure roll at 5/7 of launch speed "
+        "(swing_sim.putting.roll derivation).",
+    ),
+    "stimp": _entry(
+        "Stimp (Green Speed)",
+        "The stimpmeter reading in feet: how far a ball rolls out when "
+        "released from the USGA's 36-inch ramp at 20 degrees (~1.83 m/s). "
+        "Inverting the roll-out formula maps stimp to the green's rolling "
+        "resistance, mu = v²/(2gS) (swing_sim.putting.roll derivation).",
+    ),
+}

--- a/src/rate_of_closure/helptext.py
+++ b/src/rate_of_closure/helptext.py
@@ -188,6 +188,37 @@ HELP_TEXTS: dict[str, HelpEntry] = {
         "Failed runs are recorded as NaN rows, never aborting the "
         "batch.</p>",
     ),
+    "putting": _entry(
+        "Putting",
+        "<h3>What this tab does</h3>"
+        "<p>A putting laboratory on a uniform sloped green: pick a "
+        "putter, set the stroke pace (directly or as a pendulum "
+        "backstroke length), dial in the green speed (stimp) and the "
+        "slope, and read the full story of the putt — roll-out, the "
+        "skid-to-roll transition, time, break, and whether the ball "
+        "drops or how far it misses.</p>"
+        "<h3>Workflow</h3>"
+        "<ol><li>Choose a putter (the club-library putter by default) "
+        "and how you want to set the pace: clubhead speed at impact, "
+        "or a backstroke length through the pendulum-stroke "
+        "proxy.</li>"
+        "<li>Set the green: stimp (6 slow — 14 tournament fast), "
+        "slope grade in percent, and the downhill direction relative "
+        "to the putt line (+90° = low side on your left).</li>"
+        "<li>Set the distance to the hole and read the result rows — "
+        "click any row for its plain-language explanation with "
+        "glossary links.</li>"
+        "<li>Watch the top-down green view: the skid phase and the "
+        "pure-roll phase are colour-coded along the path, the arrow "
+        "shows the downhill direction, and the speed-vs-distance "
+        "plot marks the capture-speed bound at the hole.</li></ol>"
+        "<h3>Tips</h3>"
+        "<p>A putt only drops if it crosses the hole at or below the "
+        "capture speed (the ball must fall half its diameter while "
+        "crossing the lip) — dying the ball in beats charging it. "
+        "On a cross-slope, note how most of the break happens in the "
+        "last third of the putt, where the ball is slowest.</p>",
+    ),
     "glossary": _entry(
         "Glossary",
         "<h3>What this tab does</h3>"

--- a/src/rate_of_closure/plotting/__init__.py
+++ b/src/rate_of_closure/plotting/__init__.py
@@ -16,6 +16,12 @@ from rate_of_closure.plotting.catalog import (
     extract,
     variables_by_category,
 )
+from rate_of_closure.plotting.putting_catalog import (
+    PUTTING_CATALOG,
+    PuttingVariableSpec,
+    extract_putting,
+    putting_catalog_keys,
+)
 from rate_of_closure.plotting.render import (
     PlotData,
     compute_plot_data,
@@ -36,13 +42,17 @@ __all__ = [
     "CATALOG",
     "CATEGORIES",
     "PLOT_KINDS",
+    "PUTTING_CATALOG",
     "PlotData",
     "PlotSpec",
+    "PuttingVariableSpec",
     "VariableSpec",
     "builtin_spec",
     "catalog_keys",
     "compute_plot_data",
     "extract",
+    "extract_putting",
+    "putting_catalog_keys",
     "plot_data_rows",
     "render_plot",
     "spec_from_json",

--- a/src/rate_of_closure/plotting/putting_catalog.py
+++ b/src/rate_of_closure/plotting/putting_catalog.py
@@ -1,0 +1,128 @@
+"""Putting output catalog — additive registry for the Putting tab (#4125 H3).
+
+A parallel, additive registry in the style of
+:mod:`rate_of_closure.plotting.catalog`, scoped to
+:class:`~shared.python.swing_sim.putting.PuttResult` instead of
+``SimulationRun``. Kept separate so the pinned SimulationRun catalog
+(and its web parity fixture) is untouched — putting outputs register
+additively alongside it, and the Putting tab's plot list and exports
+read from here.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+
+from rate_of_closure._contracts import ensure, require
+from shared.python.swing_sim.putting import PuttResult
+
+__all__ = [
+    "PUTTING_CATALOG",
+    "PuttingVariableSpec",
+    "extract_putting",
+    "putting_catalog_keys",
+]
+
+PuttingExtractor = Callable[[PuttResult], "np.ndarray | float"]
+
+
+@dataclass(frozen=True)
+class PuttingVariableSpec:
+    """One plottable putting variable.
+
+    Args:
+        key: Stable namespaced identifier, ``putting.<name>``.
+        label: Title Case display label.
+        unit: Display unit string ("" for dimensionless).
+        extractor: ``result -> np.ndarray | float`` in SI units.
+        is_series: True when the extractor yields a per-sample array.
+    """
+
+    key: str
+    label: str
+    unit: str
+    extractor: PuttingExtractor
+    is_series: bool = False
+
+    def __post_init__(self) -> None:
+        require(
+            self.key.startswith("putting."),
+            "putting keys are namespaced 'putting.<name>'",
+            self.key,
+        )
+        require(bool(self.label), "label must be non-empty", self.label)
+        require(callable(self.extractor), "extractor must be callable")
+
+    @property
+    def axis_label(self) -> str:
+        """Axis label: ``Label [unit]`` (unit omitted when empty)."""
+        return f"{self.label} [{self.unit}]" if self.unit else self.label
+
+
+def _series(values: tuple[float, ...]) -> np.ndarray:
+    return np.asarray(values, dtype=float)
+
+
+def _entries() -> list[PuttingVariableSpec]:
+    """Build the putting registry (one literal list, easy to review)."""
+    series: list[tuple[str, str, str, PuttingExtractor]] = [
+        ("path_x", "Path Along Putt Line", "m", lambda r: _series(r.path_x_m)),
+        ("path_y", "Path Lateral (Left +)", "m", lambda r: _series(r.path_y_m)),
+        ("speed", "Ball Speed", "m/s", lambda r: _series(r.speeds_mps)),
+        ("time", "Time", "s", lambda r: _series(r.times_s)),
+    ]
+    scalars: list[tuple[str, str, str, PuttingExtractor]] = [
+        ("rollout", "Roll-Out Distance", "m", lambda r: r.total_distance_m),
+        ("skid_distance", "Skid Distance", "m", lambda r: r.skid_distance_m),
+        ("skid_fraction", "Skid Fraction", "", lambda r: r.skid_fraction),
+        ("time_total", "Time To Rest", "s", lambda r: r.time_s),
+        ("break", "Break (Left +)", "m", lambda r: r.break_m),
+        ("holed", "Holed (1 = Yes)", "", lambda r: 1.0 if r.holed else 0.0),
+    ]
+    return [
+        PuttingVariableSpec(
+            key=f"putting.{name}",
+            label=label,
+            unit=unit,
+            extractor=extractor,
+            is_series=True,
+        )
+        for name, label, unit, extractor in series
+    ] + [
+        PuttingVariableSpec(
+            key=f"putting.{name}", label=label, unit=unit, extractor=extractor
+        )
+        for name, label, unit, extractor in scalars
+    ]
+
+
+#: The additive putting registry, keyed ``putting.<name>``.
+PUTTING_CATALOG: dict[str, PuttingVariableSpec] = {
+    spec.key: spec for spec in _entries()
+}
+ensure(len(PUTTING_CATALOG) == len(_entries()), "putting keys must be unique")
+
+
+def putting_catalog_keys() -> tuple[str, ...]:
+    """Stable key list, catalog order."""
+    return tuple(PUTTING_CATALOG)
+
+
+def extract_putting(result: PuttResult, key: str) -> np.ndarray | float:
+    """Extract one catalogued variable from a putt result.
+
+    Args:
+        result: An integrated putt.
+        key: A :data:`PUTTING_CATALOG` key.
+
+    Returns:
+        The variable value (array for series, float for scalars).
+
+    Raises:
+        ValueError: If the key is unknown.
+    """
+    require(key in PUTTING_CATALOG, f"unknown putting key {key!r}", key)
+    return PUTTING_CATALOG[key].extractor(result)

--- a/src/rate_of_closure/putting.py
+++ b/src/rate_of_closure/putting.py
@@ -1,0 +1,91 @@
+"""Putting bridge: library putters + putt explanations (#4125 H3).
+
+The physics lives in ``shared.python.swing_sim.putting`` (self-façaded
+subpackage); this module adapts it to the app: it maps the H1 club-
+library putters onto :class:`~shared.python.swing_sim.putting.PutterSpec`
+(falling back to the module's minimal specs when the library carries no
+putter), and owns the click-through explanations for the Putting tab's
+result rows in both UIs.
+"""
+
+from __future__ import annotations
+
+from rate_of_closure.club import CLUB_LIBRARY, ClubType
+from shared.python.swing_sim.putting import (
+    DEFAULT_PUTTER_COR,
+    MINIMAL_PUTTERS,
+    PutterSpec,
+)
+
+__all__ = ["PUTT_EXPLANATIONS", "putter_specs"]
+
+
+def putter_specs() -> dict[str, PutterSpec]:
+    """Selectable putters for the Putting tab.
+
+    Prefers the H1 club-library putters (``rate_of_closure.club``),
+    converted with the typical published putter-face COR; falls back
+    to the swing_sim minimal specs when the library carries none
+    (H1 reconciliation note in ``swing_sim.putting.impact``).
+
+    Returns:
+        Ordered display-name -> spec mapping, never empty.
+    """
+    library = {
+        spec.name: PutterSpec(
+            name=spec.name,
+            head_mass_kg=spec.head_mass_kg,
+            loft_deg=spec.loft_deg,
+            cor=DEFAULT_PUTTER_COR,
+        )
+        for spec in CLUB_LIBRARY.values()
+        if spec.club_type is ClubType.PUTTER
+    }
+    return library or dict(MINIMAL_PUTTERS)
+
+
+#: Click-through text behind every Putting result row (both UIs).
+PUTT_EXPLANATIONS: dict[str, str] = {
+    "putt_rollout_m": (
+        "How far the ball travels before stopping (or dropping). The "
+        "skid phase sheds speed at the sliding-friction rate, then "
+        "pure roll decelerates at the stimp-derived rolling rate — "
+        "faster greens (higher stimp) mean a lower rolling coefficient "
+        "and a longer roll-out for the same pace."
+    ),
+    "putt_skid_m": (
+        "Ground covered while the ball is still sliding rather than "
+        "rolling. A struck putt leaves the face with backspin, so "
+        "friction must first spin it up to pure roll; the transition "
+        "happens where ball speed equals surface spin speed (v = ωr)."
+    ),
+    "putt_skid_pct": (
+        "The skid distance as a share of the whole putt. Good strokes "
+        "keep this small — the classic no-spin result is that a "
+        "sliding ball reaches pure roll at 5/7 of its launch speed, "
+        "and more backspin extends the skid."
+    ),
+    "putt_time_s": (
+        "Elapsed time from impact until the ball stops or drops. "
+        "Rolling deceleration is constant on a uniform green, so time "
+        "grows linearly with the speed the roll phase starts at."
+    ),
+    "putt_break_m": (
+        "Lateral drift of the ball off the starting line (positive = "
+        "left), caused by the in-plane component of gravity on the "
+        "sloped green. Break grows fastest late in the putt, when the "
+        "ball is slow and gravity has proportionally more say."
+    ),
+    "putt_speed_at_hole_mps": (
+        "Ball speed when it first crosses the hole mouth. The putt "
+        "drops only if this is at or below the geometric capture "
+        "bound — a ball must fall half its diameter while crossing "
+        "the opening, which caps the speed the lip can swallow."
+    ),
+    "putt_margin": (
+        "Holed putts: how far under the capture-speed bound the ball "
+        "crossed the hole (bigger = more comfortable drop). Missed "
+        "putts: the distance from the ball's resting place back to "
+        "the hole — the length of the comebacker."
+    ),
+}

--- a/src/rate_of_closure/ui/pyqt6/main_window.py
+++ b/src/rate_of_closure/ui/pyqt6/main_window.py
@@ -47,6 +47,7 @@ from rate_of_closure.ui.pyqt6.derivation_view import DerivationView
 from rate_of_closure.ui.pyqt6.flight_explorer_tab import FlightExplorerTab
 from rate_of_closure.ui.pyqt6.glossary_tab import GlossaryTab
 from rate_of_closure.ui.pyqt6.plots_tab import PlotsTab
+from rate_of_closure.ui.pyqt6.putting_tab import PuttingTab
 from rate_of_closure.ui.pyqt6.result_row import ResultRow as _ResultRow
 from rate_of_closure.ui.pyqt6.result_row import (
     explanation_html,
@@ -124,6 +125,7 @@ _TAB_HELP_KEYS: tuple[str, ...] = (
     "simulation",
     "flight_explorer",
     "variation",
+    "putting",
     "glossary",
 )
 
@@ -156,6 +158,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         self._simulation_tab.runCompleted.connect(self._plots_tab.set_run)
         self._flight_explorer_tab = FlightExplorerTab()
         self._variation_tab = VariationTab()
+        self._putting_tab = PuttingTab()
         self._glossary_tab = GlossaryTab()
 
         left_content = QWidget()
@@ -182,6 +185,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         tabs.addTab(self._simulation_tab, "Simulation")
         tabs.addTab(self._flight_explorer_tab, "Flight Explorer")
         tabs.addTab(self._variation_tab, "Variation")
+        tabs.addTab(self._putting_tab, "Putting")
         tabs.addTab(self._glossary_tab, "Glossary")
         self._tabs = tabs
         # Per-tab help (#4120 V4): the '?' corner button opens detailed
@@ -210,6 +214,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         self._simulation_tab.glossaryRequested.connect(self.open_glossary)
         self._simulation_tab.configChanged.connect(self._derivation_view.set_config)
         self._flight_explorer_tab.glossaryRequested.connect(self.open_glossary)
+        self._putting_tab.glossaryRequested.connect(self.open_glossary)
         # Theming is applied by the shared launcher (setup_themed_app),
         # which also owns the single Theme menu — calling
         # setup_theme_support() here as well would add a duplicate.

--- a/src/rate_of_closure/ui/pyqt6/putting_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/putting_tab.py
@@ -1,0 +1,420 @@
+"""Putting tab — putter, stroke, green, roll-out (#4125 H3).
+
+Left: putter picker (H1 club-library putters via
+:func:`rate_of_closure.putting.putter_specs`), stroke pace (clubhead
+speed directly, or a backstroke length through the pendulum proxy),
+green conditions (stimp, grade, downhill aspect), hole distance, and
+clickable result rows with explanations. Right: a top-down green view
+(path colour-coded by skid/pure-roll phase, hole, downhill arrow) over
+a speed-vs-distance plot with the capture-speed bound marked.
+
+The physics lives in ``shared.python.swing_sim.putting``; this widget
+is presentation only. Distances are SI (metres) end to end through the
+single ``_format_m`` chokepoint, ready for the units-quantity pass
+(H6) to route through the shared conversion table.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+from matplotlib.patches import Circle
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
+    QFormLayout,
+    QFrame,
+    QGroupBox,
+    QScrollArea,
+    QSplitter,
+    QStackedWidget,
+    QTextBrowser,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rate_of_closure.putting import PUTT_EXPLANATIONS, putter_specs
+from rate_of_closure.ui.pyqt6.result_row import ResultRow, explanation_html
+from shared.python.swing_sim.putting import (
+    GreenConditions,
+    PuttResult,
+    capture_speed_mps,
+    clubhead_speed_from_backstroke,
+    simulate_putt,
+    strike,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["PuttingTab"]
+
+#: (result field, Title Case label) in display order; every field has
+#: a PUTT_EXPLANATIONS entry (contract-tested).
+_ROWS: tuple[tuple[str, str], ...] = (
+    ("putt_rollout_m", "Roll-Out Distance"),
+    ("putt_skid_m", "Skid Distance"),
+    ("putt_skid_pct", "Skid Share of Putt"),
+    ("putt_time_s", "Time To Rest"),
+    ("putt_break_m", "Break"),
+    ("putt_speed_at_hole_mps", "Speed At The Hole"),
+    ("putt_margin", "Holed / Miss Margin"),
+)
+
+
+class PuttingTab(QWidget):
+    """Interactive putting laboratory on a uniform sloped green."""
+
+    glossaryRequested = pyqtSignal(str)  # noqa: N815 - Qt signal style
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._putters = putter_specs()
+        self._rows: dict[str, ResultRow] = {}
+        self._result: PuttResult | None = None
+
+        left = QWidget()
+        left_layout = QVBoxLayout(left)
+        left_layout.addWidget(self._build_controls_box())
+        left_layout.addWidget(self._build_rows_box())
+        left_layout.addWidget(self._build_explanation_box())
+        left_layout.addStretch(1)
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        scroll.setWidget(left)
+        scroll.setMinimumWidth(300)
+
+        self._figure = Figure(figsize=(5.0, 6.0), layout="constrained")
+        self._canvas = FigureCanvas(self._figure)
+        self._canvas.setToolTip(
+            "Top-down green: orange = skid phase, green = pure roll, "
+            "black circle = hole, grey arrow = downhill. Below: ball "
+            "speed vs distance with the capture-speed bound at the hole."
+        )
+
+        splitter = QSplitter()
+        splitter.addWidget(scroll)
+        splitter.addWidget(self._canvas)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        layout = QVBoxLayout(self)
+        layout.addWidget(splitter)
+
+        self._recompute()
+        self._show_explanation(_ROWS[0][0])
+
+    # ── construction ────────────────────────────────────────────────
+    def _spin(
+        self,
+        low: float,
+        high: float,
+        value: float,
+        step: float,
+        suffix: str,
+        tooltip: str,
+        decimals: int = 2,
+    ) -> QDoubleSpinBox:
+        box = QDoubleSpinBox()
+        box.setRange(low, high)
+        box.setValue(value)
+        box.setSingleStep(step)
+        box.setDecimals(decimals)
+        box.setSuffix(suffix)
+        box.setToolTip(tooltip)
+        box.valueChanged.connect(self._recompute)
+        return box
+
+    def _build_controls_box(self) -> QGroupBox:
+        box = QGroupBox("Putt Setup")
+        form = QFormLayout(box)
+
+        self._putter_combo = QComboBox()
+        self._putter_combo.addItems(list(self._putters))
+        self._putter_combo.setToolTip(
+            "Putter head used for the impact model. Library putters "
+            "(H1 club library) when available; head mass and loft "
+            "drive the ball-speed transfer and launch spin."
+        )
+        self._putter_combo.currentTextChanged.connect(self._recompute)
+        form.addRow("Putter", self._putter_combo)
+
+        self._pace_mode = QComboBox()
+        self._pace_mode.addItems(["Clubhead speed", "Backstroke length"])
+        self._pace_mode.setToolTip(
+            "How the stroke pace is set: the head speed at impact "
+            "directly, or a pendulum backstroke length through "
+            "v = A·sqrt(g/L) (simple-pendulum proxy)."
+        )
+        form.addRow("Pace input", self._pace_mode)
+
+        self._speed_spin = self._spin(
+            0.2,
+            6.0,
+            1.8,
+            0.05,
+            " m/s",
+            "Clubhead speed at impact. Suggested range: 0.5-3 m/s for "
+            "putts inside 15 m. Source: pendulum-stroke kinematics "
+            "(swing_sim.putting.impact).",
+        )
+        self._backstroke_spin = self._spin(
+            5.0,
+            100.0,
+            30.0,
+            1.0,
+            " cm",
+            "Backstroke arc length; converted to head speed with the "
+            "simple-pendulum proxy v = A·sqrt(g/L). Suggested range: "
+            "10-60 cm. Source: swing_sim.putting.impact derivation.",
+            decimals=0,
+        )
+        self._pace_stack = QStackedWidget()
+        self._pace_stack.setToolTip(
+            "Stroke pace entry — switches with the pace-input mode."
+        )
+        for widget in (self._speed_spin, self._backstroke_spin):
+            holder = QWidget()
+            holder_layout = QVBoxLayout(holder)
+            holder_layout.setContentsMargins(0, 0, 0, 0)
+            holder_layout.addWidget(widget)
+            self._pace_stack.addWidget(holder)
+        self._pace_stack.setCurrentIndex(0)
+        self._pace_mode.currentIndexChanged.connect(self._pace_stack.setCurrentIndex)
+        self._pace_mode.currentIndexChanged.connect(self._recompute)
+        form.addRow("Stroke pace", self._pace_stack)
+
+        self._stimp_spin = self._spin(
+            4.0,
+            15.0,
+            10.0,
+            0.5,
+            " ft",
+            "Green speed as a stimpmeter reading. Suggested range: "
+            "7 (slow) - 13 (tournament fast). Source: USGA stimpmeter "
+            "geometry (swing_sim.putting.roll derivation).",
+            decimals=1,
+        )
+        form.addRow("Green speed (stimp)", self._stimp_spin)
+
+        self._grade_spin = self._spin(
+            0.0,
+            8.0,
+            0.0,
+            0.25,
+            " %",
+            "Uniform slope grade of the green. Suggested range: 0-4 % "
+            "(greens rarely exceed ~5 %). Source: course-architecture "
+            "norms (swing_sim.putting.green).",
+        )
+        form.addRow("Slope grade", self._grade_spin)
+
+        self._aspect_spin = self._spin(
+            -180.0,
+            180.0,
+            90.0,
+            5.0,
+            "°",
+            "Downhill direction relative to the putt line: 0° = "
+            "downhill straight ahead, +90° = low side on your left, "
+            "180° = uphill putt. Source: swing_sim.putting.green frame.",
+            decimals=0,
+        )
+        form.addRow("Downhill direction", self._aspect_spin)
+
+        self._distance_spin = self._spin(
+            0.5,
+            30.0,
+            3.0,
+            0.1,
+            " m",
+            "Distance from the ball to the hole centre along the "
+            "starting line. Suggested range: 1-15 m. Source: "
+            "swing_sim.putting.green.",
+            decimals=1,
+        )
+        form.addRow("Distance to hole", self._distance_spin)
+        return box
+
+    def _build_rows_box(self) -> QGroupBox:
+        box = QGroupBox("Putt Results")
+        layout = QVBoxLayout(box)
+        layout.setSpacing(4)
+        for field, label in _ROWS:
+            row = ResultRow(field, label)
+            row.setToolTip(
+                "Click for a plain-language explanation of this number "
+                "(with a glossary link)."
+            )
+            row.clicked.connect(self._show_explanation)
+            self._rows[field] = row
+            layout.addWidget(row)
+        return box
+
+    def _build_explanation_box(self) -> QGroupBox:
+        box = QGroupBox("What This Number Means")
+        layout = QVBoxLayout(box)
+        self._explanation = QTextBrowser()
+        self._explanation.setOpenExternalLinks(False)
+        self._explanation.setOpenLinks(False)
+        self._explanation.setToolTip(
+            "Explanation of the selected result row; the Glossary link "
+            "jumps to the matching term."
+        )
+        self._explanation.anchorClicked.connect(self._on_explanation_link)
+        self._explanation.setMinimumHeight(110)
+        self._explanation.setMaximumHeight(170)
+        layout.addWidget(self._explanation)
+        return box
+
+    # ── behaviour ───────────────────────────────────────────────────
+    def _show_explanation(self, field: str) -> None:
+        labels = dict(_ROWS)
+        for row_field, row in self._rows.items():
+            row.set_selected(row_field == field)
+        self._explanation.setHtml(
+            explanation_html(labels[field], PUTT_EXPLANATIONS[field], field)
+        )
+
+    def _on_explanation_link(self, url) -> None:  # type: ignore[no-untyped-def]
+        text = url.toString()
+        if text.startswith("glossary:"):
+            self.glossaryRequested.emit(text.partition(":")[2])
+
+    def _clubhead_speed(self) -> float:
+        if self._pace_mode.currentIndex() == 1:
+            putter_length_m = 0.889  # standard 35 in putter
+            return float(
+                clubhead_speed_from_backstroke(
+                    self._backstroke_spin.value() / 100.0, putter_length_m
+                )
+            )
+        return self._speed_spin.value()
+
+    @staticmethod
+    def _format_m(value: float) -> str:
+        """Single distance-format chokepoint (SI; H6 units pass hook)."""
+        return f"{value:.2f} m"
+
+    def result(self) -> PuttResult | None:
+        """The last computed putt (LoD seam for tests)."""
+        return self._result
+
+    def _recompute(self) -> None:
+        putter = self._putters[self._putter_combo.currentText()]
+        try:
+            launch = strike(putter, self._clubhead_speed())
+            green = GreenConditions(
+                stimp_ft=self._stimp_spin.value(),
+                grade_percent=self._grade_spin.value(),
+                aspect_deg=self._aspect_spin.value(),
+            )
+            result = simulate_putt(launch, green, self._distance_spin.value())
+        except ValueError:
+            logger.exception("putt inputs rejected")
+            return
+        self._result = result
+        self._update_rows(result)
+        self._redraw(result)
+
+    def _update_rows(self, result: PuttResult) -> None:
+        values = {
+            "putt_rollout_m": self._format_m(result.total_distance_m),
+            "putt_skid_m": self._format_m(result.skid_distance_m),
+            "putt_skid_pct": f"{100.0 * result.skid_fraction:.1f} %",
+            "putt_time_s": f"{result.time_s:.2f} s",
+            "putt_break_m": self._format_m(result.break_m),
+            "putt_speed_at_hole_mps": (
+                f"{result.speed_at_hole_mps:.2f} m/s"
+                if result.speed_at_hole_mps is not None
+                else "— (never reached)"
+            ),
+            "putt_margin": (
+                f"HOLED (+{result.margin_mps:.2f} m/s under bound)"
+                if result.holed and result.margin_mps is not None
+                else f"miss by {result.miss_distance_m:.2f} m"
+                if result.miss_distance_m is not None
+                else "—"
+            ),
+        }
+        for field, text in values.items():
+            self._rows[field].value_label.setText(text)
+
+    def _redraw(self, result: PuttResult) -> None:
+        self._figure.clear()
+        top, bottom = self._figure.subplots(
+            2, 1, height_ratios=[2.2, 1.0], sharex=False
+        )
+        hole_x = self._distance_spin.value()
+        split = result.skid_end_index
+        top.plot(
+            result.path_x_m[: split + 1],
+            result.path_y_m[: split + 1],
+            color="tab:orange",
+            linewidth=2.2,
+            label="Skid",
+        )
+        top.plot(
+            result.path_x_m[split:],
+            result.path_y_m[split:],
+            color="tab:green",
+            linewidth=2.2,
+            label="Pure roll",
+        )
+        top.add_patch(
+            Circle((hole_x, 0.0), 0.054, fill=False, color="black", linewidth=1.5)
+        )
+        grade = self._grade_spin.value()
+        if grade > 0.0:
+            aspect = math.radians(self._aspect_spin.value())
+            top.annotate(
+                "",
+                xy=(
+                    hole_x * 0.5 + 0.4 * math.cos(aspect),
+                    0.4 * math.sin(aspect),
+                ),
+                xytext=(hole_x * 0.5, 0.0),
+                arrowprops={"arrowstyle": "-|>", "color": "grey"},
+            )
+            top.text(
+                hole_x * 0.5,
+                0.05,
+                f"downhill {grade:.1f} %",
+                color="grey",
+                fontsize=8,
+            )
+        top.set_xlabel("Along putt line [m]")
+        top.set_ylabel("Lateral [m] (left +)")
+        top.set_title("Top-down green")
+        top.axis("equal")
+        top.legend(loc="best", fontsize=8)
+
+        distances = [0.0]
+        for i in range(1, len(result.path_x_m)):
+            step = math.hypot(
+                result.path_x_m[i] - result.path_x_m[i - 1],
+                result.path_y_m[i] - result.path_y_m[i - 1],
+            )
+            distances.append(distances[-1] + step)
+        bottom.plot(distances, result.speeds_mps, color="tab:blue")
+        bottom.axhline(
+            capture_speed_mps(),
+            color="tab:red",
+            linestyle="--",
+            linewidth=1.0,
+            label="Capture bound",
+        )
+        bottom.axvline(
+            distances[min(split, len(distances) - 1)],
+            color="tab:orange",
+            linestyle=":",
+            linewidth=1.0,
+            label="Skid → roll",
+        )
+        bottom.set_xlabel("Distance rolled [m]")
+        bottom.set_ylabel("Speed [m/s]")
+        bottom.legend(loc="best", fontsize=8)
+        self._canvas.draw_idle()

--- a/src/rate_of_closure/web/src/App.tsx
+++ b/src/rate_of_closure/web/src/App.tsx
@@ -14,6 +14,7 @@ import { useMemo, useState } from "react";
 import { ClubCanvas } from "./components/ClubCanvas";
 import { FlightExplorerPanel } from "./components/FlightExplorerPanel";
 import { PlotsPanel } from "./components/PlotsPanel";
+import { PuttingPanel } from "./components/PuttingPanel";
 import { SimulationPanel } from "./components/SimulationPanel";
 import { VariationPanel } from "./components/VariationPanel";
 import { ClubPanel } from "./components/ClubPanel";
@@ -134,6 +135,7 @@ const TABS = [
   "Plots",
   "Flight Explorer",
   "Variation",
+  "Putting",
   "Glossary",
 ] as const;
 
@@ -269,8 +271,15 @@ export default function App() {
         ))}
       </details>
 
-      {tab === TABS[6] ? (
+      {tab === TABS[7] ? (
         <GlossaryPanel key={glossaryTerm ?? "none"} initialTerm={glossaryTerm} />
+      ) : tab === TABS[6] ? (
+        <PuttingPanel
+          onGlossary={(term) => {
+            setGlossaryTerm(term);
+            setTab(TABS[7]);
+          }}
+        />
       ) : tab === TABS[5] ? (
         <VariationPanel />
       ) : tab === TABS[4] ? (

--- a/src/rate_of_closure/web/src/components/PuttingPanel.tsx
+++ b/src/rate_of_closure/web/src/components/PuttingPanel.tsx
@@ -1,0 +1,498 @@
+/**
+ * Putting tab (epic #4125, H3) — putter, stroke, green, roll-out.
+ *
+ * Physics in model/putting.ts (pinned test-for-test against Python).
+ * The SVG top-down green view adapts UI concepts from UpstreamDrift's
+ * `ui/src/pages/PuttingGreen.tsx` (SVG-only green, hole circle, path
+ * polyline) with the skid/pure-roll phases colour-coded per this
+ * app's model. Distances are SI metres end to end through the single
+ * `formatM` chokepoint (units-quantity pass, H6, hooks in there).
+ */
+
+import { useMemo, useState } from "react";
+
+import { CLUB_LIBRARY } from "../model/club";
+import { FIELD_TO_TERM } from "../model/glossary";
+import {
+  captureSpeedMps,
+  clubheadSpeedFromBackstroke,
+  MINIMAL_PUTTERS,
+  type PutterSpec,
+  DEFAULT_PUTTER_COR,
+  simulatePutt,
+  strike,
+} from "../model/putting";
+
+/** Library putters first (H1 reconciliation), minimal specs fallback. */
+function putterChoices(): PutterSpec[] {
+  const library = CLUB_LIBRARY.filter((c) => c.clubType === "Putter").map(
+    (c) => ({
+      name: c.name,
+      headMassKg: c.headMassKg,
+      loftDeg: c.loftDeg,
+      cor: DEFAULT_PUTTER_COR,
+    }),
+  );
+  return library.length > 0 ? library : MINIMAL_PUTTERS;
+}
+
+const ROWS: { key: string; label: string; explanation: string }[] = [
+  {
+    key: "puttRolloutM",
+    label: "Roll-Out Distance",
+    explanation:
+      "How far the ball travels before stopping (or dropping). The skid " +
+      "phase sheds speed at the sliding-friction rate, then pure roll " +
+      "decelerates at the stimp-derived rolling rate — faster greens mean " +
+      "a lower rolling coefficient and a longer roll-out for the same pace.",
+  },
+  {
+    key: "puttSkidM",
+    label: "Skid Distance",
+    explanation:
+      "Ground covered while the ball is still sliding rather than rolling. " +
+      "A struck putt leaves the face with backspin, so friction must first " +
+      "spin it up to pure roll; the transition happens where ball speed " +
+      "equals surface spin speed (v = ωr).",
+  },
+  {
+    key: "puttSkidPct",
+    label: "Skid Share of Putt",
+    explanation:
+      "The skid distance as a share of the whole putt. Good strokes keep " +
+      "this small — the classic no-spin result is pure roll at 5/7 of " +
+      "launch speed, and more backspin extends the skid.",
+  },
+  {
+    key: "puttTimeS",
+    label: "Time To Rest",
+    explanation:
+      "Elapsed time from impact until the ball stops or drops. Rolling " +
+      "deceleration is constant on a uniform green, so time grows linearly " +
+      "with the speed the roll phase starts at.",
+  },
+  {
+    key: "puttBreakM",
+    label: "Break",
+    explanation:
+      "Lateral drift of the ball off the starting line (positive = left), " +
+      "caused by the in-plane component of gravity on the sloped green. " +
+      "Break grows fastest late in the putt, when the ball is slow.",
+  },
+  {
+    key: "puttSpeedAtHoleMps",
+    label: "Speed At The Hole",
+    explanation:
+      "Ball speed when it first crosses the hole mouth. The putt drops " +
+      "only if this is at or below the geometric capture bound — the ball " +
+      "must fall half its diameter while crossing the opening.",
+  },
+  {
+    key: "puttMargin",
+    label: "Holed / Miss Margin",
+    explanation:
+      "Holed putts: how far under the capture-speed bound the ball crossed " +
+      "the hole. Missed putts: the distance from the ball's resting place " +
+      "back to the hole — the length of the comebacker.",
+  },
+];
+
+/** Single distance-format chokepoint (SI; H6 units pass hook). */
+function formatM(value: number): string {
+  return `${value.toFixed(2)} m`;
+}
+
+interface PuttingPanelProps {
+  onGlossary?: (term: string) => void;
+}
+
+export function PuttingPanel({ onGlossary }: PuttingPanelProps) {
+  const putters = useMemo(putterChoices, []);
+  const [putterName, setPutterName] = useState(putters[0].name);
+  const [paceMode, setPaceMode] = useState<"speed" | "backstroke">("speed");
+  const [speed, setSpeed] = useState(1.8);
+  const [backstrokeCm, setBackstrokeCm] = useState(30);
+  const [stimp, setStimp] = useState(10);
+  const [grade, setGrade] = useState(0);
+  const [aspect, setAspect] = useState(90);
+  const [distance, setDistance] = useState(3);
+  const [explained, setExplained] = useState(ROWS[0].key);
+
+  const result = useMemo(() => {
+    const putter =
+      putters.find((p) => p.name === putterName) ?? putters[0];
+    try {
+      const clubheadSpeed =
+        paceMode === "backstroke"
+          ? clubheadSpeedFromBackstroke(backstrokeCm / 100)
+          : speed;
+      return simulatePutt(
+        strike(putter, clubheadSpeed),
+        { stimpFt: stimp, gradePercent: grade, aspectDeg: aspect },
+        distance,
+      );
+    } catch {
+      return null;
+    }
+  }, [putters, putterName, paceMode, speed, backstrokeCm, stimp, grade, aspect, distance]);
+
+  const values: Record<string, string> = result
+    ? {
+        puttRolloutM: formatM(result.totalDistanceM),
+        puttSkidM: formatM(result.skidDistanceM),
+        puttSkidPct: `${(
+          (100 * result.skidDistanceM) /
+          Math.max(result.totalDistanceM, 1e-9)
+        ).toFixed(1)} %`,
+        puttTimeS: `${result.timeS.toFixed(2)} s`,
+        puttBreakM: formatM(result.breakM),
+        puttSpeedAtHoleMps:
+          result.speedAtHoleMps !== null
+            ? `${result.speedAtHoleMps.toFixed(2)} m/s`
+            : "— (never reached)",
+        puttMargin: result.holed
+          ? `HOLED (+${(result.marginMps ?? 0).toFixed(2)} m/s under bound)`
+          : `miss by ${(result.missDistanceM ?? 0).toFixed(2)} m`,
+      }
+    : {};
+  const explainedRow = ROWS.find((r) => r.key === explained) ?? ROWS[0];
+
+  const numberField = (
+    label: string,
+    value: number,
+    set: (v: number) => void,
+    step: number,
+    title: string,
+    suffix: string,
+  ) => (
+    <label className="mb-2 flex items-center justify-between gap-2 text-sm">
+      <span className="text-slate-300">{label}</span>
+      <span className="flex items-center gap-1">
+        <input
+          type="number"
+          value={value}
+          step={step}
+          title={title}
+          onChange={(e) => {
+            const next = Number(e.target.value);
+            if (Number.isFinite(next)) set(next);
+          }}
+          className="w-24 rounded border border-slate-700 bg-slate-800 px-2 py-1 text-right text-slate-100 focus:border-blue-500 focus:outline-none"
+        />
+        <span className="text-slate-400">{suffix}</span>
+      </span>
+    </label>
+  );
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[340px_1fr]">
+      <section aria-label="Putt setup" className="space-y-4">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5 shadow-lg shadow-black/20 backdrop-blur">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Putt Setup
+          </h2>
+          <label className="mb-2 flex items-center justify-between gap-2 text-sm">
+            <span className="text-slate-300">Putter</span>
+            <select
+              value={putterName}
+              title="Putter head used for the impact model (library putters when available); head mass and loft drive ball speed and launch spin"
+              onChange={(e) => setPutterName(e.target.value)}
+              className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-slate-100 focus:border-blue-500 focus:outline-none"
+            >
+              {putters.map((p) => (
+                <option key={p.name} value={p.name}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="mb-2 flex items-center justify-between gap-2 text-sm">
+            <span className="text-slate-300">Pace input</span>
+            <select
+              value={paceMode}
+              title="Set the stroke pace directly as clubhead speed, or as a pendulum backstroke length (v = A·sqrt(g/L))"
+              onChange={(e) =>
+                setPaceMode(e.target.value as "speed" | "backstroke")
+              }
+              className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-slate-100 focus:border-blue-500 focus:outline-none"
+            >
+              <option value="speed">Clubhead speed</option>
+              <option value="backstroke">Backstroke length</option>
+            </select>
+          </label>
+          {paceMode === "speed"
+            ? numberField(
+                "Clubhead speed",
+                speed,
+                setSpeed,
+                0.05,
+                "Clubhead speed at impact; 0.5-3 m/s covers putts inside 15 m (swing_sim.putting.impact)",
+                "m/s",
+              )
+            : numberField(
+                "Backstroke",
+                backstrokeCm,
+                setBackstrokeCm,
+                1,
+                "Backstroke arc length, converted with the simple-pendulum proxy v = A·sqrt(g/L); 10-60 cm typical",
+                "cm",
+              )}
+          {numberField(
+            "Green speed (stimp)",
+            stimp,
+            setStimp,
+            0.5,
+            "Stimpmeter reading; 7 slow - 13 tournament fast (USGA stimpmeter geometry, swing_sim.putting.roll)",
+            "ft",
+          )}
+          {numberField(
+            "Slope grade",
+            grade,
+            setGrade,
+            0.25,
+            "Uniform green slope grade; greens rarely exceed ~5 % (swing_sim.putting.green)",
+            "%",
+          )}
+          {numberField(
+            "Downhill direction",
+            aspect,
+            setAspect,
+            5,
+            "Downhill direction relative to the putt line: 0° ahead, +90° low side left, 180° uphill",
+            "°",
+          )}
+          {numberField(
+            "Distance to hole",
+            distance,
+            setDistance,
+            0.1,
+            "Ball-to-hole distance along the starting line; 1-15 m typical",
+            "m",
+          )}
+        </div>
+
+        <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5 shadow-lg shadow-black/20 backdrop-blur">
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-400">
+            Putt Results
+          </h2>
+          {ROWS.map((row) => (
+            <button
+              key={row.key}
+              type="button"
+              onClick={() => setExplained(row.key)}
+              aria-pressed={explained === row.key}
+              title={`Click for a plain-language explanation of ${row.label}`}
+              className={
+                "mb-1 flex w-full items-center justify-between rounded-lg border px-3 py-1.5 text-sm transition-all " +
+                (explained === row.key
+                  ? "border-sky-400/60 bg-sky-500/10 ring-1 ring-sky-400/40"
+                  : "border-slate-800 bg-slate-900/40 hover:border-slate-600")
+              }
+            >
+              <span className="text-slate-300">{row.label}</span>
+              <span className="font-semibold text-slate-100">
+                {values[row.key] ?? "—"}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <div
+          aria-label="Explanation"
+          className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5 text-sm shadow-lg shadow-black/20 backdrop-blur"
+        >
+          <h3 className="mb-1 font-semibold text-slate-200">
+            {explainedRow.label}
+          </h3>
+          <p className="text-slate-400">{explainedRow.explanation}</p>
+          <button
+            type="button"
+            title="Open the Glossary at the matching term"
+            onClick={() => onGlossary?.(FIELD_TO_TERM[explainedRow.key] ?? "")}
+            className="mt-2 text-sky-400 hover:text-sky-300"
+          >
+            Glossary
+          </button>
+        </div>
+      </section>
+
+      <section aria-label="Green view" className="space-y-4">
+        <GreenView result={result} holeX={distance} grade={grade} aspect={aspect} />
+        <SpeedPlot result={result} />
+      </section>
+    </div>
+  );
+}
+
+function GreenView({
+  result,
+  holeX,
+  grade,
+  aspect,
+}: {
+  result: ReturnType<typeof simulatePutt> | null;
+  holeX: number;
+  grade: number;
+  aspect: number;
+}) {
+  const width = 640;
+  const height = 320;
+  if (!result) {
+    return <p className="text-sm text-slate-400">Inputs out of range.</p>;
+  }
+  const xs = result.pathXM;
+  const ys = result.pathYM;
+  const maxX = Math.max(holeX + 0.5, ...xs) + 0.3;
+  const minX = Math.min(0, ...xs) - 0.3;
+  const spanY = Math.max(0.8, 2 * Math.max(...ys.map(Math.abs), 0.3));
+  const sx = (x: number) => ((x - minX) / (maxX - minX)) * width;
+  const sy = (y: number) => height / 2 - (y / spanY) * height;
+  const toPoints = (from: number, to: number) =>
+    xs
+      .slice(from, to)
+      .map((x, i) => `${sx(x).toFixed(1)},${sy(ys[from + i]).toFixed(1)}`)
+      .join(" ");
+  const split = result.skidEndIndex;
+  const arrowLen = 40;
+  const ax = sx(holeX * 0.5);
+  const ay = sy(0);
+  return (
+    <figure
+      aria-label="Top-down green view: skid phase orange, pure roll green, hole circle, downhill arrow"
+      className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-4 shadow-lg shadow-black/20 backdrop-blur"
+    >
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label="Putt path on the green"
+        className="w-full rounded-lg bg-emerald-950/60"
+      >
+        <polyline
+          points={toPoints(0, split + 1)}
+          fill="none"
+          stroke="#fb923c"
+          strokeWidth={3}
+        />
+        <polyline
+          points={toPoints(split, xs.length)}
+          fill="none"
+          stroke="#4ade80"
+          strokeWidth={3}
+        />
+        <circle
+          cx={sx(holeX)}
+          cy={sy(0)}
+          r={Math.max(5, (0.054 / (maxX - minX)) * width)}
+          fill="none"
+          stroke="#f8fafc"
+          strokeWidth={2}
+        />
+        <circle cx={sx(0)} cy={sy(0)} r={4} fill="#f8fafc" />
+        {grade > 0 && (
+          <g stroke="#94a3b8" strokeWidth={2}>
+            <line
+              x1={ax}
+              y1={ay}
+              x2={ax + arrowLen * Math.cos((aspect * Math.PI) / 180)}
+              y2={ay - arrowLen * Math.sin((aspect * Math.PI) / 180)}
+              markerEnd="url(#downhill-arrow)"
+            />
+            <defs>
+              <marker
+                id="downhill-arrow"
+                markerWidth="8"
+                markerHeight="8"
+                refX="6"
+                refY="3"
+                orient="auto"
+              >
+                <path d="M0,0 L6,3 L0,6 z" fill="#94a3b8" />
+              </marker>
+            </defs>
+          </g>
+        )}
+        {result.holed && (
+          <text
+            x={sx(holeX)}
+            y={sy(0) - 14}
+            textAnchor="middle"
+            fill="#4ade80"
+            fontSize="13"
+          >
+            HOLED
+          </text>
+        )}
+      </svg>
+      <figcaption className="mt-2 text-xs text-slate-400">
+        Orange = skid phase, green = pure roll; the circle is the hole, the
+        grey arrow points downhill. Left in the plot is the putt's left (+y).
+      </figcaption>
+    </figure>
+  );
+}
+
+function SpeedPlot({
+  result,
+}: {
+  result: ReturnType<typeof simulatePutt> | null;
+}) {
+  const width = 640;
+  const height = 180;
+  if (!result) return null;
+  const distances: number[] = [0];
+  for (let i = 1; i < result.pathXM.length; i++) {
+    distances.push(
+      distances[i - 1] +
+        Math.hypot(
+          result.pathXM[i] - result.pathXM[i - 1],
+          result.pathYM[i] - result.pathYM[i - 1],
+        ),
+    );
+  }
+  const maxD = Math.max(distances[distances.length - 1], 0.1);
+  const maxV = Math.max(...result.speedsMps, captureSpeedMps()) * 1.08;
+  const sx = (d: number) => (d / maxD) * (width - 20) + 10;
+  const sy = (v: number) => height - 16 - (v / maxV) * (height - 32);
+  const points = distances
+    .map((d, i) => `${sx(d).toFixed(1)},${sy(result.speedsMps[i]).toFixed(1)}`)
+    .join(" ");
+  const splitD = distances[Math.min(result.skidEndIndex, distances.length - 1)];
+  return (
+    <figure
+      aria-label="Ball speed versus distance with the capture-speed bound and the skid-to-roll transition marked"
+      className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-4 shadow-lg shadow-black/20 backdrop-blur"
+    >
+      <svg
+        viewBox={`0 0 ${width} ${height}`}
+        role="img"
+        aria-label="Speed vs distance plot"
+        className="w-full rounded-lg bg-slate-950/60"
+      >
+        <polyline points={points} fill="none" stroke="#38bdf8" strokeWidth={2.5} />
+        <line
+          x1={10}
+          x2={width - 10}
+          y1={sy(captureSpeedMps())}
+          y2={sy(captureSpeedMps())}
+          stroke="#f87171"
+          strokeWidth={1.5}
+          strokeDasharray="6 4"
+        />
+        <line
+          x1={sx(splitD)}
+          x2={sx(splitD)}
+          y1={12}
+          y2={height - 16}
+          stroke="#fb923c"
+          strokeWidth={1.5}
+          strokeDasharray="3 4"
+        />
+      </svg>
+      <figcaption className="mt-2 text-xs text-slate-400">
+        Blue: ball speed vs distance rolled. Red dashes: the capture-speed
+        bound the ball must be under at the hole. Orange dashes: skid → pure
+        roll transition.
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/rate_of_closure/web/src/components/hoverHints.test.tsx
+++ b/src/rate_of_closure/web/src/components/hoverHints.test.tsx
@@ -14,6 +14,7 @@ import { Derivation } from "./Derivation";
 import { FlightExplorerPanel } from "./FlightExplorerPanel";
 import { GlossaryPanel } from "./GlossaryPanel";
 import { PlotsPanel } from "./PlotsPanel";
+import { PuttingPanel } from "./PuttingPanel";
 import { SimulationPanel } from "./SimulationPanel";
 import { VariationPanel } from "./VariationPanel";
 
@@ -98,6 +99,11 @@ describe("hover-hint completeness", () => {
       />,
     );
     assertHints(container, "SimulationPanel");
+  });
+
+  it("PuttingPanel", () => {
+    const { container } = render(<PuttingPanel />);
+    assertHints(container, "PuttingPanel");
   });
 
   it("Derivation renders (read-only page, no unlabeled controls)", () => {

--- a/src/rate_of_closure/web/src/model/glossary.fixture.json
+++ b/src/rate_of_closure/web/src/model/glossary.fixture.json
@@ -1,10 +1,11 @@
 {
-  "schema": "rate_of_closure.glossary_fixture/1",
   "keys": [
     "apex",
     "attack_angle",
     "ball_speed",
+    "break",
     "bulge",
+    "capture_speed",
     "carry",
     "ccv",
     "cg_depth",
@@ -44,11 +45,13 @@
     "one_at_a_time_sensitivity",
     "pitch",
     "plane_inclination",
+    "pure_roll",
     "r_isa",
     "roll",
     "screw_axis",
     "seed",
     "sensitivity_analysis",
+    "skid",
     "smash_factor",
     "spearman",
     "spin_axis_tilt",
@@ -56,6 +59,7 @@
     "spin_loft",
     "spin_rate",
     "spv",
+    "stimp",
     "time_to_square",
     "triangular_distribution",
     "triple_pendulum",
@@ -87,6 +91,13 @@
     "maxHeightM": "apex",
     "flightTimeS": "flight_time",
     "landingAngleDeg": "landing_angle",
-    "lateralM": "lateral_offset"
+    "lateralM": "lateral_offset",
+    "puttRolloutM": "stimp",
+    "puttSkidM": "skid",
+    "puttSkidPct": "skid",
+    "puttTimeS": "pure_roll",
+    "puttBreakM": "break",
+    "puttSpeedAtHoleMps": "capture_speed",
+    "puttMargin": "capture_speed"
   }
 }

--- a/src/rate_of_closure/web/src/model/glossary.ts
+++ b/src/rate_of_closure/web/src/model/glossary.ts
@@ -9,13 +9,14 @@
 
 import { ENTRIES as ENTRIES_A_L } from "./glossaryEntriesAL";
 import { ENTRIES as ENTRIES_L_Z } from "./glossaryEntriesLZ";
+import { ENTRIES as ENTRIES_PUTTING } from "./glossaryEntriesPutting";
 import type { GlossaryEntry } from "./glossaryTypes";
 
 export type { GlossaryEntry } from "./glossaryTypes";
 
 /** Every term used across the app, keyed snake_case (Python parity). */
 export const GLOSSARY: Record<string, GlossaryEntry> = Object.fromEntries(
-  Object.entries({ ...ENTRIES_A_L, ...ENTRIES_L_Z }).sort(([a], [b]) =>
+  Object.entries({ ...ENTRIES_A_L, ...ENTRIES_L_Z, ...ENTRIES_PUTTING }).sort(([a], [b]) =>
     a < b ? -1 : a > b ? 1 : 0,
   ),
 );
@@ -47,6 +48,13 @@ export const FIELD_TO_TERM: Record<string, string> = {
   flightTimeS: "flight_time",
   landingAngleDeg: "landing_angle",
   lateralM: "lateral_offset",
+  puttRolloutM: "stimp",
+  puttSkidM: "skid",
+  puttSkidPct: "skid",
+  puttTimeS: "pure_roll",
+  puttBreakM: "break",
+  puttSpeedAtHoleMps: "capture_speed",
+  puttMargin: "capture_speed",
 };
 
 /** Glossary keys whose term or definition matches `query`. */

--- a/src/rate_of_closure/web/src/model/glossaryEntriesPutting.ts
+++ b/src/rate_of_closure/web/src/model/glossaryEntriesPutting.ts
@@ -1,0 +1,52 @@
+/**
+ * Glossary entry data for the Putting tab (#4125 H3) — see glossary.ts.
+ *
+ * Additive split module (500-LOC file budget pattern). Mirrors
+ * `src/rate_of_closure/glossary_entries_putting.py` key-for-key.
+ */
+
+import type { GlossaryEntry } from "./glossaryTypes";
+
+export const ENTRIES: Record<string, GlossaryEntry> = {
+  break: {
+    term: "Break",
+    definition:
+      "The lateral drift of a putt off its starting line, driven by the " +
+      "in-plane component of gravity on a sloped green. Most of the break " +
+      "accumulates late in the putt, when the ball is slowest " +
+      "(swing_sim.putting.green derivation).",
+  },
+  capture_speed: {
+    term: "Capture Speed",
+    definition:
+      "The fastest a ball can cross the hole and still drop: it must fall " +
+      "half its diameter while traversing the opening, giving roughly " +
+      "0.8-1.6 m/s depending on the crossing chord (geometric derivation " +
+      "in swing_sim.putting.green; Holmes, Am. J. Phys. 59, 1991).",
+  },
+  pure_roll: {
+    term: "Pure Roll",
+    definition:
+      "The rolling state where the ball's contact point is momentarily at " +
+      "rest — forward speed equals surface spin speed (v = ωr). From here " +
+      "only rolling resistance, set by the green speed, slows the ball " +
+      "(swing_sim.putting.roll derivation).",
+  },
+  skid: {
+    term: "Skid Phase",
+    definition:
+      "The opening stretch of a putt where the ball slides rather than " +
+      "rolls: struck with backspin, it is decelerated and spun up by " +
+      "sliding friction until v = ωr. With no initial spin the classic " +
+      "result is pure roll at 5/7 of launch speed " +
+      "(swing_sim.putting.roll derivation).",
+  },
+  stimp: {
+    term: "Stimp (Green Speed)",
+    definition:
+      "The stimpmeter reading in feet: how far a ball rolls out when " +
+      "released from the USGA's 36-inch ramp at 20 degrees (~1.83 m/s). " +
+      "Inverting the roll-out formula maps stimp to the green's rolling " +
+      "resistance, mu = v²/(2gS) (swing_sim.putting.roll derivation).",
+  },
+};

--- a/src/rate_of_closure/web/src/model/helptext.test.ts
+++ b/src/rate_of_closure/web/src/model/helptext.test.ts
@@ -15,6 +15,7 @@ const TABS = [
   "Plots",
   "Flight Explorer",
   "Variation",
+  "Putting",
   "Glossary",
 ] as const;
 

--- a/src/rate_of_closure/web/src/model/helptext.ts
+++ b/src/rate_of_closure/web/src/model/helptext.ts
@@ -120,6 +120,27 @@ export const HELP_TEXTS: Record<string, HelpEntry> = {
         "further analysis.",
     ],
   },
+  Putting: {
+    title: "How to Use This Page",
+    paragraphs: [
+      "A putting laboratory on a uniform sloped green. Pick a putter " +
+        "(the club-library putter by default), set the stroke pace — " +
+        "clubhead speed directly, or a backstroke length through the " +
+        "pendulum proxy v = A·sqrt(g/L) — then dial in the green: " +
+        "stimp (6 slow to 14 tournament fast), slope grade in percent, " +
+        "and the downhill direction relative to the putt line (+90° " +
+        "puts the low side on your left). Set the distance to the " +
+        "hole and everything recomputes live.",
+      "Read the result rows — roll-out, skid distance and share, time, " +
+        "break, speed at the hole, and holed/miss margin — and click " +
+        "any row for its plain-language explanation with glossary " +
+        "links. The top-down green view colour-codes the skid phase " +
+        "and the pure-roll phase along the path and marks the hole " +
+        "and the downhill direction; the speed-vs-distance plot " +
+        "shows the capture-speed bound the ball must be under when " +
+        "it crosses the hole to drop.",
+    ],
+  },
   Glossary: {
     title: "How to Use This Page",
     paragraphs: [

--- a/src/rate_of_closure/web/src/model/putting.test.ts
+++ b/src/rate_of_closure/web/src/model/putting.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Parity pins for the putting vertical (epic #4125, H3).
+ *
+ * The pinned reference putts mirror
+ * `tests/rate_of_closure/test_putting.py::TestReferencePuttPins`
+ * value-for-value — both sides use the same closed forms and the same
+ * fixed-step RK4 (dt = 2 ms), so tolerances are tight, not banded.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  captureSpeedMps,
+  clubheadSpeedFromBackstroke,
+  GOLF_BALL_RADIUS_M,
+  simulatePutt,
+  STIMP_RELEASE_SPEED_MPS,
+  stimpToRollingMu,
+  strike,
+} from "./putting";
+
+/** The H1 club-library putter (350 g, 3 deg, COR 0.78). */
+const PUTTER = {
+  name: "Putter",
+  headMassKg: 0.35,
+  loftDeg: 3.0,
+  cor: 0.78,
+};
+
+describe("strike — Python parity", () => {
+  it("pins the reference launch (1.8 m/s clubhead)", () => {
+    const launch = strike(PUTTER, 1.8);
+    expect(launch.ballSpeedMps).toBeCloseTo(2.828565312464848, 10);
+    expect(launch.launchAngleDeg).toBeCloseTo(3.5452147542505257, 8);
+    expect(launch.horizontalSpeedMps).toBeCloseTo(2.8231523192738344, 10);
+    expect(launch.spinRadS).toBeCloseTo(-3.153929533539754, 10);
+  });
+
+  it("zero loft gives a pure 1-D COR impulse", () => {
+    const launch = strike({ ...PUTTER, loftDeg: 0 }, 2.0);
+    const expected = (2.0 * 1.78 * 0.35) / (0.35 + 0.04593);
+    expect(launch.ballSpeedMps).toBeCloseTo(expected, 12);
+    expect(launch.spinRadS).toBeCloseTo(0, 12);
+  });
+
+  it("rejects out-of-range speeds", () => {
+    expect(() => strike(PUTTER, 0)).toThrow();
+    expect(() => strike(PUTTER, 2, -30)).toThrow();
+  });
+});
+
+describe("stimpmeter — Python parity", () => {
+  it("derives the quoted ~1.83 m/s release speed", () => {
+    expect(STIMP_RELEASE_SPEED_MPS).toBeCloseTo(1.8287317526214812, 10);
+  });
+
+  it("round-trips stimp through the roll-out formula", () => {
+    for (const stimp of [6, 10, 14]) {
+      const mu = stimpToRollingMu(stimp);
+      const rolloutFt =
+        (STIMP_RELEASE_SPEED_MPS * STIMP_RELEASE_SPEED_MPS) /
+        (2 * mu * 9.80665) /
+        0.3048;
+      expect(rolloutFt).toBeCloseTo(stimp, 10);
+    }
+  });
+
+  it("pins mu at stimp 10", () => {
+    expect(stimpToRollingMu(10)).toBeCloseTo(0.05594153480923128, 12);
+  });
+});
+
+describe("capture bound", () => {
+  it("pins R sqrt(g / 2r) ~= 0.82 m/s", () => {
+    expect(captureSpeedMps()).toBeCloseTo(0.8186396513958939, 12);
+    expect(GOLF_BALL_RADIUS_M).toBeCloseTo(0.021335, 6);
+  });
+});
+
+describe("simulatePutt — Python parity", () => {
+  it("pins the breaking reference putt (stimp 10, 2 %, aspect 90)", () => {
+    const launch = strike(PUTTER, 1.8);
+    const result = simulatePutt(
+      launch,
+      { stimpFt: 10, gradePercent: 2, aspectDeg: 90 },
+      3.0,
+    );
+    expect(result.holed).toBe(false);
+    expect(result.totalDistanceM).toBeCloseTo(4.417405938785078, 7);
+    expect(result.skidDistanceM).toBeCloseTo(0.5103817275162047, 7);
+    expect(result.timeS).toBeCloseTo(4.388, 2);
+    expect(result.breakM).toBeCloseTo(0.8176068791755766, 7);
+    expect(result.missDistanceM).toBeCloseTo(1.4994647284222105, 7);
+  });
+
+  it("pins the holed reference putt (1.6 m/s, flat stimp 10)", () => {
+    const launch = strike(PUTTER, 1.6);
+    const result = simulatePutt(
+      launch,
+      { stimpFt: 10, gradePercent: 0, aspectDeg: 0 },
+      3.0,
+    );
+    expect(result.holed).toBe(true);
+    expect(result.speedAtHoleMps).toBeCloseTo(0.5903262895096224, 7);
+    expect(result.marginMps).toBeCloseTo(0.2283133618862715, 7);
+  });
+
+  it("mirror aspect mirrors the break", () => {
+    const launch = strike(PUTTER, 2.0);
+    const left = simulatePutt(
+      launch,
+      { stimpFt: 10, gradePercent: 2, aspectDeg: 90 },
+      10,
+    );
+    const right = simulatePutt(
+      launch,
+      { stimpFt: 10, gradePercent: 2, aspectDeg: -90 },
+      10,
+    );
+    expect(left.breakM).toBeCloseTo(-right.breakM, 9);
+    expect(left.totalDistanceM).toBeCloseTo(right.totalDistanceM, 9);
+  });
+
+  it("speed is monotone non-increasing on a flat green", () => {
+    const result = simulatePutt(
+      strike(PUTTER, 2.0),
+      { stimpFt: 10, gradePercent: 0, aspectDeg: 0 },
+      10,
+    );
+    for (let i = 1; i < result.speedsMps.length; i++) {
+      expect(result.speedsMps[i]).toBeLessThanOrEqual(
+        result.speedsMps[i - 1] + 1e-12,
+      );
+    }
+  });
+
+  it("backstroke proxy matches the pendulum formula", () => {
+    expect(clubheadSpeedFromBackstroke(0.3)).toBeCloseTo(
+      0.3 * Math.sqrt(9.80665 / 0.889),
+      12,
+    );
+  });
+});

--- a/src/rate_of_closure/web/src/model/putting.ts
+++ b/src/rate_of_closure/web/src/model/putting.ts
@@ -1,0 +1,281 @@
+/**
+ * Putting vertical — TypeScript mirror of
+ * `shared/python/swing_sim/putting` (epic #4125, H3).
+ *
+ * Same derivations, same constants, same fixed-step RK4 (dt = 2 ms),
+ * so the vitest parity suite pins the Python reference putt
+ * value-for-value (`tests/rate_of_closure/test_putting.py`).
+ *
+ * Physics summary (full derivations in the Python docstrings):
+ * - Impact: 1-D COR impulse along the lofted face normal plus the 2/7
+ *   rolling-cap tangential transfer -> launch speed, angle, backspin.
+ * - Skid: sliding friction decelerates the ball and spins it up until
+ *   v = omega r (pure roll at (5 v0 + 2 omega0 r) / 7).
+ * - Green speed: the USGA stimpmeter (36 in ramp, 20 deg release,
+ *   ~1.83 m/s release speed) inverts to mu_r = v^2 / (2 g S).
+ * - Capture: the ball must fall half its diameter while crossing the
+ *   hole mouth -> v_capture = R sqrt(g / 2r) ~= 0.82 m/s.
+ */
+
+export const GRAVITY_M_S2 = 9.80665;
+export const GOLF_BALL_MASS_KG = 0.04593;
+export const GOLF_BALL_RADIUS_M = 0.04267 / 2.0;
+export const HOLE_RADIUS_M = 0.054;
+export const DEFAULT_PUTTER_COR = 0.78;
+export const DEFAULT_SLIDING_MU = 0.4;
+
+const FOOT_M = 0.3048;
+const ROLLING_CAP = 2.0 / 7.0;
+const DT_S = 0.002;
+const STOP_SPEED_MPS = 0.005;
+const MAX_TIME_S = 60.0;
+
+/** Stimpmeter release speed [m/s] — USGA ramp geometry derivation. */
+export const STIMP_RELEASE_SPEED_MPS = Math.sqrt(
+  (2.0 * GRAVITY_M_S2 * 0.762 * Math.sin((20.0 * Math.PI) / 180.0)) /
+    (1.0 + 2.0 / 5.0 / (0.87 * 0.87)),
+);
+
+export interface PutterSpec {
+  name: string;
+  headMassKg: number;
+  loftDeg: number;
+  cor: number;
+}
+
+/** H3-local minimal putters (H1 club-library reconciliation note). */
+export const MINIMAL_PUTTERS: PutterSpec[] = [
+  { name: "Blade Putter", headMassKg: 0.35, loftDeg: 3.0, cor: DEFAULT_PUTTER_COR },
+  { name: "Mallet Putter", headMassKg: 0.36, loftDeg: 3.0, cor: DEFAULT_PUTTER_COR },
+];
+
+export interface PuttLaunch {
+  ballSpeedMps: number;
+  launchAngleDeg: number;
+  horizontalSpeedMps: number;
+  /** Topspin positive; a struck putt starts negative (backspin). */
+  spinRadS: number;
+  effectiveLoftDeg: number;
+}
+
+/** Putter-ball impact (COR impulse + 2/7 tangential cap). */
+export function strike(
+  putter: PutterSpec,
+  clubheadSpeedMps: number,
+  shaftLeanDeg = 0.0,
+): PuttLaunch {
+  if (!(clubheadSpeedMps > 0 && clubheadSpeedMps <= 10)) {
+    throw new Error("clubheadSpeedMps must be in (0, 10]");
+  }
+  const effectiveLoftDeg = putter.loftDeg + shaftLeanDeg;
+  if (effectiveLoftDeg < -2 || effectiveLoftDeg > 15) {
+    throw new Error("effective loft must stay in [-2, 15] deg");
+  }
+  const delta = (effectiveLoftDeg * Math.PI) / 180.0;
+  const massRatio = putter.headMassKg / (putter.headMassKg + GOLF_BALL_MASS_KG);
+  const transfer = (1.0 + putter.cor) * massRatio;
+  const vNormal = transfer * clubheadSpeedMps * Math.cos(delta);
+  const uTangential = clubheadSpeedMps * Math.sin(delta);
+  const vTangential = ROLLING_CAP * uTangential;
+  const spinRadS = (-(1.0 - ROLLING_CAP) * uTangential) / GOLF_BALL_RADIUS_M;
+  const horizontal =
+    vNormal * Math.cos(delta) - vTangential * Math.sin(delta);
+  const vertical = vNormal * Math.sin(delta) + vTangential * Math.cos(delta);
+  return {
+    ballSpeedMps: Math.hypot(horizontal, vertical),
+    launchAngleDeg: (Math.atan2(vertical, horizontal) * 180.0) / Math.PI,
+    horizontalSpeedMps: horizontal,
+    spinRadS,
+    effectiveLoftDeg,
+  };
+}
+
+/** Pendulum backstroke proxy: v = A sqrt(g / L). */
+export function clubheadSpeedFromBackstroke(
+  backstrokeM: number,
+  putterLengthM = 0.889,
+): number {
+  if (!(backstrokeM > 0 && backstrokeM <= 1.5)) {
+    throw new Error("backstrokeM must be in (0, 1.5]");
+  }
+  return backstrokeM * Math.sqrt(GRAVITY_M_S2 / putterLengthM);
+}
+
+/** Stimp [ft] -> rolling-resistance coefficient. */
+export function stimpToRollingMu(stimpFt: number): number {
+  if (!(stimpFt >= 3 && stimpFt <= 16)) {
+    throw new Error("stimpFt must be in [3, 16]");
+  }
+  return (
+    (STIMP_RELEASE_SPEED_MPS * STIMP_RELEASE_SPEED_MPS) /
+    (2.0 * GRAVITY_M_S2 * stimpFt * FOOT_M)
+  );
+}
+
+/** Geometric lip-capture bound: R sqrt(g / 2r) ~= 0.82 m/s. */
+export function captureSpeedMps(): number {
+  return HOLE_RADIUS_M * Math.sqrt(GRAVITY_M_S2 / (2.0 * GOLF_BALL_RADIUS_M));
+}
+
+export interface GreenConditions {
+  stimpFt: number;
+  gradePercent: number;
+  /** Downhill direction, CCW from the putt line [deg]. */
+  aspectDeg: number;
+  muSlide?: number;
+}
+
+export interface PuttResult {
+  pathXM: number[];
+  pathYM: number[];
+  speedsMps: number[];
+  timesS: number[];
+  skidEndIndex: number;
+  skidDistanceM: number;
+  totalDistanceM: number;
+  timeS: number;
+  breakM: number;
+  holed: boolean;
+  speedAtHoleMps: number | null;
+  marginMps: number | null;
+  missDistanceM: number | null;
+}
+
+type State = [number, number, number, number, number];
+
+function derivative(
+  state: State,
+  sliding: boolean,
+  muSlide: number,
+  muRoll: number,
+  gPar: [number, number],
+): State {
+  const [, , vx, vy] = state;
+  const speed = Math.hypot(vx, vy);
+  if (speed <= 0) return [0, 0, gPar[0], gPar[1], 0];
+  const mu = sliding ? muSlide : muRoll;
+  return [
+    vx,
+    vy,
+    (-mu * GRAVITY_M_S2 * vx) / speed + gPar[0],
+    (-mu * GRAVITY_M_S2 * vy) / speed + gPar[1],
+    sliding ? 2.5 * muSlide * GRAVITY_M_S2 : 0,
+  ];
+}
+
+function rk4Step(
+  state: State,
+  sliding: boolean,
+  muSlide: number,
+  muRoll: number,
+  gPar: [number, number],
+): State {
+  const k1 = derivative(state, sliding, muSlide, muRoll, gPar);
+  const mid1 = state.map((s, i) => s + 0.5 * DT_S * k1[i]) as State;
+  const k2 = derivative(mid1, sliding, muSlide, muRoll, gPar);
+  const mid2 = state.map((s, i) => s + 0.5 * DT_S * k2[i]) as State;
+  const k3 = derivative(mid2, sliding, muSlide, muRoll, gPar);
+  const end = state.map((s, i) => s + DT_S * k3[i]) as State;
+  const k4 = derivative(end, sliding, muSlide, muRoll, gPar);
+  return state.map(
+    (s, i) => s + (DT_S / 6.0) * (k1[i] + 2 * k2[i] + 2 * k3[i] + k4[i]),
+  ) as State;
+}
+
+/** Integrate one putt on a uniform sloped green (Python parity). */
+export function simulatePutt(
+  launch: PuttLaunch,
+  green: GreenConditions,
+  holeDistanceM: number,
+): PuttResult {
+  if (!(holeDistanceM >= 0.1 && holeDistanceM <= 40)) {
+    throw new Error("holeDistanceM must be in [0.1, 40]");
+  }
+  if (!(launch.horizontalSpeedMps > 0)) {
+    throw new Error("putt must start moving");
+  }
+  const muSlide = green.muSlide ?? DEFAULT_SLIDING_MU;
+  const muRoll = stimpToRollingMu(green.stimpFt);
+  const aspect = (green.aspectDeg * Math.PI) / 180.0;
+  const grade = green.gradePercent / 100.0;
+  const gPar: [number, number] = [
+    GRAVITY_M_S2 * grade * Math.cos(aspect),
+    GRAVITY_M_S2 * grade * Math.sin(aspect),
+  ];
+  const vCapture = captureSpeedMps();
+
+  let state: State = [
+    0,
+    0,
+    launch.horizontalSpeedMps,
+    0,
+    launch.spinRadS * GOLF_BALL_RADIUS_M,
+  ];
+  let sliding = state[4] < state[2];
+  const xs = [0];
+  const ys = [0];
+  const speeds = [launch.horizontalSpeedMps];
+  const times = [0];
+  let distance = 0;
+  let skidDistance = 0;
+  let skidEndIndex = sliding ? -1 : 0;
+  let holed = false;
+  let speedAtHole: number | null = null;
+  let time = 0;
+
+  while (time < MAX_TIME_S) {
+    const prev = state;
+    state = rk4Step(state, sliding, muSlide, muRoll, gPar);
+    time += DT_S;
+    const step = Math.hypot(state[0] - prev[0], state[1] - prev[1]);
+    distance += step;
+    const speed = Math.hypot(state[2], state[3]);
+    if (sliding) {
+      skidDistance += step;
+      if (state[4] >= speed) {
+        sliding = false;
+        skidEndIndex = xs.length;
+      }
+    }
+    xs.push(state[0]);
+    ys.push(state[1]);
+    speeds.push(speed);
+    times.push(time);
+    const toHole = Math.hypot(state[0] - holeDistanceM, state[1]);
+    if (toHole <= HOLE_RADIUS_M) {
+      if (speedAtHole === null) speedAtHole = speed;
+      if (speed <= vCapture) {
+        holed = true;
+        break;
+      }
+    }
+    if (speed <= STOP_SPEED_MPS) break;
+  }
+
+  if (skidEndIndex < 0) skidEndIndex = xs.length - 1;
+  let missDistance: number | null = null;
+  let margin: number | null = null;
+  if (holed && speedAtHole !== null) {
+    margin = vCapture - speedAtHole;
+  } else {
+    missDistance = Math.hypot(
+      xs[xs.length - 1] - holeDistanceM,
+      ys[ys.length - 1],
+    );
+  }
+  return {
+    pathXM: xs,
+    pathYM: ys,
+    speedsMps: speeds,
+    timesS: times,
+    skidEndIndex,
+    skidDistanceM: skidDistance,
+    totalDistanceM: distance,
+    timeS: time,
+    breakM: ys[ys.length - 1],
+    holed,
+    speedAtHoleMps: speedAtHole,
+    marginMps: margin,
+    missDistanceM: missDistance,
+  };
+}

--- a/src/shared/python/swing_sim/putting/__init__.py
+++ b/src/shared/python/swing_sim/putting/__init__.py
@@ -1,0 +1,78 @@
+"""Putting vertical for swing_sim (epic #4125, H3).
+
+Self-façaded: downstream code imports from
+``shared.python.swing_sim.putting`` only. The parent
+``swing_sim/__init__.py`` façade is wired up during epic integration;
+do not add putting exports there from this subpackage (same policy as
+``swing_sim.impact`` and ``swing_sim.variation``).
+
+The package covers the full putt: putter-ball impact
+(:mod:`.impact` — low-speed impulse with loft, the 2/7 rolling-cap
+tangential transfer, and putter-face COR), the skid → pure-roll model
+with stimpmeter-derived green-speed parameterization (:mod:`.roll`),
+and a planar sloped green with trajectory integration, break, and a
+geometric lip-capture condition (:mod:`.green`).
+
+Overlap review (surveyed before building, per the epic): the ideas
+adopted from UpstreamDrift's putting assets are credited inline —
+the stimp-as-friction parameterization concept and the putter COR
+0.78 default follow ``src/engines/physics_engines/putting_green``
+and ``rust_core/upstream-physics/src/contact.rs``; the explicit
+SLIDING/ROLLING mode machine follows ``ball_roll_physics.py``. All
+derivations here are re-done from first principles in the module
+docstrings (this package shares no code with UpstreamDrift).
+
+Putter specs: :data:`~.impact.MINIMAL_PUTTERS` are deliberately
+minimal H3-local specs, clearly marked for reconciliation with the H1
+club-library putters (epic #4125 H1); UIs should prefer library
+putters when present and fall back to these.
+"""
+
+from __future__ import annotations
+
+from .green import (
+    HOLE_RADIUS_M,
+    GreenConditions,
+    PuttResult,
+    capture_speed_mps,
+    simulate_putt,
+)
+from .impact import (
+    DEFAULT_PUTTER_COR,
+    MINIMAL_PUTTERS,
+    PutterSpec,
+    PuttLaunch,
+    clubhead_speed_from_backstroke,
+    strike,
+)
+from .roll import (
+    DEFAULT_SLIDING_MU,
+    STIMP_RELEASE_SPEED_MPS,
+    SkidSolution,
+    roll_out_distance,
+    roll_time_s,
+    rolling_mu_to_stimp,
+    solve_skid,
+    stimp_to_rolling_mu,
+)
+
+__all__ = [
+    "DEFAULT_PUTTER_COR",
+    "DEFAULT_SLIDING_MU",
+    "HOLE_RADIUS_M",
+    "MINIMAL_PUTTERS",
+    "STIMP_RELEASE_SPEED_MPS",
+    "GreenConditions",
+    "PuttLaunch",
+    "PuttResult",
+    "PutterSpec",
+    "SkidSolution",
+    "capture_speed_mps",
+    "clubhead_speed_from_backstroke",
+    "roll_out_distance",
+    "roll_time_s",
+    "rolling_mu_to_stimp",
+    "simulate_putt",
+    "solve_skid",
+    "stimp_to_rolling_mu",
+]

--- a/src/shared/python/swing_sim/putting/green.py
+++ b/src/shared/python/swing_sim/putting/green.py
@@ -1,0 +1,341 @@
+"""Planar sloped green: putt trajectory, break, capture (#4125, H3).
+
+Green model
+-----------
+A plane of uniform slope described by a grade (percent rise) and an
+aspect (the compass direction the green falls toward, measured
+counter-clockwise from the initial putt line; 0 = downhill straight
+ahead, +90 = downhill to the putt's left). Frame: x = initial putt
+line, y = left of the putt line, both in the green plane. Small-angle
+(grades are a few percent), so the in-plane gravity component is::
+
+    g_par = g * (grade / 100) * (cos(aspect), sin(aspect))
+
+ODE and integration
+-------------------
+State ``(x, y, vx, vy, s)`` where ``s = omega r`` is the ball's
+contact-surface speed along its direction of travel (documented
+simplification: the spin axis stays perpendicular to the velocity —
+exact for straight putts, first-order accurate for the small break
+angles of real putts). Two modes, following the skid -> roll
+derivation in :mod:`.roll`:
+
+* **Skid** (``s < |v|``): sliding friction opposes the slip;
+  ``dv/dt = -mu_k g v_hat + g_par``, ``ds/dt = +(5/2) mu_k g``.
+* **Pure roll** (``s >= |v|``): rolling resistance;
+  ``dv/dt = -mu_r g v_hat + g_par`` with ``s`` pinned to ``|v|``.
+
+Classic RK4 with a fixed step, mode held constant within a step and
+transitions applied between steps (the mode functions are smooth
+within a phase; at ``dt = 2 ms`` the transition error is sub-mm).
+The integrator is fully deterministic — the TypeScript mirror pins
+its output value-for-value.
+
+Lip capture (first principles)
+------------------------------
+The ball is supported by turf until its contact point — directly
+below its center — crosses the hole rim, i.e. until its center is
+within the hole radius ``R`` (USGA hole: 4.25 in diameter,
+``R = 0.054 m``). It is then in free fall, and is captured if it
+drops far enough to strike the far wall below its equator before
+crossing. Assumptions (documented): center-line pass, drop of half a
+ball diameter ``r`` needed, horizontal travel budget of one hole
+radius ``R``. Free fall covers ``r`` in ``t = sqrt(2 r / g)``, so::
+
+    v_capture = R * sqrt(g / (2 r)) ~= 0.82 m/s
+
+This is the conservative end of the published range: Holmes,
+"Putting: How a golf ball and hole interact", Am. J. Phys. 59 (1991)
+derives up to ~1.6 m/s for a perfectly centered pass (a travel budget
+of the full diameter). Off-center passes reduce the budget, so the
+radius-budget bound is used here as a representative capture proxy.
+A ball that crosses the hole faster than the bound rolls on
+(simplification: no lip-out deflection is modeled).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from shared.python.contracts import ensure, require, require_finite
+from shared.python.swing_sim.impact import GOLF_BALL_RADIUS_M
+
+from .impact import PuttLaunch
+from .roll import DEFAULT_SLIDING_MU, GRAVITY_M_S2, stimp_to_rolling_mu
+
+__all__ = [
+    "HOLE_RADIUS_M",
+    "GreenConditions",
+    "PuttResult",
+    "capture_speed_mps",
+    "simulate_putt",
+]
+
+#: USGA hole radius [m] (4.25 in diameter).
+HOLE_RADIUS_M = 0.054
+
+#: Integration step [s]; pinned by the TS parity tests.
+_DT_S = 0.002
+
+#: Rest threshold [m/s].
+_STOP_SPEED_MPS = 0.005
+
+#: Integration time cap [s].
+_MAX_TIME_S = 60.0
+
+
+def capture_speed_mps() -> float:
+    """Geometric lip-capture speed bound (module derivation).
+
+    Returns:
+        ``R * sqrt(g / (2 r))`` [m/s], ~0.82.
+    """
+    return HOLE_RADIUS_M * math.sqrt(GRAVITY_M_S2 / (2.0 * GOLF_BALL_RADIUS_M))
+
+
+@dataclass(frozen=True)
+class GreenConditions:
+    """Uniform planar green.
+
+    Attributes:
+        stimp_ft: Stimpmeter reading [feet] (green speed).
+        grade_percent: Uniform slope grade [%]; 0-8 covers greens.
+        aspect_deg: Downhill direction, CCW from the putt line [deg];
+            0 = downhill ahead, +90 = downhill to the left.
+        mu_slide: Sliding friction for the skid phase.
+    """
+
+    stimp_ft: float
+    grade_percent: float = 0.0
+    aspect_deg: float = 0.0
+    mu_slide: float = DEFAULT_SLIDING_MU
+
+    def __post_init__(self) -> None:
+        # stimp range is validated by stimp_to_rolling_mu.
+        stimp_to_rolling_mu(self.stimp_ft)
+        require_finite(self.grade_percent, "grade_percent")
+        require(
+            0.0 <= self.grade_percent <= 10.0,
+            "grade must be in [0, 10] percent",
+            self.grade_percent,
+        )
+        require_finite(self.aspect_deg, "aspect_deg")
+        require(
+            -360.0 <= self.aspect_deg <= 360.0,
+            "aspect must be in [-360, 360] deg",
+            self.aspect_deg,
+        )
+        require_finite(self.mu_slide, "mu_slide")
+        require(
+            0.0 < self.mu_slide <= 1.5,
+            "mu_slide must be in (0, 1.5]",
+            self.mu_slide,
+        )
+
+
+@dataclass(frozen=True)
+class PuttResult:
+    """One integrated putt.
+
+    Attributes:
+        path_x_m: Sampled x positions [m] (putt-line axis).
+        path_y_m: Sampled y positions [m] (left positive).
+        speeds_mps: Sampled speeds [m/s].
+        times_s: Sample times [s].
+        skid_end_index: First sample index in pure roll.
+        skid_distance_m: Ground covered while skidding [m].
+        total_distance_m: Total ground covered [m].
+        time_s: Time to rest or capture [s].
+        break_m: Final lateral displacement [m], left positive.
+        holed: Whether the ball was captured.
+        speed_at_hole_mps: Speed when first crossing the hole mouth
+            [m/s]; None when the ball never crossed it.
+        margin_mps: When holed, capture-bound minus crossing speed
+            [m/s]; None otherwise.
+        miss_distance_m: When missed, rest-to-hole distance [m];
+            None when holed.
+    """
+
+    path_x_m: tuple[float, ...]
+    path_y_m: tuple[float, ...]
+    speeds_mps: tuple[float, ...]
+    times_s: tuple[float, ...]
+    skid_end_index: int
+    skid_distance_m: float
+    total_distance_m: float
+    time_s: float
+    break_m: float
+    holed: bool
+    speed_at_hole_mps: float | None
+    margin_mps: float | None
+    miss_distance_m: float | None
+
+    @property
+    def skid_fraction(self) -> float:
+        """Skid distance as a fraction of the total distance."""
+        if self.total_distance_m <= 0.0:
+            return 0.0
+        return self.skid_distance_m / self.total_distance_m
+
+
+def _derivative(
+    state: tuple[float, float, float, float, float],
+    sliding: bool,
+    mu_slide: float,
+    mu_roll: float,
+    g_par: tuple[float, float],
+) -> tuple[float, float, float, float, float]:
+    """Right-hand side of the putt ODE (see module docstring)."""
+    _x, _y, vx, vy, _s = state
+    speed = math.hypot(vx, vy)
+    if speed <= 0.0:
+        return (0.0, 0.0, g_par[0], g_par[1], 0.0)
+    mu = mu_slide if sliding else mu_roll
+    ax = -mu * GRAVITY_M_S2 * vx / speed + g_par[0]
+    ay = -mu * GRAVITY_M_S2 * vy / speed + g_par[1]
+    ds = 2.5 * mu_slide * GRAVITY_M_S2 if sliding else 0.0
+    return (vx, vy, ax, ay, ds)
+
+
+def _rk4_step(
+    state: tuple[float, float, float, float, float],
+    sliding: bool,
+    mu_slide: float,
+    mu_roll: float,
+    g_par: tuple[float, float],
+) -> tuple[float, float, float, float, float]:
+    """One classic RK4 step with the mode held constant."""
+    k1 = _derivative(state, sliding, mu_slide, mu_roll, g_par)
+    mid1 = tuple(s + 0.5 * _DT_S * k for s, k in zip(state, k1, strict=True))
+    k2 = _derivative(mid1, sliding, mu_slide, mu_roll, g_par)  # type: ignore[arg-type]
+    mid2 = tuple(s + 0.5 * _DT_S * k for s, k in zip(state, k2, strict=True))
+    k3 = _derivative(mid2, sliding, mu_slide, mu_roll, g_par)  # type: ignore[arg-type]
+    end = tuple(s + _DT_S * k for s, k in zip(state, k3, strict=True))
+    k4 = _derivative(end, sliding, mu_slide, mu_roll, g_par)  # type: ignore[arg-type]
+    return tuple(  # type: ignore[return-value]
+        s + (_DT_S / 6.0) * (a + 2.0 * b + 2.0 * c + d)
+        for s, a, b, c, d in zip(state, k1, k2, k3, k4, strict=True)
+    )
+
+
+def simulate_putt(
+    launch: PuttLaunch,
+    green: GreenConditions,
+    hole_distance_m: float,
+) -> PuttResult:
+    """Integrate one putt on the planar green.
+
+    The ball starts at the origin aimed along +x with the hole at
+    ``(hole_distance_m, 0)``. Vertical launch motion is folded into
+    the ground speed (documented simplification: at ~3 deg effective
+    loft the airborne hop is a few millimetres and carries < 0.5 % of
+    the energy).
+
+    Args:
+        launch: Post-impact ball state from :func:`~.impact.strike`.
+        green: Green conditions.
+        hole_distance_m: Distance to the hole center [m].
+
+    Returns:
+        The integrated :class:`PuttResult`.
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require_finite(hole_distance_m, "hole_distance_m")
+    require(
+        0.1 <= hole_distance_m <= 40.0,
+        "hole distance must be in [0.1, 40] m",
+        hole_distance_m,
+    )
+    require(
+        launch.horizontal_speed_mps > 0.0,
+        "putt must start moving",
+        launch.horizontal_speed_mps,
+    )
+
+    mu_roll = stimp_to_rolling_mu(green.stimp_ft)
+    aspect = math.radians(green.aspect_deg)
+    grade = green.grade_percent / 100.0
+    g_par = (
+        GRAVITY_M_S2 * grade * math.cos(aspect),
+        GRAVITY_M_S2 * grade * math.sin(aspect),
+    )
+    v_capture = capture_speed_mps()
+
+    state = (
+        0.0,
+        0.0,
+        launch.horizontal_speed_mps,
+        0.0,
+        launch.spin_rad_s * GOLF_BALL_RADIUS_M,
+    )
+    sliding = state[4] < state[2]
+    xs = [0.0]
+    ys = [0.0]
+    speeds = [launch.horizontal_speed_mps]
+    times = [0.0]
+    distance = 0.0
+    skid_distance = 0.0
+    skid_end_index = 0 if not sliding else -1
+    holed = False
+    speed_at_hole: float | None = None
+    time = 0.0
+
+    while time < _MAX_TIME_S:
+        prev = state
+        state = _rk4_step(state, sliding, green.mu_slide, mu_roll, g_par)
+        time += _DT_S
+        step = math.hypot(state[0] - prev[0], state[1] - prev[1])
+        distance += step
+        speed = math.hypot(state[2], state[3])
+        if sliding:
+            skid_distance += step
+            if state[4] >= speed:
+                sliding = False
+                skid_end_index = len(xs)
+        xs.append(state[0])
+        ys.append(state[1])
+        speeds.append(speed)
+        times.append(time)
+        to_hole = math.hypot(state[0] - hole_distance_m, state[1])
+        if to_hole <= HOLE_RADIUS_M:
+            if speed_at_hole is None:
+                speed_at_hole = speed
+            if speed <= v_capture:
+                holed = True
+                break
+        if speed <= _STOP_SPEED_MPS:
+            break
+
+    if skid_end_index < 0:  # never transitioned (stopped while sliding)
+        skid_end_index = len(xs) - 1
+    miss_distance = None
+    margin = None
+    if holed and speed_at_hole is not None:
+        margin = v_capture - speed_at_hole
+    else:
+        miss_distance = math.hypot(xs[-1] - hole_distance_m, ys[-1])
+
+    ensure(distance >= 0.0, "distance must be non-negative", distance)
+    ensure(
+        skid_distance <= distance + 1e-9,
+        "skid cannot exceed the total roll",
+        (skid_distance, distance),
+    )
+    return PuttResult(
+        path_x_m=tuple(xs),
+        path_y_m=tuple(ys),
+        speeds_mps=tuple(speeds),
+        times_s=tuple(times),
+        skid_end_index=skid_end_index,
+        skid_distance_m=skid_distance,
+        total_distance_m=distance,
+        time_s=time,
+        break_m=ys[-1],
+        holed=holed,
+        speed_at_hole_mps=speed_at_hole,
+        margin_mps=margin,
+        miss_distance_m=miss_distance,
+    )

--- a/src/shared/python/swing_sim/putting/impact.py
+++ b/src/shared/python/swing_sim/putting/impact.py
@@ -1,0 +1,262 @@
+"""Putter-ball impact: low-speed impulse with loft (epic #4125, H3).
+
+Model
+-----
+The putter face is a plane tilted back from vertical by the effective
+loft ``delta`` (static loft plus shaft lean; ~3 degrees for putters).
+The head travels horizontally at ``v`` through a sub-millisecond
+contact, so gravity and the turf reaction are ignored during contact
+(documented assumption; contact ~0.5 ms, gravity changes speeds by
+~0.005 m/s over that window).
+
+Decompose along the face normal ``n = (cos d, sin d)`` and the
+in-face tangential (up-the-face) direction ``t = (-sin d, cos d)``
+in the vertical putt plane (x = putt line, y = up):
+
+* **Normal**: 1-D impulse-momentum with coefficient of restitution
+  ``e`` between a free head of mass ``M`` and ball of mass ``m``::
+
+      v_ball_n = v cos d * (1 + e) * M / (M + m)
+
+  Putter-face COR at putt speeds: 0.78 is the typical published value
+  for a steel putter face (also the default in UpstreamDrift's
+  ``putter_stroke.py`` and the green-contact default in its
+  ``contact.rs``); milled/insert faces span roughly 0.73-0.82.
+
+* **Tangential**: the face surface moves up-the-face relative to the
+  ball at ``u = v sin d``. Sliding friction acts on the ball's contact
+  point until the contact point matches the face surface speed
+  (no-slip). With tangential impulse ``P``: ``v_t = P/m`` and
+  ``omega = P r / I`` where ``I = (2/5) m r^2``, and the contact-point
+  speed is ``v_t + omega r``; no-slip gives ``P = (2/7) m u``, so::
+
+      v_ball_t = (2/7) u        omega r = (5/7) u   (backspin)
+
+  This is the standard 2/7 rolling-cap for a struck sphere — the same
+  factor used by ``swing_sim.impact`` (``SPHERE_ROLLING_CAP_FACTOR``).
+  The spin direction is backspin: friction drags the ball's back
+  surface upward, rotating the top of the ball toward the face.
+
+Recomposing gives the launch speed, a launch angle slightly above the
+effective loft, and the initial backspin — the "slide" state that the
+skid phase of :mod:`.roll` starts from.
+
+Sign conventions: ``spin_rad_s`` is about the transverse (left-
+pointing) axis with **topspin positive**, so a freshly struck putt has
+``spin_rad_s < 0`` (backspin) and pure roll is ``v = omega r`` with
+``omega > 0``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from shared.python.contracts import ensure, require, require_finite
+from shared.python.swing_sim.impact import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+)
+
+__all__ = [
+    "DEFAULT_PUTTER_COR",
+    "MINIMAL_PUTTERS",
+    "PuttLaunch",
+    "PutterSpec",
+    "clubhead_speed_from_backstroke",
+    "strike",
+]
+
+#: Typical published putter-face COR at putt speeds (steel face; the
+#: value UpstreamDrift uses for both its putter stroke model and its
+#: green-contact default). Milled/insert faces span ~0.73-0.82.
+DEFAULT_PUTTER_COR = 0.78
+
+#: Standard gravity [m/s^2].
+_GRAVITY_M_S2 = 9.80665
+
+#: 2/7 tangential rolling cap for a struck sphere (see module docs).
+_ROLLING_CAP = 2.0 / 7.0
+
+
+@dataclass(frozen=True)
+class PutterSpec:
+    """Minimal putter description for the putting vertical.
+
+    NOTE (H1 reconciliation, epic #4125): this is a deliberately
+    minimal H3-local spec. The H1 club-library putters
+    (``rate_of_closure.club.library``) carry the full geometry; UIs
+    should build a ``PutterSpec`` from a library ``ClubSpec`` when one
+    is available and fall back to :data:`MINIMAL_PUTTERS` otherwise.
+
+    Attributes:
+        name: Display name.
+        head_mass_kg: Head mass [kg]; putters are typically 0.33-0.37.
+        loft_deg: Static face loft [deg]; putters are typically 2-4.
+        cor: Face coefficient of restitution at putt speeds (0-1).
+    """
+
+    name: str
+    head_mass_kg: float
+    loft_deg: float
+    cor: float = DEFAULT_PUTTER_COR
+
+    def __post_init__(self) -> None:
+        require(bool(self.name.strip()), "putter name must be non-empty")
+        require_finite(self.head_mass_kg, "head_mass_kg")
+        require(
+            0.1 <= self.head_mass_kg <= 1.0,
+            "head mass must be plausible [kg]",
+            self.head_mass_kg,
+        )
+        require_finite(self.loft_deg, "loft_deg")
+        require(
+            -2.0 <= self.loft_deg <= 10.0,
+            "putter loft must be in [-2, 10] deg",
+            self.loft_deg,
+        )
+        require_finite(self.cor, "cor")
+        require(0.0 < self.cor < 1.0, "COR must be in (0, 1)", self.cor)
+
+
+#: H3-local minimal putter specs — marked for reconciliation with the
+#: H1 club-library putters (see :class:`PutterSpec` docstring). Head
+#: masses and lofts are typical published catalogue values.
+MINIMAL_PUTTERS: dict[str, PutterSpec] = {
+    spec.name: spec
+    for spec in (
+        PutterSpec(name="Blade Putter", head_mass_kg=0.350, loft_deg=3.0),
+        PutterSpec(name="Mallet Putter", head_mass_kg=0.360, loft_deg=3.0),
+    )
+}
+
+
+@dataclass(frozen=True)
+class PuttLaunch:
+    """Ball state immediately after putter impact.
+
+    Attributes:
+        ball_speed_mps: Launch speed magnitude [m/s].
+        launch_angle_deg: Launch angle above the horizontal [deg].
+        horizontal_speed_mps: Speed component along the green [m/s] —
+            the initial condition for the skid/roll model.
+        spin_rad_s: Spin about the transverse axis [rad/s], topspin
+            positive; a struck putt starts with backspin (negative).
+        effective_loft_deg: Loft actually presented at impact [deg]
+            (static loft + shaft lean).
+    """
+
+    ball_speed_mps: float
+    launch_angle_deg: float
+    horizontal_speed_mps: float
+    spin_rad_s: float
+    effective_loft_deg: float
+
+
+def strike(
+    putter: PutterSpec,
+    clubhead_speed_mps: float,
+    shaft_lean_deg: float = 0.0,
+) -> PuttLaunch:
+    """Solve the putter-ball impact (see module docstring derivation).
+
+    Args:
+        putter: Putter head description.
+        clubhead_speed_mps: Horizontal head speed at impact [m/s];
+            putts span roughly 0.2-4 m/s.
+        shaft_lean_deg: Forward press (negative reduces effective
+            loft) [deg].
+
+    Returns:
+        The post-impact :class:`PuttLaunch`.
+
+    Raises:
+        ValueError: If any input is out of its physical range.
+    """
+    require_finite(clubhead_speed_mps, "clubhead_speed_mps")
+    require(
+        0.0 < clubhead_speed_mps <= 10.0,
+        "clubhead speed must be in (0, 10] m/s",
+        clubhead_speed_mps,
+    )
+    require_finite(shaft_lean_deg, "shaft_lean_deg")
+    require(
+        abs(shaft_lean_deg) <= 10.0,
+        "shaft lean must be within +/-10 deg",
+        shaft_lean_deg,
+    )
+    effective_loft_deg = putter.loft_deg + shaft_lean_deg
+    require(
+        -2.0 <= effective_loft_deg <= 15.0,
+        "effective loft must stay in [-2, 15] deg",
+        effective_loft_deg,
+    )
+    delta = math.radians(effective_loft_deg)
+    mass_ratio = putter.head_mass_kg / (putter.head_mass_kg + GOLF_BALL_MASS_KG)
+    transfer = (1.0 + putter.cor) * mass_ratio
+
+    v_normal = transfer * clubhead_speed_mps * math.cos(delta)
+    u_tangential = clubhead_speed_mps * math.sin(delta)
+    v_tangential = _ROLLING_CAP * u_tangential
+    # Backspin: contact-surface speed (5/7)u, topspin-positive sign.
+    spin_rad_s = -(1.0 - _ROLLING_CAP) * u_tangential / GOLF_BALL_RADIUS_M
+
+    horizontal = v_normal * math.cos(delta) - v_tangential * math.sin(delta)
+    vertical = v_normal * math.sin(delta) + v_tangential * math.cos(delta)
+    ball_speed = math.hypot(horizontal, vertical)
+    launch_angle_deg = math.degrees(math.atan2(vertical, horizontal))
+
+    ensure(ball_speed > 0.0, "ball must leave the face", ball_speed)
+    ensure(
+        ball_speed <= 2.0 * clubhead_speed_mps,
+        "smash factor is bounded by 2 (equal-mass elastic limit)",
+        ball_speed / clubhead_speed_mps,
+    )
+    ensure(horizontal > 0.0, "putt must move toward the hole", horizontal)
+    return PuttLaunch(
+        ball_speed_mps=ball_speed,
+        launch_angle_deg=launch_angle_deg,
+        horizontal_speed_mps=horizontal,
+        spin_rad_s=spin_rad_s,
+        effective_loft_deg=effective_loft_deg,
+    )
+
+
+def clubhead_speed_from_backstroke(
+    backstroke_m: float, putter_length_m: float = 0.889
+) -> float:
+    """Head speed at the bottom of a pendulum stroke.
+
+    Proxy model (documented simplification): the putting stroke is a
+    simple pendulum of length ``L`` released from a backstroke arc
+    amplitude ``A``. Small-angle SHM gives the bottom-of-arc speed::
+
+        v = A * omega_p = A * sqrt(g / L)
+
+    Args:
+        backstroke_m: Backstroke arc length [m]; typical putts use
+            0.1-0.6 m.
+        putter_length_m: Pendulum length [m]; default is the standard
+            35 in putter (0.889 m).
+
+    Returns:
+        Clubhead speed at impact [m/s].
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require_finite(backstroke_m, "backstroke_m")
+    require(
+        0.0 < backstroke_m <= 1.5,
+        "backstroke must be in (0, 1.5] m",
+        backstroke_m,
+    )
+    require_finite(putter_length_m, "putter_length_m")
+    require(
+        0.5 <= putter_length_m <= 1.5,
+        "putter length must be in [0.5, 1.5] m",
+        putter_length_m,
+    )
+    speed = backstroke_m * math.sqrt(_GRAVITY_M_S2 / putter_length_m)
+    ensure(speed > 0.0, "pendulum speed must be positive", speed)
+    return speed

--- a/src/shared/python/swing_sim/putting/roll.py
+++ b/src/shared/python/swing_sim/putting/roll.py
@@ -1,0 +1,252 @@
+"""Skid -> pure-roll model with stimpmeter green speed (#4125, H3).
+
+Phase 1 — skid (first principles)
+---------------------------------
+A struck putt leaves the face sliding: its forward speed ``v0``
+exceeds the surface speed ``omega0 * r`` of its (back)spin. Kinetic
+friction ``mu_k`` acts backward at the contact point, decelerating the
+ball and — through the torque ``mu_k m g r`` about the center, with
+``I = (2/5) m r^2`` — spinning it up toward rolling::
+
+    dv/dt     = -mu_k g                 =>  v(t)     = v0 - mu_k g t
+    domega/dt = +(5/2) mu_k g / r       =>  omega(t) = omega0 + (5/2) mu_k g t / r
+
+Pure roll starts when the contact point stops slipping, ``v = omega r``::
+
+    t_skid = (v0 - omega0 r) / ((7/2) mu_k g)
+    v_roll = v(t_skid) = (5 v0 + 2 omega0 r) / 7
+
+(the classic 5/7 result for a sliding ball with no initial spin), and
+the skid distance is ``v0 t_skid - mu_k g t_skid^2 / 2``.
+
+The sliding friction coefficient is a turf property independent of
+green speed; 0.40 is the typical published grass sliding value (also
+the green-contact friction default in UpstreamDrift's ``contact.rs``).
+
+Phase 2 — pure roll and the stimpmeter
+--------------------------------------
+A rolling ball decelerates by rolling resistance, modeled as a
+constant deceleration ``a = mu_r g`` (small-angle turf deformation
+drag), so a ball rolling at ``v`` stops after ``v^2 / (2 mu_r g)``.
+
+``mu_r`` is parameterized by the **stimpmeter**, whose geometry is
+openly documented by the USGA: a 36 in (0.9144 m) ramp with a ball
+notch 30 in (0.762 m) from the lower end; the ball releases when the
+ramp reaches ~20 degrees. Rolling down the ramp, energy balance gives
+the release speed::
+
+    m g L sin(20 deg) = (1/2) m v^2 (1 + I / (m r_c^2))
+
+where ``r_c`` is the contact radius. The ball rides the edges of the
+ramp's V-groove, so ``r_c < r`` and the effective inertia exceeds the
+free-rolling 2/5. With the groove's contact radius at ~0.87 r
+(consistent with the ~20 mm groove width), this yields the widely
+quoted release speed of ~6.0 ft/s::
+
+    v_release = sqrt(2 g L sin20 / (1 + (2/5) / 0.87^2)) ~= 1.83 m/s
+
+A green "stimps" ``S`` feet when that release speed rolls out ``S``
+feet, which inverts to the rolling coefficient::
+
+    mu_r = v_release^2 / (2 g S)
+
+Sanity: stimp 10 (3.048 m) gives ``mu_r ~= 0.056``, inside the
+published 0.05-0.07 band for tournament greens. The stimp -> mu_r ->
+roll-out chain round-trips exactly (test-enforced).
+
+Credit: parameterizing green speed as a stimp-derived friction number
+follows UpstreamDrift's ``turf_properties.py`` concept; the derivation
+here is redone from the USGA geometry (their constant assumed a
+different release speed).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from shared.python.contracts import ensure, require, require_finite
+
+__all__ = [
+    "DEFAULT_SLIDING_MU",
+    "GRAVITY_M_S2",
+    "STIMP_RELEASE_SPEED_MPS",
+    "SkidSolution",
+    "roll_out_distance",
+    "roll_time_s",
+    "rolling_mu_to_stimp",
+    "solve_skid",
+    "stimp_to_rolling_mu",
+]
+
+#: Standard gravity [m/s^2].
+GRAVITY_M_S2 = 9.80665
+
+#: Typical published grass sliding friction (also UpstreamDrift's
+#: green-contact default in ``contact.rs``).
+DEFAULT_SLIDING_MU = 0.40
+
+#: Meters per foot.
+_FOOT_M = 0.3048
+
+#: Stimpmeter ramp travel from the ball notch to the lip [m] (30 in).
+_STIMP_RAMP_TRAVEL_M = 0.762
+
+#: Stimpmeter release angle [rad] (~20 deg, USGA documented).
+_STIMP_RELEASE_ANGLE_RAD = math.radians(20.0)
+
+#: V-groove contact radius as a fraction of the ball radius —
+#: consistent with the ~20 mm groove width; see module derivation.
+_GROOVE_CONTACT_FRACTION = 0.87
+
+#: Stimpmeter release speed [m/s], derived in the module docstring
+#: (~1.83 m/s = 6.0 ft/s, the widely quoted value).
+STIMP_RELEASE_SPEED_MPS = math.sqrt(
+    2.0
+    * GRAVITY_M_S2
+    * _STIMP_RAMP_TRAVEL_M
+    * math.sin(_STIMP_RELEASE_ANGLE_RAD)
+    / (1.0 + (2.0 / 5.0) / _GROOVE_CONTACT_FRACTION**2)
+)
+
+
+def stimp_to_rolling_mu(stimp_ft: float) -> float:
+    """Rolling-resistance coefficient for a green speed.
+
+    ``mu_r = v_release^2 / (2 g S)`` — see the module derivation.
+
+    Args:
+        stimp_ft: Stimpmeter reading [feet]; greens span ~4-16.
+
+    Returns:
+        Dimensionless rolling deceleration coefficient.
+
+    Raises:
+        ValueError: If the stimp reading is out of range.
+    """
+    require_finite(stimp_ft, "stimp_ft")
+    require(3.0 <= stimp_ft <= 16.0, "stimp must be in [3, 16] ft", stimp_ft)
+    mu = STIMP_RELEASE_SPEED_MPS**2 / (2.0 * GRAVITY_M_S2 * stimp_ft * _FOOT_M)
+    ensure(0.0 < mu < 0.2, "rolling mu must be physically small", mu)
+    return mu
+
+
+def rolling_mu_to_stimp(mu_r: float) -> float:
+    """Inverse of :func:`stimp_to_rolling_mu` (round-trip exact).
+
+    Args:
+        mu_r: Rolling-resistance coefficient.
+
+    Returns:
+        Stimpmeter reading [feet].
+
+    Raises:
+        ValueError: If the coefficient is out of range.
+    """
+    require_finite(mu_r, "mu_r")
+    require(0.0 < mu_r < 0.2, "rolling mu must be in (0, 0.2)", mu_r)
+    return STIMP_RELEASE_SPEED_MPS**2 / (2.0 * GRAVITY_M_S2 * mu_r * _FOOT_M)
+
+
+@dataclass(frozen=True)
+class SkidSolution:
+    """Closed-form skid phase (flat green; see module derivation).
+
+    Attributes:
+        duration_s: Time until pure roll begins [s].
+        distance_m: Ground covered while skidding [m].
+        exit_speed_mps: Speed when pure roll begins,
+            ``(5 v0 + 2 omega0 r) / 7`` [m/s].
+    """
+
+    duration_s: float
+    distance_m: float
+    exit_speed_mps: float
+
+
+def solve_skid(
+    speed_mps: float,
+    spin_rad_s: float,
+    ball_radius_m: float,
+    mu_slide: float = DEFAULT_SLIDING_MU,
+) -> SkidSolution:
+    """Closed-form flat-green skid phase.
+
+    Args:
+        speed_mps: Initial forward speed ``v0`` [m/s].
+        spin_rad_s: Initial spin ``omega0`` [rad/s], topspin positive
+            (a struck putt starts with backspin, negative).
+        ball_radius_m: Ball radius [m].
+        mu_slide: Sliding friction coefficient.
+
+    Returns:
+        The :class:`SkidSolution`; zero-duration when the ball is
+        already rolling (``v0 <= omega0 r``).
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require_finite(speed_mps, "speed_mps")
+    require(speed_mps > 0.0, "speed must be positive", speed_mps)
+    require_finite(spin_rad_s, "spin_rad_s")
+    require_finite(ball_radius_m, "ball_radius_m")
+    require(
+        0.01 <= ball_radius_m <= 0.05,
+        "ball radius must be plausible [m]",
+        ball_radius_m,
+    )
+    require_finite(mu_slide, "mu_slide")
+    require(0.0 < mu_slide <= 1.5, "mu_slide must be in (0, 1.5]", mu_slide)
+
+    surface_speed = spin_rad_s * ball_radius_m
+    if speed_mps <= surface_speed:
+        return SkidSolution(0.0, 0.0, speed_mps)
+    duration = (speed_mps - surface_speed) / (3.5 * mu_slide * GRAVITY_M_S2)
+    distance = speed_mps * duration - 0.5 * mu_slide * GRAVITY_M_S2 * duration**2
+    exit_speed = (5.0 * speed_mps + 2.0 * surface_speed) / 7.0
+    ensure(exit_speed > 0.0, "roll must start moving forward", exit_speed)
+    ensure(exit_speed <= speed_mps, "skid cannot speed the ball up", exit_speed)
+    ensure(distance >= 0.0, "skid distance is non-negative", distance)
+    return SkidSolution(
+        duration_s=duration, distance_m=distance, exit_speed_mps=exit_speed
+    )
+
+
+def roll_out_distance(speed_mps: float, mu_roll: float) -> float:
+    """Flat-green pure-roll stopping distance ``v^2 / (2 mu_r g)``.
+
+    Args:
+        speed_mps: Rolling speed [m/s].
+        mu_roll: Rolling-resistance coefficient.
+
+    Returns:
+        Distance to rest [m].
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require_finite(speed_mps, "speed_mps")
+    require(speed_mps >= 0.0, "speed must be non-negative", speed_mps)
+    require_finite(mu_roll, "mu_roll")
+    require(0.0 < mu_roll < 0.2, "mu_roll must be in (0, 0.2)", mu_roll)
+    return speed_mps**2 / (2.0 * mu_roll * GRAVITY_M_S2)
+
+
+def roll_time_s(speed_mps: float, mu_roll: float) -> float:
+    """Flat-green pure-roll time to rest ``v / (mu_r g)``.
+
+    Args:
+        speed_mps: Rolling speed [m/s].
+        mu_roll: Rolling-resistance coefficient.
+
+    Returns:
+        Time to rest [s].
+
+    Raises:
+        ValueError: If inputs are out of range.
+    """
+    require_finite(speed_mps, "speed_mps")
+    require(speed_mps >= 0.0, "speed must be non-negative", speed_mps)
+    require_finite(mu_roll, "mu_roll")
+    require(0.0 < mu_roll < 0.2, "mu_roll must be in (0, 0.2)", mu_roll)
+    return speed_mps / (mu_roll * GRAVITY_M_S2)

--- a/src/shared/python/swing_sim/putting/tests/__init__.py
+++ b/src/shared/python/swing_sim/putting/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the swing_sim putting subpackage (epic #4125, H3)."""

--- a/src/shared/python/swing_sim/putting/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/putting/tests/test_contract_api.py
@@ -1,0 +1,49 @@
+"""Facade contract for ``shared.python.swing_sim.putting`` (#4125 H3).
+
+Self-façaded, parent untouched: downstream code imports from this
+subpackage only; ``swing_sim/__init__.py`` deliberately carries no
+putting exports (same policy as ``swing_sim.impact`` /
+``swing_sim.variation``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import shared.python.swing_sim as swing_sim
+import shared.python.swing_sim.putting as putting
+
+pytestmark = [pytest.mark.unit, pytest.mark.contract]
+
+EXPECTED_PUBLIC_API = {
+    "DEFAULT_PUTTER_COR",
+    "DEFAULT_SLIDING_MU",
+    "HOLE_RADIUS_M",
+    "MINIMAL_PUTTERS",
+    "STIMP_RELEASE_SPEED_MPS",
+    "GreenConditions",
+    "PuttLaunch",
+    "PuttResult",
+    "PutterSpec",
+    "SkidSolution",
+    "capture_speed_mps",
+    "clubhead_speed_from_backstroke",
+    "roll_out_distance",
+    "roll_time_s",
+    "rolling_mu_to_stimp",
+    "simulate_putt",
+    "solve_skid",
+    "stimp_to_rolling_mu",
+}
+
+
+class TestPuttingFacade:
+    def test_public_api_is_pinned(self) -> None:
+        assert set(putting.__all__) == set(EXPECTED_PUBLIC_API)
+
+    def test_every_export_resolves(self) -> None:
+        for name in putting.__all__:
+            assert getattr(putting, name) is not None, name
+
+    def test_parent_facade_is_untouched(self) -> None:
+        assert not any("putting" in name.lower() for name in swing_sim.__all__)

--- a/src/shared/python/swing_sim/putting/tests/test_green.py
+++ b/src/shared/python/swing_sim/putting/tests/test_green.py
@@ -1,0 +1,128 @@
+"""Green simulation tests: slope, break, capture, energy (#4125 H3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.python.swing_sim.impact import GOLF_BALL_RADIUS_M
+from shared.python.swing_sim.putting import (
+    HOLE_RADIUS_M,
+    MINIMAL_PUTTERS,
+    GreenConditions,
+    capture_speed_mps,
+    simulate_putt,
+    solve_skid,
+    strike,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.physics]
+
+BLADE = MINIMAL_PUTTERS["Blade Putter"]
+FLAT_10 = GreenConditions(stimp_ft=10.0)
+
+
+def putt(speed: float, green: GreenConditions = FLAT_10, hole: float = 3.0):
+    return simulate_putt(strike(BLADE, speed), green, hole)
+
+
+class TestCaptureBound:
+    def test_derived_bound_value(self) -> None:
+        """R sqrt(g / 2r) with the USGA hole and ball radii."""
+        expected = HOLE_RADIUS_M * (9.80665 / (2.0 * GOLF_BALL_RADIUS_M)) ** 0.5
+        assert capture_speed_mps() == pytest.approx(expected, rel=1e-12)
+        assert capture_speed_mps() == pytest.approx(0.82, abs=0.01)
+
+    def test_dying_putt_is_holed(self) -> None:
+        """A putt that barely reaches the hole drops."""
+        result = putt(1.6)
+        assert result.holed
+        assert result.margin_mps is not None and result.margin_mps > 0.0
+        assert result.miss_distance_m is None
+
+    def test_slammed_putt_runs_past(self) -> None:
+        """Crossing the hole above the bound is not captured."""
+        result = putt(3.2)
+        assert not result.holed
+        assert result.speed_at_hole_mps is not None
+        assert result.speed_at_hole_mps > capture_speed_mps()
+        assert result.miss_distance_m is not None
+        assert result.total_distance_m > 3.0 + HOLE_RADIUS_M
+
+    def test_short_putt_misses_short(self) -> None:
+        result = putt(1.2)
+        assert not result.holed
+        assert result.speed_at_hole_mps is None
+        assert result.miss_distance_m is not None
+        assert result.total_distance_m < 3.0
+
+
+class TestSkidRollTransition:
+    def test_skid_matches_the_closed_form_on_a_flat_green(self) -> None:
+        launch = strike(BLADE, 2.2)
+        result = simulate_putt(launch, FLAT_10, 12.0)
+        closed = solve_skid(
+            launch.horizontal_speed_mps,
+            launch.spin_rad_s,
+            GOLF_BALL_RADIUS_M,
+            FLAT_10.mu_slide,
+        )
+        assert result.skid_distance_m == pytest.approx(closed.distance_m, rel=5e-3)
+        assert 0 < result.skid_end_index < len(result.path_x_m) - 1
+        # Speed at the recorded transition sample matches the 5/7 exit.
+        v_at_transition = result.speeds_mps[result.skid_end_index]
+        assert v_at_transition == pytest.approx(closed.exit_speed_mps, rel=5e-3)
+
+    def test_skid_fraction_is_a_minor_share(self) -> None:
+        result = putt(2.0, hole=10.0)
+        assert 0.0 < result.skid_fraction < 0.35
+
+
+class TestEnergyAndDeterminism:
+    def test_speed_is_monotone_non_increasing_on_a_flat_green(self) -> None:
+        result = putt(2.0, hole=10.0)
+        speeds = result.speeds_mps
+        assert all(b <= a + 1e-12 for a, b in zip(speeds, speeds[1:], strict=False))
+
+    def test_repeat_runs_are_identical(self) -> None:
+        a = putt(2.0)
+        b = putt(2.0)
+        assert a == b
+
+
+class TestSlopeAndBreak:
+    def test_flat_straight_putt_has_no_break(self) -> None:
+        result = putt(2.0, hole=10.0)
+        assert result.break_m == pytest.approx(0.0, abs=1e-12)
+
+    def test_cross_slope_breaks_toward_the_low_side(self) -> None:
+        left_low = GreenConditions(stimp_ft=10.0, grade_percent=2.0, aspect_deg=90.0)
+        result = putt(2.0, green=left_low, hole=10.0)
+        assert result.break_m > 0.01  # breaks left (+y), toward downhill
+
+    def test_mirror_aspect_mirrors_the_break(self) -> None:
+        left = GreenConditions(stimp_ft=10.0, grade_percent=2.0, aspect_deg=90.0)
+        right = GreenConditions(stimp_ft=10.0, grade_percent=2.0, aspect_deg=-90.0)
+        a = putt(2.0, green=left, hole=10.0)
+        b = putt(2.0, green=right, hole=10.0)
+        assert a.break_m == pytest.approx(-b.break_m, rel=1e-9)
+        assert a.total_distance_m == pytest.approx(b.total_distance_m, rel=1e-9)
+
+    def test_downhill_rolls_farther_than_uphill(self) -> None:
+        downhill = GreenConditions(stimp_ft=10.0, grade_percent=2.0, aspect_deg=0.0)
+        uphill = GreenConditions(stimp_ft=10.0, grade_percent=2.0, aspect_deg=180.0)
+        down = putt(1.6, green=downhill, hole=20.0)
+        up = putt(1.6, green=uphill, hole=20.0)
+        assert down.total_distance_m > up.total_distance_m
+
+    def test_faster_green_rolls_farther(self) -> None:
+        fast = putt(1.6, green=GreenConditions(stimp_ft=13.0), hole=20.0)
+        slow = putt(1.6, green=GreenConditions(stimp_ft=8.0), hole=20.0)
+        assert fast.total_distance_m > slow.total_distance_m
+
+    def test_rejects_bad_inputs(self) -> None:
+        with pytest.raises(ValueError):
+            GreenConditions(stimp_ft=1.0)
+        with pytest.raises(ValueError):
+            GreenConditions(stimp_ft=10.0, grade_percent=50.0)
+        with pytest.raises(ValueError):
+            simulate_putt(strike(BLADE, 2.0), FLAT_10, 0.0)

--- a/src/shared/python/swing_sim/putting/tests/test_impact.py
+++ b/src/shared/python/swing_sim/putting/tests/test_impact.py
@@ -1,0 +1,102 @@
+"""Putter-ball impact tests (#4125 H3)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from shared.python.swing_sim.impact import (
+    GOLF_BALL_MASS_KG,
+    GOLF_BALL_RADIUS_M,
+)
+from shared.python.swing_sim.putting import (
+    DEFAULT_PUTTER_COR,
+    MINIMAL_PUTTERS,
+    PutterSpec,
+    clubhead_speed_from_backstroke,
+    strike,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.physics]
+
+BLADE = MINIMAL_PUTTERS["Blade Putter"]
+
+
+class TestPutterSpec:
+    def test_minimal_putters_are_plausible(self) -> None:
+        for spec in MINIMAL_PUTTERS.values():
+            assert 0.3 <= spec.head_mass_kg <= 0.4
+            assert 2.0 <= spec.loft_deg <= 4.0
+            assert spec.cor == DEFAULT_PUTTER_COR
+
+    def test_rejects_out_of_range(self) -> None:
+        with pytest.raises(ValueError):
+            PutterSpec(name="x", head_mass_kg=5.0, loft_deg=3.0)
+        with pytest.raises(ValueError):
+            PutterSpec(name="x", head_mass_kg=0.35, loft_deg=45.0)
+        with pytest.raises(ValueError):
+            PutterSpec(name="x", head_mass_kg=0.35, loft_deg=3.0, cor=1.2)
+
+
+class TestStrike:
+    def test_normal_transfer_matches_impulse_momentum(self) -> None:
+        """Zero loft: pure 1-D COR impulse, no spin, no launch."""
+        flat = PutterSpec(name="Flat", head_mass_kg=0.350, loft_deg=0.0)
+        launch = strike(flat, 2.0)
+        expected = (
+            2.0
+            * (1.0 + flat.cor)
+            * flat.head_mass_kg
+            / (flat.head_mass_kg + GOLF_BALL_MASS_KG)
+        )
+        assert launch.ball_speed_mps == pytest.approx(expected, rel=1e-12)
+        assert launch.launch_angle_deg == pytest.approx(0.0, abs=1e-12)
+        assert launch.spin_rad_s == pytest.approx(0.0, abs=1e-12)
+
+    def test_lofted_strike_launches_up_with_backspin(self) -> None:
+        launch = strike(BLADE, 2.0)
+        assert launch.launch_angle_deg > 0.0
+        assert launch.launch_angle_deg < 2.0 * BLADE.loft_deg
+        assert launch.spin_rad_s < 0.0  # backspin, topspin-positive sign
+        # 2/7 cap: surface backspin speed is (5/7) * v * sin(loft).
+        u = 2.0 * math.sin(math.radians(BLADE.loft_deg))
+        assert -launch.spin_rad_s * GOLF_BALL_RADIUS_M == pytest.approx(
+            (5.0 / 7.0) * u, rel=1e-12
+        )
+
+    def test_smash_factor_is_physical(self) -> None:
+        launch = strike(BLADE, 1.5)
+        smash = launch.ball_speed_mps / 1.5
+        assert 1.4 < smash < 1.7  # typical published putter smash ~1.5-1.7
+
+    def test_forward_press_reduces_launch(self) -> None:
+        pressed = strike(BLADE, 2.0, shaft_lean_deg=-2.0)
+        neutral = strike(BLADE, 2.0)
+        assert pressed.launch_angle_deg < neutral.launch_angle_deg
+        assert pressed.effective_loft_deg == pytest.approx(1.0)
+
+    def test_rejects_bad_speeds(self) -> None:
+        with pytest.raises(ValueError):
+            strike(BLADE, 0.0)
+        with pytest.raises(ValueError):
+            strike(BLADE, 50.0)
+        with pytest.raises(ValueError):
+            strike(BLADE, 2.0, shaft_lean_deg=-30.0)
+
+
+class TestBackstrokeProxy:
+    def test_pendulum_speed_scales_linearly_with_amplitude(self) -> None:
+        v1 = clubhead_speed_from_backstroke(0.2)
+        v2 = clubhead_speed_from_backstroke(0.4)
+        assert v2 == pytest.approx(2.0 * v1, rel=1e-12)
+
+    def test_matches_simple_pendulum_formula(self) -> None:
+        v = clubhead_speed_from_backstroke(0.3, putter_length_m=0.889)
+        assert v == pytest.approx(0.3 * math.sqrt(9.80665 / 0.889), rel=1e-12)
+
+    def test_rejects_out_of_range(self) -> None:
+        with pytest.raises(ValueError):
+            clubhead_speed_from_backstroke(0.0)
+        with pytest.raises(ValueError):
+            clubhead_speed_from_backstroke(0.3, putter_length_m=3.0)

--- a/src/shared/python/swing_sim/putting/tests/test_roll.py
+++ b/src/shared/python/swing_sim/putting/tests/test_roll.py
@@ -1,0 +1,104 @@
+"""Skid/roll and stimpmeter tests (#4125 H3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.python.swing_sim.impact import GOLF_BALL_RADIUS_M
+from shared.python.swing_sim.putting import (
+    STIMP_RELEASE_SPEED_MPS,
+    roll_out_distance,
+    roll_time_s,
+    rolling_mu_to_stimp,
+    solve_skid,
+    stimp_to_rolling_mu,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.physics]
+
+FOOT_M = 0.3048
+
+
+class TestStimpmeter:
+    def test_release_speed_matches_the_quoted_value(self) -> None:
+        """USGA geometry derivation lands on the quoted ~1.83 m/s."""
+        assert STIMP_RELEASE_SPEED_MPS == pytest.approx(1.83, abs=0.01)
+
+    def test_stimp_round_trip_through_the_roll_model(self) -> None:
+        """Release speed rolled out on a stimp-S green travels S feet."""
+        for stimp in (6.0, 8.5, 10.0, 12.0, 14.0):
+            mu = stimp_to_rolling_mu(stimp)
+            distance_ft = roll_out_distance(STIMP_RELEASE_SPEED_MPS, mu) / FOOT_M
+            assert distance_ft == pytest.approx(stimp, rel=1e-12)
+
+    def test_mu_stimp_inverse_pair(self) -> None:
+        for stimp in (7.0, 10.0, 13.0):
+            assert rolling_mu_to_stimp(stimp_to_rolling_mu(stimp)) == pytest.approx(
+                stimp, rel=1e-12
+            )
+
+    def test_faster_green_means_lower_mu(self) -> None:
+        assert stimp_to_rolling_mu(13.0) < stimp_to_rolling_mu(8.0)
+
+    def test_stimp_ten_mu_is_in_the_published_band(self) -> None:
+        assert 0.05 <= stimp_to_rolling_mu(10.0) <= 0.07
+
+    def test_rejects_out_of_range(self) -> None:
+        with pytest.raises(ValueError):
+            stimp_to_rolling_mu(1.0)
+        with pytest.raises(ValueError):
+            rolling_mu_to_stimp(0.5)
+
+
+class TestSkid:
+    def test_transition_continuity_v_equals_omega_r(self) -> None:
+        """At the skid exit, v(t*) from kinematics equals omega(t*) r."""
+        v0, mu = 2.0, 0.4
+        spin0 = -50.0  # backspin [rad/s]
+        sol = solve_skid(v0, spin0, GOLF_BALL_RADIUS_M, mu)
+        g = 9.80665
+        v_end = v0 - mu * g * sol.duration_s
+        omega_r_end = spin0 * GOLF_BALL_RADIUS_M + 2.5 * mu * g * sol.duration_s
+        assert v_end == pytest.approx(omega_r_end, rel=1e-12)
+        assert sol.exit_speed_mps == pytest.approx(v_end, rel=1e-12)
+
+    def test_no_spin_gives_the_classic_five_sevenths(self) -> None:
+        sol = solve_skid(2.1, 0.0, GOLF_BALL_RADIUS_M)
+        assert sol.exit_speed_mps == pytest.approx(2.1 * 5.0 / 7.0, rel=1e-12)
+
+    def test_already_rolling_skids_zero(self) -> None:
+        omega = 2.0 / GOLF_BALL_RADIUS_M  # rolling exactly at v = omega r
+        sol = solve_skid(2.0, omega, GOLF_BALL_RADIUS_M)
+        assert sol.duration_s == 0.0
+        assert sol.distance_m == 0.0
+        assert sol.exit_speed_mps == 2.0
+
+    def test_backspin_extends_the_skid(self) -> None:
+        clean = solve_skid(2.0, 0.0, GOLF_BALL_RADIUS_M)
+        spun = solve_skid(2.0, -80.0, GOLF_BALL_RADIUS_M)
+        assert spun.duration_s > clean.duration_s
+        assert spun.exit_speed_mps < clean.exit_speed_mps
+
+    def test_rejects_bad_inputs(self) -> None:
+        with pytest.raises(ValueError):
+            solve_skid(-1.0, 0.0, GOLF_BALL_RADIUS_M)
+        with pytest.raises(ValueError):
+            solve_skid(2.0, 0.0, 0.5)
+        with pytest.raises(ValueError):
+            solve_skid(2.0, 0.0, GOLF_BALL_RADIUS_M, mu_slide=0.0)
+
+
+class TestPureRoll:
+    def test_stopping_distance_quadratic_in_speed(self) -> None:
+        mu = stimp_to_rolling_mu(10.0)
+        assert roll_out_distance(2.0, mu) == pytest.approx(
+            4.0 * roll_out_distance(1.0, mu), rel=1e-12
+        )
+
+    def test_time_and_distance_are_consistent(self) -> None:
+        """d = v t / 2 for constant deceleration to rest."""
+        mu = stimp_to_rolling_mu(11.0)
+        v = 1.7
+        assert roll_out_distance(v, mu) == pytest.approx(
+            0.5 * v * roll_time_s(v, mu), rel=1e-12
+        )

--- a/tests/rate_of_closure/test_putting.py
+++ b/tests/rate_of_closure/test_putting.py
@@ -1,0 +1,117 @@
+"""Putting bridge, catalog, and reference-putt pins (#4125 H3).
+
+The pinned reference putt is mirrored value-for-value by the vitest
+parity suite in ``web/src/model/putting.test.ts`` (identical RK4 step
+and constants on both sides).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rate_of_closure.glossary import FIELD_TO_TERM, GLOSSARY
+from rate_of_closure.plotting import (
+    PUTTING_CATALOG,
+    extract_putting,
+    putting_catalog_keys,
+)
+from rate_of_closure.putting import PUTT_EXPLANATIONS, putter_specs
+from shared.python.swing_sim.putting import (
+    GreenConditions,
+    PutterSpec,
+    simulate_putt,
+    strike,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.physics]
+
+
+class TestPutterBridge:
+    def test_library_putter_is_offered(self) -> None:
+        specs = putter_specs()
+        assert specs, "putter list must never be empty"
+        assert "Putter" in specs  # the H1 club-library putter
+        spec = specs["Putter"]
+        assert isinstance(spec, PutterSpec)
+        assert spec.head_mass_kg == pytest.approx(0.350)
+        assert spec.loft_deg == pytest.approx(3.0)
+
+    def test_every_row_field_has_explanation_and_glossary_term(self) -> None:
+        for field in PUTT_EXPLANATIONS:
+            assert len(PUTT_EXPLANATIONS[field]) > 80, field
+            assert field in FIELD_TO_TERM, field
+            assert FIELD_TO_TERM[field] in GLOSSARY, field
+
+
+class TestPuttingCatalog:
+    def test_keys_are_namespaced_and_stable(self) -> None:
+        keys = putting_catalog_keys()
+        assert all(key.startswith("putting.") for key in keys)
+        assert set(keys) == {
+            "putting.path_x",
+            "putting.path_y",
+            "putting.speed",
+            "putting.time",
+            "putting.rollout",
+            "putting.skid_distance",
+            "putting.skid_fraction",
+            "putting.time_total",
+            "putting.break",
+            "putting.holed",
+        }
+
+    def test_extractors_return_declared_shapes(self) -> None:
+        result = simulate_putt(
+            strike(putter_specs()["Putter"], 1.8),
+            GreenConditions(stimp_ft=10.0),
+            3.0,
+        )
+        for key, spec in PUTTING_CATALOG.items():
+            value = extract_putting(result, key)
+            if spec.is_series:
+                assert isinstance(value, np.ndarray), key
+                assert np.all(np.isfinite(value)), key
+            else:
+                assert isinstance(value, float), key
+                assert np.isfinite(value), key
+
+    def test_unknown_key_is_rejected(self) -> None:
+        result = simulate_putt(
+            strike(putter_specs()["Putter"], 1.5),
+            GreenConditions(stimp_ft=10.0),
+            3.0,
+        )
+        with pytest.raises(ValueError):
+            extract_putting(result, "putting.nope")
+
+
+class TestReferencePuttPins:
+    """Numeric pins mirrored by web/src/model/putting.test.ts."""
+
+    def test_reference_launch(self) -> None:
+        launch = strike(putter_specs()["Putter"], 1.8)
+        assert launch.ball_speed_mps == pytest.approx(2.828565312464848, rel=1e-12)
+        assert launch.launch_angle_deg == pytest.approx(3.5452147542505257, rel=1e-9)
+        assert launch.horizontal_speed_mps == pytest.approx(
+            2.8231523192738344, rel=1e-12
+        )
+        assert launch.spin_rad_s == pytest.approx(-3.153929533539754, rel=1e-12)
+
+    def test_reference_breaking_putt(self) -> None:
+        launch = strike(putter_specs()["Putter"], 1.8)
+        green = GreenConditions(stimp_ft=10.0, grade_percent=2.0, aspect_deg=90.0)
+        result = simulate_putt(launch, green, 3.0)
+        assert not result.holed
+        assert result.total_distance_m == pytest.approx(4.417405938785078, rel=1e-9)
+        assert result.skid_distance_m == pytest.approx(0.5103817275162047, rel=1e-9)
+        assert result.time_s == pytest.approx(4.388, abs=2e-3)
+        assert result.break_m == pytest.approx(0.8176068791755766, rel=1e-9)
+        assert result.miss_distance_m == pytest.approx(1.4994647284222105, rel=1e-9)
+
+    def test_reference_holed_putt(self) -> None:
+        launch = strike(putter_specs()["Putter"], 1.6)
+        result = simulate_putt(launch, GreenConditions(stimp_ft=10.0), 3.0)
+        assert result.holed
+        assert result.speed_at_hole_mps == pytest.approx(0.5903262895096224, rel=1e-9)
+        assert result.margin_mps == pytest.approx(0.2283133618862715, rel=1e-9)

--- a/tests/rate_of_closure/test_putting_gui.py
+++ b/tests/rate_of_closure/test_putting_gui.py
@@ -1,0 +1,67 @@
+"""PyQt6 GUI smoke tests for the Putting tab (#4125 H3).
+
+Headless-safe; exercises the LoD seam — inputs go in through the
+public widgets, results come out through ``result()`` and the row
+labels, without reaching into the physics internals.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt6")
+pytest.importorskip("pytestqt")
+
+from rate_of_closure.ui.pyqt6.putting_tab import _ROWS, PuttingTab  # noqa: E402
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+@pytest.fixture
+def tab(qtbot):  # type: ignore[no-untyped-def]
+    widget = PuttingTab()
+    qtbot.addWidget(widget)
+    return widget
+
+
+class TestPuttingTab:
+    def test_constructs_with_live_results(self, tab) -> None:  # type: ignore[no-untyped-def]
+        result = tab.result()
+        assert result is not None
+        assert result.total_distance_m > 0.0
+        for field, _label in _ROWS:
+            assert tab._rows[field].value_label.text() not in ("", "—")
+
+    def test_stimp_change_recomputes(self, tab) -> None:  # type: ignore[no-untyped-def]
+        tab._grade_spin.setValue(0.0)
+        before = tab.result().total_distance_m
+        tab._stimp_spin.setValue(13.0)
+        after = tab.result().total_distance_m
+        assert after > before  # faster green rolls out farther
+
+    def test_backstroke_mode_drives_the_putt(self, tab) -> None:  # type: ignore[no-untyped-def]
+        tab._pace_mode.setCurrentIndex(1)
+        tab._backstroke_spin.setValue(40.0)
+        result = tab.result()
+        assert result is not None
+        assert result.total_distance_m > 0.5
+
+    def test_slope_produces_break(self, tab) -> None:  # type: ignore[no-untyped-def]
+        tab._grade_spin.setValue(2.0)
+        tab._aspect_spin.setValue(90.0)
+        assert tab.result().break_m > 0.0
+        tab._aspect_spin.setValue(-90.0)
+        assert tab.result().break_m < 0.0
+
+    def test_row_click_shows_explanation_and_glossary_link(self, tab, qtbot) -> None:  # type: ignore[no-untyped-def]
+        tab._show_explanation("putt_break_m")
+        html = tab._explanation.toHtml()
+        assert "Break" in html
+        assert "glossary:" in html
+
+    def test_glossary_link_emits_signal(self, tab, qtbot) -> None:  # type: ignore[no-untyped-def]
+        from PyQt6.QtCore import QUrl
+
+        with qtbot.waitSignal(tab.glossaryRequested, timeout=2000) as blocker:
+            tab._on_explanation_link(QUrl("glossary:stimp"))
+        assert blocker.args == ["stimp"]


### PR DESCRIPTION
Implements **H3 — Putting Vertical (App + Model)** of epic #4125. Draft into `feat/investigation-suite`; do not merge yet.

## Overlap review (surveyed before building, ideas credited)

UpstreamDrift putting assets reviewed read-only before any code was written:

- `src/engines/physics_engines/putting_green/` (Python engine behind `ui/src/pages/PuttingGreen.tsx`): **adopted with credit** — the stimp-as-a-single-friction-knob concept (`turf_properties.py`), the explicit SLIDING/ROLLING mode machine with friction on slip velocity (`ball_roll_physics.py`), and putter COR 0.78 (`putter_stroke.py`). **Not copied**: their `mu = 0.196/stimp` constant (assumes a different release speed; our USGA-geometry derivation gives `mu = v²/(2gS)` with v ≈ 1.83 m/s, landing in the published 0.05–0.07 band at stimp 10 and round-tripping exactly), their ad-hoc `|Σ cross-slope|·L·0.25` break scale, and their empirical 1.5 m/s lip-out band (replaced by a derived geometric capture bound).
- `rust_core/upstream-physics/src/contact.rs`: **adopted with credit** — COR 0.78 and sliding friction 0.4 as green-contact defaults. Its `(1-μ)` tangential scaling was noted as unphysical and not copied; its bounce model targets approach-shot landing, not rolling putts.
- `ui/src/pages/PuttingGreen.tsx`: **adopted with credit** — SVG-only top-down green (no WebGL), hole-circle rendering, path polyline; re-styled to this app's slate/sky design with skid/roll phase colour-coding added.
- `sg_optimizer/shot_model/putting.py` (statistical make-% model): reviewed, out of scope for a physics vertical; noted for a future make-probability layer.
- Tools repo itself had no prior putting physics (only the H1 club-library `Putter` spec row, which this PR consumes through the library API).

## Physics (first-principles derivations in module docstrings)

- **Impact** (`swing_sim/putting/impact.py`): 1-D COR impulse along the lofted face normal + the 2/7 rolling-cap tangential transfer (same factor as `swing_sim.impact`) ⇒ launch speed, launch angle, and the initial backspin "slide" state. Putter COR 0.78 cited as the typical published steel-face value. Pendulum backstroke proxy `v = A·sqrt(g/L)`.
- **Skid → roll** (`roll.py`): `dv/dt = −μ_k g`, `dω/dt = (5/2)μ_k g/r` ⇒ pure roll at `v = ωr` with `v_roll = (5v₀+2ω₀r)/7`; sliding μ 0.4 (typical published grass value).
- **Stimpmeter** (`roll.py`): USGA geometry (36 in ramp, 30 in notch travel, 20° release) with the V-groove inertia correction (contact radius ≈ 0.87 r) ⇒ release speed ≈ 1.83 m/s (the widely quoted 6.0 ft/s), inverted to `μ_r = v²/(2gS)`; the stimp → μ → roll-out chain round-trips exactly (test-enforced).
- **Green** (`green.py`): uniform planar slope (grade % + downhill aspect), deterministic 2 ms RK4 with the mode machine; break, skid split, and the geometric lip-capture bound — ball must fall half a diameter while crossing the hole mouth ⇒ `v_capture = R·sqrt(g/2r) ≈ 0.82 m/s` (Holmes, Am. J. Phys. 59 (1991) cited for the full-chord ~1.6 m/s variant; no lip-out deflection modeled).

## App

- **PyQt6 Putting tab**: putter picker (H1 library putter preferred, minimal specs fallback marked for H1 reconciliation), clubhead-speed or backstroke pace input, stimp/grade/aspect/distance controls (sourced tooltips everywhere), clickable result rows → explanations with glossary deep-links, top-down green (skid orange / pure-roll green, hole, downhill arrow) over speed-vs-distance with the capture bound; '?' help entry.
- **Web Putting tab**: `model/putting.ts` mirror (same constants, same RK4) + `PuttingPanel.tsx` SVG green + speed plot; help section; hover-hint sweep extended.
- **Additive registrations**: `plotting/putting_catalog.py` (PuttResult-scoped registry; the pinned SimulationRun catalog and its fixture are untouched), 5 glossary terms (stimp, skid, pure_roll, capture_speed, break) in a new split entries module + TS mirror + regenerated parity fixture, helptext entries both sides. `swing_sim/__init__.py` untouched (self-façaded subpackage). Distances stay SI through single format chokepoints for the H6 units pass.

## Tests & gates

- 40 new package tests (skid→roll v=ωr continuity, stimp round-trip, slope mirror symmetry, capture-bound behaviour, flat-green speed monotonicity, determinism, DbC rejection) + app bridge/catalog tests + Python↔TS parity pins on reference putts + GUI smoke; tooltip/help/glossary sweeps cover the new tab.
- `pytest tests/rate_of_closure src/shared/python/swing_sim`: **620 passed**.
- `ruff check` / `ruff format --check`: clean on all touched paths; `mypy` (repo config): clean on the new modules.
- Web: `npm run lint`, `type-check`, `vitest run` (**138 passed**), `build`: clean. (One pre-existing statistical-band variation parity test flaked once and passed on re-run; unrelated to this PR.)

## Not touched (sibling scopes)

`club/` geometry (H1 — consumed via the library API only), kinetics (H2), existing glossary/help content beyond additive entries.

Closes nothing on its own; part of #4125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
