### PR TITLE
🎨 Palette: Add accessible roles to mapped tab components in Rotation Converter

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -46,3 +46,6 @@
 ## 2024-07-30 - Added focus-visible states to Rotation Converter
 **Learning:** Found an accessibility issue pattern where inputs and buttons in Rotation Converter have `outline-none` but lack focus indicators, making keyboard navigation difficult.
 **Action:** Replace `outline-none` with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` to preserve keyboard accessibility while styling interactive elements.
+## 2024-05-31 - Tab Roles vs aria-pressed
+**Learning:** When implementing custom tab components in React, use `role="tab"` paired strictly with `aria-selected` (not `aria-pressed`, which is intended for toggle buttons) and ensure `aria-controls` points to a valid `role="tabpanel"` container whose `aria-labelledby` points back to the tab.
+**Action:** When adding accessible properties to custom tabs, replace `aria-pressed` with `aria-selected`, ensure a `role="tablist"` wrapper is present, and correctly cross-reference `aria-controls` with the tab panel IDs.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2381,6 +2381,12 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 ## 9. Changelog
 
+### Version 1.1.599
+
+- 2026-08-05: fix(rotation-converter) — update application navigation tabs
+  with accessible roles and unique IDs, linking buttons to tab panels via
+  `aria-controls` and `aria-labelledby` for screen reader semantic correctness.
+
 ### Version 1.1.598
 
 - 2026-06-18: fix(data-processor, #3745) — keep cross-correlation importable

--- a/src/rotation_converter/web/src/App.tsx
+++ b/src/rotation_converter/web/src/App.tsx
@@ -13,29 +13,40 @@ function App() {
           <p className="mt-1 text-sm text-slate-400">
             Educational conversion tool for rotations, twists, SE(3), and so(3)/SO(3) maps.
           </p>
-          <div className="mt-4 flex gap-2">
+          <div className="mt-4 flex gap-2" role="tablist" aria-label="Converter views">
             <button
+              id="tab-rotation"
+              role="tab"
+              aria-controls="panel-rotation"
+              aria-selected={activeTab === "rotation"}
               className={`px-3 py-1 rounded text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
                 activeTab === "rotation" ? "bg-blue-600 text-white" : "bg-slate-700 text-slate-200 hover:bg-slate-600"
               }`}
               onClick={() => setActiveTab("rotation")}
-              aria-pressed={activeTab === "rotation"}
             >
               Rotation Formats
             </button>
             <button
+              id="tab-reference"
+              role="tab"
+              aria-controls="panel-reference"
+              aria-selected={activeTab === "reference"}
               className={`px-3 py-1 rounded text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 ${
                 activeTab === "reference" ? "bg-blue-600 text-white" : "bg-slate-700 text-slate-200 hover:bg-slate-600"
               }`}
               onClick={() => setActiveTab("reference")}
-              aria-pressed={activeTab === "reference"}
             >
               Reference Frames & Lie Groups
             </button>
           </div>
         </div>
       </header>
-      <main className="mx-auto max-w-7xl px-4 py-6">
+      <main
+        id={`panel-${activeTab}`}
+        role="tabpanel"
+        aria-labelledby={`tab-${activeTab}`}
+        className="mx-auto max-w-7xl px-4 py-6"
+      >
         {activeTab === "rotation" ? <RotationConverter /> : <ReferenceFrameConverter />}
       </main>
     </div>


### PR DESCRIPTION
💡 What: Added accessible roles to the navigation tabs in the Rotation Converter application. Wrapped tabs in `role="tablist"`, added `role="tab"`, unique `id`s, `aria-controls`, and `aria-selected` to the tab buttons. Wrapped the main content in `role="tabpanel"` and added `aria-labelledby`.
🎯 Why: The dynamic tab components lacked essential accessibility structure, leaving screen reader users without proper context (e.g. knowing it's a tab list, which tab is selected).
📸 Before/After: No visual changes, only semantic HTML attributes were added for accessibility.
♿ Accessibility: Screen readers can now correctly identify the navigation as a tab list, announce the selected tab, and navigate to the associated tab panel using standard keyboard navigation and screen reader shortcuts.

---
*PR created automatically by Jules for task [3972585790635382312](https://jules.google.com/task/3972585790635382312) started by @dieterolson*