### PR TITLE
fix(ci): validate PyO3 Python link libraries

### DIFF
--- a/.github/scripts/clean-python-toolcache.sh
+++ b/.github/scripts/clean-python-toolcache.sh
@@ -7,12 +7,25 @@ if [[ ! "$requested_minor" =~ ^[0-9]+\.[0-9]+$ ]]; then
   exit 2
 fi
 
-cache_roots=(
-  "${AGENT_TOOLSDIRECTORY:-}"
-  "/opt/runner-tool-cache"
-  "/home/dieterolson/actions-runners/.shared-tool-cache"
-  "/home/dieterolson/actions-runners-nvme/.shared-tool-cache"
-)
+require_link_library=false
+if [ "${2:-}" = "--require-link-library" ]; then
+  require_link_library=true
+elif [ -n "${2:-}" ]; then
+  echo "::error::Unknown option: $2"
+  exit 2
+fi
+
+if [ -n "${PYTHON_TOOLCACHE_ROOTS:-}" ]; then
+  IFS=':' read -r -a cache_roots <<< "$PYTHON_TOOLCACHE_ROOTS"
+else
+  cache_roots=(
+    "${AGENT_TOOLSDIRECTORY:-}"
+    "/opt/hostedtoolcache"
+    "/opt/runner-tool-cache"
+    "/home/dieterolson/actions-runners/.shared-tool-cache"
+    "/home/dieterolson/actions-runners-nvme/.shared-tool-cache"
+  )
+fi
 
 clean_cache_entry() {
   local arch_dir="$1"
@@ -64,9 +77,27 @@ for cache_root in "${cache_roots[@]}"; do
       if [ "$python_version" != "$expected_version" ] ||
         [[ "$pip_version" != pip\ *" from "* ]]; then
         clean_cache_entry "$arch_dir"
-      else
-        echo "Directory $arch_dir is healthy."
+        continue
       fi
+
+      if $require_link_library; then
+        mapfile -t library_metadata < <(
+          LD_LIBRARY_PATH="$arch_dir/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+            "$py_bin" -c \
+            'import sysconfig; print(sysconfig.get_config_var("LIBDIR") or ""); print(sysconfig.get_config_var("LDLIBRARY") or "")' \
+            2>/dev/null
+        )
+        library_dir="${library_metadata[0]:-}"
+        library_name="${library_metadata[1]:-}"
+        if [ -z "$library_dir" ] || [ -z "$library_name" ] ||
+          [ ! -e "$library_dir/$library_name" ]; then
+          echo "Python link library is missing: $library_dir/$library_name"
+          clean_cache_entry "$arch_dir"
+          continue
+        fi
+      fi
+
+      echo "Directory $arch_dir is healthy."
     done
   done
 done

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -925,6 +925,10 @@ jobs:
           shared-key: ci-standard-rust-quality-gate
           cache-on-failure: true
 
+      - name: Force-clean incomplete Python tool cache for PyO3
+        if: steps.rust-changes.outputs.has_changes == 'true'
+        run: bash .github/scripts/clean-python-toolcache.sh '3.11' --require-link-library
+
       - name: Set up Python for wheel checks
         env:
           AGENT_TOOLSDIRECTORY: ${{ runner.temp }}/_tool_cache

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -19,6 +19,11 @@ stack of golf-simulation epics:
 | #4125 — Realistic Clubs/Kinetics/Putting/Public Release Mgmt/Showcase Styling | H1-H7 implemented, stacked on #4124, consolidated into PR **#4129** (open, draft-for-review, targets `feat/course-showcase`, stacked on #4124). H5 (public release-management repo) is cross-repo, not yet started. |
 | #4130 — Impact-Interval Club Dynamics (contact-interval rigid-body model) | Foundation epic only (F1 formulation doc not yet started); no PR yet. Next major physics wave after #4125 lands. |
 
+Active infrastructure repair: #4155 hardens the Rust/PyO3 job against
+incomplete setup-python cache entries whose interpreter works but whose
+declared link library is missing. The repair is isolated on
+`fix/4155-rust-libpython-cache` and does not change simulation code.
+
 See `src/rate_of_closure/AGENT_HANDOFF.md` for the detailed stack breakdown
 and architecture pointers for this tool specifically.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1722,6 +1722,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-05 | 1.5.5 | fix(ci, #4155): make the Python tool-cache guard inspect `/opt/hostedtoolcache` and optionally require the interpreter's declared link library; run that stronger semantic preflight immediately before the Rust/PyO3 job provisions Python, with Linux fixture and workflow-order contracts. |
 | 2026-08-04 | 1.5.4 | docs(agent-handoff, Repository_Management#1390): add root `AGENT_HANDOFF.md` plus per-tool `AGENT_HANDOFF.md` under `src/rate_of_closure`, `src/pendulum_simulator`, and `src/rotation_converter`; add `docs/AGENT_HANDOFF_TEMPLATE.md` for future tools; add the "Agent Handoff & PR Policy" section to `CLAUDE.md`. |
 | 2026-07-26 | 1.5.3 | fix(test): create the standalone-wheel smoke environment from the real base interpreter rather than nesting it under the active CI virtualenv, keeping installed-artifact validation portable across relocated self-hosted Python 3.10 runtimes. |
 | 2026-07-26 | 1.5.3 | fix(ci): isolate both protected Python jobs in per-job virtual environments after validating the persistent setup-python runtime; repair and import-probe the matrix NumPy/SciPy stack with compatible bounds, and reinstall OpenCV without dependency resolution so it cannot replace the verified NumPy wheel. |

--- a/tests/ops/test_python_toolcache_guard.py
+++ b/tests/ops/test_python_toolcache_guard.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / ".github" / "scripts" / "clean-python-toolcache.sh"
+CI_STANDARD = REPO_ROOT / ".github" / "workflows" / "ci-standard.yml"
+
+
+def test_pyo3_guard_precedes_setup_python_in_rust_job() -> None:
+    guard = GUARD.read_text(encoding="utf-8")
+    assert '"/opt/hostedtoolcache"' in guard
+    assert 'sysconfig.get_config_var("LDLIBRARY")' in guard
+    assert '"--require-link-library"' in guard
+
+    workflow = yaml.safe_load(CI_STANDARD.read_text(encoding="utf-8"))
+    rust_steps = workflow["jobs"]["rust-quality-gate"]["steps"]
+    clean_index = next(
+        index
+        for index, step in enumerate(rust_steps)
+        if step.get("name") == "Force-clean incomplete Python tool cache for PyO3"
+    )
+    assert rust_steps[clean_index]["run"].endswith("'3.11' --require-link-library")
+    assert str(rust_steps[clean_index + 1].get("uses", "")).startswith(
+        "actions/setup-python@"
+    )
+
+
+def _write_fake_python(arch_dir: Path, *, with_link_library: bool) -> None:
+    python = arch_dir / "bin" / "python"
+    library_dir = arch_dir / "lib"
+    python.parent.mkdir(parents=True)
+    library_dir.mkdir()
+    python.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$*" == *sys.version_info* ]]; then echo 3.11.15; exit 0; fi\n'
+        'if [[ "$*" == *sysconfig* ]]; then\n'
+        f"  echo '{library_dir}'\n"
+        "  echo 'libpython3.11.so'\n"
+        "  exit 0\n"
+        "fi\n"
+        "if [[ \"$*\" == *'pip --version'* ]]; then\n"
+        "  echo 'pip 25.0 from /fixture/pip (python 3.11)'\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    python.chmod(python.stat().st_mode | stat.S_IXUSR)
+    if with_link_library:
+        (library_dir / "libpython3.11.so").write_bytes(b"fixture")
+
+
+def _run_guard(cache_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHON_TOOLCACHE_ROOTS"] = str(cache_root)
+    return subprocess.run(
+        ["bash", str(GUARD), "3.11", *args],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Linux tool-cache contract")
+def test_pyo3_guard_keeps_cache_with_a_link_library(tmp_path: Path) -> None:
+    arch_dir = tmp_path / "Python" / "3.11.15" / "x64"
+    _write_fake_python(arch_dir, with_link_library=True)
+
+    result = _run_guard(tmp_path, "--require-link-library")
+
+    assert result.returncode == 0, result.stderr
+    assert arch_dir.is_dir()
+    assert f"Directory {arch_dir} is healthy." in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Linux tool-cache contract")
+def test_pyo3_guard_removes_cache_without_a_link_library(tmp_path: Path) -> None:
+    arch_dir = tmp_path / "Python" / "3.11.15" / "x64"
+    _write_fake_python(arch_dir, with_link_library=False)
+    complete_marker = arch_dir.with_name("x64.complete")
+    complete_marker.write_text("fixture", encoding="utf-8")
+
+    result = _run_guard(tmp_path, "--require-link-library")
+
+    assert result.returncode == 0, result.stderr
+    assert not arch_dir.exists()
+    assert not complete_marker.exists()
+    assert "Python link library is missing" in result.stdout
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Linux tool-cache contract")
+def test_general_guard_does_not_require_a_link_library(tmp_path: Path) -> None:
+    arch_dir = tmp_path / "Python" / "3.11.15" / "x64"
+    _write_fake_python(arch_dir, with_link_library=False)
+
+    result = _run_guard(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert arch_dir.is_dir()


### PR DESCRIPTION
## Summary  - extend the semantic Python tool-cache guard to inspect `/opt/hostedtoolcache` - add an opt-in `--require-link-library` contract that validates `sysconfig`'s `LIBDIR/LDLIBRARY` target - run that stronger preflight immediately before setup-python in the Rust/PyO3 quality gate - add workflow-order and Linux behavior fixtures for healthy, incomplete, and general-purpose cache entries  ## Root cause  The Rust quality gate could select an apparently usable cached Python 3.11 interpreter whose standard-library and pip probes passed while `libpython3.11` was absent. PyO3 then reached the final link step and failed with `rust-lld: error: unable to find library -lpython3.11`. The existing cleaner neither scanned the selected `/opt/hostedtoolcache` root nor validated the declared link library, and the Rust job did not invoke it.  ## Behavior and safety  The stronger link-library requirement is opt-in and used only by the PyO3 job. General Python jobs retain the existing interpreter/zlib/pip health contract. Cleanup remains bounded to the exact version/architecture directory plus its adjacent `.complete` marker.  Related to #4155.  ## Validation  - `bash -n .github/scripts/clean-python-toolcache.sh` - `pytest tests/ops/test_python_toolcache_guard.py tests/scripts/test_ci_bandwidth_routing.py -q -n 0`: 4 passed, 3 Linux-only fixtures skipped on Windows - Ruff check and format check: passed - `git diff --check`: passed - hosted CI is expected to execute the three Linux-only behavioral fixtures and the repaired Rust/PyO3 gate  ## Baseline note  The broader `tests/ops/test_ci_standard_web_dependencies.py` currently has three failures on `origin/main` because its persistent-cache expectations have drifted from the checked-in quality-gate workflow. This PR does not mask or expand into that separate baseline issue. 