### PR TITLE
Add Screw-Axis Analytics and Motion Glyphs

### DIFF
--- a/docs/rate_of_closure/screw_axis_analysis.md
+++ b/docs/rate_of_closure/screw_axis_analysis.md
@@ -1,0 +1,149 @@
+# Screw-Axis Analysis and Motion Glyphs
+
+## Purpose
+
+The Rate of Closure workbench uses instantaneous screw theory to explain how a
+club or an articulated joint moves through three-dimensional space. A screw axis
+is not an extra fitted golf variable. It is a geometric decomposition of the
+same rigid-body angular and linear velocity already produced by the simulation.
+The implementation follows the twist and screw-axis convention described in
+Lynch and Park's *Modern Robotics*, Chapter 3.3.2 ([Northwestern video and
+transcript](https://modernrobotics.northwestern.edu/nu-gm-book-resource/3-3-2-twists-part-1-of-2/),
+[book preprint](https://hades.mech.northwestern.edu/images/7/7f/MR.pdf)).
+
+## Frame and Twist Contract
+
+All displayed values use the app/world frame:
+
+- `x`: toward the target;
+- `y`: up;
+- `z`: right of the target line when looking downrange.
+
+At a named reference point \(P\), the sampled twist is
+
+\[
+\mathcal{V}_P = (\boldsymbol{\omega}, \mathbf{v}_P),
+\]
+
+where \(\boldsymbol{\omega}\) is in rad/s and \(\mathbf{v}_P\) is the linear
+velocity at \(P\) in m/s. This reference-point convention must not be confused
+with a spatial twist whose linear term is defined at the world origin.
+
+For \(\lVert\boldsymbol{\omega}\rVert > 0\), the finite instantaneous screw is
+
+\[
+\hat{\mathbf{s}} = \frac{\boldsymbol{\omega}}{\lVert\boldsymbol{\omega}\rVert},
+\qquad
+h = \frac{\boldsymbol{\omega}\cdot\mathbf{v}_P}
+         {\lVert\boldsymbol{\omega}\rVert^2},
+\]
+
+\[
+\mathbf{q} = \mathbf{P} +
+\frac{\boldsymbol{\omega}\times\mathbf{v}_P}
+     {\lVert\boldsymbol{\omega}\rVert^2}.
+\]
+
+Here \(\mathbf{q}\) is the closest point on the axis to \(P\), \(h\) is pitch
+in m/rad, and the signed axial speed is
+\(h\lVert\boldsymbol{\omega}\rVert\). The reference velocity is reconstructed
+exactly as
+
+\[
+\mathbf{v}_P =
+\underbrace{\boldsymbol{\omega}\times(\mathbf{P}-\mathbf{q})}_{\text{orbital}}
++
+\underbrace{h\boldsymbol{\omega}}_{\text{axial}}.
+\]
+
+The software reports the numerical norm of the reconstruction error. A finite
+axis is invariant to the chosen point on the same rigid body; only the named
+point's radius and velocity change.
+
+## Degenerate Motion States
+
+The interface deliberately distinguishes three states:
+
+1. **Finite Screw:** nonzero angular velocity; axis point, pitch, radius, and
+   helical glyph are defined.
+2. **Pure Translation:** zero angular velocity and nonzero linear velocity; the
+   screw axis is at infinity. The scene draws a translation arrow and never a
+   finite axis.
+3. **Stationary:** both velocities are zero; no instantaneous axis exists.
+
+This distinction prevents the visually attractive but physically incorrect
+practice of drawing an arbitrary axis during straight translation or rest.
+
+## Graphic Legend
+
+- **Magenta main line and tip:** the directed instantaneous screw axis. The tip
+  follows the right-hand-rule direction of \(\boldsymbol{\omega}\).
+- **Orange wrapped curve:** a bounded engineering helix. Its handedness shows
+  rotational direction. Its axial length grows monotonically with angular rate
+  but is capped by the current swing-scale scene; it is an explanatory glyph,
+  not a literal material trajectory.
+- **Cyan dotted radius:** \(R_{ISA}\), from the selected reference point to the
+  closest point on the axis.
+- **White/purple skeleton:** physical segment geometry sampled from the same
+  integrated joint state used by the clubhead path.
+
+The glyph radius and displayed axis length are normalized for readability.
+Numerical rate, pitch, axial speed, and \(R_{ISA}\) in the adjacent readout are
+the quantitative values; screen length must not be measured as data.
+
+## Club and Joint Views
+
+**Club** uses the simulator's directly sampled club pose, angular velocity, and
+reference-point velocity. It applies to every selected club specification,
+including wedges, because screw geometry depends on the sampled rigid-body
+motion rather than the head category.
+
+**Joint** views reconstruct the instantaneous angular velocity of each sampled
+link from its direction derivative. A joint's relative angular velocity is the
+distal link angular velocity minus the proximal link angular velocity. Its
+contribution at the clubhead is
+
+\[
+\mathbf{v}_{P,j} = \boldsymbol{\omega}_j \times
+(\mathbf{P}-\mathbf{q}_j).
+\]
+
+The sum is compared with the numerical clubhead endpoint velocity, and the
+residual is displayed. This residual exposes sampling, numerical differentiation,
+base-motion, or model-contract disagreement rather than hiding it.
+
+## Delivery Projections
+
+Total, orbital, axial, and joint-contribution velocities can be projected onto
+named unit directions using \(v_d=\mathbf{v}\cdot\hat{\mathbf{d}}\). The UI
+reports target-line, vertical/AoA, lateral/path, and nominal face-normal
+projections. It also reports the exact direction angles of the selected velocity:
+
+\[
+\mathrm{AoA}=\operatorname{atan2}(v_y,\sqrt{v_x^2+v_z^2}),
+\qquad
+\mathrm{Path}=\operatorname{atan2}(v_z,v_x).
+\]
+
+Orbital and axial vectors are additive; their AoA and path angles are not.
+Component direction angles therefore remain labeled as diagnostics rather than
+being summed into a fabricated total angle.
+
+## Limitations
+
+- The result is instantaneous and inherits the simulator's rigid-body and joint
+  model assumptions; it does not prove causality in a measured golfer.
+- Joint reconstruction assumes revolute links represented by nonzero sampled
+  segment vectors. Translating base joints require an additional base-motion
+  term.
+- Numerical joint derivatives are most reliable on the simulator's uniform
+  1 ms grid. The residual should be inspected before interpreting small
+  differences.
+- The nominal face-normal direction uses the configured loft and square-face
+  delivery convention. Face curvature and local strike normals belong to the
+  impact model and should be selected explicitly for off-center contact studies.
+- Near-zero angular rates make a finite ISA ill-conditioned; such samples are
+  classified by the documented tolerance instead of amplifying noise.
+
+Implementation and delivery are tracked in
+[Tools issue #4168](https://github.com/D-sorganization/Tools/issues/4168).

--- a/src/rate_of_closure/README.md
+++ b/src/rate_of_closure/README.md
@@ -20,6 +20,11 @@ over the distance to the instantaneous screw axis, and `1 / R_ISA =
 omega / v` — which is why the speed-invariant closure unit the tool
 reports is **degrees per foot of travel**.
 
+The Simulation view also renders selectable club and joint screw-motion
+glyphs, velocity-component projections, and reconstruction residuals. See the
+[Screw-Axis Analysis and Motion Glyphs](../../docs/rate_of_closure/screw_axis_analysis.md)
+guide for equations, display semantics, degeneracy rules, and limitations.
+
 ## Conventions and Sources
 
 * **Frame** (AffineDrift house convention, `sections/02-parameters.tex`,

--- a/src/rate_of_closure/simulation/__init__.py
+++ b/src/rate_of_closure/simulation/__init__.py
@@ -18,10 +18,13 @@ from __future__ import annotations
 
 from .contact import ContactMode, ImpactOutcome, ImpactStatus
 from .export import (
+    SCREW_CSV_COLUMNS,
     ball_setup_from_json_dict,
     run_to_json_dict,
+    screw_series_rows,
     write_csv,
     write_json,
+    write_screw_csv,
     write_torque_csv,
 )
 from .flight_explorer import (
@@ -71,6 +74,7 @@ __all__ = [
     "EXPLORER_METRIC_KEYS",
     "KINETIC_JOINT_NAMES",
     "SOURCE_KINDS",
+    "SCREW_CSV_COLUMNS",
     "AppFrameSwing",
     "FlightExploration",
     "KineticsSeries",
@@ -95,7 +99,9 @@ __all__ = [
     "run_simulation",
     "run_to_json_dict",
     "screw_axis_samples",
+    "screw_series_rows",
     "write_csv",
     "write_json",
+    "write_screw_csv",
     "write_torque_csv",
 ]

--- a/src/rate_of_closure/simulation/export.py
+++ b/src/rate_of_closure/simulation/export.py
@@ -26,18 +26,22 @@ from typing import Any
 import numpy as np
 
 from rate_of_closure._contracts import require
+from rate_of_closure.simulation.screw_analysis import analyze_twist
 from rate_of_closure.simulation.session import SimulationRun
 from shared.python.swing_sim.ball_setup import BallSetup
 
 __all__ = [
     "CSV_COLUMNS",
+    "SCREW_CSV_COLUMNS",
     "TORQUE_CSV_COLUMNS",
     "ball_setup_from_json_dict",
     "run_to_json_dict",
     "series_rows",
+    "screw_series_rows",
     "torque_series_rows",
     "write_csv",
     "write_json",
+    "write_screw_csv",
     "write_torque_csv",
 ]
 
@@ -58,6 +62,28 @@ CSV_COLUMNS: tuple[str, ...] = (
 )
 
 TORQUE_CSV_COLUMNS: tuple[str, ...] = ("t_s", "joint_id", "applied_torque_nm")
+
+SCREW_CSV_COLUMNS: tuple[str, ...] = (
+    "t_s",
+    "motion_kind",
+    "angular_rate_rad_s",
+    "pitch_m_rad",
+    "axial_speed_m_s",
+    "r_isa_m",
+    "axis_x",
+    "axis_y",
+    "axis_z",
+    "axis_point_x_m",
+    "axis_point_y_m",
+    "axis_point_z_m",
+    "orbital_vx_m_s",
+    "orbital_vy_m_s",
+    "orbital_vz_m_s",
+    "axial_vx_m_s",
+    "axial_vy_m_s",
+    "axial_vz_m_s",
+    "reconstruction_residual_m_s",
+)
 
 
 def ball_setup_from_json_dict(data: Mapping[str, Any]) -> BallSetup:
@@ -131,6 +157,32 @@ def torque_series_rows(run: SimulationRun) -> list[tuple[float, str, float]]:
     ]
 
 
+def screw_series_rows(run: SimulationRun) -> list[tuple[Any, ...]]:
+    """Return the typed club screw decomposition for every swing sample."""
+    rows: list[tuple[Any, ...]] = []
+    for time_s, point, twist in zip(
+        run.swing_times, run.swing_positions, run.swing_twists, strict=True
+    ):
+        motion = analyze_twist(twist, point)
+        axis_point = motion.axis_point_m
+        rows.append(
+            (
+                float(time_s),
+                motion.kind.value,
+                motion.angular_rate_rad_s,
+                motion.pitch_m_rad,
+                motion.axial_speed_m_s,
+                motion.radius_m,
+                *motion.axis_direction.tolist(),
+                *(axis_point.tolist() if axis_point is not None else (None,) * 3),
+                *motion.orbital_velocity_m_s.tolist(),
+                *motion.axial_velocity_m_s.tolist(),
+                motion.reconstruction_residual_m_s,
+            )
+        )
+    return rows
+
+
 def _contact_columns(
     run: SimulationRun,
 ) -> tuple[int, int, float | None, float, float, float]:
@@ -167,6 +219,15 @@ def write_torque_csv(run: SimulationRun, path: str | Path) -> None:
         writer = csv.writer(handle)
         writer.writerow(TORQUE_CSV_COLUMNS)
         writer.writerows(torque_series_rows(run))
+
+
+def write_screw_csv(run: SimulationRun, path: str | Path) -> None:
+    """Write a dedicated SI/app-frame club screw-motion time series."""
+    require(isinstance(run, SimulationRun), "run must be a SimulationRun", run)
+    with Path(path).open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(SCREW_CSV_COLUMNS)
+        writer.writerows(screw_series_rows(run))
 
 
 def run_to_json_dict(run: SimulationRun) -> dict[str, Any]:
@@ -225,6 +286,12 @@ def run_to_json_dict(run: SimulationRun) -> dict[str, Any]:
                 "unit": "N*m",
                 "joint_ids": list(run.swing_joint_ids),
                 "values": run.swing_applied_torques_nm.tolist(),
+            },
+            "club_screw_motion": {
+                "frame": "app/world",
+                "units": "SI",
+                "columns": list(SCREW_CSV_COLUMNS),
+                "rows": [list(row) for row in screw_series_rows(run)],
             },
         },
     }

--- a/src/rate_of_closure/simulation/screw_analysis.py
+++ b/src/rate_of_closure/simulation/screw_analysis.py
@@ -1,0 +1,304 @@
+"""Typed instantaneous screw-motion analysis for clubs and articulated joints.
+
+The app-frame convention is ``x`` toward the target, ``y`` up, and ``z``
+right of target.  A club twist stores angular velocity followed by the linear
+velocity of the explicitly supplied reference point.  This differs from a
+spatial twist whose linear term is defined at the world origin, so the
+reference point is a mandatory part of this API.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+
+import numpy as np
+
+from rate_of_closure._contracts import ensure, require
+
+__all__ = [
+    "JointMotionSeries",
+    "MotionKind",
+    "MotionProjection",
+    "ScrewGlyph",
+    "ScrewMotion",
+    "analyze_joint_motion",
+    "analyze_twist",
+    "build_screw_glyph",
+    "project_motion",
+]
+
+_MOTION_EPS = 1e-10
+_GLYPH_POINTS = 96
+_DEFAULT_DIRECTIONS = MappingProxyType(
+    {
+        "target": np.array([1.0, 0.0, 0.0]),
+        "vertical": np.array([0.0, 1.0, 0.0]),
+        "lateral": np.array([0.0, 0.0, 1.0]),
+    }
+)
+
+
+class MotionKind(StrEnum):
+    """Truthful geometric state of an instantaneous rigid-body motion."""
+
+    FINITE = "finite"
+    TRANSLATION = "translation"
+    STATIONARY = "stationary"
+
+
+@dataclass(frozen=True)
+class ScrewMotion:
+    """One rigid body's instantaneous screw decomposition in the app frame."""
+
+    kind: MotionKind
+    reference_point_m: np.ndarray
+    reference_velocity_m_s: np.ndarray
+    angular_velocity_rad_s: np.ndarray
+    axis_direction: np.ndarray
+    axis_point_m: np.ndarray | None
+    pitch_m_rad: float | None
+    angular_rate_rad_s: float
+    axial_speed_m_s: float
+    radius_m: float | None
+    orbital_velocity_m_s: np.ndarray
+    axial_velocity_m_s: np.ndarray
+    reconstruction_residual_m_s: float
+
+
+@dataclass(frozen=True)
+class MotionProjection:
+    """Signed velocity breakdown along one named unit direction."""
+
+    direction: np.ndarray
+    total_m_s: float
+    orbital_m_s: float
+    axial_m_s: float
+
+
+@dataclass(frozen=True)
+class ScrewGlyph:
+    """Renderer-neutral engineering glyph for one finite screw axis."""
+
+    axis_line_m: np.ndarray
+    helix_m: np.ndarray
+    radius_line_m: np.ndarray
+    handedness: int
+
+
+@dataclass(frozen=True)
+class JointMotionSeries:
+    """Per-joint revolute screw contributions to the distal endpoint."""
+
+    joint_ids: tuple[str, ...]
+    axis_points_m: np.ndarray
+    angular_velocity_rad_s: np.ndarray
+    contribution_velocity_m_s: np.ndarray
+    endpoint_velocity_m_s: np.ndarray
+    reconstruction_residual_m_s: np.ndarray
+
+
+def _vector3(value: np.ndarray, name: str) -> np.ndarray:
+    """Return a finite three-vector after enforcing the public contract."""
+    vector = np.asarray(value, dtype=float)
+    require(vector.shape == (3,), f"{name} must have shape (3,)", vector.shape)
+    require(bool(np.all(np.isfinite(vector))), f"{name} must be finite", vector)
+    return vector
+
+
+def _finite_motion(
+    omega: np.ndarray, velocity: np.ndarray, reference: np.ndarray
+) -> ScrewMotion:
+    """Decompose a nonzero-angular-velocity reference-point twist."""
+    rate_squared = float(omega @ omega)
+    rate = math.sqrt(rate_squared)
+    direction = omega / rate
+    pitch = float(omega @ velocity / rate_squared)
+    axis_point = reference + np.cross(omega, velocity) / rate_squared
+    axial = pitch * omega
+    orbital = velocity - axial
+    radius = float(np.linalg.norm(reference - axis_point))
+    residual = float(np.linalg.norm(orbital + axial - velocity))
+    ensure(residual <= 1e-9, "screw components must reconstruct velocity", residual)
+    return ScrewMotion(
+        MotionKind.FINITE,
+        reference,
+        velocity,
+        omega,
+        direction,
+        axis_point,
+        pitch,
+        rate,
+        pitch * rate,
+        radius,
+        orbital,
+        axial,
+        residual,
+    )
+
+
+def analyze_twist(twist: np.ndarray, reference_point_m: np.ndarray) -> ScrewMotion:
+    """Decompose ``[omega, velocity_at_reference]`` into screw motion.
+
+    Pure translation has its screw axis at infinity and stationary motion has
+    no axis.  Both therefore return ``axis_point_m=None`` rather than inventing
+    finite display geometry.
+    """
+    values = np.asarray(twist, dtype=float)
+    require(values.shape == (6,), "twist must have shape (6,)", values.shape)
+    require(bool(np.all(np.isfinite(values))), "twist must be finite", values)
+    reference = _vector3(reference_point_m, "reference_point_m")
+    omega, velocity = values[:3], values[3:]
+    if float(np.linalg.norm(omega)) > _MOTION_EPS:
+        return _finite_motion(omega, velocity, reference)
+    speed = float(np.linalg.norm(velocity))
+    kind = MotionKind.TRANSLATION if speed > _MOTION_EPS else MotionKind.STATIONARY
+    direction = velocity / speed if speed > _MOTION_EPS else np.zeros(3)
+    return ScrewMotion(
+        kind,
+        reference,
+        velocity,
+        omega,
+        direction,
+        None,
+        None,
+        0.0,
+        speed if kind is MotionKind.TRANSLATION else 0.0,
+        None,
+        np.zeros(3),
+        velocity.copy(),
+        0.0,
+    )
+
+
+def _unit_direction(value: np.ndarray, name: str) -> np.ndarray:
+    """Return a validated unit direction for a signed projection."""
+    direction = _vector3(value, name)
+    magnitude = float(np.linalg.norm(direction))
+    require(magnitude > _MOTION_EPS, f"{name} must be nonzero", direction)
+    return direction / magnitude
+
+
+def project_motion(
+    motion: ScrewMotion,
+    directions: Mapping[str, np.ndarray] | None = None,
+) -> dict[str, MotionProjection]:
+    """Project total, orbital, and axial velocity onto named directions."""
+    require(isinstance(motion, ScrewMotion), "motion must be a ScrewMotion")
+    selected = directions or _DEFAULT_DIRECTIONS
+    result: dict[str, MotionProjection] = {}
+    for name, raw_direction in selected.items():
+        require(bool(name.strip()), "projection names must be nonempty", name)
+        direction = _unit_direction(raw_direction, f"direction[{name}]")
+        result[name] = MotionProjection(
+            direction,
+            float(motion.reference_velocity_m_s @ direction),
+            float(motion.orbital_velocity_m_s @ direction),
+            float(motion.axial_velocity_m_s @ direction),
+        )
+    return result
+
+
+def _orthogonal_basis(axis: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Build a deterministic right-handed basis normal to ``axis``."""
+    seed = np.eye(3)[int(np.argmin(np.abs(axis)))]
+    first = np.cross(axis, seed)
+    first /= np.linalg.norm(first)
+    return first, np.cross(axis, first)
+
+
+def _dominant_sign(vector: np.ndarray) -> int:
+    """Encode angular direction independently of floating-point near-zero noise."""
+    value = float(vector[int(np.argmax(np.abs(vector)))])
+    return 1 if value >= 0.0 else -1
+
+
+def build_screw_glyph(motion: ScrewMotion, scene_extent_m: float) -> ScrewGlyph | None:
+    """Build bounded axis, helix, and reference-radius geometry.
+
+    Axis length grows monotonically with angular rate but is capped by the
+    current swing-scale extent, preventing extreme rates or pitch from changing
+    plot bounds.  Helix handedness follows the dominant signed angular component.
+    """
+    require(
+        math.isfinite(scene_extent_m) and scene_extent_m > 0.0,
+        "scene_extent_m must be finite and > 0",
+        scene_extent_m,
+    )
+    if motion.kind is not MotionKind.FINITE or motion.axis_point_m is None:
+        return None
+    growth = 0.55 + 0.35 * math.tanh(motion.angular_rate_rad_s / 10.0)
+    half_length = scene_extent_m * growth
+    axis = motion.axis_direction
+    point = motion.axis_point_m
+    axis_line = np.vstack([point - half_length * axis, point + half_length * axis])
+    first, second = _orthogonal_basis(axis)
+    handedness = _dominant_sign(motion.angular_velocity_rad_s)
+    phase = np.linspace(-2.0 * math.pi, 2.0 * math.pi, _GLYPH_POINTS)
+    axial = np.linspace(-0.82 * half_length, 0.82 * half_length, _GLYPH_POINTS)
+    radius = scene_extent_m * 0.055
+    helix = (
+        point
+        + np.outer(axial, axis)
+        + radius * np.outer(np.cos(phase), first)
+        + handedness * radius * np.outer(np.sin(phase), second)
+    )
+    radius_line = np.vstack([point, motion.reference_point_m])
+    return ScrewGlyph(axis_line, helix, radius_line, handedness)
+
+
+def _joint_inputs(
+    times_s: np.ndarray, joint_positions_m: np.ndarray, joint_ids: tuple[str, ...]
+) -> tuple[np.ndarray, np.ndarray]:
+    """Validate and normalize sampled articulated geometry."""
+    times = np.asarray(times_s, dtype=float)
+    points = np.asarray(joint_positions_m, dtype=float)
+    require(times.ndim == 1 and len(times) >= 3, "times_s must contain >= 3 samples")
+    require(bool(np.all(np.isfinite(times))), "times_s must be finite")
+    require(bool(np.all(np.diff(times) > 0.0)), "times_s must be strictly increasing")
+    require(
+        points.shape == (len(times), len(joint_ids) + 1, 3),
+        "joint_positions_m must have shape (N, len(joint_ids)+1, 3)",
+        points.shape,
+    )
+    require(bool(np.all(np.isfinite(points))), "joint_positions_m must be finite")
+    require(len(set(joint_ids)) == len(joint_ids), "joint_ids must be unique")
+    return times, points
+
+
+def analyze_joint_motion(
+    times_s: np.ndarray,
+    joint_positions_m: np.ndarray,
+    joint_ids: tuple[str, ...],
+) -> JointMotionSeries:
+    """Reconstruct planar revolute-joint contributions from sampled link geometry.
+
+    Each joint's angular velocity is the relative angular velocity between its
+    distal and proximal links.  Contributions are evaluated at the distal
+    endpoint.  The returned residual quantifies disagreement with the numerical
+    derivative of that endpoint and must remain visible to consumers.
+    """
+    times, points = _joint_inputs(times_s, joint_positions_m, joint_ids)
+    segments = points[:, 1:, :] - points[:, :-1, :]
+    segment_rates = np.gradient(segments, times, axis=0, edge_order=2)
+    lengths_squared = np.einsum("nji,nji->nj", segments, segments)
+    require(bool(np.all(lengths_squared > _MOTION_EPS)), "segments must be nonzero")
+    absolute_omega = np.cross(segments, segment_rates) / lengths_squared[..., None]
+    relative_omega = absolute_omega.copy()
+    relative_omega[:, 1:, :] -= absolute_omega[:, :-1, :]
+    endpoint = points[:, -1, :]
+    arms = endpoint[:, None, :] - points[:, :-1, :]
+    contributions = np.cross(relative_omega, arms)
+    endpoint_velocity = np.gradient(endpoint, times, axis=0, edge_order=2)
+    residual = np.linalg.norm(contributions.sum(axis=1) - endpoint_velocity, axis=1)
+    return JointMotionSeries(
+        tuple(joint_ids),
+        points[:, :-1, :].copy(),
+        relative_omega,
+        contributions,
+        endpoint_velocity,
+        residual,
+    )

--- a/src/rate_of_closure/ui/pyqt6/inspector_view.py
+++ b/src/rate_of_closure/ui/pyqt6/inspector_view.py
@@ -25,7 +25,12 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from rate_of_closure.simulation import SimulationRun, write_csv, write_json
+from rate_of_closure.simulation import (
+    SimulationRun,
+    write_csv,
+    write_json,
+    write_screw_csv,
+)
 from rate_of_closure.simulation.export import CSV_COLUMNS, series_rows
 
 logger = logging.getLogger(__name__)
@@ -94,6 +99,15 @@ class InspectorView(QWidget):
         self._export_csv_button.clicked.connect(self._on_export_csv)
         header.addWidget(self._export_csv_button)
 
+        self._export_screw_csv_button = QPushButton("Export Screw CSV…")
+        self._export_screw_csv_button.setToolTip(
+            "Write the club screw-axis decomposition, velocity components, "
+            "and reconstruction residual at every swing sample."
+        )
+        self._export_screw_csv_button.setEnabled(False)
+        self._export_screw_csv_button.clicked.connect(self._on_export_screw_csv)
+        header.addWidget(self._export_screw_csv_button)
+
         self._export_json_button = QPushButton("Export JSON…")
         self._export_json_button.setToolTip(
             "Write parameters, delivery/launch summaries, and the time "
@@ -115,6 +129,7 @@ class InspectorView(QWidget):
         """Populate (or clear, with ``None``) the inspector."""
         self._run = run
         self._export_csv_button.setEnabled(run is not None)
+        self._export_screw_csv_button.setEnabled(run is not None)
         self._export_json_button.setEnabled(run is not None)
         self._table.setSortingEnabled(False)
         self._table.setRowCount(0)
@@ -182,3 +197,21 @@ class InspectorView(QWidget):
 
     def _on_export_json(self) -> None:
         self._export("json")
+
+    def _on_export_screw_csv(self) -> None:
+        """Prompt for the dedicated screw-motion CSV destination."""
+        if self._run is None:
+            return
+        path, _selected = QFileDialog.getSaveFileName(
+            self,
+            "Export Club Screw Motion (CSV)",
+            "club_screw_motion.csv",
+            "CSV files (*.csv);;All files (*)",
+        )
+        if not path:
+            return
+        try:
+            write_screw_csv(self._run, path)
+        except OSError as exc:
+            logger.warning("screw export failed: %s", exc)
+            QMessageBox.warning(self, "Export Failed", str(exc))

--- a/src/rate_of_closure/ui/pyqt6/screw_overlay.py
+++ b/src/rate_of_closure/ui/pyqt6/screw_overlay.py
@@ -1,0 +1,140 @@
+"""Engineering presentation helpers for instantaneous screw motion."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from rate_of_closure.simulation.screw_analysis import (
+    MotionKind,
+    ScrewMotion,
+    build_screw_glyph,
+    project_motion,
+)
+
+
+def _velocity_angles(velocity: np.ndarray) -> tuple[float, float] | None:
+    """Return exact (angle of attack, path) angles, or ``None`` at rest."""
+    if float(np.linalg.norm(velocity)) < 1e-10:
+        return None
+    attack = np.degrees(np.arctan2(velocity[1], np.hypot(velocity[0], velocity[2])))
+    path = np.degrees(np.arctan2(velocity[2], velocity[0]))
+    return float(attack), float(path)
+
+
+def format_screw_readout(
+    label: str,
+    motion: ScrewMotion,
+    loft_deg: float,
+    contribution_residual_m_s: float | None = None,
+) -> str:
+    """Describe one screw-motion glyph, decomposition, and output projections."""
+    if motion.kind is not MotionKind.FINITE:
+        description = (
+            "Pure translation: the screw axis is at infinity; the arrow shows "
+            "the translation direction."
+            if motion.kind is MotionKind.TRANSLATION
+            else "Stationary: angular and reference-point speeds are zero, so no "
+            "axis exists."
+        )
+        return f"{label} — {description}"
+
+    loft = np.radians(loft_deg)
+    directions = {
+        "target": np.array([1.0, 0.0, 0.0]),
+        "vertical": np.array([0.0, 1.0, 0.0]),
+        "lateral": np.array([0.0, 0.0, 1.0]),
+        "face_normal": np.array([np.cos(loft), np.sin(loft), 0.0]),
+    }
+    projections = project_motion(motion, directions)
+    angles = _velocity_angles(motion.reference_velocity_m_s)
+    angle_text = (
+        f" AoA {angles[0]:+.2f}°, Path {angles[1]:+.2f}°; "
+        if angles is not None
+        else " AoA/Path undefined at zero speed; "
+    )
+    residual_text = (
+        f" · Joint Contribution Residual {contribution_residual_m_s:.3e} m/s"
+        if contribution_residual_m_s is not None
+        else ""
+    )
+    projection_text = "; ".join(
+        f"{display_name} {projection.total_m_s:+.3f} = "
+        f"{projection.orbital_m_s:+.3f} orbital + "
+        f"{projection.axial_m_s:+.3f} axial"
+        for display_name, projection in (
+            ("Target", projections["target"]),
+            ("Vertical/AoA", projections["vertical"]),
+            ("Lateral/Path", projections["lateral"]),
+            ("Face Normal", projections["face_normal"]),
+        )
+    )
+    return (
+        f"{label} — Finite screw in app/world frame (x target, y up, z right). "
+        "Axis arrow follows ω; wrapped arc shows rotation handedness. "
+        f"ω {np.degrees(motion.angular_rate_rad_s):.1f} °/s · "
+        f"Pitch {motion.pitch_m_rad:+.4f} m/rad · "
+        f"Axial {motion.axial_speed_m_s:+.3f} m/s · R_ISA {motion.radius_m:.3f} m. "
+        "Orbital + axial velocity reconstructs the selected-point velocity. "
+        "Signed projection breakdown [total = orbital + axial] (m/s): "
+        f"{projection_text}."
+        f"{angle_text}orbital/axial direction angles are diagnostics, not additive"
+        f"{residual_text}."
+    )
+
+
+@dataclass(frozen=True)
+class ScrewOverlayRenderer:
+    """Render a screw glyph through a scene's coordinate presentation adapter."""
+
+    axes: Any
+    display: Callable[[np.ndarray], np.ndarray]
+    chart_color: Callable[[int], str]
+
+    def draw(self, motion: ScrewMotion, extent: float, label: str) -> None:
+        """Draw a directed axis, wrapped helix, reference radius, or translation."""
+        glyph = build_screw_glyph(motion, extent)
+        if glyph is None:
+            self._draw_degenerate(motion, extent)
+            return
+
+        axis = self.display(glyph.axis_line_m)
+        helix = self.display(glyph.helix_m)
+        radius = self.display(glyph.radius_line_m)
+        color = self.chart_color(5)
+        self.axes.plot(*axis.T, color=color, lw=2.4, label=f"Screw Axis — {label}")
+        self.axes.plot(
+            *helix.T,
+            color=self.chart_color(3),
+            lw=2.0,
+            label="Helical Motion — rotation handedness",
+        )
+        self.axes.plot(
+            *radius.T,
+            color=self.chart_color(6),
+            lw=1.4,
+            ls=":",
+            label="R_ISA — reference-point radius",
+        )
+        direction = self.display(motion.axis_direction) * extent * 0.22
+        start = self.display(
+            glyph.axis_line_m[1] - motion.axis_direction * extent * 0.22
+        )
+        self.axes.quiver(*start, *direction, color=color, arrow_length_ratio=0.32)
+
+    def _draw_degenerate(self, motion: ScrewMotion, extent: float) -> None:
+        """Truthfully render translation direction or a stationary point."""
+        if motion.kind is MotionKind.STATIONARY:
+            return
+        start = self.display(motion.reference_point_m)
+        direction = self.display(motion.axis_direction) * extent * 0.7
+        self.axes.quiver(
+            *start,
+            *direction,
+            color=self.chart_color(5),
+            arrow_length_ratio=0.18,
+            label="Pure Translation — Screw Axis at Infinity",
+        )

--- a/src/rate_of_closure/ui/pyqt6/simulation_view.py
+++ b/src/rate_of_closure/ui/pyqt6/simulation_view.py
@@ -27,9 +27,13 @@ from PyQt6.QtWidgets import (
 from rate_of_closure.simulation import (
     KineticsSeries,
     SimulationRun,
-    screw_axis_samples,
 )
-from rate_of_closure.simulation.isa import MIN_RATE_DPS
+from rate_of_closure.simulation.screw_analysis import (
+    JointMotionSeries,
+    ScrewMotion,
+    analyze_joint_motion,
+    analyze_twist,
+)
 from rate_of_closure.ui.course import CourseLayout
 from rate_of_closure.ui.pyqt6.ball_setup_scene import draw_representative_tee
 from rate_of_closure.ui.pyqt6.course_scene import draw_course_ground_3d
@@ -39,6 +43,10 @@ from rate_of_closure.ui.pyqt6.figure_canvas import (
 from rate_of_closure.ui.pyqt6.kinetics_overlay import overlay_frame
 from rate_of_closure.ui.pyqt6.pendulum_scene import draw_pendulum_skeleton
 from rate_of_closure.ui.pyqt6.presentation_kinetics import kinetics_for_presentation
+from rate_of_closure.ui.pyqt6.screw_overlay import (
+    ScrewOverlayRenderer,
+    format_screw_readout,
+)
 from rate_of_closure.ui.pyqt6.simulation_specs import RATE_PRESETS
 from rate_of_closure.units import FIELD_GUIDANCE
 
@@ -58,6 +66,27 @@ __all__ = ["RATE_PRESETS", "SimulationView"]
 _TIMER_INTERVAL_MS = 40
 _SLIDER_STEPS = 1000
 _BALL_DRAW_RADIUS_M = 0.03  # slightly over scale so the ball stays visible
+_JOINT_LABELS = {
+    "joint.shoulder": "Shoulder Joint",
+    "joint.elbow": "Elbow Joint",
+    "joint.wrist": "Wrist Joint",
+}
+
+
+def _fallback_joint_ids(count: int) -> tuple[str, ...]:
+    """Return stable display IDs for articulated sources without torque IDs."""
+    canonical = ("joint.shoulder", "joint.elbow", "joint.wrist")
+    return tuple(
+        canonical[index] if index < len(canonical) else f"joint.{index + 1}"
+        for index in range(count)
+    )
+
+
+def _joint_label(joint_id: str) -> str:
+    """Return an engineering-facing label for one stable joint identifier."""
+    return _JOINT_LABELS.get(
+        joint_id, joint_id.removeprefix("joint.").replace("_", " ").title() + " Joint"
+    )
 
 
 class SimulationView(QWidget):
@@ -71,7 +100,7 @@ class SimulationView(QWidget):
 
         self._course_layout = CourseLayout()
         self._run: SimulationRun | None = None
-        self._screws: list[dict] | None = None
+        self._joint_motion: JointMotionSeries | None = None
         # None = not resolved yet; False = source has no joint states.
         self._kinetics: KineticsSeries | None | bool = None
         self._time = 0.0
@@ -82,6 +111,15 @@ class SimulationView(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addLayout(self._build_playback_bar())
         layout.addLayout(self._build_toggle_bar())
+        self._screw_readout = QLabel()
+        self._screw_readout.setWordWrap(True)
+        self._screw_readout.setVisible(False)
+        self._screw_readout.setToolTip(
+            "Engineering screw-motion readout in the app frame: x target, "
+            "y up, z right. Orbital + axial velocity reconstructs the selected "
+            "point velocity. Pure translation has an axis at infinity."
+        )
+        layout.addWidget(self._screw_readout)
         layout.addWidget(self._canvas)
 
         self._timer = QTimer(self)
@@ -153,6 +191,13 @@ class SimulationView(QWidget):
         self._screw_check = QCheckBox("Screw Axis")
         self._screw_check.setChecked(False)
         self._screw_check.setToolTip(FIELD_GUIDANCE["screw_axis_visible"])
+        self._screw_entity = QComboBox()
+        self._screw_entity.addItem("Club", "club")
+        self._screw_entity.setToolTip(
+            "Select the club rigid body or a modeled revolute joint. "
+            "Joint glyphs show that joint's instantaneous contribution at the clubhead."
+        )
+        self._screw_entity.currentIndexChanged.connect(lambda _index: self._draw())
         # Kinetics overlay (#4125 H2): torque arcs + force arrows.
         self._kinetics_check = QCheckBox("Show Kinetics")
         self._kinetics_check.setChecked(False)
@@ -176,6 +221,7 @@ class SimulationView(QWidget):
         ):
             check.toggled.connect(lambda _checked: self._draw())
             bar.addWidget(check)
+        bar.addWidget(self._screw_entity)
         bar.addStretch(1)
         return bar
 
@@ -183,9 +229,10 @@ class SimulationView(QWidget):
     def set_run(self, run: SimulationRun | None) -> None:
         """Adopt a run (or clear with ``None``) and reset the timeline."""
         self._run = run
-        self._screws = None
+        self._joint_motion = None
         self._kinetics = None
         self._time = 0.0
+        self._populate_screw_entities()
         self._sync_slider()
         self._draw()
 
@@ -309,13 +356,57 @@ class SimulationView(QWidget):
         self._sync_slider()
         self._draw()
 
-    def _screw_entries(self) -> list[dict]:
-        if self._run is None:
-            return []
-        if self._screws is None:
-            dt = float(self._run.swing_times[1] - self._run.swing_times[0])
-            self._screws = screw_axis_samples(self._run.swing_poses, dt)
-        return self._screws
+    def _populate_screw_entities(self) -> None:
+        """Expose the club plus every articulated revolute joint in the run."""
+        selected = self._screw_entity.currentData()
+        self._screw_entity.blockSignals(True)
+        self._screw_entity.clear()
+        self._screw_entity.addItem("Club", "club")
+        if self._run is not None and self._run.swing_joints.shape[1] >= 2:
+            count = self._run.swing_joints.shape[1] - 1
+            identifiers = self._run.swing_joint_ids or _fallback_joint_ids(count)
+            for joint_id in identifiers:
+                self._screw_entity.addItem(_joint_label(joint_id), joint_id)
+        match = self._screw_entity.findData(selected)
+        self._screw_entity.setCurrentIndex(max(match, 0))
+        self._screw_entity.blockSignals(False)
+
+    def _joint_series(self) -> JointMotionSeries | None:
+        """Lazily reconstruct joint contributions for articulated sources."""
+        if self._run is None or self._run.swing_joints.shape[1] < 2:
+            return None
+        if self._joint_motion is None:
+            count = self._run.swing_joints.shape[1] - 1
+            identifiers = self._run.swing_joint_ids or _fallback_joint_ids(count)
+            self._joint_motion = analyze_joint_motion(
+                self._run.swing_times, self._run.swing_joints, identifiers
+            )
+        return self._joint_motion
+
+    def _selected_motion(self, index: int) -> tuple[str, ScrewMotion, float | None]:
+        """Return label, motion, and optional joint reconstruction residual."""
+        assert self._run is not None
+        entity = str(self._screw_entity.currentData() or "club")
+        if entity == "club":
+            motion = analyze_twist(
+                self._run.swing_twists[index], self._run.swing_positions[index]
+            )
+            return "Club", motion, None
+        series = self._joint_series()
+        assert series is not None
+        joint_index = series.joint_ids.index(entity)
+        twist = np.concatenate(
+            [
+                series.angular_velocity_rad_s[index, joint_index],
+                series.contribution_velocity_m_s[index, joint_index],
+            ]
+        )
+        motion = analyze_twist(twist, self._run.swing_positions[index])
+        return (
+            _joint_label(entity),
+            motion,
+            float(series.reconstruction_residual_m_s[index]),
+        )
 
     @staticmethod
     def _display(points: np.ndarray) -> np.ndarray:
@@ -376,28 +467,16 @@ class SimulationView(QWidget):
             self._axes.quiver(*s, *v, color=color, label=label, **style)
 
     def _draw_screw_axis(self, index: int, extent: float) -> None:
-        entries = self._screw_entries()
-        if not entries:
-            return
-        entry = entries[min(index, len(entries) - 1)]
-        if entry["rate_dps"] < MIN_RATE_DPS:
-            return
-        axis, point = entry["axis"], entry["point"]
-        length = extent * 1.2
-        line = np.vstack([point - length * axis, point + length * axis])
-        pts = self._display(line)
-        self._axes.plot(
-            pts[:, 0],
-            pts[:, 1],
-            pts[:, 2],
-            color=get_chart_color(5),
-            lw=1.6,
-            ls="--",
-            label=(
-                f"screw axis — {entry['rate_dps']:.0f} °/s, "
-                f"pitch {entry['pitch']:.3f} m/rad, "
-                f"R_ISA {entry['r_isa_m']:.2f} m"
-            ),
+        """Draw a directed axis, wrapped helix, radius, and live explanation."""
+        label, motion, residual = self._selected_motion(index)
+        assert self._run is not None
+        self._screw_readout.setText(
+            format_screw_readout(
+                label, motion, self._run.config.club.loft_deg, residual
+            )
+        )
+        ScrewOverlayRenderer(self._axes, self._display, get_chart_color).draw(
+            motion, extent, label
         )
 
     def _draw(self) -> None:
@@ -408,6 +487,7 @@ class SimulationView(QWidget):
         self._tee_artist_count = 0
         run = self._run
         if run is None:
+            self._screw_readout.setVisible(False)
             axes.set_title("Run a simulation to populate the scene")
             self._canvas.draw_idle()
             return
@@ -506,7 +586,9 @@ class SimulationView(QWidget):
                 ball = self._display(run.flight_positions[n_flight - 1])
                 axes.scatter(*ball, color=get_chart_color(4), s=25, zorder=5)
 
-        if self._screw_check.isChecked() and not in_flight:
+        show_screw = self._screw_check.isChecked() and not in_flight
+        self._screw_readout.setVisible(show_screw)
+        if show_screw:
             self._draw_screw_axis(index, extent)
         if self._kinetics_check.isChecked() and not in_flight:
             self._draw_kinetics(index)

--- a/src/rate_of_closure/web/src/components/SimulationDisplay.tsx
+++ b/src/rate_of_closure/web/src/components/SimulationDisplay.tsx
@@ -13,6 +13,11 @@ import { StrikeCanvas } from "./StrikeCanvas";
 import { SwingPlaybackControls } from "./SwingPlaybackControls";
 import { TargetSection } from "./TargetSection";
 import { drawSwingScene } from "./swingSceneDraw";
+import {
+  screwEntityOptions,
+  screwExplanation,
+  screwPresentation,
+} from "./screwPresentation";
 
 const VIEWS = ["Strike", "Swing", "Kinetics", "Flight"] as const;
 type ViewName = (typeof VIEWS)[number];
@@ -21,6 +26,7 @@ const TOGGLE_GUIDANCE = {
   ball: FIELD_GUIDANCE.ballVisible,
   ground: FIELD_GUIDANCE.groundVisible,
   course: FIELD_GUIDANCE.courseVisible,
+  screw: FIELD_GUIDANCE.screwAxisVisible,
   flight: `Warning: expands the scene to flight scale, dwarfing the swing. ${FIELD_GUIDANCE.swingFlightToggle}`,
 };
 
@@ -52,9 +58,15 @@ export function SimulationDisplay({
   const [showBall, setShowBall] = useState(true);
   const [showGround, setShowGround] = useState(true);
   const [showCourse, setShowCourse] = useState(true);
+  const [showScrew, setShowScrew] = useState(true);
+  const [screwEntityId, setScrewEntityId] = useState("club");
   const [showFlight, setShowFlight] = useState(false);
   const [view, setView] = useState<ViewName>("Swing");
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const screwEntities = useMemo(() => screwEntityOptions(run), [run]);
+  const screwData = useMemo(() =>
+    run && showScrew ? screwPresentation(run, time, screwEntityId) : null,
+  [run, time, showScrew, screwEntityId]);
 
   const targetLayout = useMemo<CourseLayout>(() =>
     target.kind === "green"
@@ -83,6 +95,7 @@ export function SimulationDisplay({
   useEffect(() => {
     setTime(0);
     setPlaying(false);
+    setScrewEntityId("club");
   }, [run]);
   useEffect(() => {
     if (!playing || !run) return undefined;
@@ -107,9 +120,13 @@ export function SimulationDisplay({
     if (canvasRef.current) {
       drawSwingScene(canvasRef.current, run, {
         time, showBall, showGround, showCourse, showFlight,
+        showScrew, screwEntityId,
       });
     }
-  }, [run, time, showBall, showGround, showCourse, showFlight, view]);
+  }, [
+    run, time, showBall, showGround, showCourse, showFlight,
+    showScrew, screwEntityId, view,
+  ]);
 
   return (
     <section className="min-w-0 space-y-3">
@@ -150,11 +167,42 @@ export function SimulationDisplay({
               ["Ball", showBall, setShowBall, TOGGLE_GUIDANCE.ball, "text-slate-300"],
               ["Ground", showGround, setShowGround, TOGGLE_GUIDANCE.ground, "text-slate-300"],
               ["Course Elements", showCourse, setShowCourse, TOGGLE_GUIDANCE.course, "text-slate-300"],
+              ["Screw Axis", showScrew, setShowScrew, TOGGLE_GUIDANCE.screw, "text-fuchsia-300"],
               ["Show Ball Flight", showFlight, setShowFlight, TOGGLE_GUIDANCE.flight, "text-amber-300/90"],
             ]} />
+          {showScrew && (
+            <div className="mb-3 grid gap-3 rounded-lg border border-fuchsia-400/30 bg-fuchsia-950/10 p-3 md:grid-cols-[190px_1fr]">
+              <label className="text-sm font-medium text-fuchsia-200">
+                Screw Motion Entity
+                <select
+                  aria-label="Screw Motion Entity"
+                  value={screwEntityId}
+                  onChange={(event) => setScrewEntityId(event.target.value)}
+                  className="mt-1 w-full rounded-md border border-fuchsia-400/40 bg-slate-950 px-2 py-1.5 text-slate-100"
+                >
+                  {screwEntities.map((entity) => (
+                    <option key={entity.id} value={entity.id}>{entity.label}</option>
+                  ))}
+                </select>
+              </label>
+              <p
+                role="note"
+                aria-label="Screw Motion Explanation"
+                className="text-xs leading-relaxed text-slate-300"
+              >
+                {screwData
+                  ? screwExplanation(screwData, [
+                      Math.cos(effectiveLoftDeg * Math.PI / 180),
+                      Math.sin(effectiveLoftDeg * Math.PI / 180),
+                      0,
+                    ])
+                  : "Run a simulation to calculate the selected screw motion."}
+              </p>
+            </div>
+          )}
           <canvas ref={canvasRef} width={860} height={480}
             className="w-full min-w-0 rounded-lg border border-slate-800 bg-slate-950/60"
-            aria-label="Simulation scene (side view, swing scale)" />
+            aria-label="Simulation scene with selectable screw-axis motion glyph" />
         </>}
       </div>
     </section>

--- a/src/rate_of_closure/web/src/components/SimulationPanel.test.tsx
+++ b/src/rate_of_closure/web/src/components/SimulationPanel.test.tsx
@@ -52,6 +52,28 @@ function displayedLaunchAngle(): number {
 }
 
 describe("SimulationPanel impact club", () => {
+  it("shows a selectable, explained screw-axis glyph for club and joints", () => {
+    renderPanel(getClub("Driver 10.5°"));
+    expect(screen.getByRole("checkbox", { name: "Screw Axis" })).toBeChecked();
+    expect(screen.getByRole("combobox", { name: "Screw Motion Entity" }))
+      .toHaveValue("club");
+    expect(screen.getByRole("note", { name: "Screw Motion Explanation" }))
+      .toHaveTextContent(/pure translation.*axis is at infinity/i);
+
+    fireEvent.change(screen.getByLabelText("Swing Source"), {
+      target: { value: "double_pendulum" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run Simulation" }));
+    const selector = screen.getByRole("combobox", { name: "Screw Motion Entity" });
+    expect(selector).toHaveTextContent("Shoulder Joint");
+    expect(selector).toHaveTextContent("Wrist Joint");
+    fireEvent.change(selector, { target: { value: "joint.shoulder" } });
+    expect(screen.getByRole("note", { name: "Screw Motion Explanation" }))
+      .toHaveTextContent(/Shoulder Joint.*contribution residual/i);
+    expect(screen.getByRole("note", { name: "Screw Motion Explanation" }))
+      .toHaveTextContent("total = orbital + axial");
+  });
+
   it("applies club defaults, preserves explicit overrides, and can restore the default", () => {
     const driver = getClub("Driver 10.5°");
     const view = renderPanel(driver);

--- a/src/rate_of_closure/web/src/components/screwPresentation.ts
+++ b/src/rate_of_closure/web/src/components/screwPresentation.ts
@@ -1,0 +1,141 @@
+/** UI-neutral selection and explanation helpers for the swing screw overlay. */
+
+import type { SimulationRunTs } from "../model/simulation";
+import {
+  analyzeTwist,
+  jointMotionAt,
+  projectMotion,
+  type MotionProjectionTs,
+  type ScrewMotionTs,
+  type Twist6,
+  type Vec3,
+} from "../model/screwAnalysis";
+
+const JOINT_LABELS: Record<string, string> = {
+  "joint.shoulder": "Shoulder Joint",
+  "joint.elbow": "Elbow Joint",
+  "joint.wrist": "Wrist Joint",
+};
+
+export interface ScrewEntityOption {
+  id: string;
+  label: string;
+}
+
+export interface ScrewPresentation {
+  label: string;
+  motion: ScrewMotionTs;
+  jointResidualMps: number | null;
+}
+
+function jointIds(run: SimulationRunTs): string[] {
+  const count = Math.max(0, (run.swing[0]?.joints.length ?? 1) - 1);
+  const canonical = run.sourceKind === "triple_pendulum"
+    ? ["joint.shoulder", "joint.elbow", "joint.wrist"]
+    : ["joint.shoulder", "joint.wrist"];
+  return Array.from({ length: count }, (_, index) =>
+    canonical[index] ?? `joint.${index + 1}`);
+}
+
+export function screwEntityOptions(run: SimulationRunTs | null): ScrewEntityOption[] {
+  const options: ScrewEntityOption[] = [{ id: "club", label: "Club" }];
+  if (!run || run.swing.length === 0) return options;
+  jointIds(run).forEach((id) => options.push({
+    id,
+    label: JOINT_LABELS[id] ?? `${id.replace("joint.", "")} Joint`,
+  }));
+  return options;
+}
+
+function swingIndex(run: SimulationRunTs, time: number): number {
+  const end = run.swing[run.swing.length - 1].t;
+  const bounded = Number.isFinite(time) ? Math.max(0, Math.min(time, end)) : 0;
+  const progress = end > 0 ? bounded / end : 0;
+  return Math.max(0, Math.min(
+    run.swing.length - 1,
+    Math.round(progress * (run.swing.length - 1)),
+  ));
+}
+
+export function screwPresentation(
+  run: SimulationRunTs,
+  time: number,
+  entityId: string,
+): ScrewPresentation {
+  const index = swingIndex(run, time);
+  const sample = run.swing[index];
+  if (entityId === "club") {
+    const twist: Twist6 = [...sample.angularVelocity, ...sample.velocity];
+    return { label: "Club", motion: analyzeTwist(twist, sample.position), jointResidualMps: null };
+  }
+  const ids = jointIds(run);
+  const jointIndex = ids.indexOf(entityId);
+  if (jointIndex < 0) throw new Error(`unknown screw entity ${entityId}`);
+  const joint = jointMotionAt(
+    run.swing.map((row) => row.t),
+    run.swing.map((row) => row.joints),
+    ids,
+    index,
+  );
+  const twist: Twist6 = [
+    ...joint.angularVelocityRadS[jointIndex],
+    ...joint.contributionVelocityMps[jointIndex],
+  ];
+  return {
+    label: JOINT_LABELS[entityId] ?? entityId,
+    motion: analyzeTwist(twist, sample.position),
+    jointResidualMps: joint.reconstructionResidualMps,
+  };
+}
+
+function directionAngles(velocity: Vec3): { aoaDeg: number; pathDeg: number } | null {
+  if (Math.hypot(...velocity) < 1e-10) return null;
+  return {
+    aoaDeg: Math.atan2(velocity[1], Math.hypot(velocity[0], velocity[2])) * 180 / Math.PI,
+    pathDeg: Math.atan2(velocity[2], velocity[0]) * 180 / Math.PI,
+  };
+}
+
+export function screwExplanation(
+  presentation: ScrewPresentation,
+  faceNormal: Vec3 = [1, 0, 0],
+): string {
+  const { label, motion, jointResidualMps } = presentation;
+  if (motion.kind === "translation") {
+    return `${label}: pure translation. The screw axis is at infinity; the arrow shows translation direction.`;
+  }
+  if (motion.kind === "stationary") {
+    return `${label}: stationary at this sample, so no instantaneous axis exists.`;
+  }
+  const projections = projectMotion(motion, {
+    target: [1, 0, 0],
+    vertical: [0, 1, 0],
+    lateral: [0, 0, 1],
+    faceNormal,
+  });
+  const angles = directionAngles(motion.referenceVelocityMps);
+  const angleText = angles
+    ? ` AoA ${angles.aoaDeg.toFixed(2)} deg; path ${angles.pathDeg.toFixed(2)} deg.`
+    : " AoA and path are undefined at zero speed.";
+  const rateDps = motion.angularRateRadS * 180 / Math.PI;
+  const residual = jointResidualMps === null
+    ? ""
+    : ` Joint contribution residual ${jointResidualMps.toExponential(2)} m/s.`;
+  const projectionRows: Array<[string, MotionProjectionTs]> = [
+    ["target", projections.target],
+    ["vertical/AoA", projections.vertical],
+    ["lateral/path", projections.lateral],
+    ["face normal", projections.faceNormal],
+  ];
+  const projectionText = projectionRows.map(([name, projection]) =>
+    `${name} ${projection.totalMps.toFixed(3)} = `
+    + `${projection.orbitalMps.toFixed(3)} orbital + `
+    + `${projection.axialMps.toFixed(3)} axial`).join("; ");
+  return `${label}: finite screw in app/world frame (x target, y up, z right). `
+    + `The axis arrow follows angular velocity; the wrapped arc shows handedness. `
+    + `Rate ${rateDps.toFixed(1)} deg/s; pitch ${motion.pitchMPerRad!.toFixed(4)} m/rad; `
+    + `axial speed ${motion.axialSpeedMps.toFixed(3)} m/s; R_ISA ${motion.radiusM!.toFixed(3)} m. `
+    + `Orbital + axial velocity reconstructs the selected-point velocity. `
+    + `Signed projection breakdown [total = orbital + axial] (m/s): ${projectionText}.`
+    + `${angleText} Orbital/axial direction angles are diagnostics, not additive.${residual}`;
+}

--- a/src/rate_of_closure/web/src/components/swingSceneDraw.ts
+++ b/src/rate_of_closure/web/src/components/swingSceneDraw.ts
@@ -13,7 +13,9 @@ import {
   type CourseLayout,
 } from "../model/course";
 import { GOLF_BALL_RADIUS_M, type SimulationRunTs } from "../model/simulation";
+import { buildScrewGlyph, type Vec3 } from "../model/screwAnalysis";
 import { withAlpha } from "../model/theme";
+import { screwPresentation } from "./screwPresentation";
 
 export interface SwingSceneOptions {
   time: number;
@@ -23,13 +25,71 @@ export interface SwingSceneOptions {
   showCourse: boolean;
   /** Opt-in flight display; off keeps the scene at swing scale. */
   showFlight: boolean;
+  /** Engineering screw glyph for the selected club or joint. */
+  showScrew: boolean;
+  screwEntityId: string;
   layout?: CourseLayout;
+}
+
+type ScreenPoint = [number, number];
+
+function strokePolyline(
+  ctx: CanvasRenderingContext2D,
+  points: Vec3[],
+  project: (point: Vec3) => ScreenPoint,
+  color: string,
+  width: number,
+): void {
+  if (points.length < 2) return;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = width;
+  ctx.beginPath();
+  points.forEach((point, index) => {
+    const [x, y] = project(point);
+    if (index === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+  ctx.lineWidth = 1;
+}
+
+function drawScrewOverlay(
+  ctx: CanvasRenderingContext2D,
+  run: SimulationRunTs,
+  time: number,
+  entityId: string,
+  extent: number,
+  project: (point: Vec3) => ScreenPoint,
+): void {
+  const presentation = screwPresentation(run, time, entityId);
+  const glyph = buildScrewGlyph(presentation.motion, extent);
+  if (glyph === null) {
+    if (presentation.motion.kind !== "translation") return;
+    const end: Vec3 = presentation.motion.referencePointM.map((value, index) =>
+      value + presentation.motion.axisDirection[index] * extent * 0.7) as Vec3;
+    strokePolyline(ctx, [presentation.motion.referencePointM, end], project, "#e879f9", 2.5);
+    return;
+  }
+  strokePolyline(ctx, glyph.axisLineM, project, "#e879f9", 2.6);
+  strokePolyline(ctx, glyph.helixM, project, "#fb923c", 2.1);
+  strokePolyline(ctx, glyph.radiusLineM, project, "#22d3ee", 1.4);
+  const [tipX, tipY] = project(glyph.axisLineM[1]);
+  ctx.fillStyle = "#e879f9";
+  ctx.beginPath();
+  ctx.arc(tipX, tipY, 4, 0, 2 * Math.PI);
+  ctx.fill();
+  ctx.fillStyle = "#f0abfc";
+  ctx.font = "600 12px sans-serif";
+  ctx.fillText(`${presentation.label} Screw Axis`, 12, 52);
 }
 
 export function drawSwingScene(
   canvas: HTMLCanvasElement,
   run: SimulationRunTs | null,
-  { time, showBall, showGround, showCourse, showFlight, layout }: SwingSceneOptions,
+  {
+    time, showBall, showGround, showCourse, showFlight,
+    showScrew, screwEntityId, layout,
+  }: SwingSceneOptions,
 ): void {
   const ctx = canvas.getContext("2d");
   if (!ctx) return;
@@ -200,6 +260,14 @@ export function drawSwingScene(
       12,
       34,
     );
+  }
+
+  if (showScrew && !inFlight) {
+    const project = (point: Vec3): ScreenPoint => [
+      px(point[0] + 0.25 * point[2]),
+      py(point[1] + 0.15 * point[2]),
+    ];
+    drawScrewOverlay(ctx, run, boundedTime, screwEntityId, Math.max(extentX, extentY), project);
   }
 
   // Flight trajectory polyline: opt-in only (scale separation).

--- a/src/rate_of_closure/web/src/model/ballSetupPersistence.test.ts
+++ b/src/rate_of_closure/web/src/model/ballSetupPersistence.test.ts
@@ -42,6 +42,11 @@ describe("ball setup persistence", () => {
       height_reference: "ground_plane_to_ball_bottom",
       ball_center_m: [0, 0.059435, 0],
     });
+    expect(document.series.clubScrewMotion).toMatchObject({
+      frame: "app/world",
+      units: "SI",
+    });
+    expect(document.series.clubScrewMotion.rows).toHaveLength(document.series.swing.length);
   });
 
   it("round-trips the setup, override policy, and reference metadata", () => {

--- a/src/rate_of_closure/web/src/model/ballSetupPersistence.ts
+++ b/src/rate_of_closure/web/src/model/ballSetupPersistence.ts
@@ -7,6 +7,7 @@ import {
   resolveBallSetup,
   type BallSetup,
 } from "./ballSetup";
+import { analyzeTwist, type Twist6 } from "./screwAnalysis";
 import type { SimulationInput, SimulationRunTs } from "./simulation";
 
 export const BALL_SETUP_STORAGE_KEY = "rate_of_closure.ball_setup.web/v1";
@@ -110,6 +111,23 @@ export function createSimulationRunDocument(
   prescribedTorqueProfile: unknown = null,
 ) {
   const setup = resolveBallSetup(input.ballSetup);
+  const clubScrewMotion = run.swing.map((sample) => {
+    const twist: Twist6 = [...sample.angularVelocity, ...sample.velocity];
+    const motion = analyzeTwist(twist, sample.position);
+    return {
+      t_s: sample.t,
+      motion_kind: motion.kind,
+      angular_rate_rad_s: motion.angularRateRadS,
+      pitch_m_rad: motion.pitchMPerRad,
+      axial_speed_m_s: motion.axialSpeedMps,
+      r_isa_m: motion.radiusM,
+      axis_direction: motion.axisDirection,
+      axis_point_m: motion.axisPointM,
+      orbital_velocity_m_s: motion.orbitalVelocityMps,
+      axial_velocity_m_s: motion.axialVelocityMps,
+      reconstruction_residual_m_s: motion.reconstructionResidualMps,
+    };
+  });
   return {
     format: SIMULATION_EXPORT_FORMAT,
     parameters: {
@@ -123,7 +141,11 @@ export function createSimulationRunDocument(
     impactTimeS: run.impactTimeS,
     torqueRun: run.torqueRun,
     prescribedTorqueProfile,
-    series: { swing: run.swing, flight: run.flight },
+    series: {
+      swing: run.swing,
+      flight: run.flight,
+      clubScrewMotion: { frame: "app/world", units: "SI", rows: clubScrewMotion },
+    },
   };
 }
 

--- a/src/rate_of_closure/web/src/model/screwAnalysis.test.ts
+++ b/src/rate_of_closure/web/src/model/screwAnalysis.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeTwist,
+  buildScrewGlyph,
+  jointMotionAt,
+  projectMotion,
+  type Vec3,
+} from "./screwAnalysis";
+
+const closeVector = (actual: Vec3, expected: Vec3): void => {
+  actual.forEach((value, index) => expect(value).toBeCloseTo(expected[index], 10));
+};
+
+describe("screw motion analysis", () => {
+  it("reconstructs a finite screw at the named reference point", () => {
+    const motion = analyzeTwist(
+      [0, 0, 4, 0, 4, 0.5],
+      [1, 0, 0],
+    );
+
+    expect(motion.kind).toBe("finite");
+    closeVector(motion.axisDirection, [0, 0, 1]);
+    closeVector(motion.axisPointM!, [0, 0, 0]);
+    expect(motion.pitchMPerRad).toBeCloseTo(0.125, 12);
+    closeVector(
+      motion.orbitalVelocityMps.map((value, index) =>
+        value + motion.axialVelocityMps[index]) as Vec3,
+      motion.referenceVelocityMps,
+    );
+  });
+
+  it("does not invent a finite axis for translation or rest", () => {
+    const translation = analyzeTwist([0, 0, 0, 3, 4, 0], [0, 0, 0]);
+    const stationary = analyzeTwist([0, 0, 0, 0, 0, 0], [0, 0, 0]);
+
+    expect(translation.kind).toBe("translation");
+    expect(translation.axisPointM).toBeNull();
+    expect(stationary.kind).toBe("stationary");
+    expect(stationary.axisPointM).toBeNull();
+    expect(buildScrewGlyph(translation, 2)).toBeNull();
+  });
+
+  it("returns signed target, vertical, and lateral projections", () => {
+    const projections = projectMotion(
+      analyzeTwist([0, 0, 2, 4, -3, 1.5], [0, 0, 0]),
+    );
+
+    expect(projections.target.totalMps).toBeCloseTo(4);
+    expect(projections.vertical.totalMps).toBeCloseTo(-3);
+    expect(projections.lateral.totalMps).toBeCloseTo(1.5);
+  });
+
+  it("builds bounded helix geometry around the finite axis", () => {
+    const glyph = buildScrewGlyph(
+      analyzeTwist([0, 0, 20, 5, 0, 2], [0, 0, 0]),
+      2,
+    );
+
+    expect(glyph).not.toBeNull();
+    expect(glyph!.axisLineM).toHaveLength(2);
+    expect(glyph!.helixM).toHaveLength(96);
+    expect(glyph!.handedness).toBe(1);
+  });
+
+  it("reconstructs endpoint velocity from planar revolute joints", () => {
+    const times = Array.from({ length: 21 }, (_, index) => index * 0.001);
+    const positions = times.map((time) => {
+      const first = 2 * time;
+      const second = -1.25 * time;
+      const shoulder: Vec3 = [0, 0, 0];
+      const wrist: Vec3 = [0.8 * Math.cos(first), 0.8 * Math.sin(first), 0];
+      const head: Vec3 = [
+        wrist[0] + 1.1 * Math.cos(second),
+        wrist[1] + 1.1 * Math.sin(second),
+        0,
+      ];
+      return [shoulder, wrist, head];
+    });
+
+    const result = jointMotionAt(
+      times,
+      positions,
+      ["joint.shoulder", "joint.wrist"],
+      10,
+    );
+
+    expect(result.contributionVelocityMps).toHaveLength(2);
+    expect(result.reconstructionResidualMps).toBeLessThan(2e-5);
+  });
+});

--- a/src/rate_of_closure/web/src/model/screwAnalysis.ts
+++ b/src/rate_of_closure/web/src/model/screwAnalysis.ts
@@ -1,0 +1,251 @@
+/** Renderer-neutral instantaneous screw analysis in the app/world frame. */
+
+export type Vec3 = [number, number, number];
+export type Twist6 = [number, number, number, number, number, number];
+export type MotionKind = "finite" | "translation" | "stationary";
+
+export interface ScrewMotionTs {
+  kind: MotionKind;
+  referencePointM: Vec3;
+  referenceVelocityMps: Vec3;
+  angularVelocityRadS: Vec3;
+  axisDirection: Vec3;
+  axisPointM: Vec3 | null;
+  pitchMPerRad: number | null;
+  angularRateRadS: number;
+  axialSpeedMps: number;
+  radiusM: number | null;
+  orbitalVelocityMps: Vec3;
+  axialVelocityMps: Vec3;
+  reconstructionResidualMps: number;
+}
+
+export interface MotionProjectionTs {
+  direction: Vec3;
+  totalMps: number;
+  orbitalMps: number;
+  axialMps: number;
+}
+
+export interface ScrewGlyphTs {
+  axisLineM: [Vec3, Vec3];
+  helixM: Vec3[];
+  radiusLineM: [Vec3, Vec3];
+  handedness: 1 | -1;
+}
+
+export interface JointMotionAtTs {
+  jointIds: string[];
+  axisPointsM: Vec3[];
+  angularVelocityRadS: Vec3[];
+  contributionVelocityMps: Vec3[];
+  endpointVelocityMps: Vec3;
+  reconstructionResidualMps: number;
+}
+
+const EPSILON = 1e-10;
+const GLYPH_POINTS = 96;
+
+const add = (first: Vec3, second: Vec3): Vec3 => [
+  first[0] + second[0], first[1] + second[1], first[2] + second[2],
+];
+const subtract = (first: Vec3, second: Vec3): Vec3 => [
+  first[0] - second[0], first[1] - second[1], first[2] - second[2],
+];
+const scale = (vector: Vec3, factor: number): Vec3 => [
+  vector[0] * factor, vector[1] * factor, vector[2] * factor,
+];
+const dot = (first: Vec3, second: Vec3): number =>
+  first[0] * second[0] + first[1] * second[1] + first[2] * second[2];
+const cross = (first: Vec3, second: Vec3): Vec3 => [
+  first[1] * second[2] - first[2] * second[1],
+  first[2] * second[0] - first[0] * second[2],
+  first[0] * second[1] - first[1] * second[0],
+];
+const norm = (vector: Vec3): number => Math.hypot(...vector);
+
+function finiteVector(vector: Vec3, name: string): void {
+  if (vector.length !== 3 || vector.some((value) => !Number.isFinite(value))) {
+    throw new Error(`${name} must be a finite three-vector`);
+  }
+}
+
+function finiteMotion(
+  omega: Vec3,
+  velocity: Vec3,
+  reference: Vec3,
+): ScrewMotionTs {
+  const rateSquared = dot(omega, omega);
+  const rate = Math.sqrt(rateSquared);
+  const pitch = dot(omega, velocity) / rateSquared;
+  const axisPoint = add(reference, scale(cross(omega, velocity), 1 / rateSquared));
+  const axial = scale(omega, pitch);
+  const orbital = subtract(velocity, axial);
+  return {
+    kind: "finite",
+    referencePointM: [...reference],
+    referenceVelocityMps: [...velocity],
+    angularVelocityRadS: [...omega],
+    axisDirection: scale(omega, 1 / rate),
+    axisPointM: axisPoint,
+    pitchMPerRad: pitch,
+    angularRateRadS: rate,
+    axialSpeedMps: pitch * rate,
+    radiusM: norm(subtract(reference, axisPoint)),
+    orbitalVelocityMps: orbital,
+    axialVelocityMps: axial,
+    reconstructionResidualMps: norm(subtract(add(orbital, axial), velocity)),
+  };
+}
+
+/** Decompose [angular velocity, velocity at reference] into screw motion. */
+export function analyzeTwist(twist: Twist6, referencePointM: Vec3): ScrewMotionTs {
+  if (twist.length !== 6 || twist.some((value) => !Number.isFinite(value))) {
+    throw new Error("twist must be a finite six-vector");
+  }
+  finiteVector(referencePointM, "referencePointM");
+  const omega: Vec3 = [twist[0], twist[1], twist[2]];
+  const velocity: Vec3 = [twist[3], twist[4], twist[5]];
+  if (norm(omega) > EPSILON) return finiteMotion(omega, velocity, referencePointM);
+  const speed = norm(velocity);
+  const translating = speed > EPSILON;
+  return {
+    kind: translating ? "translation" : "stationary",
+    referencePointM: [...referencePointM],
+    referenceVelocityMps: [...velocity],
+    angularVelocityRadS: omega,
+    axisDirection: translating ? scale(velocity, 1 / speed) : [0, 0, 0],
+    axisPointM: null,
+    pitchMPerRad: null,
+    angularRateRadS: 0,
+    axialSpeedMps: translating ? speed : 0,
+    radiusM: null,
+    orbitalVelocityMps: [0, 0, 0],
+    axialVelocityMps: [...velocity],
+    reconstructionResidualMps: 0,
+  };
+}
+
+const DEFAULT_DIRECTIONS = {
+  target: [1, 0, 0] as Vec3,
+  vertical: [0, 1, 0] as Vec3,
+  lateral: [0, 0, 1] as Vec3,
+};
+
+/** Return signed total, orbital, and axial velocity projections. */
+export function projectMotion(
+  motion: ScrewMotionTs,
+  directions: Record<string, Vec3> = DEFAULT_DIRECTIONS,
+): Record<string, MotionProjectionTs> {
+  return Object.fromEntries(Object.entries(directions).map(([name, rawDirection]) => {
+    finiteVector(rawDirection, `direction[${name}]`);
+    const magnitude = norm(rawDirection);
+    if (magnitude <= EPSILON) throw new Error(`direction[${name}] must be nonzero`);
+    const direction = scale(rawDirection, 1 / magnitude);
+    return [name, {
+      direction,
+      totalMps: dot(motion.referenceVelocityMps, direction),
+      orbitalMps: dot(motion.orbitalVelocityMps, direction),
+      axialMps: dot(motion.axialVelocityMps, direction),
+    }];
+  }));
+}
+
+function orthogonalBasis(axis: Vec3): [Vec3, Vec3] {
+  const index = axis.map(Math.abs).indexOf(Math.min(...axis.map(Math.abs)));
+  const seeds: Vec3[] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
+  const firstRaw = cross(axis, seeds[index]);
+  const first = scale(firstRaw, 1 / norm(firstRaw));
+  return [first, cross(axis, first)];
+}
+
+function dominantSign(vector: Vec3): 1 | -1 {
+  const index = vector.map(Math.abs).indexOf(Math.max(...vector.map(Math.abs)));
+  return vector[index] >= 0 ? 1 : -1;
+}
+
+/** Build bounded 3D axis/helix/radius geometry for a finite screw. */
+export function buildScrewGlyph(
+  motion: ScrewMotionTs,
+  sceneExtentM: number,
+): ScrewGlyphTs | null {
+  if (!Number.isFinite(sceneExtentM) || sceneExtentM <= 0) {
+    throw new Error("sceneExtentM must be finite and positive");
+  }
+  if (motion.kind !== "finite" || motion.axisPointM === null) return null;
+  const growth = 0.55 + 0.35 * Math.tanh(motion.angularRateRadS / 10);
+  const halfLength = sceneExtentM * growth;
+  const axis = motion.axisDirection;
+  const point = motion.axisPointM;
+  const [first, second] = orthogonalBasis(axis);
+  const handedness = dominantSign(motion.angularVelocityRadS);
+  const radius = sceneExtentM * 0.055;
+  const helixM = Array.from({ length: GLYPH_POINTS }, (_, index): Vec3 => {
+    const fraction = index / (GLYPH_POINTS - 1);
+    const phase = -2 * Math.PI + fraction * 4 * Math.PI;
+    const axial = (-0.82 + fraction * 1.64) * halfLength;
+    return add(add(
+      add(point, scale(axis, axial)),
+      scale(first, radius * Math.cos(phase)),
+    ), scale(second, handedness * radius * Math.sin(phase)));
+  });
+  return {
+    axisLineM: [subtract(point, scale(axis, halfLength)), add(point, scale(axis, halfLength))],
+    helixM,
+    radiusLineM: [point, motion.referencePointM],
+    handedness,
+  };
+}
+
+function derivativeAt(values: Vec3[], times: number[], index: number): Vec3 {
+  const lower = index === 0 ? 0 : index - 1;
+  const upper = index === values.length - 1 ? values.length - 1 : index + 1;
+  const interval = times[upper] - times[lower];
+  if (!(interval > 0)) throw new Error("times must be strictly increasing");
+  return scale(subtract(values[upper], values[lower]), 1 / interval);
+}
+
+/** Reconstruct revolute-joint screw contributions at one sampled instant. */
+export function jointMotionAt(
+  times: number[],
+  jointPositionsM: Vec3[][],
+  jointIds: string[],
+  rawIndex: number,
+): JointMotionAtTs {
+  if (times.length < 3 || jointPositionsM.length !== times.length) {
+    throw new Error("joint motion requires at least three aligned samples");
+  }
+  if (jointPositionsM.some((row) => row.length !== jointIds.length + 1)) {
+    throw new Error("each joint row must contain one more point than joint IDs");
+  }
+  const index = Math.max(0, Math.min(Math.round(rawIndex), times.length - 1));
+  const segmentsByJoint = jointIds.map((_, jointIndex) =>
+    jointPositionsM.map((row) => subtract(row[jointIndex + 1], row[jointIndex])));
+  const absoluteOmega = segmentsByJoint.map((segments) => {
+    const segment = segments[index];
+    const rate = derivativeAt(segments, times, index);
+    const lengthSquared = dot(segment, segment);
+    if (lengthSquared <= EPSILON) throw new Error("joint segments must be nonzero");
+    return scale(cross(segment, rate), 1 / lengthSquared);
+  });
+  const relativeOmega = absoluteOmega.map((omega, jointIndex) =>
+    jointIndex === 0 ? omega : subtract(omega, absoluteOmega[jointIndex - 1]));
+  const points = jointPositionsM[index];
+  const endpoint = points[points.length - 1];
+  const contributions = relativeOmega.map((omega, jointIndex) =>
+    cross(omega, subtract(endpoint, points[jointIndex])));
+  const endpointVelocity = derivativeAt(
+    jointPositionsM.map((row) => row[row.length - 1]),
+    times,
+    index,
+  );
+  const reconstructed = contributions.reduce(add, [0, 0, 0]);
+  return {
+    jointIds: [...jointIds],
+    axisPointsM: points.slice(0, -1),
+    angularVelocityRadS: relativeOmega,
+    contributionVelocityMps: contributions,
+    endpointVelocityMps: endpointVelocity,
+    reconstructionResidualMps: norm(subtract(reconstructed, endpointVelocity)),
+  };
+}

--- a/src/rate_of_closure/web/src/model/simulation.ts
+++ b/src/rate_of_closure/web/src/model/simulation.ts
@@ -50,6 +50,7 @@ import {
 import {
   MPH_PER_MPS,
   add,
+  cross,
   fromFlightFrame,
   norm,
   scale,
@@ -112,6 +113,7 @@ export interface SwingSampleTs {
   t: number;
   position: Vec3; // app frame; aligned only in delivery-inspection mode
   velocity: Vec3;
+  angularVelocity: Vec3; // app frame, rad/s, for club screw-axis analysis
   joints: Vec3[]; // pivot -> articulated joints -> clubhead
 }
 
@@ -164,6 +166,7 @@ function swingSamples(input: SimulationInput): SwingSampleTs[] {
         t,
         position: [speed * rel, 0, 0],
         velocity: [speed, 0, 0],
+        angularVelocity: omega,
         joints: [],
       });
     }
@@ -208,6 +211,7 @@ function swingSamples(input: SimulationInput): SwingSampleTs[] {
   const upAxisSwing: Vec3 = [cy * sf + sy * ss * cf, sy * sf - cy * ss * cf, cs * cf];
   const xAxis = fromFlightFrame(xAxisSwing);
   const upAxis = fromFlightFrame(upAxisSwing);
+  const planeNormal = cross(upAxis, xAxis);
   return states.map((state, index) => {
     const triple = golfTripleParameters();
     const angles = input.sourceKind === "double_pendulum"
@@ -236,6 +240,7 @@ function swingSamples(input: SimulationInput): SwingSampleTs[] {
       t: index * dt,
       position: add(scale(xAxis, x), scale(upAxis, yLoc)),
       velocity: add(scale(xAxis, vx), scale(upAxis, vy)),
+      angularVelocity: scale(planeNormal, rates[rates.length - 1]),
       joints: [
         ...localJoints.map(([jointX, jointY]) =>
           add(scale(xAxis, jointX), scale(upAxis, jointY)),

--- a/src/rate_of_closure/web/src/model/units.ts
+++ b/src/rate_of_closure/web/src/model/units.ts
@@ -169,6 +169,13 @@ export const FIELD_GUIDANCE: Record<string, string> = {
     "configurable green distance, tee marker at the origin. Source: " +
     "standard golf-course presentation; tones derived from the theme " +
     "palette.",
+  screwAxisVisible:
+    "Suggested range: on for swing-scale engineering analysis. The magenta " +
+    "line is the directed instantaneous screw axis, the orange wrapped curve " +
+    "shows rotational handedness, and the cyan radius is R_ISA. Pure " +
+    "translation is shown as an arrow because its axis is at infinity. " +
+    "Source: Lynch and Park, Modern Robotics, Chapter 3.3.2 (twists). " +
+    "Reference frame: app/world x target, y up, z right.",
   swingFlightToggle:
     "Off by default: the flight envelope (100+ m) dwarfs the swing " +
     "envelope (~3 m), collapsing the swing to a dot when both share one " +

--- a/tests/rate_of_closure/test_screw_analysis.py
+++ b/tests/rate_of_closure/test_screw_analysis.py
@@ -1,0 +1,166 @@
+"""Scientific contracts for club and articulated-joint screw analysis."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from rate_of_closure.club import club_names, get_club
+from rate_of_closure.model import ImpactScenario
+from rate_of_closure.simulation import SimulationConfig, run_simulation
+from rate_of_closure.simulation.screw_analysis import (
+    MotionKind,
+    analyze_joint_motion,
+    analyze_twist,
+    build_screw_glyph,
+    project_motion,
+)
+
+
+def test_finite_screw_reconstructs_reference_velocity() -> None:
+    omega = np.array([0.0, 0.0, 4.0])
+    pitch_m_rad = 0.125
+    axis_point = np.array([1.0, -2.0, 0.5])
+    reference = np.array([2.0, -2.0, 0.5])
+    velocity = np.cross(omega, reference - axis_point) + pitch_m_rad * omega
+
+    motion = analyze_twist(np.concatenate([omega, velocity]), reference)
+
+    assert motion.kind is MotionKind.FINITE
+    np.testing.assert_allclose(motion.axis_direction, [0.0, 0.0, 1.0])
+    np.testing.assert_allclose(motion.axis_point_m, axis_point)
+    assert motion.pitch_m_rad == pytest.approx(pitch_m_rad)
+    assert motion.radius_m == pytest.approx(1.0)
+    np.testing.assert_allclose(
+        motion.orbital_velocity_m_s + motion.axial_velocity_m_s,
+        velocity,
+        atol=1e-12,
+    )
+    assert motion.reconstruction_residual_m_s < 1e-12
+
+
+def test_finite_axis_is_invariant_to_reference_point_choice() -> None:
+    omega = np.array([1.0, 2.0, -3.0])
+    first_point = np.array([0.2, -0.5, 1.1])
+    first_velocity = np.array([4.0, -2.0, 3.0])
+    second_point = np.array([-0.3, 0.4, 0.7])
+    second_velocity = first_velocity + np.cross(omega, second_point - first_point)
+
+    first = analyze_twist(np.concatenate([omega, first_velocity]), first_point)
+    second = analyze_twist(np.concatenate([omega, second_velocity]), second_point)
+
+    np.testing.assert_allclose(first.axis_direction, second.axis_direction, atol=1e-12)
+    delta = second.axis_point_m - first.axis_point_m
+    assert np.linalg.norm(np.cross(delta, first.axis_direction)) < 1e-12
+    assert first.pitch_m_rad == pytest.approx(second.pitch_m_rad, abs=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("twist", "kind"),
+    [
+        (np.array([0.0, 0.0, 0.0, 3.0, 4.0, 0.0]), MotionKind.TRANSLATION),
+        (np.zeros(6), MotionKind.STATIONARY),
+    ],
+)
+def test_degenerate_motion_never_invents_a_finite_axis(
+    twist: np.ndarray, kind: MotionKind
+) -> None:
+    motion = analyze_twist(twist, np.array([1.0, 2.0, 3.0]))
+
+    assert motion.kind is kind
+    assert motion.axis_point_m is None
+    assert motion.radius_m is None
+    assert motion.pitch_m_rad is None
+
+
+def test_projection_breakdown_preserves_signed_velocity_components() -> None:
+    motion = analyze_twist(
+        np.array([0.0, 0.0, 2.0, 4.0, -3.0, 1.5]),
+        np.zeros(3),
+    )
+
+    projections = project_motion(motion)
+
+    assert projections["target"].total_m_s == pytest.approx(4.0)
+    assert projections["vertical"].total_m_s == pytest.approx(-3.0)
+    assert projections["lateral"].total_m_s == pytest.approx(1.5)
+    for projection in projections.values():
+        assert projection.total_m_s == pytest.approx(
+            projection.orbital_m_s + projection.axial_m_s
+        )
+
+
+def test_joint_contributions_reconstruct_planar_two_link_endpoint_velocity() -> None:
+    times = np.linspace(0.0, 0.02, 21)
+    first_rate = 2.0
+    second_rate = -1.25
+    length_1, length_2 = 0.8, 1.1
+    points = []
+    for time_s in times:
+        first_angle = first_rate * time_s
+        second_angle = second_rate * time_s
+        shoulder = np.zeros(3)
+        wrist = shoulder + length_1 * np.array(
+            [math.cos(first_angle), math.sin(first_angle), 0.0]
+        )
+        head = wrist + length_2 * np.array(
+            [math.cos(second_angle), math.sin(second_angle), 0.0]
+        )
+        points.append(np.vstack([shoulder, wrist, head]))
+
+    joint_motion = analyze_joint_motion(
+        times,
+        np.stack(points),
+        ("joint.shoulder", "joint.wrist"),
+    )
+    middle = len(times) // 2
+    expected = np.cross(
+        [0.0, 0.0, first_rate], points[middle][1] - points[middle][0]
+    ) + np.cross([0.0, 0.0, second_rate], points[middle][2] - points[middle][1])
+
+    np.testing.assert_allclose(
+        joint_motion.endpoint_velocity_m_s[middle], expected, atol=2e-5
+    )
+    np.testing.assert_allclose(
+        joint_motion.contribution_velocity_m_s[middle].sum(axis=0),
+        expected,
+        atol=2e-5,
+    )
+    assert joint_motion.reconstruction_residual_m_s[middle] < 2e-5
+
+
+def test_screw_glyph_is_bounded_and_encodes_handedness() -> None:
+    positive = analyze_twist(np.array([0.0, 0.0, 20.0, 5.0, 0.0, 2.0]), np.zeros(3))
+    negative = analyze_twist(np.array([0.0, 0.0, -20.0, 5.0, 0.0, 2.0]), np.zeros(3))
+
+    positive_glyph = build_screw_glyph(positive, scene_extent_m=2.0)
+    negative_glyph = build_screw_glyph(negative, scene_extent_m=2.0)
+
+    assert positive_glyph is not None
+    assert negative_glyph is not None
+    assert positive_glyph.axis_line_m.shape == (2, 3)
+    assert positive_glyph.helix_m.shape == (96, 3)
+    assert np.max(np.linalg.norm(positive_glyph.helix_m, axis=1)) < 5.0
+    assert positive_glyph.handedness == 1
+    assert negative_glyph.handedness == -1
+
+
+@pytest.mark.parametrize("club_name", club_names())
+def test_every_club_and_wedge_produces_finite_club_screw_motion(
+    club_name: str,
+) -> None:
+    run = run_simulation(
+        SimulationConfig(
+            scenario=ImpactScenario(clubhead_speed_mph=100.0),
+            club=get_club(club_name),
+        )
+    )
+    assert run.impact_time_s is not None
+    index = int(np.argmin(np.abs(run.swing_times - run.impact_time_s)))
+    motion = analyze_twist(run.swing_twists[index], run.swing_positions[index])
+
+    assert motion.kind is MotionKind.FINITE
+    assert motion.angular_rate_rad_s > 0.0
+    assert motion.reconstruction_residual_m_s < 1e-9

--- a/tests/rate_of_closure/test_simulation.py
+++ b/tests/rate_of_closure/test_simulation.py
@@ -32,8 +32,10 @@ from rate_of_closure.simulation import (
     run_simulation,
     run_to_json_dict,
     screw_axis_samples,
+    screw_series_rows,
     write_csv,
     write_json,
+    write_screw_csv,
 )
 from shared.python.swing_sim.types import PlaneOrientation
 
@@ -266,8 +268,29 @@ class TestExport:
         phases = {row[0] for row in rows[1:]}
         assert phases == {"swing", "flight"}
         # Times must be numeric and non-decreasing within each phase.
-        swing_ts = [float(r[1]) for r in rows[1:] if r[0] == "swing"]
+        swing_ts = [float(row[1]) for row in rows[1:] if row[0] == "swing"]
         assert swing_ts == sorted(swing_ts)
+
+    def test_screw_motion_has_dedicated_csv_and_json_series(
+        self, run: SimulationRun, tmp_path
+    ) -> None:  # type: ignore[no-untyped-def]
+        rows = screw_series_rows(run)
+        assert len(rows) == len(run.swing_times)
+        assert rows[0][1] == "finite"
+        assert rows[0][2] == pytest.approx(np.linalg.norm(run.swing_twists[0, :3]))
+        path = tmp_path / "screw-motion.csv"
+        write_screw_csv(run, path)
+        with path.open(newline="", encoding="utf-8") as handle:
+            exported = list(csv.reader(handle))
+        assert exported[0][:4] == [
+            "t_s",
+            "motion_kind",
+            "angular_rate_rad_s",
+            "pitch_m_rad",
+        ]
+        document = run_to_json_dict(run)
+        assert document["series"]["club_screw_motion"]["frame"] == "app/world"
+        assert len(document["series"]["club_screw_motion"]["rows"]) == len(rows)
 
     def test_json_round_trip(self, run: SimulationRun, tmp_path) -> None:  # type: ignore[no-untyped-def]
         path = tmp_path / "run.json"

--- a/tests/rate_of_closure/test_simulation_gui.py
+++ b/tests/rate_of_closure/test_simulation_gui.py
@@ -169,7 +169,28 @@ class TestSimulationView:
         view._screw_check.setChecked(True)
         view.set_playback_time(ran_tab.last_run().impact_time_s * 0.5)
         labels = [line.get_label() for line in view._axes.lines]
-        assert any("screw axis" in str(label) for label in labels)
+        assert any("Screw Axis" in str(label) for label in labels)
+        assert any("Helical Motion" in str(label) for label in labels)
+        assert "Finite screw" in view._screw_readout.text()
+        assert "Orbital" in view._screw_readout.text()
+        assert "total = orbital + axial" in view._screw_readout.text()
+
+    def test_screw_selector_exposes_club_and_articulated_joints(
+        self, tab, qtbot
+    ) -> None:  # type: ignore[no-untyped-def]
+        tab._source_combo.setCurrentIndex(1)
+        with qtbot.waitSignal(tab.runCompleted, timeout=10000):
+            tab.run_now()
+        view = tab.view()
+        choices = [
+            view._screw_entity.itemText(i) for i in range(view._screw_entity.count())
+        ]
+        assert choices == ["Club", "Shoulder Joint", "Wrist Joint"]
+        view._screw_check.setChecked(True)
+        view._screw_entity.setCurrentIndex(1)
+        view.set_playback_time(0.5)
+        assert "Shoulder Joint" in view._screw_readout.text()
+        assert "Contribution" in view._screw_readout.text()
 
 
 class TestInspector:
@@ -178,6 +199,7 @@ class TestInspector:
         assert not fresh._export_csv_button.isEnabled() or fresh.run() is not None
         inspector = ran_tab.inspector()
         assert inspector._export_csv_button.isEnabled()
+        assert inspector._export_screw_csv_button.isEnabled()
         assert inspector._export_json_button.isEnabled()
 
     def test_table_populates_and_sorts(self, ran_tab) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary

Adds production-grade instantaneous screw-axis analysis for the Rate of Closure club and articulated-joint simulations in both the PyQt6 and React applications.

Closes #4168.

## What Changed

- adds a typed Python and TypeScript screw-motion core for finite screws, pure translation (axis at infinity), and stationary motion
- computes axis direction and closest point, pitch, axial speed, reference radius, orbital/axial velocity decomposition, and reconstruction residual
- reconstructs relative screw motion for every sampled double- and triple-pendulum joint and reports the joint-contribution residual
- renders a directed magenta main axis, orange handed helix, cyan reference-radius line, and truthful translation/stationary states
- provides a selectable Club / Shoulder / Elbow / Wrist presentation with live app-frame definitions and units
- displays exact AoA and path plus signed target, vertical/AoA, lateral/path, and face-normal projection breakdowns as total = orbital + axial
- enables the screw overlay by default on the web swing view and exposes it as an opt-in PyQt overlay
- adds dedicated club screw CSV export and embeds the SI/app-frame screw series in Python and web JSON exports
- documents equations, frame conventions, glyph semantics, degenerate cases, numerical residuals, references, and limitations
- validates all registered clubs, including all wedges and putters

## Engineering Notes

The twist API explicitly accepts linear velocity at a named reference point rather than silently treating it as the world-origin spatial-twist term. Finite-axis geometry reconstructs the supplied reference-point velocity. Pure translation and rest never invent a finite axis.

The helix is a bounded explanatory glyph: handedness is physical, while display radius and axis length are normalized for readability. Numerical values in the readout and export are authoritative.

## Validation

- `python -m pytest tests/rate_of_closure -q` — 546 passed
- post-rebase focused Python suite — 63 passed
- complete web Vitest suite — 47 files / 328 tests passed
- post-rebase focused web suite — 18 passed
- ESLint — passed
- TypeScript `tsc --noEmit` — passed
- production Vite build — passed
- targeted Ruff and mypy — passed
- live PyQt rendering and web interaction inspected

## Dependency

Targets `feat/4144-variation-visualizations` so it can integrate with the active Rate of Closure feature campaign without modifying or bypassing that branch's protected workflow.
