### PR TITLE
⚡ Bolt: Replace map and reduce array methods with single-pass loops in default tab initializers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -86,3 +86,6 @@
 ## 2024-08-01 - Avoid allocating string arrays for SVG paths
 **Learning:** In high-frequency chart updates, building SVG `d` paths using `.map(p => '...').join(' ')` allocates a new array of strings on every frame, causing unnecessary garbage collection pressure and main thread stalls.
 **Action:** Build SVG `d` paths using a single-pass `for` loop and string concatenation to eliminate intermediate array allocations.
+## 2025-05-18 - Avoid array methods for small static arrays in frequently called initializers
+**Learning:** Using `.reduce()` or `.map()` on static arrays like tabs definitions inside frequently called functions (e.g. state initializers or local storage hydration) incurs unnecessary closure and function call overhead.
+**Action:** Replace `.reduce()` and `.map()` with single-pass `for` loops in simple data transformation functions (like `defaultTabVisibility`) to eliminate closure allocations.

--- a/pr_details.md
+++ b/pr_details.md
@@ -1,0 +1,7 @@
+Title: ⚡ Bolt: Replace map and reduce array methods with single-pass loops in default tab initializers
+
+Description:
+💡 What: Replaced `.reduce()` in `defaultTabVisibility()` and `.map()` in `defaultTabOrder()` with single-pass `for` loops in `tabs.ts`.
+🎯 Why: `defaultTabVisibility` and `defaultTabOrder` are called frequently (e.g., during localStorage hydration or component state initialization). Using `.reduce()` and `.map()` on the static `TABS` array allocates unnecessary intermediate array elements, function calls, and closures on every pass, generating garbage collection pressure.
+📊 Impact: Eliminates callback allocation and intermediate array creation for these tab initialization routines, slightly reducing GC overhead.
+🔬 Measurement: Verified that unit tests for components using these tabs (like TabBar and PanelStack) continue to pass.

--- a/src/p1am_control_system/frontend/src/lib/tabs.ts
+++ b/src/p1am_control_system/frontend/src/lib/tabs.ts
@@ -104,18 +104,22 @@ export const TABS: readonly TabDef[] = [
 
 /** Default visibility map (all tabs visible) derived from {@link TABS}. */
 export function defaultTabVisibility(): Record<TabId, boolean> {
-  return TABS.reduce(
-    (acc, tab) => {
-      acc[tab.id] = true;
-      return acc;
-    },
-    {} as Record<TabId, boolean>,
-  );
+  // ⚡ Bolt Optimization: Replace chained array operations (.reduce, .map) with single-pass loops to avoid callback and closure overhead.
+  const acc = {} as Record<TabId, boolean>;
+  for (let i = 0; i < TABS.length; i++) {
+    acc[TABS[i].id] = true;
+  }
+  return acc;
 }
 
 /** The canonical tab id order as declared in {@link TABS}. */
 export function defaultTabOrder(): TabId[] {
-  return TABS.map((tab) => tab.id);
+  // ⚡ Bolt Optimization: Replace array map with a single-pass loop to avoid callback and closure overhead.
+  const order = new Array<TabId>(TABS.length);
+  for (let i = 0; i < TABS.length; i++) {
+    order[i] = TABS[i].id;
+  }
+  return order;
 }
 
 const ORDER_KEY = "p1am.tabOrder.v1";


### PR DESCRIPTION
💡 What: Replaced `.reduce()` in `defaultTabVisibility()` and `.map()` in `defaultTabOrder()` with single-pass `for` loops in `tabs.ts`.
🎯 Why: `defaultTabVisibility` and `defaultTabOrder` are called frequently (e.g., during localStorage hydration or component state initialization). Using `.reduce()` and `.map()` on the static `TABS` array allocates unnecessary intermediate array elements, function calls, and closures on every pass, generating garbage collection pressure.
📊 Impact: Eliminates callback allocation and intermediate array creation for these tab initialization routines, slightly reducing GC overhead.
🔬 Measurement: Verified that unit tests for components using these tabs (like TabBar and PanelStack) continue to pass.

---
*PR created automatically by Jules for task [17905348997553252552](https://jules.google.com/task/17905348997553252552) started by @dieterolson*