### PR TITLE
feat(rate-of-closure): add launch direction conventions

### DIFF
--- a/src/rate_of_closure/derivation.py
+++ b/src/rate_of_closure/derivation.py
@@ -209,7 +209,7 @@ LAUNCH_EXPLANATIONS: dict[str, str] = {
     "lateral_m": (
         "Sideways landing offset from the target line (+ = right of "
         "target for a right-handed player): the integrated effect of "
-        "launch azimuth plus spin-axis-tilt curvature (the D-plane's "
+        "launch direction plus spin-axis-tilt curvature (the D-plane's "
         "Magnus component), reported the way launch monitors report "
         "carry offline."
     ),

--- a/src/rate_of_closure/glossary_entries_a_l.py
+++ b/src/rate_of_closure/glossary_entries_a_l.py
@@ -160,7 +160,7 @@ ENTRIES: dict[str, GlossaryEntry] = {
         "Face Angle",
         "The horizontal direction of the delivered face normal relative "
         "to the target line: positive = open (pointing right of target). "
-        "The dominant contributor to launch azimuth (launch-monitor "
+        "The dominant contributor to launch direction (launch-monitor "
         "conventions; AffineDrift 02-parameters).",
     ),
     "flight_time": _entry(
@@ -234,7 +234,7 @@ ENTRIES: dict[str, GlossaryEntry] = {
     "lateral_offset": _entry(
         "Lateral Landing Offset",
         "The sideways distance from the target line at landing (+ = "
-        "right of target): the integrated effect of launch azimuth plus "
+        "right of target): the integrated effect of launch direction plus "
         "the curvature from spin-axis tilt — the way launch monitors "
         "report carry offline (swing_sim.flight metrics).",
     ),
@@ -246,7 +246,7 @@ ENTRIES: dict[str, GlossaryEntry] = {
         "(launch-monitor conventions).",
     ),
     "launch_azimuth": _entry(
-        "Launch Azimuth",
+        "Launch Direction",
         "The horizontal direction of the ball's initial velocity relative "
         "to the target line (+ = right). Dominated by the delivered face "
         "angle with a smaller club-path contribution (D-plane "

--- a/src/rate_of_closure/plotting/catalog.py
+++ b/src/rate_of_closure/plotting/catalog.py
@@ -117,7 +117,8 @@ DISTANCE_KEYS: frozenset[str] = frozenset(
 
 
 def _speed_series(vectors: np.ndarray) -> np.ndarray:
-    return np.asarray(np.linalg.norm(vectors, axis=1), dtype=float)
+    speeds: np.ndarray = np.asarray(np.linalg.norm(vectors, axis=1), dtype=float)
+    return speeds
 
 
 def _kinetics_series(picker: Callable[[KineticsSeries], np.ndarray]) -> Extractor:
@@ -129,8 +130,10 @@ def _kinetics_series(picker: Callable[[KineticsSeries], np.ndarray]) -> Extracto
     def _extract(run: SimulationRun) -> np.ndarray:
         series = kinetics_for_run(run)
         if series is None:
-            return np.full(run.swing_times.shape[0], np.nan)
-        return np.asarray(picker(series), dtype=float)
+            missing: np.ndarray = np.full(run.swing_times.shape[0], np.nan)
+            return missing
+        values: np.ndarray = np.asarray(picker(series), dtype=float)
+        return values
 
     return _extract
 
@@ -523,7 +526,7 @@ def extract(run: SimulationRun, key: str) -> np.ndarray | float:
     spec = CATALOG[key]
     value = spec.extractor(run)
     if spec.is_series:
-        array = np.asarray(value, dtype=float)
+        array: np.ndarray = np.asarray(value, dtype=float)
         ensure(array.ndim == 1, f"{key} extractor must yield a 1-D array")
         return array
     ensure(isinstance(value, float), f"{key} extractor must yield a float")

--- a/src/rate_of_closure/plotting/catalog.py
+++ b/src/rate_of_closure/plotting/catalog.py
@@ -391,7 +391,7 @@ def _entries() -> list[VariableSpec]:
         ),
         (
             "launch_azimuth_deg",
-            "Launch Azimuth",
+            "Launch Direction",
             "deg",
             lambda r: optional_values.launch_scalar(r, "launch_azimuth_deg"),
         ),

--- a/src/rate_of_closure/simulation/flight_explorer.py
+++ b/src/rate_of_closure/simulation/flight_explorer.py
@@ -3,13 +3,13 @@
 Logic layer of the V2 Flight Explorer (epic #4120): build
 :class:`~shared.python.swing_sim.flight.types.LaunchConditions` either
 directly from launch-monitor ball numbers (ball speed, launch angle,
-azimuth, spin, spin-axis tilt) or from club delivery numbers run through
+launch direction, spin, spin-axis tilt) or from club delivery numbers run through
 ``swing_sim.impact.delivery`` and the rigid-body impact model, then
 integrate the flight with any of the 7 literature models in
 ``swing_sim.flight`` and return an app-frame trajectory + metrics.
 
 Sign conventions match the simulation session (app frame: x target,
-y up, z right): azimuth and lateral are + right of target; spin-axis
+y up, z right): launch direction and lateral are + right of target; spin-axis
 tilt is + fade-side (curves right), matching the D-plane diagnostics in
 ``swing_sim.impact.delivery``.
 """
@@ -26,8 +26,11 @@ from rate_of_closure.model import MPH_PER_MPS
 from rate_of_closure.simulation.session import BALL_POSITION_M
 from shared.python.swing_sim.flight import (
     LaunchConditions,
+    LaunchDirection,
+    LaunchDirectionConvention,
     derive_launch_conditions,
     from_flight_frame,
+    launch_direction_to_flight_azimuth,
     to_flight_frame,
 )
 from shared.python.swing_sim.flight import simulate as flight_simulate
@@ -50,6 +53,8 @@ __all__ = [
 EXPLORER_METRIC_KEYS: tuple[str, ...] = (
     "ball_speed_mph",
     "launch_angle_deg",
+    "launch_direction_deg",
+    # Deprecated persistence alias retained for lossless older exports.
     "launch_azimuth_deg",
     "spin_rpm",
     "carry_m",
@@ -83,20 +88,28 @@ class FlightExploration:
 def launch_from_direct(
     ball_speed_mph: float,
     launch_angle_deg: float,
-    azimuth_deg: float,
-    spin_rpm: float,
-    spin_axis_tilt_deg: float,
+    launch_direction_deg: float | None = None,
+    spin_rpm: float | None = None,
+    spin_axis_tilt_deg: float | None = None,
+    *,
+    azimuth_deg: float | None = None,
+    direction_convention: LaunchDirectionConvention = (
+        LaunchDirectionConvention.APP_NATIVE
+    ),
 ) -> LaunchConditions:
-    """Launch conditions from launch-monitor ball numbers (app signs).
+    """Launch conditions from right-positive launch-monitor ball numbers.
 
     Args:
         ball_speed_mph: Ball speed [mph], > 0.
         launch_angle_deg: Launch angle above horizontal [deg].
-        azimuth_deg: Launch direction [deg]; + = right of target.
+        launch_direction_deg: Horizontal launch direction [deg]; positive
+            starts right and negative starts left of the target line.
         spin_rpm: Total spin rate [rpm], >= 0.
         spin_axis_tilt_deg: Spin-axis tilt [deg]; + = fade-side (curves
             right for a right-handed player), matching the D-plane tilt
             reported by ``swing_sim.impact.delivery``.
+        azimuth_deg: Deprecated app-native alias for imported/caller data.
+        direction_convention: Explicit convention of ``launch_direction_deg``.
 
     Returns:
         Flight-frame :class:`LaunchConditions`.
@@ -106,7 +119,21 @@ def launch_from_direct(
         "ball_speed_mph must be finite and > 0",
         ball_speed_mph,
     )
-    # App azimuth + = right; flight-frame azimuth + = left (+y): flip.
+    # Accept the historical keyword without silently choosing between conflicts.
+    if launch_direction_deg is None:
+        if azimuth_deg is None:
+            raise TypeError("launch_direction_deg is required")
+        launch_direction_deg = azimuth_deg
+    elif azimuth_deg is not None and not math.isclose(
+        launch_direction_deg, azimuth_deg, rel_tol=0.0, abs_tol=1e-12
+    ):
+        raise ValueError("conflicting launch-direction and legacy azimuth values")
+    if spin_rpm is None or spin_axis_tilt_deg is None:
+        raise TypeError("spin_rpm and spin_axis_tilt_deg are required")
+    flight_azimuth_deg = launch_direction_to_flight_azimuth(
+        LaunchDirection(launch_direction_deg, direction_convention)
+    )
+    # App direction + = right; flight-frame azimuth + = left (+y): flip.
     # Fade-side tilt (+) needs a downward (-z flight) sidespin component,
     # which the legacy spin_axis_angle decomposition produces for a
     # negative angle — hence both signs flip here.
@@ -114,7 +141,7 @@ def launch_from_direct(
         ball_speed_mph=ball_speed_mph,
         launch_angle_deg=launch_angle_deg,
         spin_rate_rpm=spin_rpm,
-        azimuth_angle_deg=-azimuth_deg,
+        azimuth_angle_deg=flight_azimuth_deg,
         spin_axis_angle_deg=-spin_axis_tilt_deg,
     )
 
@@ -171,7 +198,8 @@ def explore_flight(
     metrics = {
         "ball_speed_mph": launch.ball_speed * MPH_PER_MPS,
         "launch_angle_deg": math.degrees(launch.launch_angle),
-        # Flight azimuth + = left; app convention + = right of target.
+        # Flight azimuth + = left; public launch direction + = right.
+        "launch_direction_deg": -math.degrees(launch.azimuth_angle),
         "launch_azimuth_deg": -math.degrees(launch.azimuth_angle),
         "spin_rpm": launch.spin_rate,
         "carry_m": float(flight.carry_distance),

--- a/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 
 import logging
 import math
+from typing import cast
 
 from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtGui import QStandardItemModel
 from PyQt6.QtWidgets import (
     QAbstractSpinBox,
     QComboBox,
@@ -255,6 +257,18 @@ class FlightExplorerTab(QWidget):
         self._direction_convention_combo.addItem(
             "TrackMan-Comparable (+ Right)",
             LaunchDirectionConvention.TRACKMAN_COMPARABLE,
+        )
+        self._direction_convention_combo.addItem(
+            "Foresight-Comparable (Sign Unavailable)"
+        )
+        foresight_item = cast(
+            QStandardItemModel, self._direction_convention_combo.model()
+        ).item(2)
+        assert foresight_item is not None
+        foresight_item.setEnabled(False)
+        foresight_item.setToolTip(
+            "Unavailable: the general public sign convention is not established "
+            "independently of player handedness."
         )
         self._direction_convention_combo.setAccessibleName(
             "Launch Direction Convention"

--- a/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
@@ -54,6 +54,7 @@ from rate_of_closure.units import FIELD_GUIDANCE, format_distance_m
 from shared.python.swing_sim.flight import (
     LAUNCH_DIRECTION_DEFINITIONS,
     LaunchDirectionConvention,
+    launch_direction_sign_labels,
 )
 from shared.python.swing_sim.flight.registry import FlightModelType
 from shared.python.swing_sim.impact import DeliveryParameters
@@ -253,7 +254,7 @@ class FlightExplorerTab(QWidget):
         )
         self._direction_convention_combo.addItem(
             "TrackMan-Comparable (+ Right)",
-            LaunchDirectionConvention.LAUNCH_MONITOR_COMPARABLE,
+            LaunchDirectionConvention.TRACKMAN_COMPARABLE,
         )
         self._direction_convention_combo.setAccessibleName(
             "Launch Direction Convention"
@@ -444,9 +445,10 @@ class FlightExplorerTab(QWidget):
     def _refresh_direction_example(self) -> None:
         convention = self._direction_convention_combo.currentData()
         definition = LAUNCH_DIRECTION_DEFINITIONS[convention]
+        positive, negative = launch_direction_sign_labels(convention)
         self._direction_example.setText(
-            f"0° = straight · + = {definition.positive_direction} · "
-            f"− = {definition.negative_direction}"
+            f"0° = straight · + = {positive} · − = {negative} · "
+            f"{definition.quantity_status.value}"
         )
 
     def _show_explanation(self, key: str) -> None:

--- a/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
@@ -352,11 +352,11 @@ class FlightExplorerTab(QWidget):
     # ── public API ──────────────────────────────────────────────────
     def speed_mps(self) -> float:
         """The entered speed converted to m/s."""
-        return self._speed_spin.value() * _SPEED_UNITS[self._speed_unit]
+        return float(self._speed_spin.value()) * _SPEED_UNITS[self._speed_unit]
 
     def mode(self) -> str:
         """The selected entry mode label."""
-        return _MODES[self._mode_combo.currentIndex()]
+        return cast(str, _MODES[self._mode_combo.currentIndex()])
 
     def flight_view(self) -> FlightView:
         """The embedded flight-scale viewer."""

--- a/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
@@ -1,7 +1,7 @@
 """Standalone Ball-Flight Explorer tab — launch entry to flight, no swing.
 
 Epic #4120 (V2): type launch conditions directly (ball speed with a
-unit drop-down, launch angle, azimuth, spin, spin-axis tilt) OR club
+unit drop-down, launch angle, launch direction, spin, spin-axis tilt) OR club
 delivery numbers run through ``swing_sim.impact.delivery`` and the
 rigid-body impact model, pick any of the 7 literature flight models,
 and render the result in the dedicated flight-scale
@@ -27,13 +27,16 @@ from PyQt6.QtWidgets import (
     QFrame,
     QGroupBox,
     QHBoxLayout,
+    QLabel,
     QMessageBox,
     QPushButton,
     QScrollArea,
     QSplitter,
     QStackedWidget,
     QTextBrowser,
+    QToolButton,
     QVBoxLayout,
+    QWhatsThis,
     QWidget,
 )
 
@@ -48,6 +51,10 @@ from rate_of_closure.simulation import (
 from rate_of_closure.ui.pyqt6.flight_view import FlightView
 from rate_of_closure.ui.pyqt6.result_row import ResultRow, explanation_html
 from rate_of_closure.units import FIELD_GUIDANCE, format_distance_m
+from shared.python.swing_sim.flight import (
+    LAUNCH_DIRECTION_DEFINITIONS,
+    LaunchDirectionConvention,
+)
 from shared.python.swing_sim.flight.registry import FlightModelType
 from shared.python.swing_sim.impact import DeliveryParameters
 
@@ -80,7 +87,16 @@ _DISTANCE_ROWS: frozenset[str] = frozenset({"carry_m", "lateral_m"})
 #: decimals, suffix).
 _DIRECT_FIELDS: tuple[tuple[str, str, str, float, float, float, int, str], ...] = (
     ("launch_angle_deg", "Launch Angle", "fx_launch_angle", -89.0, 89.0, 10.9, 1, "°"),
-    ("azimuth_deg", "Launch Azimuth", "fx_azimuth", -45.0, 45.0, 0.0, 1, "°"),
+    (
+        "launch_direction_deg",
+        "Launch Direction",
+        "fx_launch_direction",
+        -45.0,
+        45.0,
+        0.0,
+        1,
+        "°",
+    ),
     ("spin_rpm", "Total Spin", "fx_spin_rpm", 0.0, 15000.0, 2686.0, 0, " rpm"),
     (
         "spin_axis_tilt_deg",
@@ -137,6 +153,29 @@ def _make_spin(
     spin.setToolTip(tooltip)
     spin.setMinimumWidth(84)  # stays readable at small windows
     return spin
+
+
+def _field_label(label: str, attr: str, guidance: str) -> QWidget:
+    """Return a visibly clickable field label with non-modal guidance."""
+    container = QWidget()
+    row = QHBoxLayout(container)
+    row.setContentsMargins(0, 0, 0, 0)
+    row.setSpacing(4)
+    row.addWidget(QLabel(label))
+    button = QToolButton()
+    button.setText("Details")
+    button.setAutoRaise(True)
+    button.setObjectName(f"{attr.removesuffix('_deg')}_info")
+    button.setAccessibleName(f"Explain {label}")
+    button.setAccessibleDescription(guidance)
+    button.setToolTip(guidance)
+    button.clicked.connect(
+        lambda _checked=False: QWhatsThis.showText(
+            button.mapToGlobal(button.rect().bottomLeft()), guidance, button
+        )
+    )
+    row.addWidget(button)
+    return container
 
 
 class FlightExplorerTab(QWidget):
@@ -207,6 +246,32 @@ class FlightExplorerTab(QWidget):
         self._mode_combo.currentIndexChanged.connect(self._on_mode_changed)
         layout.addWidget(self._stack)
 
+        direction_form = QFormLayout()
+        self._direction_convention_combo = QComboBox()
+        self._direction_convention_combo.addItem(
+            "App Native (+ Right)", LaunchDirectionConvention.APP_NATIVE
+        )
+        self._direction_convention_combo.addItem(
+            "TrackMan-Comparable (+ Right)",
+            LaunchDirectionConvention.LAUNCH_MONITOR_COMPARABLE,
+        )
+        self._direction_convention_combo.setAccessibleName(
+            "Launch Direction Convention"
+        )
+        self._direction_convention_combo.setToolTip(
+            "Choose how entered Launch Direction values are interpreted."
+        )
+        self._direction_convention_combo.currentIndexChanged.connect(
+            self._refresh_direction_example
+        )
+        direction_form.addRow("Direction Convention", self._direction_convention_combo)
+        self._direction_example = QLabel()
+        self._direction_example.setWordWrap(True)
+        self._direction_example.setAccessibleName("Launch Direction Sign Example")
+        direction_form.addRow("", self._direction_example)
+        layout.addLayout(direction_form)
+        self._refresh_direction_example()
+
         model_form = QFormLayout()
         self._model_combo = QComboBox()
         self._model_combo.addItems([m.value for m in FlightModelType])
@@ -239,7 +304,7 @@ class FlightExplorerTab(QWidget):
                 low, high, default, decimals, suffix, FIELD_GUIDANCE[guidance_key]
             )
             target[attr] = spin
-            form.addRow(label, spin)
+            form.addRow(_field_label(label, attr, FIELD_GUIDANCE[guidance_key]), spin)
         return page
 
     def _build_results_box(self) -> QGroupBox:
@@ -293,9 +358,12 @@ class FlightExplorerTab(QWidget):
                 launch = launch_from_direct(
                     ball_speed_mph=self.speed_mps() * MPH_PER_MPS,
                     launch_angle_deg=self._direct_spins["launch_angle_deg"].value(),
-                    azimuth_deg=self._direct_spins["azimuth_deg"].value(),
+                    launch_direction_deg=self._direct_spins[
+                        "launch_direction_deg"
+                    ].value(),
                     spin_rpm=self._direct_spins["spin_rpm"].value(),
                     spin_axis_tilt_deg=self._direct_spins["spin_axis_tilt_deg"].value(),
+                    direction_convention=self._direction_convention_combo.currentData(),
                 )
             else:
                 launch = launch_from_delivery(
@@ -372,6 +440,14 @@ class FlightExplorerTab(QWidget):
         self._speed_spin.blockSignals(True)
         self._speed_spin.setValue(mps / _SPEED_UNITS[unit])
         self._speed_spin.blockSignals(False)
+
+    def _refresh_direction_example(self) -> None:
+        convention = self._direction_convention_combo.currentData()
+        definition = LAUNCH_DIRECTION_DEFINITIONS[convention]
+        self._direction_example.setText(
+            f"0° = straight · + = {definition.positive_direction} · "
+            f"− = {definition.negative_direction}"
+        )
 
     def _show_explanation(self, key: str) -> None:
         labels = {row_key: label for row_key, label, _unit in EXPLORER_ROWS}

--- a/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/flight_explorer_tab.py
@@ -356,7 +356,7 @@ class FlightExplorerTab(QWidget):
 
     def mode(self) -> str:
         """The selected entry mode label."""
-        return cast(str, _MODES[self._mode_combo.currentIndex()])
+        return _MODES[self._mode_combo.currentIndex()]
 
     def flight_view(self) -> FlightView:
         """The embedded flight-scale viewer."""

--- a/src/rate_of_closure/ui/pyqt6/inspector_view.py
+++ b/src/rate_of_closure/ui/pyqt6/inspector_view.py
@@ -10,7 +10,7 @@ and offers CSV / JSON export through the shared
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
@@ -62,7 +62,7 @@ class _NumericItem(QTableWidgetItem):
         theirs = other.data(Qt.ItemDataRole.UserRole)
         if isinstance(mine, float) and isinstance(theirs, float):
             return mine < theirs
-        return cast(bool, super().__lt__(other))
+        return bool(super().__lt__(other))
 
 
 def _series_item(value: Any) -> QTableWidgetItem:
@@ -121,7 +121,9 @@ class InspectorView(QWidget):
         self._table = QTableWidget(0, len(CSV_COLUMNS))
         self._table.setHorizontalHeaderLabels(list(CSV_COLUMNS))
         self._table.setSortingEnabled(True)
-        self._table.verticalHeader().setVisible(False)
+        vertical_header = self._table.verticalHeader()
+        if vertical_header is not None:
+            vertical_header.setVisible(False)
         layout.addWidget(self._table)
 
     # ── public API ──────────────────────────────────────────────────

--- a/src/rate_of_closure/ui/pyqt6/inspector_view.py
+++ b/src/rate_of_closure/ui/pyqt6/inspector_view.py
@@ -10,7 +10,7 @@ and offers CSV / JSON export through the shared
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import (
@@ -62,7 +62,7 @@ class _NumericItem(QTableWidgetItem):
         theirs = other.data(Qt.ItemDataRole.UserRole)
         if isinstance(mine, float) and isinstance(theirs, float):
             return mine < theirs
-        return super().__lt__(other)
+        return cast(bool, super().__lt__(other))
 
 
 def _series_item(value: Any) -> QTableWidgetItem:
@@ -121,7 +121,7 @@ class InspectorView(QWidget):
         self._table = QTableWidget(0, len(CSV_COLUMNS))
         self._table.setHorizontalHeaderLabels(list(CSV_COLUMNS))
         self._table.setSortingEnabled(True)
-        self._table.verticalHeader().setVisible(False)  # type: ignore[union-attr]
+        self._table.verticalHeader().setVisible(False)
         layout.addWidget(self._table)
 
     # ── public API ──────────────────────────────────────────────────

--- a/src/rate_of_closure/ui/pyqt6/inspector_view.py
+++ b/src/rate_of_closure/ui/pyqt6/inspector_view.py
@@ -40,7 +40,7 @@ __all__ = ["InspectorView"]
 _SUMMARY_ORDER: tuple[tuple[str, str, str], ...] = (
     ("ball_speed_mph", "Ball Speed", "mph"),
     ("launch_angle_deg", "Launch Angle", "°"),
-    ("launch_azimuth_deg", "Launch Azimuth", "°"),
+    ("launch_azimuth_deg", "Launch Direction", "°"),
     ("spin_rpm", "Spin", "rpm"),
     ("carry_m", "Carry", "m"),
     ("max_height_m", "Apex", "m"),

--- a/src/rate_of_closure/ui/pyqt6/simulation_specs.py
+++ b/src/rate_of_closure/ui/pyqt6/simulation_specs.py
@@ -14,7 +14,7 @@ SOURCE_LABELS: dict[str, str] = {
 LAUNCH_ROWS: tuple[tuple[str, str, str], ...] = (
     ("ball_speed_mph", "Ball Speed", " mph"),
     ("launch_angle_deg", "Launch Angle", "°"),
-    ("launch_azimuth_deg", "Launch Azimuth", "°"),
+    ("launch_azimuth_deg", "Launch Direction", "°"),
     ("spin_rpm", "Total Spin", " rpm"),
     ("carry_m", "Carry Distance", " m"),
     ("max_height_m", "Apex Height", " m"),

--- a/src/rate_of_closure/ui/pyqt6/solver_specs.py
+++ b/src/rate_of_closure/ui/pyqt6/solver_specs.py
@@ -110,7 +110,7 @@ GOAL_SPECS: tuple[GoalSpec, ...] = (
     ),
     GoalSpec(
         "launch_azimuth_deg",
-        "Launch Azimuth",
+        "Launch Direction",
         "°",
         0.0,
         (-45.0, 45.0),

--- a/src/rate_of_closure/units.py
+++ b/src/rate_of_closure/units.py
@@ -334,10 +334,20 @@ FIELD_GUIDANCE: dict[str, str] = {
         "near 10.9 deg); higher for irons and wedges. Source: openly "
         "published tour launch-monitor averages."
     ),
+    "fx_launch_direction": (
+        "Suggested range: within +/-10 deg of the target line; positive values "
+        "start right of the target line, negative values start left, and zero "
+        "starts on target. Source: TrackMan's published Launch Direction "
+        "definition. Reference frame: horizontal ball-CG motion relative to "
+        "the target line immediately after separation."
+    ),
+    # Compatibility alias for older UI/plugin callers.
     "fx_azimuth": (
-        "Suggested range: within +/-10 deg of the target line; + = "
-        "right of target. Source: standard launch-monitor sign "
-        "convention (launch direction)."
+        "Suggested range: within +/-10 deg of the target line; positive values "
+        "start right of the target line, negative values start left, and zero "
+        "starts on target. Source: TrackMan's published Launch Direction "
+        "definition. Reference frame: horizontal ball-CG motion relative to "
+        "the target line immediately after separation."
     ),
     "fx_spin_rpm": (
         "Suggested range: 2,000-3,500 rpm total spin for drivers (tour "

--- a/src/rate_of_closure/variation/plot_labels.py
+++ b/src/rate_of_closure/variation/plot_labels.py
@@ -45,7 +45,7 @@ OUTPUT_LABELS: Mapping[str, str] = MappingProxyType(
         "spin_axis_tilt_deg": "Spin-Axis Tilt",
         "ball_speed_mph": "Ball Speed",
         "launch_angle_deg": "Launch Angle",
-        "launch_azimuth_deg": "Launch Azimuth",
+        "launch_azimuth_deg": "Launch Direction",
         "spin_rpm": "Spin Rate",
         "carry_m": "Carry",
         "lateral_m": "Lateral Landing Position",

--- a/src/rate_of_closure/web/src/components/FieldInfo.tsx
+++ b/src/rate_of_closure/web/src/components/FieldInfo.tsx
@@ -1,15 +1,19 @@
+import { useId } from "react";
+
 export function FieldInfo({ label, guidance }: { label: string; guidance: string }) {
+  const descriptionId = useId();
   return (
     <details className="group relative inline-block">
       <summary
         className="ml-1 inline-flex cursor-pointer list-none items-center gap-1 rounded-md border border-sky-500/35 bg-sky-500/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-300 transition hover:border-sky-400 hover:bg-sky-500/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-400"
         title={`Explain ${label}`}
         aria-label={`Explain ${label}`}
+        aria-describedby={descriptionId}
       >
         <span aria-hidden="true">ⓘ</span>
         Details
       </summary>
-      <p className="absolute left-0 top-full z-30 mt-1 w-72 max-w-[80vw] rounded-lg border border-sky-500/35 bg-slate-950 p-3 text-left text-xs font-normal normal-case tracking-normal text-slate-300 shadow-2xl shadow-black/50">
+      <p id={descriptionId} className="absolute left-0 top-full z-30 mt-1 w-72 max-w-[80vw] rounded-lg border border-sky-500/35 bg-slate-950 p-3 text-left text-xs font-normal normal-case tracking-normal text-slate-300 shadow-2xl shadow-black/50">
         {guidance}
       </p>
     </details>

--- a/src/rate_of_closure/web/src/components/FlightExplorerPanel.test.tsx
+++ b/src/rate_of_closure/web/src/components/FlightExplorerPanel.test.tsx
@@ -16,6 +16,21 @@ beforeAll(() => {
 });
 
 describe("FlightExplorerPanel input editing", () => {
+  it("uses launch-monitor terminology and exposes a working definition", () => {
+    render(<FlightExplorerPanel />);
+
+    expect(screen.queryByText("Launch Azimuth")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Launch Direction")).toBeInTheDocument();
+    expect(screen.getByLabelText("Launch Direction Convention")).toHaveValue(
+      "app_native",
+    );
+    expect(screen.getByTestId("direction-sign-example")).toHaveTextContent(
+      "0° = straight · + = right of the target line",
+    );
+    fireEvent.click(screen.getByLabelText("Explain Launch Direction"));
+    expect(screen.getByText(/positive values start right of the target line/i)).toBeVisible();
+  });
+
   it("accepts and preserves a negative spin-axis tilt", () => {
     render(<FlightExplorerPanel />);
     const input = screen.getByLabelText("Spin-Axis Tilt") as HTMLInputElement;

--- a/src/rate_of_closure/web/src/components/FlightExplorerPanel.test.tsx
+++ b/src/rate_of_closure/web/src/components/FlightExplorerPanel.test.tsx
@@ -24,6 +24,14 @@ describe("FlightExplorerPanel input editing", () => {
     expect(screen.getByLabelText("Launch Direction Convention")).toHaveValue(
       "app_native",
     );
+    const foresight = screen.getByRole("option", {
+      name: "Foresight-Comparable (Sign Unavailable)",
+    });
+    expect(foresight).toBeDisabled();
+    expect(foresight).toHaveAttribute(
+      "title",
+      expect.stringMatching(/public sign convention/i),
+    );
     expect(screen.getByTestId("direction-sign-example")).toHaveTextContent(
       "0° = straight · + = right of the target line",
     );

--- a/src/rate_of_closure/web/src/components/FlightExplorerPanel.tsx
+++ b/src/rate_of_closure/web/src/components/FlightExplorerPanel.tsx
@@ -2,7 +2,7 @@
  * Standalone Ball-Flight Explorer section (epic #4120, V2 web parity).
  *
  * Direct entry of launch conditions (ball speed with a unit drop-down,
- * launch angle, azimuth, spin, spin-axis tilt — sourced hover guidance
+ * launch angle, launch direction, spin, spin-axis tilt — sourced guidance
  * on every control) integrated with the Waterloo/Penner model and
  * rendered in the flight profile canvases with result rows. No swing
  * required. The 7-model picker and delivery mode stay Python-side
@@ -19,9 +19,24 @@ import {
   exploreFlight,
   type FlightExplorationTs,
 } from "../model/flightExplorer";
+import {
+  LAUNCH_DIRECTION_DEFINITIONS,
+  type LaunchDirectionConvention,
+} from "../model/launchDirection";
 import { FIELD_GUIDANCE, formatDistanceM } from "../model/units";
 
 const SPEED_UNITS: Record<string, number> = { mph: 1.0, "m/s": 2.236936292054402 };
+
+const DIRECTION_CONVENTIONS: Array<{
+  value: LaunchDirectionConvention;
+  label: string;
+}> = [
+  { value: "app_native", label: "App Native (+ Right)" },
+  {
+    value: "launch_monitor_comparable",
+    label: "TrackMan-Comparable (+ Right)",
+  },
+];
 
 const RESULT_ROWS: Array<{
   key: keyof FlightExplorationTs["metrics"];
@@ -36,7 +51,7 @@ const RESULT_ROWS: Array<{
 ];
 
 interface FieldSpec {
-  key: "launchAngleDeg" | "azimuthDeg" | "spinRpm" | "spinAxisTiltDeg";
+  key: "launchAngleDeg" | "launchDirectionDeg" | "spinRpm" | "spinAxisTiltDeg";
   label: string;
   unit: string;
   guidance: string;
@@ -44,7 +59,7 @@ interface FieldSpec {
 
 const FIELDS: FieldSpec[] = [
   { key: "launchAngleDeg", label: "Launch Angle", unit: "deg", guidance: "fxLaunchAngle" },
-  { key: "azimuthDeg", label: "Launch Azimuth", unit: "deg", guidance: "fxAzimuth" },
+  { key: "launchDirectionDeg", label: "Launch Direction", unit: "deg", guidance: "fxLaunchDirection" },
   { key: "spinRpm", label: "Total Spin", unit: "rpm", guidance: "fxSpinRpm" },
   { key: "spinAxisTiltDeg", label: "Spin-Axis Tilt", unit: "deg", guidance: "fxSpinAxisTilt" },
 ];
@@ -57,9 +72,11 @@ export function FlightExplorerPanel({
 } = {}) {
   const [speed, setSpeed] = useState(167.0);
   const [speedUnit, setSpeedUnit] = useState("mph");
+  const [directionConvention, setDirectionConvention] =
+    useState<LaunchDirectionConvention>("app_native");
   const [fields, setFields] = useState({
     launchAngleDeg: 10.9,
-    azimuthDeg: 0.0,
+    launchDirectionDeg: 0.0,
     spinRpm: 2686.0,
     spinAxisTiltDeg: 0.0,
   });
@@ -71,6 +88,7 @@ export function FlightExplorerPanel({
       const exploration = exploreFlight(
         directLaunch({
           ballSpeedMph: speed * (SPEED_UNITS[speedUnit] / SPEED_UNITS.mph),
+          launchDirectionConvention: directionConvention,
           ...fields,
         }),
       );
@@ -122,6 +140,24 @@ export function FlightExplorerPanel({
                   </option>
                 ))}
               </select>
+            </span>
+          </label>
+          <label className="mb-2 block text-sm text-slate-300">
+            <span className="mb-1 block">Direction Convention</span>
+            <select
+              aria-label="Launch Direction Convention"
+              value={directionConvention}
+              onChange={(event) =>
+                setDirectionConvention(event.target.value as LaunchDirectionConvention)
+              }
+              className="w-full rounded border border-slate-700 bg-slate-800 px-2 py-1.5 text-slate-100"
+            >
+              {DIRECTION_CONVENTIONS.map(({ value, label }) => (
+                <option key={value} value={value}>{label}</option>
+              ))}
+            </select>
+            <span className="mt-1 block text-xs text-slate-500" data-testid="direction-sign-example">
+              0° = straight · + = {LAUNCH_DIRECTION_DEFINITIONS[directionConvention].positiveDirection} · − = {LAUNCH_DIRECTION_DEFINITIONS[directionConvention].negativeDirection}
             </span>
           </label>
           {FIELDS.map(({ key, label, unit, guidance }) => (

--- a/src/rate_of_closure/web/src/components/FlightExplorerPanel.tsx
+++ b/src/rate_of_closure/web/src/components/FlightExplorerPanel.tsx
@@ -21,6 +21,7 @@ import {
 } from "../model/flightExplorer";
 import {
   LAUNCH_DIRECTION_DEFINITIONS,
+  launchDirectionSignLabels,
   type LaunchDirectionConvention,
 } from "../model/launchDirection";
 import { FIELD_GUIDANCE, formatDistanceM } from "../model/units";
@@ -33,7 +34,7 @@ const DIRECTION_CONVENTIONS: Array<{
 }> = [
   { value: "app_native", label: "App Native (+ Right)" },
   {
-    value: "launch_monitor_comparable",
+    value: "trackman_comparable",
     label: "TrackMan-Comparable (+ Right)",
   },
 ];
@@ -82,6 +83,7 @@ export function FlightExplorerPanel({
   });
   const [result, setResult] = useState<FlightExplorationTs | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const directionSigns = launchDirectionSignLabels(directionConvention);
 
   const run = () => {
     try {
@@ -157,7 +159,7 @@ export function FlightExplorerPanel({
               ))}
             </select>
             <span className="mt-1 block text-xs text-slate-500" data-testid="direction-sign-example">
-              0° = straight · + = {LAUNCH_DIRECTION_DEFINITIONS[directionConvention].positiveDirection} · − = {LAUNCH_DIRECTION_DEFINITIONS[directionConvention].negativeDirection}
+              0° = straight · + = {directionSigns.positive} · − = {directionSigns.negative} · {LAUNCH_DIRECTION_DEFINITIONS[directionConvention].quantityStatus}
             </span>
           </label>
           {FIELDS.map(({ key, label, unit, guidance }) => (

--- a/src/rate_of_closure/web/src/components/FlightExplorerPanel.tsx
+++ b/src/rate_of_closure/web/src/components/FlightExplorerPanel.tsx
@@ -29,13 +29,21 @@ import { FIELD_GUIDANCE, formatDistanceM } from "../model/units";
 const SPEED_UNITS: Record<string, number> = { mph: 1.0, "m/s": 2.236936292054402 };
 
 const DIRECTION_CONVENTIONS: Array<{
-  value: LaunchDirectionConvention;
+  value: string;
   label: string;
+  disabled?: boolean;
+  title?: string;
 }> = [
   { value: "app_native", label: "App Native (+ Right)" },
   {
     value: "trackman_comparable",
     label: "TrackMan-Comparable (+ Right)",
+  },
+  {
+    value: "foresight_comparable",
+    label: "Foresight-Comparable (Sign Unavailable)",
+    disabled: true,
+    title: "Unavailable: the general public sign convention is not established independently of player handedness.",
   },
 ];
 
@@ -154,8 +162,10 @@ export function FlightExplorerPanel({
               }
               className="w-full rounded border border-slate-700 bg-slate-800 px-2 py-1.5 text-slate-100"
             >
-              {DIRECTION_CONVENTIONS.map(({ value, label }) => (
-                <option key={value} value={value}>{label}</option>
+              {DIRECTION_CONVENTIONS.map(({ value, label, disabled, title }) => (
+                <option key={label} value={value} disabled={disabled} title={title}>
+                  {label}
+                </option>
               ))}
             </select>
             <span className="mt-1 block text-xs text-slate-500" data-testid="direction-sign-example">

--- a/src/rate_of_closure/web/src/components/SimulationLaunchNumbers.tsx
+++ b/src/rate_of_closure/web/src/components/SimulationLaunchNumbers.tsx
@@ -9,7 +9,7 @@ import { formatDistanceM } from "../model/units";
 const ROWS: Array<{ key: keyof SimulationLaunchTs; label: string; unit: string }> = [
   { key: "ballSpeedMph", label: "Ball Speed", unit: "mph" },
   { key: "launchAngleDeg", label: "Launch Angle", unit: "°" },
-  { key: "launchAzimuthDeg", label: "Launch Azimuth", unit: "°" },
+  { key: "launchAzimuthDeg", label: "Launch Direction", unit: "°" },
   { key: "spinRpm", label: "Total Spin", unit: "rpm" },
   { key: "carryM", label: "Carry", unit: "m" },
   { key: "maxHeightM", label: "Apex", unit: "m" },

--- a/src/rate_of_closure/web/src/components/SolverPanel.tsx
+++ b/src/rate_of_closure/web/src/components/SolverPanel.tsx
@@ -45,7 +45,7 @@ const GOAL_ROWS: GoalRowSpec[] = [
   { key: "dynamicLoftDeg", label: "Dynamic Loft", unit: "°", target: 12 },
   { key: "ballSpeedMph", label: "Ball Speed", unit: "mph", target: 150 },
   { key: "launchAngleDeg", label: "Launch Angle", unit: "°", target: 12 },
-  { key: "launchAzimuthDeg", label: "Launch Azimuth", unit: "°", target: 0 },
+  { key: "launchAzimuthDeg", label: "Launch Direction", unit: "°", target: 0 },
   { key: "spinRpm", label: "Total Spin", unit: "rpm", target: 2600 },
   { key: "carryM", label: "Carry Distance", unit: "m", target: 230 },
 ];

--- a/src/rate_of_closure/web/src/model/flightExplorer.test.ts
+++ b/src/rate_of_closure/web/src/model/flightExplorer.test.ts
@@ -15,7 +15,7 @@ import { BALL_POSITION } from "./simulation";
 const PINNED = {
   ballSpeedMph: 167.0,
   launchAngleDeg: 10.9,
-  azimuthDeg: 0.0,
+  launchDirectionDeg: 0.0,
   spinRpm: 2686.0,
   spinAxisTiltDeg: 0.0,
 };
@@ -53,9 +53,9 @@ describe("exploreFlight", () => {
     expect(Math.abs(metrics.lateralM)).toBeLessThan(0.5);
   });
 
-  it("keeps app sign conventions: + azimuth and + tilt land right", () => {
+  it("keeps app sign conventions: + direction and + tilt land right", () => {
     const right = exploreFlight(
-      directLaunch({ ...PINNED, azimuthDeg: 5.0 }),
+      directLaunch({ ...PINNED, launchDirectionDeg: 5.0 }),
     ).metrics;
     const fade = exploreFlight(
       directLaunch({ ...PINNED, spinAxisTiltDeg: 10.0 }),
@@ -64,6 +64,7 @@ describe("exploreFlight", () => {
       directLaunch({ ...PINNED, spinAxisTiltDeg: -10.0 }),
     ).metrics;
     expect(right.lateralM).toBeGreaterThan(1.0);
+    expect(right.launchDirectionDeg).toBeCloseTo(5.0, 8);
     expect(right.launchAzimuthDeg).toBeCloseTo(5.0, 8);
     expect(fade.lateralM).toBeGreaterThan(1.0);
     expect(draw.lateralM).toBeLessThan(-1.0);

--- a/src/rate_of_closure/web/src/model/flightExplorer.ts
+++ b/src/rate_of_closure/web/src/model/flightExplorer.ts
@@ -4,13 +4,18 @@
  * TypeScript twin of `rate_of_closure/simulation/flight_explorer.py`,
  * parity-banded by `flightExplorer.test.ts` against the pytest pinned
  * case: build flight-frame launch conditions from launch-monitor ball
- * numbers (app signs: azimuth and lateral + = right of target, spin
+ * numbers (app signs: launch direction and lateral + = right of target, spin
  * axis tilt + = fade side) and integrate with the Waterloo/Penner
  * model. The full 7-model picker stays Python-side until the P7 WASM
  * kernels land.
  */
 
 import { simulateFlight, type FlightPoint, type Launch } from "./flight";
+import {
+  launchDirectionFromRecord,
+  launchDirectionToFlightAzimuth,
+  type LaunchDirectionConvention,
+} from "./launchDirection";
 import {
   BALL_POSITION,
   MPH_PER_MPS,
@@ -25,7 +30,11 @@ const deg = (r: number): number => (r * 180.0) / Math.PI;
 export interface DirectLaunchInput {
   ballSpeedMph: number;
   launchAngleDeg: number;
-  azimuthDeg: number; // + = right of target (app convention)
+  /** Canonical positive-right horizontal direction. */
+  launchDirectionDeg?: number;
+  /** @deprecated Lossless import compatibility for pre-#4193 callers. */
+  azimuthDeg?: number;
+  launchDirectionConvention?: LaunchDirectionConvention;
   spinRpm: number;
   spinAxisTiltDeg: number; // + = fade side (curves right)
 }
@@ -35,11 +44,14 @@ export function directLaunch(input: DirectLaunchInput): Launch {
   if (!(input.ballSpeedMph > 0)) {
     throw new Error("ballSpeedMph must be > 0");
   }
-  // App azimuth + = right; flight-frame azimuth + = left: flip. The
+  const direction = launchDirectionFromRecord(input as unknown as Record<string, unknown>);
+  // App direction + = right; flight-frame azimuth + = left: flip. The
   // fade-side tilt (+) needs a downward (-z flight) sidespin component,
   // so the legacy spin-axis-angle decomposition gets the flipped angle
   // too (same derivation as the Python twin).
-  const azimuthRad = -rad(input.azimuthDeg);
+  const azimuthRad = rad(
+    launchDirectionToFlightAzimuth(direction.degrees, direction.convention),
+  );
   const axisAngle = -rad(input.spinAxisTiltDeg);
   const backspin = Math.cos(axisAngle);
   const sidespin = Math.sin(axisAngle);
@@ -63,6 +75,8 @@ export interface FlightExplorationTs {
   metrics: {
     ballSpeedMph: number;
     launchAngleDeg: number;
+    launchDirectionDeg: number; // + = right of target
+    /** @deprecated Persistence alias retained for older exports. */
     launchAzimuthDeg: number; // + = right of target
     spinRpm: number;
     carryM: number;
@@ -86,7 +100,8 @@ export function exploreFlight(launch: Launch): FlightExplorationTs {
     metrics: {
       ballSpeedMph: launch.ballSpeedMps * MPH_PER_MPS,
       launchAngleDeg: deg(launch.launchAngleRad),
-      // Flight azimuth + = left; app convention + = right of target.
+      // Flight azimuth + = left; public launch direction + = right.
+      launchDirectionDeg: -deg(launch.azimuthRad),
       launchAzimuthDeg: -deg(launch.azimuthRad),
       spinRpm: launch.spinRpm,
       carryM: result.carryM,

--- a/src/rate_of_closure/web/src/model/glossaryEntriesAL.ts
+++ b/src/rate_of_closure/web/src/model/glossaryEntriesAL.ts
@@ -196,7 +196,7 @@ export const ENTRIES: Record<string, GlossaryEntry> = {
     definition:
       "The horizontal direction of the delivered face normal relative to " +
       "the target line: positive = open (pointing right of target). The " +
-      "dominant contributor to launch azimuth (launch-monitor conventions; " +
+      "dominant contributor to launch direction (launch-monitor conventions; " +
       "AffineDrift 02-parameters).",
   },
   flight_time: {
@@ -286,7 +286,7 @@ export const ENTRIES: Record<string, GlossaryEntry> = {
     term: "Lateral Landing Offset",
     definition:
       "The sideways distance from the target line at landing (+ = right of " +
-      "target): the integrated effect of launch azimuth plus the curvature " +
+      "target): the integrated effect of launch direction plus the curvature " +
       "from spin-axis tilt — the way launch monitors report carry offline " +
       "(swing_sim.flight metrics).",
   },
@@ -299,7 +299,7 @@ export const ENTRIES: Record<string, GlossaryEntry> = {
       "conventions).",
   },
   launch_azimuth: {
-    term: "Launch Azimuth",
+    term: "Launch Direction",
     definition:
       "The horizontal direction of the ball's initial velocity relative to " +
       "the target line (+ = right). Dominated by the delivered face angle " +

--- a/src/rate_of_closure/web/src/model/helptext.test.ts
+++ b/src/rate_of_closure/web/src/model/helptext.test.ts
@@ -29,7 +29,7 @@ describe("per-tab help", () => {
       "planeYawDeg",
       "planeSideTiltDeg",
       "planeForwardTiltDeg",
-      "fxAzimuth",
+      "fxLaunchDirection",
       "fxSpinAxisTilt",
     ]) {
       expect(FIELD_GUIDANCE[key], key).toContain("Reference frame:");

--- a/src/rate_of_closure/web/src/model/launchDirection.test.ts
+++ b/src/rate_of_closure/web/src/model/launchDirection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  convertLaunchDirection,
+  launchDirectionFromRecord,
+  launchDirectionToFlightAzimuth,
+  migrateLaunchDirectionRecord,
+  type LaunchDirectionConvention,
+} from "./launchDirection";
+
+const CONVENTIONS: LaunchDirectionConvention[] = [
+  "app_native",
+  "launch_monitor_comparable",
+  "flight_frame",
+];
+
+describe("launch-direction conventions", () => {
+  it.each([0, 7.25, -7.25, 90, -90, 179.999, -179.999])(
+    "round-trips every convention pair at %s degrees",
+    (degrees) => {
+      for (const source of CONVENTIONS) {
+        for (const target of CONVENTIONS) {
+          const converted = convertLaunchDirection(degrees, source, target);
+          expect(convertLaunchDirection(converted, target, source)).toBeCloseTo(degrees, 12);
+        }
+      }
+    },
+  );
+
+  it("maps right-positive app direction to left-positive flight azimuth", () => {
+    expect(launchDirectionToFlightAzimuth(6, "app_native")).toBe(-6);
+  });
+});
+
+describe("launch-direction migration", () => {
+  it("adds canonical fields without dropping legacy or unknown data", () => {
+    const migrated = migrateLaunchDirectionRecord({
+      launchAzimuthDeg: -3.5,
+      shotName: "soft draw",
+    });
+    expect(migrated).toEqual({
+      launchAzimuthDeg: -3.5,
+      shotName: "soft draw",
+      launchDirectionDeg: -3.5,
+      launchDirectionConvention: "app_native",
+      launchDirectionSchemaVersion: 1,
+    });
+    expect(launchDirectionFromRecord(migrated)).toEqual({
+      degrees: -3.5,
+      convention: "app_native",
+    });
+  });
+
+  it("rejects conflicting canonical and legacy values", () => {
+    expect(() =>
+      migrateLaunchDirectionRecord({ launchDirectionDeg: 2, azimuthDeg: -2 }),
+    ).toThrow(/conflicting launch-direction/);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 181])("rejects invalid value %s", (value) => {
+    expect(() => migrateLaunchDirectionRecord({ launchDirectionDeg: value })).toThrow();
+  });
+});

--- a/src/rate_of_closure/web/src/model/launchDirection.test.ts
+++ b/src/rate_of_closure/web/src/model/launchDirection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  LAUNCH_DIRECTION_DEFINITIONS,
   convertLaunchDirection,
   launchDirectionFromRecord,
   launchDirectionToFlightAzimuth,
@@ -10,8 +11,7 @@ import {
 
 const CONVENTIONS: LaunchDirectionConvention[] = [
   "app_native",
-  "launch_monitor_comparable",
-  "flight_frame",
+  "trackman_comparable",
 ];
 
 describe("launch-direction conventions", () => {
@@ -29,6 +29,14 @@ describe("launch-direction conventions", () => {
 
   it("maps right-positive app direction to left-positive flight azimuth", () => {
     expect(launchDirectionToFlightAzimuth(6, "app_native")).toBe(-6);
+  });
+
+  it("uses the canonical registry definition", () => {
+    expect(LAUNCH_DIRECTION_DEFINITIONS.trackman_comparable).toMatchObject({
+      parameterId: "launch_direction",
+      signRule: "positive_right",
+      retrievedOn: "2026-08-05",
+    });
   });
 });
 
@@ -55,6 +63,24 @@ describe("launch-direction migration", () => {
     expect(() =>
       migrateLaunchDirectionRecord({ launchDirectionDeg: 2, azimuthDeg: -2 }),
     ).toThrow(/conflicting launch-direction/);
+  });
+
+  it("migrates the legacy generic convention name to the registry ID", () => {
+    expect(
+      migrateLaunchDirectionRecord({
+        launchDirectionDeg: 2,
+        launchDirectionConvention: "launch_monitor_comparable",
+      }),
+    ).toMatchObject({ launchDirectionConvention: "trackman_comparable" });
+  });
+
+  it("does not activate the unverified Foresight sign in this adapter", () => {
+    expect(() =>
+      migrateLaunchDirectionRecord({
+        launchDirectionDeg: 2,
+        launchDirectionConvention: "foresight_comparable",
+      }),
+    ).toThrow(/unknown launch-direction convention/);
   });
 
   it.each([Number.NaN, Number.POSITIVE_INFINITY, 181])("rejects invalid value %s", (value) => {

--- a/src/rate_of_closure/web/src/model/launchDirection.ts
+++ b/src/rate_of_closure/web/src/model/launchDirection.ts
@@ -1,0 +1,129 @@
+/** Explicit launch-direction conventions and lossless legacy migration. */
+
+export type LaunchDirectionConvention =
+  | "app_native"
+  | "launch_monitor_comparable"
+  | "flight_frame";
+
+export interface LaunchDirectionValue {
+  degrees: number;
+  convention: LaunchDirectionConvention;
+}
+
+export interface LaunchDirectionDefinition {
+  positiveDirection: string;
+  negativeDirection: string;
+  reference: string;
+  sourceUrl?: string;
+  retrievedOn?: string;
+  definitionVersion: string;
+  comparabilityStatus: string;
+}
+
+export const LAUNCH_DIRECTION_DEFINITIONS: Record<
+  LaunchDirectionConvention,
+  LaunchDirectionDefinition
+> = {
+  app_native: {
+    positiveDirection: "right of the target line",
+    negativeDirection: "left of the target line",
+    reference: "horizontal angle from the target line",
+    definitionVersion: "roc-launch-direction-v1",
+    comparabilityStatus: "canonical",
+  },
+  launch_monitor_comparable: {
+    positiveDirection: "right of the target line",
+    negativeDirection: "left of the target line",
+    reference: "horizontal ball-CG motion relative to the target line after separation",
+    sourceUrl: "https://www.trackman.com/blog/golf/what-is-launch-direction",
+    retrievedOn: "2026-08-06",
+    definitionVersion: "trackman-public-definition-2026-08-06",
+    comparabilityStatus: "definition-and-sign-comparable",
+  },
+  flight_frame: {
+    positiveDirection: "left of the target line (+y flight)",
+    negativeDirection: "right of the target line (-y flight)",
+    reference: "horizontal angle from +x in the internal flight frame",
+    definitionVersion: "swing-sim-flight-frame-v1",
+    comparabilityStatus: "internal-only",
+  },
+};
+
+const CONVENTIONS = new Set<LaunchDirectionConvention>([
+  "app_native",
+  "launch_monitor_comparable",
+  "flight_frame",
+]);
+
+function validatedDegrees(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError("launch direction must be a finite number");
+  }
+  if (value < -180 || value > 180) {
+    throw new RangeError("launch direction must be within [-180, 180] degrees");
+  }
+  return value;
+}
+
+function validatedConvention(value: unknown): LaunchDirectionConvention {
+  if (typeof value !== "string" || !CONVENTIONS.has(value as LaunchDirectionConvention)) {
+    throw new RangeError(`unknown launch-direction convention: ${String(value)}`);
+  }
+  return value as LaunchDirectionConvention;
+}
+
+export function convertLaunchDirection(
+  degrees: number,
+  source: LaunchDirectionConvention,
+  target: LaunchDirectionConvention,
+): number {
+  const validDegrees = validatedDegrees(degrees);
+  validatedConvention(source);
+  validatedConvention(target);
+  const rightPositive = source === "flight_frame" ? -validDegrees : validDegrees;
+  return target === "flight_frame" ? -rightPositive : rightPositive;
+}
+
+export function launchDirectionToFlightAzimuth(
+  degrees: number,
+  convention: LaunchDirectionConvention,
+): number {
+  return convertLaunchDirection(degrees, convention, "flight_frame");
+}
+
+export function migrateLaunchDirectionRecord(
+  values: Readonly<Record<string, unknown>>,
+): Record<string, unknown> {
+  const keys = ["launchDirectionDeg", "launchAzimuthDeg", "azimuthDeg"] as const;
+  const present = keys
+    .filter((key) => Object.prototype.hasOwnProperty.call(values, key))
+    .map((key) => [key, validatedDegrees(values[key])] as const);
+  if (present.length === 0) {
+    throw new Error("no launch-direction field found");
+  }
+  const [firstKey, firstValue] = present[0];
+  for (const [key, value] of present.slice(1)) {
+    if (Math.abs(firstValue - value) > 1e-12) {
+      throw new Error(`conflicting launch-direction values in '${firstKey}' and '${key}'`);
+    }
+  }
+  const convention = validatedConvention(
+    values.launchDirectionConvention ?? "app_native",
+  );
+  return {
+    ...values,
+    launchDirectionDeg: firstValue,
+    launchDirectionConvention: convention,
+    launchDirectionSchemaVersion: 1,
+  };
+}
+
+export function launchDirectionFromRecord(
+  values: Readonly<Record<string, unknown>>,
+): LaunchDirectionValue {
+  const migrated = migrateLaunchDirectionRecord(values);
+  return {
+    degrees: validatedDegrees(migrated.launchDirectionDeg),
+    convention: validatedConvention(migrated.launchDirectionConvention),
+  };
+}

--- a/src/rate_of_closure/web/src/model/launchDirection.ts
+++ b/src/rate_of_closure/web/src/model/launchDirection.ts
@@ -1,59 +1,38 @@
-/** Explicit launch-direction conventions and lossless legacy migration. */
+/** Registry-backed launch-direction conversion and lossless legacy migration. */
 
+import {
+  conventionRegistry,
+  type ConventionId,
+  type ParameterDefinitionTs,
+} from "./launchMonitorConventions";
+
+const SUPPORTED_DIRECTION_CONVENTIONS = [
+  "app_native",
+  "trackman_comparable",
+] as const satisfies readonly ConventionId[];
 export type LaunchDirectionConvention =
-  | "app_native"
-  | "launch_monitor_comparable"
-  | "flight_frame";
+  (typeof SUPPORTED_DIRECTION_CONVENTIONS)[number];
 
 export interface LaunchDirectionValue {
   degrees: number;
   convention: LaunchDirectionConvention;
 }
 
-export interface LaunchDirectionDefinition {
-  positiveDirection: string;
-  negativeDirection: string;
-  reference: string;
-  sourceUrl?: string;
-  retrievedOn?: string;
-  definitionVersion: string;
-  comparabilityStatus: string;
-}
+const registry = conventionRegistry();
 
-export const LAUNCH_DIRECTION_DEFINITIONS: Record<
-  LaunchDirectionConvention,
-  LaunchDirectionDefinition
-> = {
-  app_native: {
-    positiveDirection: "right of the target line",
-    negativeDirection: "left of the target line",
-    reference: "horizontal angle from the target line",
-    definitionVersion: "roc-launch-direction-v1",
-    comparabilityStatus: "canonical",
-  },
-  launch_monitor_comparable: {
-    positiveDirection: "right of the target line",
-    negativeDirection: "left of the target line",
-    reference: "horizontal ball-CG motion relative to the target line after separation",
-    sourceUrl: "https://www.trackman.com/blog/golf/what-is-launch-direction",
-    retrievedOn: "2026-08-06",
-    definitionVersion: "trackman-public-definition-2026-08-06",
-    comparabilityStatus: "definition-and-sign-comparable",
-  },
-  flight_frame: {
-    positiveDirection: "left of the target line (+y flight)",
-    negativeDirection: "right of the target line (-y flight)",
-    reference: "horizontal angle from +x in the internal flight frame",
-    definitionVersion: "swing-sim-flight-frame-v1",
-    comparabilityStatus: "internal-only",
-  },
-};
+export const LAUNCH_DIRECTION_DEFINITIONS: Readonly<
+  Record<LaunchDirectionConvention, ParameterDefinitionTs>
+> = Object.freeze(
+  Object.fromEntries(
+    SUPPORTED_DIRECTION_CONVENTIONS.map((convention) => [
+      convention,
+      registry.definition(convention, "launch_direction"),
+    ]),
+  ) as Record<LaunchDirectionConvention, ParameterDefinitionTs>,
+);
 
-const CONVENTIONS = new Set<LaunchDirectionConvention>([
-  "app_native",
-  "launch_monitor_comparable",
-  "flight_frame",
-]);
+const LEGACY_CONVENTIONS: Readonly<Record<string, LaunchDirectionConvention>> =
+  Object.freeze({ launch_monitor_comparable: "trackman_comparable" });
 
 function validatedDegrees(value: unknown): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -66,10 +45,25 @@ function validatedDegrees(value: unknown): number {
 }
 
 function validatedConvention(value: unknown): LaunchDirectionConvention {
-  if (typeof value !== "string" || !CONVENTIONS.has(value as LaunchDirectionConvention)) {
+  if (typeof value !== "string") {
     throw new RangeError(`unknown launch-direction convention: ${String(value)}`);
   }
-  return value as LaunchDirectionConvention;
+  const canonical = LEGACY_CONVENTIONS[value] ?? value;
+  if (
+    !SUPPORTED_DIRECTION_CONVENTIONS.includes(
+      canonical as LaunchDirectionConvention,
+    )
+  ) {
+    throw new RangeError(`unknown launch-direction convention: ${String(value)}`);
+  }
+  const convention = canonical as LaunchDirectionConvention;
+  const definition = LAUNCH_DIRECTION_DEFINITIONS[convention];
+  if (definition.signRule !== "positive_right") {
+    throw new RangeError(
+      `unsupported launch-direction sign rule: ${definition.signRule}`,
+    );
+  }
+  return convention;
 }
 
 export function convertLaunchDirection(
@@ -80,15 +74,25 @@ export function convertLaunchDirection(
   const validDegrees = validatedDegrees(degrees);
   validatedConvention(source);
   validatedConvention(target);
-  const rightPositive = source === "flight_frame" ? -validDegrees : validDegrees;
-  return target === "flight_frame" ? -rightPositive : rightPositive;
+  return validDegrees;
 }
 
 export function launchDirectionToFlightAzimuth(
   degrees: number,
   convention: LaunchDirectionConvention,
 ): number {
-  return convertLaunchDirection(degrees, convention, "flight_frame");
+  validatedConvention(convention);
+  return -validatedDegrees(degrees);
+}
+
+export function launchDirectionSignLabels(
+  convention: LaunchDirectionConvention,
+): Readonly<{ positive: string; negative: string }> {
+  validatedConvention(convention);
+  return Object.freeze({
+    positive: "right of the target line",
+    negative: "left of the target line",
+  });
 }
 
 export function migrateLaunchDirectionRecord(
@@ -104,7 +108,9 @@ export function migrateLaunchDirectionRecord(
   const [firstKey, firstValue] = present[0];
   for (const [key, value] of present.slice(1)) {
     if (Math.abs(firstValue - value) > 1e-12) {
-      throw new Error(`conflicting launch-direction values in '${firstKey}' and '${key}'`);
+      throw new Error(
+        `conflicting launch-direction values in '${firstKey}' and '${key}'`,
+      );
     }
   }
   const convention = validatedConvention(

--- a/src/rate_of_closure/web/src/model/plotcatalog.ts
+++ b/src/rate_of_closure/web/src/model/plotcatalog.ts
@@ -188,7 +188,7 @@ export const PLOT_CATALOG: PlotVariable[] = [
     (c) => launchValue(c, "ballSpeedMph")),
   v("launch.launch_angle_deg", "Launch Angle", "deg", "Launch",
     (c) => launchValue(c, "launchAngleDeg")),
-  v("launch.launch_azimuth_deg", "Launch Azimuth", "deg", "Launch",
+  v("launch.launch_azimuth_deg", "Launch Direction", "deg", "Launch",
     (c) => launchValue(c, "launchAzimuthDeg")),
   v("launch.spin_rpm", "Total Spin", "rpm", "Launch",
     (c) => launchValue(c, "spinRpm")),

--- a/src/rate_of_closure/web/src/model/units.ts
+++ b/src/rate_of_closure/web/src/model/units.ts
@@ -202,11 +202,19 @@ export const FIELD_GUIDANCE: Record<string, string> = {
     "Suggested range: 8-16 deg launch for drivers (tour average near " +
     "10.9 deg); higher for irons and wedges. Source: openly published " +
     "tour launch-monitor averages.",
+  fxLaunchDirection:
+    "Suggested range: within +/-10 deg of the target line; positive values " +
+    "start right of the target line, negative values start left, and zero " +
+    "starts on target. Source: TrackMan's published Launch Direction " +
+    "definition. Reference frame: horizontal ball-CG motion relative to " +
+    "the target line immediately after separation.",
+  // Compatibility alias for older UI/plugin callers.
   fxAzimuth:
-    "Suggested range: within +/-10 deg of the target line; + = right of " +
-    "target. Source: standard launch-monitor sign convention (launch " +
-    "direction). Reference frame: horizontal angle from +x target line " +
-    "toward +z right of target.",
+    "Suggested range: within +/-10 deg of the target line; positive values " +
+    "start right of the target line, negative values start left, and zero " +
+    "starts on target. Source: TrackMan's published Launch Direction " +
+    "definition. Reference frame: horizontal ball-CG motion relative to " +
+    "the target line immediately after separation.",
   fxSpinRpm:
     "Suggested range: 2,000-3,500 rpm total spin for drivers (tour " +
     "average near 2,686 rpm); 4,000-10,000+ for irons and wedges. " +

--- a/src/rate_of_closure/web/src/model/variationPlotData.ts
+++ b/src/rate_of_closure/web/src/model/variationPlotData.ts
@@ -81,7 +81,7 @@ const OUTPUT_LABELS: Record<string, string> = {
   dynamic_loft_deg: "Dynamic Loft",
   ball_speed_mph: "Ball Speed",
   launch_angle_deg: "Launch Angle",
-  launch_azimuth_deg: "Launch Azimuth",
+  launch_azimuth_deg: "Launch Direction",
   spin_rpm: "Spin Rate",
   spin_axis_deg: "Spin-Axis Tilt",
   carry_m: "Carry",

--- a/src/rate_of_closure/web/src/model/variationRegistry.ts
+++ b/src/rate_of_closure/web/src/model/variationRegistry.ts
@@ -184,7 +184,7 @@ export const VARIABLE_REGISTRY: VariableDefTs[] = [
   },
   {
     key: `${CATEGORY_LAUNCH}.launch_azimuth_deg`,
-    label: "Launch Azimuth",
+    label: "Launch Direction",
     unit: "deg",
     default: 0.0,
     typicalScale: 0.8,

--- a/src/shared/python/swing_sim/flight/__init__.py
+++ b/src/shared/python/swing_sim/flight/__init__.py
@@ -22,6 +22,7 @@ from .direction import (
     LaunchDirection,
     LaunchDirectionConvention,
     launch_direction_from_mapping,
+    launch_direction_sign_labels,
     launch_direction_to_flight_azimuth,
     migrate_launch_direction_mapping,
 )
@@ -66,6 +67,7 @@ __all__ = [
     "from_flight_frame",
     "is_rust_available",
     "launch_direction_from_mapping",
+    "launch_direction_sign_labels",
     "launch_direction_to_flight_azimuth",
     "migrate_launch_direction_mapping",
     "simulate",

--- a/src/shared/python/swing_sim/flight/__init__.py
+++ b/src/shared/python/swing_sim/flight/__init__.py
@@ -15,6 +15,16 @@ Import from this facade only; module layout underneath is private.
 from __future__ import annotations
 
 from ._rust_facade import is_rust_available, simulate_trajectory_rust
+from .direction import (
+    DEFINITIONS as LAUNCH_DIRECTION_DEFINITIONS,
+)
+from .direction import (
+    LaunchDirection,
+    LaunchDirectionConvention,
+    launch_direction_from_mapping,
+    launch_direction_to_flight_azimuth,
+    migrate_launch_direction_mapping,
+)
 from .frames import from_flight_frame, to_flight_frame
 from .launch import derive_launch_conditions
 from .models import (
@@ -44,6 +54,9 @@ __all__ = [
     "FlightResult",
     "FlightSimulatorProtocol",
     "LaunchConditions",
+    "LaunchDirection",
+    "LaunchDirectionConvention",
+    "LAUNCH_DIRECTION_DEFINITIONS",
     "MacDonaldHanzelyModel",
     "TrajectoryPoint",
     "WaterlooPennerModel",
@@ -52,6 +65,9 @@ __all__ = [
     "derive_launch_conditions",
     "from_flight_frame",
     "is_rust_available",
+    "launch_direction_from_mapping",
+    "launch_direction_to_flight_azimuth",
+    "migrate_launch_direction_mapping",
     "simulate",
     "simulate_trajectory_rust",
     "to_flight_frame",

--- a/src/shared/python/swing_sim/flight/direction.py
+++ b/src/shared/python/swing_sim/flight/direction.py
@@ -1,9 +1,10 @@
-"""Canonical launch-direction conventions and lossless legacy migration.
+"""Registry-backed launch-direction conversion and legacy migration.
 
-Launch Direction is the horizontal angle at launch relative to the target
-line.  The application and launch-monitor-comparable conventions use
-positive right / negative left.  The internal flight frame uses +y left,
-so its azimuth has the opposite sign.
+Public conventions are owned by :mod:`shared.python.swing_sim.conventions`.
+Every catalogued launch direction is target-frame, degree-valued, and
+positive right.  The internal flight frame is x forward / y left / z up,
+so conversion to its azimuth is an explicit sign flip rather than another
+vendor convention.
 """
 
 from __future__ import annotations
@@ -11,72 +12,42 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping
 from dataclasses import dataclass
-from enum import StrEnum
 from numbers import Real
-from typing import Final
+from types import MappingProxyType
+from typing import Final, TypeAlias
 
-TRACKMAN_LAUNCH_DIRECTION_SOURCE: Final = (
-    "https://www.trackman.com/blog/golf/what-is-launch-direction"
+from shared.python.swing_sim.conventions import (
+    ConventionId,
+    ParameterDefinition,
+    ParameterId,
+    SignRule,
+    convention_registry,
 )
+
 CANONICAL_DIRECTION_KEY: Final = "launch_direction_deg"
 CONVENTION_KEY: Final = "launch_direction_convention"
 SCHEMA_VERSION_KEY: Final = "launch_direction_schema_version"
 SCHEMA_VERSION: Final = 1
 LEGACY_DIRECTION_KEYS: Final = ("launch_azimuth_deg", "azimuth_deg")
 
+# Backward-compatible public type name, now an alias to the canonical registry ID.
+LaunchDirectionConvention: TypeAlias = ConventionId
 
-class LaunchDirectionConvention(StrEnum):
-    """Supported numeric sign conventions for horizontal launch direction."""
-
-    APP_NATIVE = "app_native"
-    LAUNCH_MONITOR_COMPARABLE = "launch_monitor_comparable"
-    FLIGHT_FRAME = "flight_frame"
-
-
-@dataclass(frozen=True)
-class LaunchDirectionDefinition:
-    """Human-readable convention metadata carried beside numeric values."""
-
-    positive_direction: str
-    negative_direction: str
-    reference: str
-    source_url: str | None
-    retrieved_on: str | None
-    definition_version: str
-    comparability_status: str
-
-
-DEFINITIONS: Final[dict[LaunchDirectionConvention, LaunchDirectionDefinition]] = {
-    LaunchDirectionConvention.APP_NATIVE: LaunchDirectionDefinition(
-        positive_direction="right of the target line",
-        negative_direction="left of the target line",
-        reference="horizontal angle from the target line",
-        source_url=None,
-        retrieved_on=None,
-        definition_version="roc-launch-direction-v1",
-        comparability_status="canonical",
-    ),
-    LaunchDirectionConvention.LAUNCH_MONITOR_COMPARABLE: LaunchDirectionDefinition(
-        positive_direction="right of the target line",
-        negative_direction="left of the target line",
-        reference=(
-            "horizontal ball-CG motion relative to the target line after separation"
-        ),
-        source_url=TRACKMAN_LAUNCH_DIRECTION_SOURCE,
-        retrieved_on="2026-08-06",
-        definition_version="trackman-public-definition-2026-08-06",
-        comparability_status="definition-and-sign-comparable",
-    ),
-    LaunchDirectionConvention.FLIGHT_FRAME: LaunchDirectionDefinition(
-        positive_direction="left of the target line (+y flight)",
-        negative_direction="right of the target line (-y flight)",
-        reference="horizontal angle from +x in the internal flight frame",
-        source_url=None,
-        retrieved_on=None,
-        definition_version="swing-sim-flight-frame-v1",
-        comparability_status="internal-only",
-    ),
+_LEGACY_CONVENTION_ALIASES: Final = {
+    "launch_monitor_comparable": ConventionId.TRACKMAN_COMPARABLE.value,
 }
+_SUPPORTED_CONVENTIONS: Final = (
+    ConventionId.APP_NATIVE,
+    ConventionId.TRACKMAN_COMPARABLE,
+)
+
+_registry = convention_registry()
+DEFINITIONS: Final[Mapping[ConventionId, ParameterDefinition]] = MappingProxyType(
+    {
+        convention: _registry.definition(convention, ParameterId.LAUNCH_DIRECTION)
+        for convention in _SUPPORTED_CONVENTIONS
+    }
+)
 
 
 def _validated_degrees(value: object) -> float:
@@ -90,47 +61,57 @@ def _validated_degrees(value: object) -> float:
     return degrees
 
 
-def _right_positive(degrees: float, convention: LaunchDirectionConvention) -> float:
-    return -degrees if convention is LaunchDirectionConvention.FLIGHT_FRAME else degrees
+def _validated_convention(value: object) -> ConventionId:
+    if not isinstance(value, (str, ConventionId)):
+        raise ValueError(f"unknown launch-direction convention: {value!r}")
+    canonical = _LEGACY_CONVENTION_ALIASES.get(str(value), str(value))
+    try:
+        convention = ConventionId(canonical)
+        definition = DEFINITIONS[convention]
+    except (KeyError, ValueError) as exc:
+        raise ValueError(f"unsupported launch-direction convention: {value!r}") from exc
+    if definition.sign_rule is not SignRule.POSITIVE_RIGHT:
+        raise ValueError(
+            f"unsupported launch-direction sign rule: {definition.sign_rule.value}"
+        )
+    return convention
 
 
 @dataclass(frozen=True)
 class LaunchDirection:
-    """A direction value whose sign convention cannot be implicit."""
+    """A direction value tied to one source-backed registry convention."""
 
     degrees: float
-    convention: LaunchDirectionConvention
+    convention: ConventionId
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "degrees", _validated_degrees(self.degrees))
-        if not isinstance(self.convention, LaunchDirectionConvention):
-            raise TypeError("convention must be a LaunchDirectionConvention")
+        object.__setattr__(self, "convention", _validated_convention(self.convention))
 
-    def to(self, target: LaunchDirectionConvention) -> LaunchDirection:
-        """Convert to *target* without changing the represented direction."""
-        if not isinstance(target, LaunchDirectionConvention):
-            raise TypeError("target must be a LaunchDirectionConvention")
-        canonical = _right_positive(self.degrees, self.convention)
-        converted = (
-            -canonical
-            if target is LaunchDirectionConvention.FLIGHT_FRAME
-            else canonical
-        )
-        return LaunchDirection(converted, target)
+    @property
+    def definition(self) -> ParameterDefinition:
+        """Return the canonical provenance and geometry definition."""
+        return DEFINITIONS[self.convention]
+
+    def to(self, target: ConventionId) -> LaunchDirection:
+        """Convert through registry sign rules without changing physical state."""
+        return LaunchDirection(self.degrees, _validated_convention(target))
 
 
 def launch_direction_to_flight_azimuth(direction: LaunchDirection) -> float:
     """Return the internal left-positive flight-frame azimuth in degrees."""
-    return direction.to(LaunchDirectionConvention.FLIGHT_FRAME).degrees
+    _validated_convention(direction.convention)
+    return -direction.degrees
+
+
+def launch_direction_sign_labels(convention: ConventionId) -> tuple[str, str]:
+    """Return positive/negative labels derived from the registry sign rule."""
+    _validated_convention(convention)
+    return "right of the target line", "left of the target line"
 
 
 def migrate_launch_direction_mapping(values: Mapping[str, object]) -> dict[str, object]:
-    """Add canonical direction fields while preserving every imported field.
-
-    Legacy fields are interpreted as the historical app-native convention.
-    Duplicate aliases are accepted only when they agree, preventing silent
-    corruption during mixed-version imports.
-    """
+    """Add canonical fields while preserving all imported fields and aliases."""
     migrated = dict(values)
     present = [
         (key, _validated_degrees(values[key]))
@@ -145,17 +126,9 @@ def migrate_launch_direction_mapping(values: Mapping[str, object]) -> dict[str, 
             raise ValueError(
                 f"conflicting launch-direction values in {first_key!r} and {key!r}"
             )
-    raw_convention = values.get(
-        CONVENTION_KEY, LaunchDirectionConvention.APP_NATIVE.value
+    convention = _validated_convention(
+        values.get(CONVENTION_KEY, ConventionId.APP_NATIVE.value)
     )
-    if not isinstance(raw_convention, str):
-        raise ValueError(f"unknown launch-direction convention: {raw_convention!r}")
-    try:
-        convention = LaunchDirectionConvention(raw_convention)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"unknown launch-direction convention: {raw_convention!r}"
-        ) from exc
     migrated[CANONICAL_DIRECTION_KEY] = first_value
     migrated[CONVENTION_KEY] = convention.value
     migrated[SCHEMA_VERSION_KEY] = SCHEMA_VERSION
@@ -165,10 +138,9 @@ def migrate_launch_direction_mapping(values: Mapping[str, object]) -> dict[str, 
 def launch_direction_from_mapping(values: Mapping[str, object]) -> LaunchDirection:
     """Parse canonical or legacy imported fields as a typed direction."""
     migrated = migrate_launch_direction_mapping(values)
-    degrees = _validated_degrees(migrated[CANONICAL_DIRECTION_KEY])
     return LaunchDirection(
-        degrees,
-        LaunchDirectionConvention(str(migrated[CONVENTION_KEY])),
+        _validated_degrees(migrated[CANONICAL_DIRECTION_KEY]),
+        _validated_convention(migrated[CONVENTION_KEY]),
     )
 
 
@@ -179,11 +151,10 @@ __all__ = [
     "LEGACY_DIRECTION_KEYS",
     "SCHEMA_VERSION",
     "SCHEMA_VERSION_KEY",
-    "TRACKMAN_LAUNCH_DIRECTION_SOURCE",
     "LaunchDirection",
     "LaunchDirectionConvention",
-    "LaunchDirectionDefinition",
     "launch_direction_from_mapping",
+    "launch_direction_sign_labels",
     "launch_direction_to_flight_azimuth",
     "migrate_launch_direction_mapping",
 ]

--- a/src/shared/python/swing_sim/flight/direction.py
+++ b/src/shared/python/swing_sim/flight/direction.py
@@ -1,0 +1,189 @@
+"""Canonical launch-direction conventions and lossless legacy migration.
+
+Launch Direction is the horizontal angle at launch relative to the target
+line.  The application and launch-monitor-comparable conventions use
+positive right / negative left.  The internal flight frame uses +y left,
+so its azimuth has the opposite sign.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from numbers import Real
+from typing import Final
+
+TRACKMAN_LAUNCH_DIRECTION_SOURCE: Final = (
+    "https://www.trackman.com/blog/golf/what-is-launch-direction"
+)
+CANONICAL_DIRECTION_KEY: Final = "launch_direction_deg"
+CONVENTION_KEY: Final = "launch_direction_convention"
+SCHEMA_VERSION_KEY: Final = "launch_direction_schema_version"
+SCHEMA_VERSION: Final = 1
+LEGACY_DIRECTION_KEYS: Final = ("launch_azimuth_deg", "azimuth_deg")
+
+
+class LaunchDirectionConvention(StrEnum):
+    """Supported numeric sign conventions for horizontal launch direction."""
+
+    APP_NATIVE = "app_native"
+    LAUNCH_MONITOR_COMPARABLE = "launch_monitor_comparable"
+    FLIGHT_FRAME = "flight_frame"
+
+
+@dataclass(frozen=True)
+class LaunchDirectionDefinition:
+    """Human-readable convention metadata carried beside numeric values."""
+
+    positive_direction: str
+    negative_direction: str
+    reference: str
+    source_url: str | None
+    retrieved_on: str | None
+    definition_version: str
+    comparability_status: str
+
+
+DEFINITIONS: Final[dict[LaunchDirectionConvention, LaunchDirectionDefinition]] = {
+    LaunchDirectionConvention.APP_NATIVE: LaunchDirectionDefinition(
+        positive_direction="right of the target line",
+        negative_direction="left of the target line",
+        reference="horizontal angle from the target line",
+        source_url=None,
+        retrieved_on=None,
+        definition_version="roc-launch-direction-v1",
+        comparability_status="canonical",
+    ),
+    LaunchDirectionConvention.LAUNCH_MONITOR_COMPARABLE: LaunchDirectionDefinition(
+        positive_direction="right of the target line",
+        negative_direction="left of the target line",
+        reference=(
+            "horizontal ball-CG motion relative to the target line after separation"
+        ),
+        source_url=TRACKMAN_LAUNCH_DIRECTION_SOURCE,
+        retrieved_on="2026-08-06",
+        definition_version="trackman-public-definition-2026-08-06",
+        comparability_status="definition-and-sign-comparable",
+    ),
+    LaunchDirectionConvention.FLIGHT_FRAME: LaunchDirectionDefinition(
+        positive_direction="left of the target line (+y flight)",
+        negative_direction="right of the target line (-y flight)",
+        reference="horizontal angle from +x in the internal flight frame",
+        source_url=None,
+        retrieved_on=None,
+        definition_version="swing-sim-flight-frame-v1",
+        comparability_status="internal-only",
+    ),
+}
+
+
+def _validated_degrees(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError("launch direction must be a real number, not bool")
+    degrees = float(value)
+    if not math.isfinite(degrees):
+        raise ValueError("launch direction must be finite")
+    if not -180.0 <= degrees <= 180.0:
+        raise ValueError("launch direction must be within [-180, 180] degrees")
+    return degrees
+
+
+def _right_positive(degrees: float, convention: LaunchDirectionConvention) -> float:
+    return -degrees if convention is LaunchDirectionConvention.FLIGHT_FRAME else degrees
+
+
+@dataclass(frozen=True)
+class LaunchDirection:
+    """A direction value whose sign convention cannot be implicit."""
+
+    degrees: float
+    convention: LaunchDirectionConvention
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "degrees", _validated_degrees(self.degrees))
+        if not isinstance(self.convention, LaunchDirectionConvention):
+            raise TypeError("convention must be a LaunchDirectionConvention")
+
+    def to(self, target: LaunchDirectionConvention) -> LaunchDirection:
+        """Convert to *target* without changing the represented direction."""
+        if not isinstance(target, LaunchDirectionConvention):
+            raise TypeError("target must be a LaunchDirectionConvention")
+        canonical = _right_positive(self.degrees, self.convention)
+        converted = (
+            -canonical
+            if target is LaunchDirectionConvention.FLIGHT_FRAME
+            else canonical
+        )
+        return LaunchDirection(converted, target)
+
+
+def launch_direction_to_flight_azimuth(direction: LaunchDirection) -> float:
+    """Return the internal left-positive flight-frame azimuth in degrees."""
+    return direction.to(LaunchDirectionConvention.FLIGHT_FRAME).degrees
+
+
+def migrate_launch_direction_mapping(values: Mapping[str, object]) -> dict[str, object]:
+    """Add canonical direction fields while preserving every imported field.
+
+    Legacy fields are interpreted as the historical app-native convention.
+    Duplicate aliases are accepted only when they agree, preventing silent
+    corruption during mixed-version imports.
+    """
+    migrated = dict(values)
+    present = [
+        (key, _validated_degrees(values[key]))
+        for key in (CANONICAL_DIRECTION_KEY, *LEGACY_DIRECTION_KEYS)
+        if key in values
+    ]
+    if not present:
+        raise KeyError("no launch-direction field found")
+    first_key, first_value = present[0]
+    for key, value in present[1:]:
+        if not math.isclose(first_value, value, rel_tol=0.0, abs_tol=1e-12):
+            raise ValueError(
+                f"conflicting launch-direction values in {first_key!r} and {key!r}"
+            )
+    raw_convention = values.get(
+        CONVENTION_KEY, LaunchDirectionConvention.APP_NATIVE.value
+    )
+    if not isinstance(raw_convention, str):
+        raise ValueError(f"unknown launch-direction convention: {raw_convention!r}")
+    try:
+        convention = LaunchDirectionConvention(raw_convention)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"unknown launch-direction convention: {raw_convention!r}"
+        ) from exc
+    migrated[CANONICAL_DIRECTION_KEY] = first_value
+    migrated[CONVENTION_KEY] = convention.value
+    migrated[SCHEMA_VERSION_KEY] = SCHEMA_VERSION
+    return migrated
+
+
+def launch_direction_from_mapping(values: Mapping[str, object]) -> LaunchDirection:
+    """Parse canonical or legacy imported fields as a typed direction."""
+    migrated = migrate_launch_direction_mapping(values)
+    degrees = _validated_degrees(migrated[CANONICAL_DIRECTION_KEY])
+    return LaunchDirection(
+        degrees,
+        LaunchDirectionConvention(str(migrated[CONVENTION_KEY])),
+    )
+
+
+__all__ = [
+    "CANONICAL_DIRECTION_KEY",
+    "CONVENTION_KEY",
+    "DEFINITIONS",
+    "LEGACY_DIRECTION_KEYS",
+    "SCHEMA_VERSION",
+    "SCHEMA_VERSION_KEY",
+    "TRACKMAN_LAUNCH_DIRECTION_SOURCE",
+    "LaunchDirection",
+    "LaunchDirectionConvention",
+    "LaunchDirectionDefinition",
+    "launch_direction_from_mapping",
+    "launch_direction_to_flight_azimuth",
+    "migrate_launch_direction_mapping",
+]

--- a/src/shared/python/swing_sim/flight/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/flight/tests/test_contract_api.py
@@ -35,6 +35,7 @@ EXPECTED_PUBLIC_API = {
     "from_flight_frame",
     "is_rust_available",
     "launch_direction_from_mapping",
+    "launch_direction_sign_labels",
     "launch_direction_to_flight_azimuth",
     "migrate_launch_direction_mapping",
     "simulate",

--- a/src/shared/python/swing_sim/flight/tests/test_contract_api.py
+++ b/src/shared/python/swing_sim/flight/tests/test_contract_api.py
@@ -23,6 +23,9 @@ EXPECTED_PUBLIC_API = {
     "FlightResult",
     "FlightSimulatorProtocol",
     "LaunchConditions",
+    "LaunchDirection",
+    "LaunchDirectionConvention",
+    "LAUNCH_DIRECTION_DEFINITIONS",
     "MacDonaldHanzelyModel",
     "TrajectoryPoint",
     "WaterlooPennerModel",
@@ -31,6 +34,9 @@ EXPECTED_PUBLIC_API = {
     "derive_launch_conditions",
     "from_flight_frame",
     "is_rust_available",
+    "launch_direction_from_mapping",
+    "launch_direction_to_flight_azimuth",
+    "migrate_launch_direction_mapping",
     "simulate",
     "simulate_trajectory_rust",
     "to_flight_frame",
@@ -63,6 +69,7 @@ def test_value_types_are_frozen_dataclasses() -> None:
         flight.TrajectoryPoint,
         flight.FlightResult,
         flight.ConstantCoefficientSpec,
+        flight.LaunchDirection,
     ):
         assert dataclasses.is_dataclass(cls), f"{cls.__name__} not a dataclass"
         assert cls.__dataclass_params__.frozen, f"{cls.__name__} must be frozen"

--- a/src/shared/python/swing_sim/flight/tests/test_direction.py
+++ b/src/shared/python/swing_sim/flight/tests/test_direction.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import pytest
 
 from shared.python.swing_sim.flight.direction import (
+    DEFINITIONS,
     LaunchDirection,
     LaunchDirectionConvention,
     launch_direction_from_mapping,
+    launch_direction_sign_labels,
     launch_direction_to_flight_azimuth,
     migrate_launch_direction_mapping,
 )
@@ -15,17 +17,25 @@ from shared.python.swing_sim.flight.direction import (
 
 @pytest.mark.parametrize("degrees", [0.0, 7.25, -7.25, 90.0, -90.0, 179.999, -179.999])
 def test_round_trip_between_every_convention(degrees: float) -> None:
-    for source in LaunchDirectionConvention:
+    for source in DEFINITIONS:
         direction = LaunchDirection(degrees, source)
-        for target in LaunchDirectionConvention:
+        for target in DEFINITIONS:
             assert direction.to(target).to(source).degrees == pytest.approx(degrees)
 
 
 def test_internal_flight_azimuth_has_the_opposite_sign() -> None:
     right = LaunchDirection(6.0, LaunchDirectionConvention.APP_NATIVE)
     assert launch_direction_to_flight_azimuth(right) == pytest.approx(-6.0)
-    assert right.to(LaunchDirectionConvention.FLIGHT_FRAME).degrees == pytest.approx(
-        -6.0
+
+
+def test_definitions_are_the_canonical_registry_records() -> None:
+    trackman = DEFINITIONS[LaunchDirectionConvention.TRACKMAN_COMPARABLE]
+    assert trackman.parameter_id.value == "launch_direction"
+    assert trackman.sign_rule.value == "positive_right"
+    assert trackman.retrieved_on == "2026-08-05"
+    assert launch_direction_sign_labels(trackman.convention_id) == (
+        "right of the target line",
+        "left of the target line",
     )
 
 
@@ -47,6 +57,21 @@ def test_equivalent_canonical_and_legacy_values_are_accepted() -> None:
         {"launch_direction_deg": 2.0, "azimuth_deg": 2.0}
     )
     assert migrated["launch_direction_deg"] == pytest.approx(2.0)
+
+
+def test_legacy_generic_convention_name_migrates_to_registry_id() -> None:
+    migrated = migrate_launch_direction_mapping(
+        {
+            "launch_direction_deg": 2.0,
+            "launch_direction_convention": "launch_monitor_comparable",
+        }
+    )
+    assert migrated["launch_direction_convention"] == "trackman_comparable"
+
+
+def test_unverified_foresight_sign_is_not_activated_by_this_adapter() -> None:
+    with pytest.raises(ValueError, match="unsupported launch-direction convention"):
+        LaunchDirection(2.0, LaunchDirectionConvention.FORESIGHT_COMPARABLE)
 
 
 def test_conflicting_canonical_and_legacy_values_are_rejected() -> None:

--- a/src/shared/python/swing_sim/flight/tests/test_direction.py
+++ b/src/shared/python/swing_sim/flight/tests/test_direction.py
@@ -1,0 +1,62 @@
+"""Contracts for canonical launch-direction conventions and migration."""
+
+from __future__ import annotations
+
+import pytest
+
+from shared.python.swing_sim.flight.direction import (
+    LaunchDirection,
+    LaunchDirectionConvention,
+    launch_direction_from_mapping,
+    launch_direction_to_flight_azimuth,
+    migrate_launch_direction_mapping,
+)
+
+
+@pytest.mark.parametrize("degrees", [0.0, 7.25, -7.25, 90.0, -90.0, 179.999, -179.999])
+def test_round_trip_between_every_convention(degrees: float) -> None:
+    for source in LaunchDirectionConvention:
+        direction = LaunchDirection(degrees, source)
+        for target in LaunchDirectionConvention:
+            assert direction.to(target).to(source).degrees == pytest.approx(degrees)
+
+
+def test_internal_flight_azimuth_has_the_opposite_sign() -> None:
+    right = LaunchDirection(6.0, LaunchDirectionConvention.APP_NATIVE)
+    assert launch_direction_to_flight_azimuth(right) == pytest.approx(-6.0)
+    assert right.to(LaunchDirectionConvention.FLIGHT_FRAME).degrees == pytest.approx(
+        -6.0
+    )
+
+
+def test_legacy_import_is_migrated_without_dropping_fields() -> None:
+    source = {"launch_azimuth_deg": -3.5, "shot_name": "soft draw"}
+    migrated = migrate_launch_direction_mapping(source)
+    assert migrated == {
+        "launch_azimuth_deg": -3.5,
+        "shot_name": "soft draw",
+        "launch_direction_deg": -3.5,
+        "launch_direction_convention": "app_native",
+        "launch_direction_schema_version": 1,
+    }
+    assert launch_direction_from_mapping(migrated).degrees == pytest.approx(-3.5)
+
+
+def test_equivalent_canonical_and_legacy_values_are_accepted() -> None:
+    migrated = migrate_launch_direction_mapping(
+        {"launch_direction_deg": 2.0, "azimuth_deg": 2.0}
+    )
+    assert migrated["launch_direction_deg"] == pytest.approx(2.0)
+
+
+def test_conflicting_canonical_and_legacy_values_are_rejected() -> None:
+    with pytest.raises(ValueError, match="conflicting launch-direction"):
+        migrate_launch_direction_mapping(
+            {"launch_direction_deg": 2.0, "launch_azimuth_deg": -2.0}
+        )
+
+
+@pytest.mark.parametrize("value", [True, float("nan"), float("inf"), 181.0])
+def test_invalid_values_are_rejected(value: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        migrate_launch_direction_mapping({"launch_direction_deg": value})

--- a/src/shared/python/swing_sim/variation/registry.py
+++ b/src/shared/python/swing_sim/variation/registry.py
@@ -285,7 +285,7 @@ def _register_builtins() -> None:
         ),
         (
             f"{CATEGORY_LAUNCH}.launch_azimuth_deg",
-            "Launch Azimuth",
+            "Launch Direction",
             "deg",
             0.0,
             0.8,

--- a/tests/rate_of_closure/test_flight_explorer.py
+++ b/tests/rate_of_closure/test_flight_explorer.py
@@ -28,7 +28,7 @@ pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
 PINNED_DIRECT = {
     "ball_speed_mph": 167.0,
     "launch_angle_deg": 10.9,
-    "azimuth_deg": 0.0,
+    "launch_direction_deg": 0.0,
     "spin_rpm": 2686.0,
     "spin_axis_tilt_deg": 0.0,
 }
@@ -54,10 +54,11 @@ class TestLaunchFromDirect:
         exploration = explore_flight(launch_from_direct(150.0, 14.0, -3.0, 3100.0, 0.0))
         assert exploration.metrics["ball_speed_mph"] == pytest.approx(150.0)
         assert exploration.metrics["launch_angle_deg"] == pytest.approx(14.0)
+        assert exploration.metrics["launch_direction_deg"] == pytest.approx(-3.0)
         assert exploration.metrics["launch_azimuth_deg"] == pytest.approx(-3.0)
         assert exploration.metrics["spin_rpm"] == pytest.approx(3100.0)
 
-    def test_positive_azimuth_lands_right_of_target(self) -> None:
+    def test_positive_launch_direction_lands_right_of_target(self) -> None:
         right = explore_flight(launch_from_direct(150.0, 12.0, 5.0, 2700.0, 0.0))
         left = explore_flight(launch_from_direct(150.0, 12.0, -5.0, 2700.0, 0.0))
         assert right.metrics["lateral_m"] > 1.0
@@ -96,7 +97,7 @@ class TestLaunchFromDelivery:
         )
         exploration = explore_flight(launch)
         # An open face starts the ball right and adds fade-side spin.
-        assert exploration.metrics["launch_azimuth_deg"] > 0.5
+        assert exploration.metrics["launch_direction_deg"] > 0.5
         assert exploration.metrics["lateral_m"] > 1.0
 
 

--- a/tests/rate_of_closure/test_viewers_gui.py
+++ b/tests/rate_of_closure/test_viewers_gui.py
@@ -218,7 +218,10 @@ class TestFlightExplorerTab:
         assert button.accessibleName() == "Explain Launch Direction"
         combo = explorer._direction_convention_combo
         assert combo.accessibleName() == "Launch Direction Convention"
-        assert combo.count() == 2
+        assert combo.count() == 3
+        assert combo.itemText(2) == "Foresight-Comparable (Sign Unavailable)"
+        assert not combo.model().item(2).isEnabled()
+        assert "public sign convention" in combo.model().item(2).toolTip()
         assert "0° = straight" in explorer._direction_example.text()
 
     def test_direct_mode_end_to_end_matches_the_pinned_case(self, explorer) -> None:  # type: ignore[no-untyped-def]

--- a/tests/rate_of_closure/test_viewers_gui.py
+++ b/tests/rate_of_closure/test_viewers_gui.py
@@ -208,7 +208,8 @@ class TestFlightExplorerTab:
             assert key in LAUNCH_EXPLANATIONS, key
 
     def test_launch_direction_has_an_obvious_clickable_definition(
-        self, explorer  # type: ignore[no-untyped-def]
+        self,
+        explorer,  # type: ignore[no-untyped-def]
     ) -> None:
         button = explorer.findChild(QToolButton, "launch_direction_info")
         assert button is not None

--- a/tests/rate_of_closure/test_viewers_gui.py
+++ b/tests/rate_of_closure/test_viewers_gui.py
@@ -16,6 +16,8 @@ import pytest
 pytest.importorskip("PyQt6")
 pytest.importorskip("pytestqt")
 
+from PyQt6.QtWidgets import QToolButton  # noqa: E402
+
 from rate_of_closure.derivation import LAUNCH_EXPLANATIONS  # noqa: E402
 from rate_of_closure.model import ImpactScenario  # noqa: E402
 from rate_of_closure.ui.pyqt6.flight_explorer_tab import (  # noqa: E402
@@ -204,6 +206,20 @@ class TestFlightExplorerTab:
     def test_every_result_row_has_an_explanation(self) -> None:
         for key, _label, _unit in EXPLORER_ROWS:
             assert key in LAUNCH_EXPLANATIONS, key
+
+    def test_launch_direction_has_an_obvious_clickable_definition(
+        self, explorer  # type: ignore[no-untyped-def]
+    ) -> None:
+        button = explorer.findChild(QToolButton, "launch_direction_info")
+        assert button is not None
+        assert button.text() == "Details"
+        assert button.toolTip().startswith("Suggested range:")
+        assert "positive values start right" in button.toolTip()
+        assert button.accessibleName() == "Explain Launch Direction"
+        combo = explorer._direction_convention_combo
+        assert combo.accessibleName() == "Launch Direction Convention"
+        assert combo.count() == 2
+        assert "0° = straight" in explorer._direction_example.text()
 
     def test_direct_mode_end_to_end_matches_the_pinned_case(self, explorer) -> None:  # type: ignore[no-untyped-def]
         exploration = explorer.run_now()


### PR DESCRIPTION
## Summary
- rename Launch Azimuth to Launch Direction throughout the Rate of Closure Python and React surfaces
- add explicit app-native and TrackMan display conventions while keeping the internal left-positive physics frame visible and losslessly converted
- consume the canonical launch-monitor convention registry, preserve legacy persistence aliases, and reject conflicting migrated values
- derive selector status and provenance from the registry instead of maintaining a competing vendor-definition table

## Validation
- 643 relevant Python tests passed with 4 expected Rust-wheel skips
- 382 React tests passed across 58 files
- focused final gates: 23 Python and 18 web tests
- production build, TypeScript, ESLint, Ruff, Black, targeted mypy, placeholder, and whitespace gates passed

## Evidence boundary
- the public Foresight definition did not explicitly establish a numeric left/right sign convention; this adapter therefore exposes app-native and TrackMan choices only instead of inventing a Foresight conversion
- draft stacked on `feat/4181-launch-monitor-registry`
- the parallel wind PR #4207 touches the same explorer surfaces and will require an explicit integration pass after both contracts are reviewed

Refs #4180
Refs #4191
Refs #4193