### PR TITLE
feat(rate-of-closure): add launch monitor analytics tabs

### DIFF
--- a/docs/development/LAUNCH_MONITOR_ANALYTICS_HANDOFF.md
+++ b/docs/development/LAUNCH_MONITOR_ANALYTICS_HANDOFF.md
@@ -1,0 +1,75 @@
+# Launch Monitor Analytics Handoff
+
+## Scope and repository state
+
+- Repository: `D-sorganization/Tools`
+- Draft pull request: `#4212`, `feat(rate-of-closure): add launch monitor analytics tabs`
+- Head branch: `feat/4205-launch-monitor-analytics`
+- Base branch: `feat/4181-launch-monitor-registry`
+- Last remote head before this CI recovery: `4b22e79cf829bac12217e60634ffbfbea5c40d6b`
+- Related integration pull request: `#4217`
+- Consumer pull request: `D-sorganization/UpstreamDrift#8369`
+
+The analytics implementation supplies UI-neutral Python and TypeScript contracts,
+statistics, parsing, and dataset fingerprinting behind stable facade modules. The
+facades are intentionally retained so the PyQt6 and React clients do not depend on
+private module layout.
+
+## Completed hardening
+
+The production modules were split by responsibility without changing their public
+facade APIs. The resulting focused Python and React validation completed before
+publication:
+
+- 583 Rate of Closure Python tests passed.
+- 374 React tests passed.
+- TypeScript type-check, ESLint, and the production build passed.
+- Python 3.12 mypy, Ruff, Black, and the repository module-size gate passed.
+- Python 3.13 mypy encountered an upstream internal cache assertion; this is not
+  claimed as a successful lane.
+
+## Exact-head CI recovery
+
+The first protected run on remote head `4b22e79c` exposed two deterministic issues:
+
+1. CI-pinned Ruff 0.14.10 required one formatter-only line break in
+   `src/rate_of_closure/launch_monitor_analysis.py`.
+2. `detect-secrets` classified the published SHA-256 test vector for `"abc"` as a
+   high-entropy credential. The exact test-vector line now carries the scanner's
+   narrow `pragma: allowlist secret` annotation; no baseline entry or broad
+   exclusion was added.
+
+Local recovery evidence:
+
+- `ruff check` and `ruff format --check`: passed.
+- Focused `detect-secrets` scan: zero findings.
+- `launchMonitorAnalysis.test.ts`: 5 passed.
+- TypeScript type-check and ESLint with zero allowed warnings: passed.
+- Python fail-closed/missingness boundary test: 1 passed.
+- `git diff --check`: passed.
+
+The full Python analytics file is comparatively expensive in this Windows test
+environment and exceeded a three-minute wrapper during the recovery rerun. The
+earlier 583-test hardening run remains the full-suite evidence; the recovery changes
+are formatter-only Python and a scanner-only TypeScript comment.
+
+## Remaining release gates
+
+- Publish the recovery commit to `feat/4205-launch-monitor-analytics`.
+- Require a new protected run on the exact published head; do not reuse results
+  from `4b22e79c`.
+- Resolve any new actionable failures and wait for queued repository-runner jobs.
+- Obtain required review and resolve all review threads before undrafting or
+  merging.
+- Preserve the declared PR stack and dependency order. Do not force-push,
+  retarget, admin-merge, or bypass protected checks.
+- Reconcile the exact released Tools dependency in UpstreamDrift before claiming
+  consumer release completion.
+
+## Next epic
+
+Tools epic `#4218` and children `#4219` through `#4225` track the modern top
+toolstrip, persistent File operations, Glossary/Theme/hotkeys, module visibility,
+Impact/Swing/Flight multi-view compositor, and distinct plot/legend controls. Per
+the epic sequencing contract, implementation starts only after the current
+ball-flight/variation/wedge campaign reaches its declared completion gate.

--- a/docs/development/LAUNCH_MONITOR_ANALYTICS_HANDOFF.md
+++ b/docs/development/LAUNCH_MONITOR_ANALYTICS_HANDOFF.md
@@ -39,6 +39,11 @@ The first protected run on remote head `4b22e79c` exposed two deterministic issu
    high-entropy credential. The exact test-vector line now carries the scanner's
    narrow `pragma: allowlist secret` annotation; no baseline entry or broad
    exclusion was added.
+3. The next protected run reached pinned mypy 1.13 and rejected raw Qt combo-box
+   strings at three Literal-typed request boundaries, then inferred one reused
+   loop variable as incompatible correlation and coefficient types. The adapter
+   now narrows the three values at the UI boundary and uses type-specific loop
+   names; the analysis contract itself was not weakened.
 
 Local recovery evidence:
 
@@ -47,6 +52,8 @@ Local recovery evidence:
 - `launchMonitorAnalysis.test.ts`: 5 passed.
 - TypeScript type-check and ESLint with zero allowed warnings: passed.
 - Python fail-closed/missingness boundary test: 1 passed.
+- PyQt analytics tab tests: 2 passed.
+- Exact mypy 1.13 check of the corrected PyQt adapter: passed.
 - `git diff --check`: passed.
 
 The full Python analytics file is comparatively expensive in this Windows test

--- a/docs/development/LAUNCH_MONITOR_ANALYTICS_HANDOFF.md
+++ b/docs/development/LAUNCH_MONITOR_ANALYTICS_HANDOFF.md
@@ -7,6 +7,7 @@
 - Head branch: `feat/4205-launch-monitor-analytics`
 - Base branch: `feat/4181-launch-monitor-registry`
 - Last remote head before this CI recovery: `4b22e79cf829bac12217e60634ffbfbea5c40d6b`
+- Published CI-recovery implementation: `ee917d80f`
 - Related integration pull request: `#4217`
 - Consumer pull request: `D-sorganization/UpstreamDrift#8369`
 
@@ -55,9 +56,8 @@ are formatter-only Python and a scanner-only TypeScript comment.
 
 ## Remaining release gates
 
-- Publish the recovery commit to `feat/4205-launch-monitor-analytics`.
-- Require a new protected run on the exact published head; do not reuse results
-  from `4b22e79c`.
+- Verify that the current branch head contains `ee917d80f`, then require a new
+  protected run on that exact head; do not reuse results from `4b22e79c`.
 - Resolve any new actionable failures and wait for queued repository-runner jobs.
 - Obtain required review and resolve all review threads before undrafting or
   merging.

--- a/docs/specs/LAUNCH_MONITOR_ANALYTICS.md
+++ b/docs/specs/LAUNCH_MONITOR_ANALYTICS.md
@@ -1,6 +1,6 @@
 # Launch Monitor Analytics
 
-Issue: [Tools #4205](https://github.com/D-sorganization/Tools/issues/4205)  
+Issue: [Tools #4205](https://github.com/D-sorganization/Tools/issues/4205)
 Program epic: [UpstreamDrift #8364](https://github.com/D-sorganization/UpstreamDrift/issues/8364)
 
 ## Purpose

--- a/docs/specs/LAUNCH_MONITOR_ANALYTICS.md
+++ b/docs/specs/LAUNCH_MONITOR_ANALYTICS.md
@@ -1,0 +1,80 @@
+# Launch Monitor Analytics
+
+Issue: [Tools #4205](https://github.com/D-sorganization/Tools/issues/4205)  
+Program epic: [UpstreamDrift #8364](https://github.com/D-sorganization/UpstreamDrift/issues/8364)
+
+## Purpose
+
+Launch Monitor Analytics is a primary Rate of Closure workspace in both PyQt6
+and React/Vite. It preserves every imported CSV or JSON field and supports
+flexible statistical analysis across any compatible numeric variables.
+
+The public, source-traceable evidence database remains the separate
+[Launch-Monitor-Data repository](https://github.com/D-sorganization/Launch-Monitor-Data).
+That repository records source URLs, monitor identity, environment, measurement
+status, reported and canonical units, aggregation level, and verification
+checks. Published aggregates must remain aggregates; neither UI expands them
+into fabricated shot rows.
+
+## Shared Contract
+
+Both surfaces implement contract version `1.0.0`:
+
+| Capability | PyQt6 | React/Vite |
+| --- | --- | --- |
+| CSV/JSON record import with source columns retained | Yes | Yes |
+| Any numeric outcome and multiple predictors | Yes | Yes |
+| Pearson, Spearman, and Kendall correlation | Yes | Yes |
+| Pairwise, listwise, and fail-closed missingness | Yes | Yes |
+| Benjamini-Hochberg multiplicity correction | Yes | Yes |
+| Multivariable OLS with coefficient intervals | Yes | Yes |
+| R², adjusted R², RMSE, MAE, Durbin-Watson, influential count | Yes | Yes |
+| Arbitrary categorical grouping | Yes | Yes |
+| Dataset SHA-256 and complete JSON evidence export | Yes | Yes |
+| Aggregate-regression and pooled `source::` safeguards | Yes | Yes |
+
+The UpstreamDrift implementation exposes the same semantics through
+`POST /tools/launch-monitor-analytics/analyze` and publishes its machine-readable
+capability set through `GET /tools/launch-monitor-analytics/capabilities`.
+
+## Convention and Provenance Boundary
+
+Both tabs consume the immutable registry in
+`shared/python/swing_sim/conventions` and its TypeScript twin. Labels are
+**TrackMan-Comparable** and **Foresight-Comparable**. They identify sourced
+parameter definitions, reference points, event times, frames, units, and
+availability rules; they do not claim vendor-device emulation, certification,
+or interchangeability.
+
+Vendor-specific source fields are blocked from analysis pooled across multiple
+monitor vendors. Cross-monitor comparison should use canonical fields only
+after the reference point, time, frame, geometry, sign, unit, and availability
+contracts have been reconciled.
+
+## Statistical Interpretation
+
+- Pairwise correlation uses the pair-specific sample count; listwise mode uses
+  one complete-case population; fail-closed mode rejects missing or nonnumeric
+  selections.
+- Pearson intervals use Fisher's z transform. Spearman and Kendall intervals
+  are intentionally omitted rather than represented as Pearson intervals.
+- OLS uses complete cases for the selected outcome and predictors and rejects
+  rank-deficient or undersized designs.
+- Group results are calculated independently and keep their own sample counts,
+  estimates, diagnostics, and warnings.
+- Association and held-sample fit do not establish causality or transport to a
+  different player, club, ball, environment, software release, or monitor.
+- Aggregate correlations are descriptive and subject to ecological bias.
+  Aggregate observations never enter regression.
+
+## Verification
+
+```powershell
+python -m pytest tests/rate_of_closure/test_launch_monitor_analysis.py tests/rate_of_closure/test_launch_monitor_analytics_tab.py tests/rate_of_closure/test_primary_navigation.py
+python -m ruff check src/rate_of_closure/launch_monitor_analysis.py src/rate_of_closure/ui/pyqt6/launch_monitor_analytics_tab.py
+cd src/rate_of_closure/web
+npm test
+npm run type-check
+npm run lint
+npm run build
+```

--- a/src/rate_of_closure/_launch_monitor_analysis_statistics.py
+++ b/src/rate_of_closure/_launch_monitor_analysis_statistics.py
@@ -1,0 +1,200 @@
+"""Correlation and regression calculations for launch-monitor analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from ._launch_monitor_analysis_types import (
+    AnalysisRequest,
+    CoefficientEstimate,
+    CorrelationEstimate,
+    RegressionEstimate,
+    ResidualDiagnostics,
+)
+
+
+@dataclass(frozen=True)
+class _RegressionWork:
+    design: np.ndarray
+    residuals: np.ndarray
+    residual_sum: float
+    inverse_information: np.ndarray
+    parameter_count: int
+
+
+def correlations(
+    frame: pd.DataFrame, request: AnalysisRequest
+) -> tuple[CorrelationEstimate, ...]:
+    """Calculate requested pairwise correlations and adjusted p-values."""
+
+    selected = (request.outcome, *request.predictors)
+    working = (
+        frame.dropna(subset=list(selected))
+        if request.missing_policy == "listwise"
+        else frame
+    )
+    provisional = tuple(
+        _correlation_for_predictor(working, request, predictor)
+        for predictor in request.predictors
+    )
+    adjusted = _adjust_p_values([item.p_value for item in provisional])
+    return tuple(
+        replace(item, adjusted_p_value=adjusted[index])
+        for index, item in enumerate(provisional)
+    )
+
+
+def _correlation_for_predictor(
+    frame: pd.DataFrame, request: AnalysisRequest, predictor: str
+) -> CorrelationEstimate:
+    pair = (
+        frame[[request.outcome, predictor]]
+        .apply(pd.to_numeric, errors="coerce")
+        .dropna()
+    )
+    count = len(pair)
+    if count < request.min_samples:
+        return CorrelationEstimate(
+            predictor, None, None, None, None, None, count, request.correlation_method
+        )
+    left = pair[request.outcome].to_numpy(float)
+    right = pair[predictor].to_numpy(float)
+    estimate = _correlation_estimate(left, right, request)
+    lower, upper = _pearson_interval(float(estimate.statistic), count, request)
+    return CorrelationEstimate(
+        predictor,
+        float(estimate.statistic),
+        float(estimate.pvalue),
+        None,
+        lower,
+        upper,
+        count,
+        request.correlation_method,
+    )
+
+
+def _correlation_estimate(
+    left: np.ndarray, right: np.ndarray, request: AnalysisRequest
+) -> stats.SignificanceResult:
+    if request.correlation_method == "pearson":
+        return stats.pearsonr(left, right)
+    if request.correlation_method == "spearman":
+        return stats.spearmanr(left, right)
+    return stats.kendalltau(left, right)
+
+
+def _pearson_interval(
+    coefficient: float, count: int, request: AnalysisRequest
+) -> tuple[float | None, float | None]:
+    if request.correlation_method != "pearson" or count <= 3:
+        return None, None
+    transformed = np.arctanh(np.clip(coefficient, -0.999999, 0.999999))
+    margin = stats.norm.ppf(0.5 + request.confidence_level / 2) / np.sqrt(count - 3)
+    return float(np.tanh(transformed - margin)), float(np.tanh(transformed + margin))
+
+
+def _adjust_p_values(values: list[float | None]) -> list[float | None]:
+    finite = sorted(
+        ((index, value) for index, value in enumerate(values) if value is not None),
+        key=lambda item: item[1],
+    )
+    output: list[float | None] = [None] * len(values)
+    previous = 1.0
+    for rank in range(len(finite), 0, -1):
+        index, value = finite[rank - 1]
+        corrected = min(previous, value * len(finite) / rank)
+        output[index] = min(1.0, corrected)
+        previous = corrected
+    return output
+
+
+def regression(frame: pd.DataFrame, request: AnalysisRequest) -> RegressionEstimate:
+    """Calculate ordinary least squares with uncertainty and diagnostics."""
+
+    columns = (request.outcome, *request.predictors)
+    numeric = frame[list(columns)].apply(pd.to_numeric, errors="coerce").dropna()
+    count = len(numeric)
+    parameter_count = len(request.predictors) + 1
+    if count < max(request.min_samples, parameter_count + 2):
+        raise ValueError("Too few complete observations for regression")
+    outcome = numeric[request.outcome].to_numpy(float)
+    design = np.column_stack(
+        (np.ones(count), numeric[list(request.predictors)].to_numpy(float))
+    )
+    beta, _, rank, _ = np.linalg.lstsq(design, outcome, rcond=None)
+    if rank < parameter_count:
+        raise ValueError("Regression design matrix is rank deficient")
+    fitted = design @ beta
+    residuals = outcome - fitted
+    residual_sum = float(residuals @ residuals)
+    total_sum = float(((outcome - outcome.mean()) ** 2).sum())
+    r_squared = 1 - residual_sum / total_sum
+    degrees = count - parameter_count
+    inverse_information = np.linalg.inv(design.T @ design)
+    standard_errors = np.sqrt(np.diag(residual_sum / degrees * inverse_information))
+    coefficients = _coefficient_estimates(beta, standard_errors, degrees, request)
+    diagnostics = _residual_diagnostics(
+        _RegressionWork(
+            design, residuals, residual_sum, inverse_information, parameter_count
+        )
+    )
+    return RegressionEstimate(
+        count,
+        r_squared,
+        1 - (1 - r_squared) * (count - 1) / degrees,
+        coefficients,
+        diagnostics,
+    )
+
+
+def _coefficient_estimates(
+    beta: np.ndarray,
+    standard_errors: np.ndarray,
+    degrees: int,
+    request: AnalysisRequest,
+) -> dict[str, CoefficientEstimate]:
+    t_values = beta / standard_errors
+    p_values = 2 * stats.t.sf(np.abs(t_values), degrees)
+    critical = stats.t.ppf(0.5 + request.confidence_level / 2, degrees)
+    names = ("intercept", *request.predictors)
+    return {
+        name: CoefficientEstimate(
+            float(beta[index]),
+            float(standard_errors[index]),
+            float(t_values[index]),
+            float(p_values[index]),
+            float(beta[index] - critical * standard_errors[index]),
+            float(beta[index] + critical * standard_errors[index]),
+        )
+        for index, name in enumerate(names)
+    }
+
+
+def _residual_diagnostics(work: _RegressionWork) -> ResidualDiagnostics:
+    count = len(work.residuals)
+    degrees = count - work.parameter_count
+    leverage = np.einsum(
+        "ij,jk,ik->i", work.design, work.inverse_information, work.design
+    )
+    variance = work.residual_sum / degrees
+    cooks = work.residuals**2 / max(
+        np.finfo(float).eps, work.parameter_count * variance
+    )
+    cooks *= leverage / np.maximum((1 - leverage) ** 2, np.finfo(float).eps)
+    durbin_watson = (
+        float(np.diff(work.residuals) @ np.diff(work.residuals) / work.residual_sum)
+        if work.residual_sum > 0
+        else None
+    )
+    return ResidualDiagnostics(
+        float(np.sqrt(np.mean(work.residuals**2))),
+        float(np.mean(np.abs(work.residuals))),
+        float(np.mean(work.residuals)),
+        float(np.std(work.residuals, ddof=work.parameter_count)),
+        durbin_watson,
+        int(np.sum(cooks > 4 / count)),
+    )

--- a/src/rate_of_closure/_launch_monitor_analysis_types.py
+++ b/src/rate_of_closure/_launch_monitor_analysis_types.py
@@ -1,0 +1,137 @@
+"""Immutable data contracts for launch-monitor statistical analysis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields, is_dataclass
+from typing import Any, Literal, cast
+
+import numpy as np
+
+AnalysisMode = Literal["correlation", "regression", "comprehensive"]
+CorrelationMethod = Literal["pearson", "spearman", "kendall"]
+MissingPolicy = Literal["pairwise", "listwise", "fail"]
+CONTRACT_VERSION = "1.0.0"
+
+
+@dataclass(frozen=True)
+class AnalysisRequest:
+    """Configuration for one launch-monitor analysis run."""
+
+    outcome: str
+    predictors: tuple[str, ...]
+    analysis_mode: AnalysisMode = "comprehensive"
+    correlation_method: CorrelationMethod = "pearson"
+    missing_policy: MissingPolicy = "pairwise"
+    group_by: str | None = None
+    confidence_level: float = 0.95
+    min_samples: int = 10
+    allow_aggregate: bool = False
+
+
+@dataclass(frozen=True)
+class DatasetSummary:
+    """Provenance and completeness metadata for analyzed observations."""
+
+    row_count: int
+    complete_row_count: int
+    selected_columns: tuple[str, ...]
+    monitor_vendors: tuple[str, ...]
+    session_ids: tuple[str, ...]
+    observation_kinds: tuple[str, ...]
+    fingerprint_sha256: str
+
+
+@dataclass(frozen=True)
+class CorrelationEstimate:
+    """One predictor's correlation estimate and uncertainty metadata."""
+
+    predictor: str
+    coefficient: float | None
+    p_value: float | None
+    adjusted_p_value: float | None
+    ci_lower: float | None
+    ci_upper: float | None
+    sample_count: int
+    method: str
+
+
+@dataclass(frozen=True)
+class CoefficientEstimate:
+    """One ordinary least-squares coefficient estimate."""
+
+    estimate: float
+    standard_error: float
+    t_statistic: float
+    p_value: float
+    ci_lower: float
+    ci_upper: float
+
+
+@dataclass(frozen=True)
+class ResidualDiagnostics:
+    """Residual quality and influence diagnostics for a regression."""
+
+    rmse: float
+    mae: float
+    residual_mean: float
+    residual_std: float
+    durbin_watson: float | None
+    influential_count: int
+
+
+@dataclass(frozen=True)
+class RegressionEstimate:
+    """Ordinary least-squares result and diagnostics."""
+
+    sample_count: int
+    r_squared: float
+    adjusted_r_squared: float
+    coefficients: dict[str, CoefficientEstimate]
+    residual_diagnostics: ResidualDiagnostics
+
+
+@dataclass(frozen=True)
+class GroupAnalysis:
+    """Analysis result for one group value."""
+
+    group_value: str
+    row_count: int
+    correlations: tuple[CorrelationEstimate, ...]
+    regression: RegressionEstimate | None
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    """Complete, serializable launch-monitor analysis result."""
+
+    contract_version: str
+    request: AnalysisRequest
+    dataset: DatasetSummary
+    correlations: tuple[CorrelationEstimate, ...]
+    regression: RegressionEstimate | None
+    groups: tuple[GroupAnalysis, ...]
+    warnings: tuple[str, ...]
+
+    def to_wire(self) -> dict[str, Any]:
+        """Return the camel-case JSON structure consumed by the React twin."""
+
+        def camel(name: str) -> str:
+            head, *tail = name.split("_")
+            return head + "".join(word.title() for word in tail)
+
+        def convert(value: Any) -> Any:
+            if is_dataclass(value) and not isinstance(value, type):
+                return {
+                    camel(item.name): convert(getattr(value, item.name))
+                    for item in fields(value)
+                }
+            if isinstance(value, dict):
+                return {str(key): convert(item) for key, item in value.items()}
+            if isinstance(value, (tuple, list)):
+                return [convert(item) for item in value]
+            if isinstance(value, float) and not np.isfinite(value):
+                return None
+            return value
+
+        return cast(dict[str, Any], convert(self))

--- a/src/rate_of_closure/helptext.py
+++ b/src/rate_of_closure/helptext.py
@@ -160,6 +160,28 @@ HELP_TEXTS: dict[str, HelpEntry] = {
         "models by re-running with a different model at identical "
         "launch conditions.</p>",
     ),
+    "launch_monitor_analytics": _entry(
+        "Launch Monitor Analytics",
+        "<h3>What this tab does</h3>"
+        "<p>Imports local CSV or JSON launch-monitor records without dropping "
+        "source columns, then runs flexible correlation, multivariable ordinary "
+        "least-squares regression, uncertainty, residual, and grouped analysis. "
+        "The built-in demonstration data lets you inspect the workflow before "
+        "loading a file.</p>"
+        "<h3>Workflow</h3>"
+        "<ol><li>Import data and confirm the retained row and column counts.</li>"
+        "<li>Choose the documented interpretation convention, outcome, any "
+        "number of predictors, missing-data policy, method, and grouping.</li>"
+        "<li>Run the analysis and inspect pair counts, corrected p-values, OLS "
+        "coefficient intervals, fit metrics, residual diagnostics, group results, "
+        "and the SHA-256 dataset fingerprint.</li>"
+        "<li>Export retained records and the complete analysis JSON.</li></ol>"
+        "<h3>Tips and Scientific Boundary</h3>"
+        "<p>Association and predictive fit do not establish causality. Aggregate "
+        "records never enter regression. TrackMan-Comparable and Foresight-"
+        "Comparable describe sourced definition frames; they do not emulate or "
+        "certify vendor devices.</p>",
+    ),
     "variation": _entry(
         "Variation",
         "<h3>What this tab does</h3>"

--- a/src/rate_of_closure/launch_monitor_analysis.py
+++ b/src/rate_of_closure/launch_monitor_analysis.py
@@ -68,7 +68,9 @@ def _fingerprint(frame: pd.DataFrame, selected: tuple[str, ...]) -> str:
             column: (
                 None
                 if pd.isna(value)
-                else value.item() if hasattr(value, "item") else value
+                else value.item()
+                if hasattr(value, "item")
+                else value
             )
             for column, value in row.items()
         }

--- a/src/rate_of_closure/launch_monitor_analysis.py
+++ b/src/rate_of_closure/launch_monitor_analysis.py
@@ -1,0 +1,414 @@
+"""UI-neutral launch-monitor statistics matching the React contract."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, fields, is_dataclass, replace
+from hashlib import sha256
+from typing import Any, Literal, cast
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+AnalysisMode = Literal["correlation", "regression", "comprehensive"]
+CorrelationMethod = Literal["pearson", "spearman", "kendall"]
+MissingPolicy = Literal["pairwise", "listwise", "fail"]
+CONTRACT_VERSION = "1.0.0"
+
+
+@dataclass(frozen=True)
+class AnalysisRequest:
+    outcome: str
+    predictors: tuple[str, ...]
+    analysis_mode: AnalysisMode = "comprehensive"
+    correlation_method: CorrelationMethod = "pearson"
+    missing_policy: MissingPolicy = "pairwise"
+    group_by: str | None = None
+    confidence_level: float = 0.95
+    min_samples: int = 10
+    allow_aggregate: bool = False
+
+
+@dataclass(frozen=True)
+class DatasetSummary:
+    row_count: int
+    complete_row_count: int
+    selected_columns: tuple[str, ...]
+    monitor_vendors: tuple[str, ...]
+    session_ids: tuple[str, ...]
+    observation_kinds: tuple[str, ...]
+    fingerprint_sha256: str
+
+
+@dataclass(frozen=True)
+class CorrelationEstimate:
+    predictor: str
+    coefficient: float | None
+    p_value: float | None
+    adjusted_p_value: float | None
+    ci_lower: float | None
+    ci_upper: float | None
+    sample_count: int
+    method: str
+
+
+@dataclass(frozen=True)
+class CoefficientEstimate:
+    estimate: float
+    standard_error: float
+    t_statistic: float
+    p_value: float
+    ci_lower: float
+    ci_upper: float
+
+
+@dataclass(frozen=True)
+class ResidualDiagnostics:
+    rmse: float
+    mae: float
+    residual_mean: float
+    residual_std: float
+    durbin_watson: float | None
+    influential_count: int
+
+
+@dataclass(frozen=True)
+class RegressionEstimate:
+    sample_count: int
+    r_squared: float
+    adjusted_r_squared: float
+    coefficients: dict[str, CoefficientEstimate]
+    residual_diagnostics: ResidualDiagnostics
+
+
+@dataclass(frozen=True)
+class GroupAnalysis:
+    group_value: str
+    row_count: int
+    correlations: tuple[CorrelationEstimate, ...]
+    regression: RegressionEstimate | None
+    warnings: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    contract_version: str
+    request: AnalysisRequest
+    dataset: DatasetSummary
+    correlations: tuple[CorrelationEstimate, ...]
+    regression: RegressionEstimate | None
+    groups: tuple[GroupAnalysis, ...]
+    warnings: tuple[str, ...]
+
+    def to_wire(self) -> dict[str, Any]:
+        """Return the camel-case JSON structure consumed by the React twin."""
+
+        def camel(name: str) -> str:
+            head, *tail = name.split("_")
+            return head + "".join(word.title() for word in tail)
+
+        def convert(value: Any) -> Any:
+            if is_dataclass(value) and not isinstance(value, type):
+                return {
+                    camel(item.name): convert(getattr(value, item.name))
+                    for item in fields(value)
+                }
+            if isinstance(value, dict):
+                return {str(key): convert(item) for key, item in value.items()}
+            if isinstance(value, (tuple, list)):
+                return [convert(item) for item in value]
+            if isinstance(value, float) and not np.isfinite(value):
+                return None
+            return value
+
+        return cast(dict[str, Any], convert(self))
+
+
+def numeric_columns(frame: pd.DataFrame) -> list[str]:
+    """Return columns with at least three numeric values, including source fields."""
+
+    return sorted(
+        str(column)
+        for column in frame.columns
+        if pd.to_numeric(frame[column], errors="coerce").notna().sum() >= 3
+    )
+
+
+def _strings(frame: pd.DataFrame, column: str) -> tuple[str, ...]:
+    if column not in frame:
+        return ()
+    return tuple(sorted(frame[column].dropna().astype(str).unique()))
+
+
+def _fingerprint(frame: pd.DataFrame, selected: tuple[str, ...]) -> str:
+    identity = tuple(
+        column
+        for column in ("shot_id", "session_id", "source_row", "monitor_vendor")
+        if column in frame and column not in selected
+    )
+    columns = identity + selected
+    records = [
+        {
+            column: None
+            if pd.isna(value)
+            else value.item()
+            if hasattr(value, "item")
+            else value
+            for column, value in row.items()
+        }
+        for row in frame[list(columns)].to_dict(orient="records")
+    ]
+    serialized = json.dumps(records, ensure_ascii=False, separators=(",", ":"))
+    return sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _adjust(values: list[float | None]) -> list[float | None]:
+    finite = sorted(
+        ((index, value) for index, value in enumerate(values) if value is not None),
+        key=lambda item: item[1],
+    )
+    output: list[float | None] = [None] * len(values)
+    previous = 1.0
+    for rank in range(len(finite), 0, -1):
+        index, value = finite[rank - 1]
+        corrected = min(previous, value * len(finite) / rank)
+        output[index] = min(1.0, corrected)
+        previous = corrected
+    return output
+
+
+def _correlations(
+    frame: pd.DataFrame, request: AnalysisRequest
+) -> tuple[CorrelationEstimate, ...]:
+    selected = (request.outcome, *request.predictors)
+    working = (
+        frame.dropna(subset=list(selected))
+        if request.missing_policy == "listwise"
+        else frame
+    )
+    provisional: list[CorrelationEstimate] = []
+    for predictor in request.predictors:
+        pair = (
+            working[[request.outcome, predictor]]
+            .apply(pd.to_numeric, errors="coerce")
+            .dropna()
+        )
+        count = len(pair)
+        if count < request.min_samples:
+            provisional.append(
+                CorrelationEstimate(
+                    predictor,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    count,
+                    request.correlation_method,
+                )
+            )
+            continue
+        left = pair[request.outcome].to_numpy(float)
+        right = pair[predictor].to_numpy(float)
+        if request.correlation_method == "pearson":
+            estimate = stats.pearsonr(left, right)
+        elif request.correlation_method == "spearman":
+            estimate = stats.spearmanr(left, right)
+        else:
+            estimate = stats.kendalltau(left, right)
+        coefficient = float(estimate.statistic)
+        lower: float | None = None
+        upper: float | None = None
+        if request.correlation_method == "pearson" and count > 3:
+            transformed = np.arctanh(np.clip(coefficient, -0.999999, 0.999999))
+            margin = stats.norm.ppf(0.5 + request.confidence_level / 2) / np.sqrt(
+                count - 3
+            )
+            lower, upper = (
+                float(np.tanh(transformed - margin)),
+                float(np.tanh(transformed + margin)),
+            )
+        provisional.append(
+            CorrelationEstimate(
+                predictor,
+                coefficient,
+                float(estimate.pvalue),
+                None,
+                lower,
+                upper,
+                count,
+                request.correlation_method,
+            )
+        )
+    adjusted = _adjust([item.p_value for item in provisional])
+    return tuple(
+        replace(item, adjusted_p_value=adjusted[index])
+        for index, item in enumerate(provisional)
+    )
+
+
+def _regression(frame: pd.DataFrame, request: AnalysisRequest) -> RegressionEstimate:
+    columns = (request.outcome, *request.predictors)
+    numeric = frame[list(columns)].apply(pd.to_numeric, errors="coerce").dropna()
+    count = len(numeric)
+    parameter_count = len(request.predictors) + 1
+    if count < max(request.min_samples, parameter_count + 2):
+        raise ValueError("Too few complete observations for regression")
+    y = numeric[request.outcome].to_numpy(float)
+    design = np.column_stack(
+        (np.ones(count), numeric[list(request.predictors)].to_numpy(float))
+    )
+    beta, _, rank, _ = np.linalg.lstsq(design, y, rcond=None)
+    if rank < parameter_count:
+        raise ValueError("Regression design matrix is rank deficient")
+    fitted = design @ beta
+    residuals = y - fitted
+    residual_sum = float(residuals @ residuals)
+    total_sum = float(((y - y.mean()) ** 2).sum())
+    r_squared = 1 - residual_sum / total_sum
+    degrees = count - parameter_count
+    covariance = residual_sum / degrees * np.linalg.inv(design.T @ design)
+    standard_errors = np.sqrt(np.diag(covariance))
+    t_values = beta / standard_errors
+    p_values = 2 * stats.t.sf(np.abs(t_values), degrees)
+    critical = stats.t.ppf(0.5 + request.confidence_level / 2, degrees)
+    names = ("intercept", *request.predictors)
+    coefficients = {
+        name: CoefficientEstimate(
+            float(beta[index]),
+            float(standard_errors[index]),
+            float(t_values[index]),
+            float(p_values[index]),
+            float(beta[index] - critical * standard_errors[index]),
+            float(beta[index] + critical * standard_errors[index]),
+        )
+        for index, name in enumerate(names)
+    }
+    leverage = np.einsum(
+        "ij,jk,ik->i", design, np.linalg.inv(design.T @ design), design
+    )
+    variance = residual_sum / degrees
+    cooks = residuals**2 / max(np.finfo(float).eps, parameter_count * variance)
+    cooks *= leverage / np.maximum((1 - leverage) ** 2, np.finfo(float).eps)
+    return RegressionEstimate(
+        count,
+        r_squared,
+        1 - (1 - r_squared) * (count - 1) / degrees,
+        coefficients,
+        ResidualDiagnostics(
+            float(np.sqrt(np.mean(residuals**2))),
+            float(np.mean(np.abs(residuals))),
+            float(np.mean(residuals)),
+            float(np.std(residuals, ddof=parameter_count)),
+            (
+                float(np.diff(residuals) @ np.diff(residuals) / residual_sum)
+                if residual_sum > 0
+                else None
+            ),
+            int(np.sum(cooks > 4 / count)),
+        ),
+    )
+
+
+def analyze_launch_monitor_data(
+    frame: pd.DataFrame, request: AnalysisRequest
+) -> AnalysisResult:
+    """Analyze arbitrary numeric columns with explicit scientific boundaries."""
+
+    selected = (request.outcome, *request.predictors)
+    if not request.outcome or not request.predictors:
+        raise ValueError("Select an outcome and predictors")
+    if request.outcome in request.predictors:
+        raise ValueError("outcome cannot also be a predictor")
+    if len(set(request.predictors)) != len(request.predictors):
+        raise ValueError("predictors must be unique")
+    if not 0.5 < request.confidence_level < 1 or request.min_samples < 3:
+        raise ValueError("Invalid confidence level or minimum sample count")
+    required = set(selected) | ({request.group_by} if request.group_by else set())
+    missing = required - set(frame.columns)
+    if missing:
+        raise ValueError(f"Columns not present: {sorted(missing)}")
+    numeric = frame[list(selected)].apply(pd.to_numeric, errors="coerce")
+    constants = [
+        column for column in selected if numeric[column].dropna().nunique() < 2
+    ]
+    if constants:
+        raise ValueError(f"Constant variables cannot be analyzed: {constants}")
+    if request.missing_policy == "fail" and numeric.isna().any().any():
+        raise ValueError("Selected variables contain missing or non-numeric values")
+    vendors = _strings(frame, "monitor_vendor")
+    if any(column.startswith("source::") for column in selected) and len(vendors) > 1:
+        raise ValueError("source fields cannot be pooled across multiple monitors")
+    kinds = _strings(frame, "observation_kind") or ("shot",)
+    aggregate = any(kind.lower() != "shot" for kind in kinds)
+    if aggregate and request.analysis_mode != "correlation":
+        raise ValueError("Aggregate observations cannot enter regression")
+    if aggregate and not request.allow_aggregate:
+        raise ValueError("Aggregate observations require allow_aggregate=True")
+    warnings: list[str] = []
+    if aggregate:
+        warnings.append(
+            "Aggregate correlations are descriptive only and may exhibit "
+            "ecological bias."
+        )
+    if (
+        request.correlation_method != "pearson"
+        and request.analysis_mode != "regression"
+    ):
+        warnings.append(
+            "Analytical confidence intervals are only reported for Pearson correlation."
+        )
+    correlations = (
+        _correlations(frame, request) if request.analysis_mode != "regression" else ()
+    )
+    regression = (
+        _regression(frame, request) if request.analysis_mode != "correlation" else None
+    )
+    groups: list[GroupAnalysis] = []
+    if request.group_by:
+        ungrouped = replace(request, group_by=None)
+        for value, group in frame.dropna(subset=[request.group_by]).groupby(
+            request.group_by, sort=True, observed=True
+        ):
+            try:
+                result = analyze_launch_monitor_data(group, ungrouped)
+                groups.append(
+                    GroupAnalysis(
+                        str(value),
+                        len(group),
+                        result.correlations,
+                        result.regression,
+                        result.warnings,
+                    )
+                )
+            except ValueError as error:
+                groups.append(
+                    GroupAnalysis(str(value), len(group), (), None, (str(error),))
+                )
+    return AnalysisResult(
+        CONTRACT_VERSION,
+        request,
+        DatasetSummary(
+            len(frame),
+            int(numeric.dropna().shape[0]),
+            selected,
+            vendors,
+            _strings(frame, "session_id"),
+            kinds,
+            _fingerprint(frame, selected),
+        ),
+        correlations,
+        regression,
+        tuple(groups),
+        tuple(warnings),
+    )
+
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "AnalysisRequest",
+    "AnalysisResult",
+    "analyze_launch_monitor_data",
+    "numeric_columns",
+]

--- a/src/rate_of_closure/launch_monitor_analysis.py
+++ b/src/rate_of_closure/launch_monitor_analysis.py
@@ -3,126 +3,41 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, fields, is_dataclass, replace
+from dataclasses import replace
 from hashlib import sha256
-from typing import Any, Literal, cast
+from typing import cast
 
-import numpy as np
 import pandas as pd
-from scipy import stats
 
-AnalysisMode = Literal["correlation", "regression", "comprehensive"]
-CorrelationMethod = Literal["pearson", "spearman", "kendall"]
-MissingPolicy = Literal["pairwise", "listwise", "fail"]
-CONTRACT_VERSION = "1.0.0"
-
-
-@dataclass(frozen=True)
-class AnalysisRequest:
-    outcome: str
-    predictors: tuple[str, ...]
-    analysis_mode: AnalysisMode = "comprehensive"
-    correlation_method: CorrelationMethod = "pearson"
-    missing_policy: MissingPolicy = "pairwise"
-    group_by: str | None = None
-    confidence_level: float = 0.95
-    min_samples: int = 10
-    allow_aggregate: bool = False
-
-
-@dataclass(frozen=True)
-class DatasetSummary:
-    row_count: int
-    complete_row_count: int
-    selected_columns: tuple[str, ...]
-    monitor_vendors: tuple[str, ...]
-    session_ids: tuple[str, ...]
-    observation_kinds: tuple[str, ...]
-    fingerprint_sha256: str
-
-
-@dataclass(frozen=True)
-class CorrelationEstimate:
-    predictor: str
-    coefficient: float | None
-    p_value: float | None
-    adjusted_p_value: float | None
-    ci_lower: float | None
-    ci_upper: float | None
-    sample_count: int
-    method: str
-
-
-@dataclass(frozen=True)
-class CoefficientEstimate:
-    estimate: float
-    standard_error: float
-    t_statistic: float
-    p_value: float
-    ci_lower: float
-    ci_upper: float
-
-
-@dataclass(frozen=True)
-class ResidualDiagnostics:
-    rmse: float
-    mae: float
-    residual_mean: float
-    residual_std: float
-    durbin_watson: float | None
-    influential_count: int
-
-
-@dataclass(frozen=True)
-class RegressionEstimate:
-    sample_count: int
-    r_squared: float
-    adjusted_r_squared: float
-    coefficients: dict[str, CoefficientEstimate]
-    residual_diagnostics: ResidualDiagnostics
-
-
-@dataclass(frozen=True)
-class GroupAnalysis:
-    group_value: str
-    row_count: int
-    correlations: tuple[CorrelationEstimate, ...]
-    regression: RegressionEstimate | None
-    warnings: tuple[str, ...]
-
-
-@dataclass(frozen=True)
-class AnalysisResult:
-    contract_version: str
-    request: AnalysisRequest
-    dataset: DatasetSummary
-    correlations: tuple[CorrelationEstimate, ...]
-    regression: RegressionEstimate | None
-    groups: tuple[GroupAnalysis, ...]
-    warnings: tuple[str, ...]
-
-    def to_wire(self) -> dict[str, Any]:
-        """Return the camel-case JSON structure consumed by the React twin."""
-
-        def camel(name: str) -> str:
-            head, *tail = name.split("_")
-            return head + "".join(word.title() for word in tail)
-
-        def convert(value: Any) -> Any:
-            if is_dataclass(value) and not isinstance(value, type):
-                return {
-                    camel(item.name): convert(getattr(value, item.name))
-                    for item in fields(value)
-                }
-            if isinstance(value, dict):
-                return {str(key): convert(item) for key, item in value.items()}
-            if isinstance(value, (tuple, list)):
-                return [convert(item) for item in value]
-            if isinstance(value, float) and not np.isfinite(value):
-                return None
-            return value
-
-        return cast(dict[str, Any], convert(self))
+from ._launch_monitor_analysis_statistics import correlations, regression
+from ._launch_monitor_analysis_types import (
+    CONTRACT_VERSION,
+    AnalysisRequest,
+    AnalysisResult,
+    DatasetSummary,
+    GroupAnalysis,
+)
+from ._launch_monitor_analysis_types import (
+    AnalysisMode as AnalysisMode,
+)
+from ._launch_monitor_analysis_types import (
+    CoefficientEstimate as CoefficientEstimate,
+)
+from ._launch_monitor_analysis_types import (
+    CorrelationEstimate as CorrelationEstimate,
+)
+from ._launch_monitor_analysis_types import (
+    CorrelationMethod as CorrelationMethod,
+)
+from ._launch_monitor_analysis_types import (
+    MissingPolicy as MissingPolicy,
+)
+from ._launch_monitor_analysis_types import (
+    RegressionEstimate as RegressionEstimate,
+)
+from ._launch_monitor_analysis_types import (
+    ResidualDiagnostics as ResidualDiagnostics,
+)
 
 
 def numeric_columns(frame: pd.DataFrame) -> list[str]:
@@ -150,11 +65,11 @@ def _fingerprint(frame: pd.DataFrame, selected: tuple[str, ...]) -> str:
     columns = identity + selected
     records = [
         {
-            column: None
-            if pd.isna(value)
-            else value.item()
-            if hasattr(value, "item")
-            else value
+            column: (
+                None
+                if pd.isna(value)
+                else value.item() if hasattr(value, "item") else value
+            )
             for column, value in row.items()
         }
         for row in frame[list(columns)].to_dict(orient="records")
@@ -163,159 +78,7 @@ def _fingerprint(frame: pd.DataFrame, selected: tuple[str, ...]) -> str:
     return sha256(serialized.encode("utf-8")).hexdigest()
 
 
-def _adjust(values: list[float | None]) -> list[float | None]:
-    finite = sorted(
-        ((index, value) for index, value in enumerate(values) if value is not None),
-        key=lambda item: item[1],
-    )
-    output: list[float | None] = [None] * len(values)
-    previous = 1.0
-    for rank in range(len(finite), 0, -1):
-        index, value = finite[rank - 1]
-        corrected = min(previous, value * len(finite) / rank)
-        output[index] = min(1.0, corrected)
-        previous = corrected
-    return output
-
-
-def _correlations(
-    frame: pd.DataFrame, request: AnalysisRequest
-) -> tuple[CorrelationEstimate, ...]:
-    selected = (request.outcome, *request.predictors)
-    working = (
-        frame.dropna(subset=list(selected))
-        if request.missing_policy == "listwise"
-        else frame
-    )
-    provisional: list[CorrelationEstimate] = []
-    for predictor in request.predictors:
-        pair = (
-            working[[request.outcome, predictor]]
-            .apply(pd.to_numeric, errors="coerce")
-            .dropna()
-        )
-        count = len(pair)
-        if count < request.min_samples:
-            provisional.append(
-                CorrelationEstimate(
-                    predictor,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    count,
-                    request.correlation_method,
-                )
-            )
-            continue
-        left = pair[request.outcome].to_numpy(float)
-        right = pair[predictor].to_numpy(float)
-        if request.correlation_method == "pearson":
-            estimate = stats.pearsonr(left, right)
-        elif request.correlation_method == "spearman":
-            estimate = stats.spearmanr(left, right)
-        else:
-            estimate = stats.kendalltau(left, right)
-        coefficient = float(estimate.statistic)
-        lower: float | None = None
-        upper: float | None = None
-        if request.correlation_method == "pearson" and count > 3:
-            transformed = np.arctanh(np.clip(coefficient, -0.999999, 0.999999))
-            margin = stats.norm.ppf(0.5 + request.confidence_level / 2) / np.sqrt(
-                count - 3
-            )
-            lower, upper = (
-                float(np.tanh(transformed - margin)),
-                float(np.tanh(transformed + margin)),
-            )
-        provisional.append(
-            CorrelationEstimate(
-                predictor,
-                coefficient,
-                float(estimate.pvalue),
-                None,
-                lower,
-                upper,
-                count,
-                request.correlation_method,
-            )
-        )
-    adjusted = _adjust([item.p_value for item in provisional])
-    return tuple(
-        replace(item, adjusted_p_value=adjusted[index])
-        for index, item in enumerate(provisional)
-    )
-
-
-def _regression(frame: pd.DataFrame, request: AnalysisRequest) -> RegressionEstimate:
-    columns = (request.outcome, *request.predictors)
-    numeric = frame[list(columns)].apply(pd.to_numeric, errors="coerce").dropna()
-    count = len(numeric)
-    parameter_count = len(request.predictors) + 1
-    if count < max(request.min_samples, parameter_count + 2):
-        raise ValueError("Too few complete observations for regression")
-    y = numeric[request.outcome].to_numpy(float)
-    design = np.column_stack(
-        (np.ones(count), numeric[list(request.predictors)].to_numpy(float))
-    )
-    beta, _, rank, _ = np.linalg.lstsq(design, y, rcond=None)
-    if rank < parameter_count:
-        raise ValueError("Regression design matrix is rank deficient")
-    fitted = design @ beta
-    residuals = y - fitted
-    residual_sum = float(residuals @ residuals)
-    total_sum = float(((y - y.mean()) ** 2).sum())
-    r_squared = 1 - residual_sum / total_sum
-    degrees = count - parameter_count
-    covariance = residual_sum / degrees * np.linalg.inv(design.T @ design)
-    standard_errors = np.sqrt(np.diag(covariance))
-    t_values = beta / standard_errors
-    p_values = 2 * stats.t.sf(np.abs(t_values), degrees)
-    critical = stats.t.ppf(0.5 + request.confidence_level / 2, degrees)
-    names = ("intercept", *request.predictors)
-    coefficients = {
-        name: CoefficientEstimate(
-            float(beta[index]),
-            float(standard_errors[index]),
-            float(t_values[index]),
-            float(p_values[index]),
-            float(beta[index] - critical * standard_errors[index]),
-            float(beta[index] + critical * standard_errors[index]),
-        )
-        for index, name in enumerate(names)
-    }
-    leverage = np.einsum(
-        "ij,jk,ik->i", design, np.linalg.inv(design.T @ design), design
-    )
-    variance = residual_sum / degrees
-    cooks = residuals**2 / max(np.finfo(float).eps, parameter_count * variance)
-    cooks *= leverage / np.maximum((1 - leverage) ** 2, np.finfo(float).eps)
-    return RegressionEstimate(
-        count,
-        r_squared,
-        1 - (1 - r_squared) * (count - 1) / degrees,
-        coefficients,
-        ResidualDiagnostics(
-            float(np.sqrt(np.mean(residuals**2))),
-            float(np.mean(np.abs(residuals))),
-            float(np.mean(residuals)),
-            float(np.std(residuals, ddof=parameter_count)),
-            (
-                float(np.diff(residuals) @ np.diff(residuals) / residual_sum)
-                if residual_sum > 0
-                else None
-            ),
-            int(np.sum(cooks > 4 / count)),
-        ),
-    )
-
-
-def analyze_launch_monitor_data(
-    frame: pd.DataFrame, request: AnalysisRequest
-) -> AnalysisResult:
-    """Analyze arbitrary numeric columns with explicit scientific boundaries."""
-
+def _validate_request(frame: pd.DataFrame, request: AnalysisRequest) -> pd.DataFrame:
     selected = (request.outcome, *request.predictors)
     if not request.outcome or not request.predictors:
         raise ValueError("Select an outcome and predictors")
@@ -337,6 +100,12 @@ def analyze_launch_monitor_data(
         raise ValueError(f"Constant variables cannot be analyzed: {constants}")
     if request.missing_policy == "fail" and numeric.isna().any().any():
         raise ValueError("Selected variables contain missing or non-numeric values")
+    return cast(pd.DataFrame, numeric)
+
+
+def _validate_observation_scope(
+    frame: pd.DataFrame, request: AnalysisRequest, selected: tuple[str, ...]
+) -> tuple[tuple[str, ...], tuple[str, ...], list[str]]:
     vendors = _strings(frame, "monitor_vendor")
     if any(column.startswith("source::") for column in selected) and len(vendors) > 1:
         raise ValueError("source fields cannot be pooled across multiple monitors")
@@ -359,33 +128,51 @@ def analyze_launch_monitor_data(
         warnings.append(
             "Analytical confidence intervals are only reported for Pearson correlation."
         )
-    correlations = (
-        _correlations(frame, request) if request.analysis_mode != "regression" else ()
-    )
-    regression = (
-        _regression(frame, request) if request.analysis_mode != "correlation" else None
-    )
+    return vendors, kinds, warnings
+
+
+def _group_analyses(
+    frame: pd.DataFrame, request: AnalysisRequest
+) -> tuple[GroupAnalysis, ...]:
+    if not request.group_by:
+        return ()
     groups: list[GroupAnalysis] = []
-    if request.group_by:
-        ungrouped = replace(request, group_by=None)
-        for value, group in frame.dropna(subset=[request.group_by]).groupby(
-            request.group_by, sort=True, observed=True
-        ):
-            try:
-                result = analyze_launch_monitor_data(group, ungrouped)
-                groups.append(
-                    GroupAnalysis(
-                        str(value),
-                        len(group),
-                        result.correlations,
-                        result.regression,
-                        result.warnings,
-                    )
+    ungrouped = replace(request, group_by=None)
+    for value, group in frame.dropna(subset=[request.group_by]).groupby(
+        request.group_by, sort=True, observed=True
+    ):
+        try:
+            result = analyze_launch_monitor_data(group, ungrouped)
+            groups.append(
+                GroupAnalysis(
+                    str(value),
+                    len(group),
+                    result.correlations,
+                    result.regression,
+                    result.warnings,
                 )
-            except ValueError as error:
-                groups.append(
-                    GroupAnalysis(str(value), len(group), (), None, (str(error),))
-                )
+            )
+        except ValueError as error:
+            groups.append(
+                GroupAnalysis(str(value), len(group), (), None, (str(error),))
+            )
+    return tuple(groups)
+
+
+def analyze_launch_monitor_data(
+    frame: pd.DataFrame, request: AnalysisRequest
+) -> AnalysisResult:
+    """Analyze arbitrary numeric columns with explicit scientific boundaries."""
+
+    selected = (request.outcome, *request.predictors)
+    numeric = _validate_request(frame, request)
+    vendors, kinds, warnings = _validate_observation_scope(frame, request, selected)
+    correlation_results = (
+        correlations(frame, request) if request.analysis_mode != "regression" else ()
+    )
+    regression_result = (
+        regression(frame, request) if request.analysis_mode != "correlation" else None
+    )
     return AnalysisResult(
         CONTRACT_VERSION,
         request,
@@ -398,9 +185,9 @@ def analyze_launch_monitor_data(
             kinds,
             _fingerprint(frame, selected),
         ),
-        correlations,
-        regression,
-        tuple(groups),
+        correlation_results,
+        regression_result,
+        _group_analyses(frame, request),
         tuple(warnings),
     )
 

--- a/src/rate_of_closure/ui/pyqt6/launch_monitor_analytics_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/launch_monitor_analytics_tab.py
@@ -1,0 +1,393 @@
+"""PyQt6 twin of the React Launch Monitor Analytics tab."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QComboBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QMessageBox,
+    QPlainTextEdit,
+    QPushButton,
+    QSpinBox,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from rate_of_closure.launch_monitor_analysis import (
+    AnalysisRequest,
+    AnalysisResult,
+    analyze_launch_monitor_data,
+    numeric_columns,
+)
+from shared.python.swing_sim.conventions import (
+    ConventionId,
+    ParameterId,
+    convention_registry,
+)
+
+
+def _demo_frame() -> pd.DataFrame:
+    index = np.arange(120)
+    club_speed = 38.0 + index * 0.11
+    attack_angle = -4.0 + (index % 17) * 0.4
+    club_path = -3.0 + (index % 13) * 0.5
+    face_angle = club_path * 0.65 + np.sin(index * 0.7) * 0.8
+    ball_speed = club_speed * 1.46 + attack_angle * 0.08 + np.sin(index) * 0.25
+    return pd.DataFrame(
+        {
+            "shot_id": [f"demo-{item + 1}" for item in index],
+            "session_id": np.where(index < 60, "demo-a", "demo-b"),
+            "monitor_vendor": np.where(index % 2, "FlightScope", "TrackMan"),
+            "observation_kind": "shot",
+            "club_speed": club_speed,
+            "attack_angle": attack_angle,
+            "club_path": club_path,
+            "face_angle": face_angle,
+            "ball_speed": ball_speed,
+            "carry_distance": ball_speed * 3.25 + attack_angle * 0.9,
+        }
+    )
+
+
+class LaunchMonitorAnalyticsTab(QWidget):
+    """Import retained records and run arbitrary traceable analyses."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.frame = _demo_frame()
+        self.source_name = "Built-In Demonstration Data"
+        self.last_result: AnalysisResult | None = None
+        self._build_ui()
+        self._refresh_columns()
+
+    def _build_ui(self) -> None:
+        heading = QLabel("Launch Monitor Analytics")
+        heading.setStyleSheet("font-size: 20px; font-weight: 600;")
+        boundary = QLabel(
+            "Import CSV or JSON without dropping source columns. Correlations and "
+            "fitted models are associations, not causal evidence. TrackMan-Comparable "
+            "and Foresight-Comparable are documented frames, not device emulation "
+            "or certification."
+        )
+        boundary.setWordWrap(True)
+        boundary.setAccessibleName("Launch Monitor Analytics Scientific Boundary")
+        self.source_label = QLabel()
+        self.source_label.setWordWrap(True)
+
+        self.import_button = QPushButton("Import Data...")
+        self.demo_button = QPushButton("Load Demo")
+        self.export_data_button = QPushButton("Export Retained Data...")
+        self.export_result_button = QPushButton("Export Analysis...")
+        self.export_result_button.setEnabled(False)
+        buttons = QHBoxLayout()
+        for button in (
+            self.import_button,
+            self.demo_button,
+            self.export_data_button,
+            self.export_result_button,
+        ):
+            buttons.addWidget(button)
+        buttons.addStretch(1)
+
+        self.convention_combo = QComboBox()
+        self.convention_combo.addItem("App-Native", ConventionId.APP_NATIVE)
+        self.convention_combo.addItem(
+            "TrackMan-Comparable", ConventionId.TRACKMAN_COMPARABLE
+        )
+        self.convention_combo.addItem(
+            "Foresight-Comparable", ConventionId.FORESIGHT_COMPARABLE
+        )
+        self.convention_evidence = QLabel()
+        self.convention_evidence.setWordWrap(True)
+        self.convention_evidence.setOpenExternalLinks(True)
+        self.outcome_combo = QComboBox()
+        self.predictor_list = QListWidget()
+        self.predictor_list.setSelectionMode(
+            QListWidget.SelectionMode.ExtendedSelection
+        )
+        self.mode_combo = QComboBox()
+        self.mode_combo.addItems(["comprehensive", "correlation", "regression"])
+        self.method_combo = QComboBox()
+        self.method_combo.addItems(["pearson", "spearman", "kendall"])
+        self.missing_combo = QComboBox()
+        self.missing_combo.addItems(["pairwise", "listwise", "fail"])
+        self.group_combo = QComboBox()
+        self.confidence_spin = QDoubleSpinBox()
+        self.confidence_spin.setRange(0.51, 0.999)
+        self.confidence_spin.setDecimals(3)
+        self.confidence_spin.setValue(0.95)
+        self.min_samples_spin = QSpinBox()
+        self.min_samples_spin.setRange(3, 1_000_000)
+        self.min_samples_spin.setValue(10)
+        self.run_button = QPushButton("Run Analysis")
+
+        controls = (
+            (self.import_button, "Import a CSV or JSON launch-monitor export"),
+            (self.demo_button, "Restore the built-in demonstration data"),
+            (self.export_data_button, "Export every retained input record"),
+            (self.export_result_button, "Export request, results, and lineage"),
+            (self.convention_combo, "Interpretation Convention"),
+            (self.outcome_combo, "Outcome Variable"),
+            (self.predictor_list, "Predictor Variables"),
+            (self.mode_combo, "Analysis Mode"),
+            (self.method_combo, "Correlation Method"),
+            (self.missing_combo, "Missing-Data Policy"),
+            (self.group_combo, "Optional Grouping Variable"),
+            (self.confidence_spin, "Confidence Level"),
+            (self.min_samples_spin, "Minimum Sample Count"),
+            (self.run_button, "Run the selected statistical analysis"),
+        )
+        for control, description in controls:
+            control.setAccessibleName(description)
+            control.setToolTip(description)
+
+        form = QFormLayout()
+        form.addRow("Convention:", self.convention_combo)
+        form.addRow(self.convention_evidence)
+        form.addRow("Outcome:", self.outcome_combo)
+        form.addRow("Predictors:", self.predictor_list)
+        form.addRow("Analysis Mode:", self.mode_combo)
+        form.addRow("Correlation:", self.method_combo)
+        form.addRow("Missing Data:", self.missing_combo)
+        form.addRow("Group By:", self.group_combo)
+        form.addRow("Confidence:", self.confidence_spin)
+        form.addRow("Minimum N:", self.min_samples_spin)
+        form.addRow(self.run_button)
+
+        self.result_table = QTableWidget()
+        self.result_table.setAccessibleName("Launch Monitor Statistical Results")
+        self.result_table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.details = QPlainTextEdit()
+        self.details.setReadOnly(True)
+        self.details.setAccessibleName("Launch Monitor Analysis Traceability")
+        output = QSplitter(Qt.Orientation.Vertical)
+        output.addWidget(self.result_table)
+        output.addWidget(self.details)
+        output.setSizes([350, 300])
+
+        body = QSplitter(Qt.Orientation.Horizontal)
+        controls_widget = QWidget()
+        controls_layout = QVBoxLayout(controls_widget)
+        controls_layout.addLayout(form)
+        controls_layout.addStretch(1)
+        body.addWidget(controls_widget)
+        body.addWidget(output)
+        body.setSizes([360, 900])
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(heading)
+        layout.addWidget(boundary)
+        layout.addLayout(buttons)
+        layout.addWidget(self.source_label)
+        layout.addWidget(body, 1)
+
+        self.import_button.clicked.connect(self.import_dialog)
+        self.demo_button.clicked.connect(self.load_demo)
+        self.export_data_button.clicked.connect(self.export_data_dialog)
+        self.export_result_button.clicked.connect(self.export_result_dialog)
+        self.run_button.clicked.connect(self.run_analysis_safely)
+        self.convention_combo.currentIndexChanged.connect(
+            self._refresh_convention_evidence
+        )
+        self.outcome_combo.currentTextChanged.connect(self._refresh_convention_evidence)
+
+    def _refresh_columns(self) -> None:
+        numeric = numeric_columns(self.frame)
+        previous = self.outcome_combo.currentText()
+        self.outcome_combo.clear()
+        self.outcome_combo.addItems(numeric)
+        self.outcome_combo.setCurrentText(
+            previous if previous in numeric else "ball_speed"
+        )
+        self.predictor_list.clear()
+        self.predictor_list.addItems(numeric)
+        defaults = {"club_speed", "attack_angle"}
+        for index in range(self.predictor_list.count()):
+            item = self.predictor_list.item(index)
+            if item is not None:
+                item.setSelected(item.text() in defaults)
+        groups = sorted(
+            str(column)
+            for column in self.frame.columns
+            if self.frame[column].notna().any()
+            and self.frame[column].nunique(dropna=True) <= 100
+        )
+        self.group_combo.clear()
+        self.group_combo.addItem("(none)")
+        self.group_combo.addItems(groups)
+        if "monitor_vendor" in groups:
+            self.group_combo.setCurrentText("monitor_vendor")
+        self.source_label.setText(
+            f"Source: {self.source_name} · {len(self.frame)} retained rows · "
+            f"{len(self.frame.columns)} source columns"
+        )
+        self.last_result = None
+        self.export_result_button.setEnabled(False)
+        self.result_table.clear()
+        self.details.clear()
+        self._refresh_convention_evidence()
+
+    def _refresh_convention_evidence(self) -> None:
+        convention = self.convention_combo.currentData()
+        parameter_text = self.outcome_combo.currentText()
+        try:
+            parameter = ParameterId(parameter_text)
+        except ValueError:
+            parameter = ParameterId.CLUB_SPEED
+        definition = convention_registry().definition(convention, parameter)
+        reference = definition.reference_point.value.replace("_", " ")
+        event_time = definition.event_time.value.replace("_", " ")
+        self.convention_evidence.setText(
+            f"<b>{definition.label}</b>: {reference}, {event_time}. "
+            f"<a href='{definition.source_url}'>Source definition</a>"
+        )
+
+    def set_frame(
+        self, frame: pd.DataFrame, source_name: str = "In-Memory Data"
+    ) -> None:
+        """Replace all records without discarding any source columns."""
+
+        self.frame = frame.copy()
+        self.source_name = source_name
+        self._refresh_columns()
+
+    def load_demo(self) -> None:
+        self.set_frame(_demo_frame(), "Built-In Demonstration Data")
+
+    def import_path(self, path: Path) -> None:
+        suffix = path.suffix.lower()
+        if suffix == ".csv":
+            frame = pd.read_csv(path)
+        elif suffix == ".json":
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(payload, list) or any(
+                not isinstance(row, dict) for row in payload
+            ):
+                raise ValueError("JSON launch-monitor data must be an array of records")
+            frame = pd.DataFrame.from_records(payload)
+        else:
+            raise ValueError("Launch-monitor import supports CSV and JSON")
+        if len(frame) < 3 or len(numeric_columns(frame)) < 2:
+            raise ValueError(
+                "The file needs at least three rows and two numeric columns"
+            )
+        self.set_frame(frame, path.name)
+
+    def import_dialog(self) -> None:
+        selected, _ = QFileDialog.getOpenFileName(
+            self, "Import Launch Monitor Data", "", "Data Files (*.csv *.json)"
+        )
+        if not selected:
+            return
+        try:
+            self.import_path(Path(selected))
+        except (OSError, ValueError, json.JSONDecodeError) as error:
+            QMessageBox.critical(self, "Import Failed", str(error))
+
+    def _selected_predictors(self) -> tuple[str, ...]:
+        return tuple(item.text() for item in self.predictor_list.selectedItems())
+
+    def run_analysis(self) -> AnalysisResult:
+        group = self.group_combo.currentText()
+        result = analyze_launch_monitor_data(
+            self.frame,
+            AnalysisRequest(
+                outcome=self.outcome_combo.currentText(),
+                predictors=self._selected_predictors(),
+                analysis_mode=self.mode_combo.currentText(),
+                correlation_method=self.method_combo.currentText(),
+                missing_policy=self.missing_combo.currentText(),
+                group_by=None if group == "(none)" else group,
+                confidence_level=self.confidence_spin.value(),
+                min_samples=self.min_samples_spin.value(),
+            ),
+        )
+        rows: list[list[str]] = []
+        for item in result.correlations:
+            rows.append(
+                [
+                    item.predictor,
+                    "correlation",
+                    "—" if item.coefficient is None else f"{item.coefficient:.6g}",
+                    "—" if item.p_value is None else f"{item.p_value:.6g}",
+                    "—"
+                    if item.adjusted_p_value is None
+                    else f"{item.adjusted_p_value:.6g}",
+                    str(item.sample_count),
+                ]
+            )
+        if result.regression:
+            for name, item in result.regression.coefficients.items():
+                rows.append(
+                    [
+                        name,
+                        "OLS coefficient",
+                        f"{item.estimate:.6g}",
+                        f"{item.p_value:.6g}",
+                        f"[{item.ci_lower:.6g}, {item.ci_upper:.6g}]",
+                        str(result.regression.sample_count),
+                    ]
+                )
+        headers = ["Variable", "Statistic", "Estimate", "p", "Adjusted p / CI", "N"]
+        self.result_table.setColumnCount(len(headers))
+        self.result_table.setHorizontalHeaderLabels(headers)
+        self.result_table.setRowCount(len(rows))
+        for row_index, values in enumerate(rows):
+            for column_index, value in enumerate(values):
+                self.result_table.setItem(
+                    row_index, column_index, QTableWidgetItem(value)
+                )
+        self.result_table.resizeColumnsToContents()
+        self.details.setPlainText(
+            json.dumps(result.to_wire(), indent=2, sort_keys=True)
+        )
+        self.last_result = result
+        self.export_result_button.setEnabled(True)
+        return result
+
+    def run_analysis_safely(self) -> None:
+        try:
+            self.run_analysis()
+        except ValueError as error:
+            QMessageBox.warning(self, "Analysis Not Run", str(error))
+
+    def export_data_dialog(self) -> None:
+        selected, _ = QFileDialog.getSaveFileName(
+            self, "Export Retained Data", "launch-monitor-records.json", "JSON (*.json)"
+        )
+        if selected:
+            Path(selected).write_text(
+                self.frame.to_json(orient="records", indent=2), encoding="utf-8"
+            )
+
+    def export_result_dialog(self) -> None:
+        if self.last_result is None:
+            return
+        selected, _ = QFileDialog.getSaveFileName(
+            self,
+            "Export Launch Monitor Analysis",
+            "launch-monitor-analysis.json",
+            "JSON (*.json)",
+        )
+        if selected:
+            Path(selected).write_text(
+                json.dumps(self.last_result.to_wire(), indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+
+
+__all__ = ["LaunchMonitorAnalyticsTab"]

--- a/src/rate_of_closure/ui/pyqt6/launch_monitor_analytics_tab.py
+++ b/src/rate_of_closure/ui/pyqt6/launch_monitor_analytics_tab.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -28,8 +29,11 @@ from PyQt6.QtWidgets import (
 )
 
 from rate_of_closure.launch_monitor_analysis import (
+    AnalysisMode,
     AnalysisRequest,
     AnalysisResult,
+    CorrelationMethod,
+    MissingPolicy,
     analyze_launch_monitor_data,
     numeric_columns,
 )
@@ -308,37 +312,49 @@ class LaunchMonitorAnalyticsTab(QWidget):
             AnalysisRequest(
                 outcome=self.outcome_combo.currentText(),
                 predictors=self._selected_predictors(),
-                analysis_mode=self.mode_combo.currentText(),
-                correlation_method=self.method_combo.currentText(),
-                missing_policy=self.missing_combo.currentText(),
+                analysis_mode=cast(AnalysisMode, self.mode_combo.currentText()),
+                correlation_method=cast(
+                    CorrelationMethod, self.method_combo.currentText()
+                ),
+                missing_policy=cast(MissingPolicy, self.missing_combo.currentText()),
                 group_by=None if group == "(none)" else group,
                 confidence_level=self.confidence_spin.value(),
                 min_samples=self.min_samples_spin.value(),
             ),
         )
         rows: list[list[str]] = []
-        for item in result.correlations:
+        for correlation in result.correlations:
             rows.append(
                 [
-                    item.predictor,
+                    correlation.predictor,
                     "correlation",
-                    "—" if item.coefficient is None else f"{item.coefficient:.6g}",
-                    "—" if item.p_value is None else f"{item.p_value:.6g}",
-                    "—"
-                    if item.adjusted_p_value is None
-                    else f"{item.adjusted_p_value:.6g}",
-                    str(item.sample_count),
+                    (
+                        "—"
+                        if correlation.coefficient is None
+                        else f"{correlation.coefficient:.6g}"
+                    ),
+                    (
+                        "—"
+                        if correlation.p_value is None
+                        else f"{correlation.p_value:.6g}"
+                    ),
+                    (
+                        "—"
+                        if correlation.adjusted_p_value is None
+                        else f"{correlation.adjusted_p_value:.6g}"
+                    ),
+                    str(correlation.sample_count),
                 ]
             )
         if result.regression:
-            for name, item in result.regression.coefficients.items():
+            for name, coefficient in result.regression.coefficients.items():
                 rows.append(
                     [
                         name,
                         "OLS coefficient",
-                        f"{item.estimate:.6g}",
-                        f"{item.p_value:.6g}",
-                        f"[{item.ci_lower:.6g}, {item.ci_upper:.6g}]",
+                        f"{coefficient.estimate:.6g}",
+                        f"{coefficient.p_value:.6g}",
+                        (f"[{coefficient.ci_lower:.6g}, {coefficient.ci_upper:.6g}]"),
                         str(result.regression.sample_count),
                     ]
                 )

--- a/src/rate_of_closure/ui/pyqt6/main_window.py
+++ b/src/rate_of_closure/ui/pyqt6/main_window.py
@@ -55,6 +55,9 @@ from rate_of_closure.ui.pyqt6.controls_panel import ControlsPanel
 from rate_of_closure.ui.pyqt6.derivation_view import DerivationView
 from rate_of_closure.ui.pyqt6.flight_explorer_tab import FlightExplorerTab
 from rate_of_closure.ui.pyqt6.glossary_tab import GlossaryTab
+from rate_of_closure.ui.pyqt6.launch_monitor_analytics_tab import (
+    LaunchMonitorAnalyticsTab,
+)
 from rate_of_closure.ui.pyqt6.plots_tab import PlotsTab
 from rate_of_closure.ui.pyqt6.putting_tab import PuttingTab
 from rate_of_closure.ui.pyqt6.result_row import ResultRow as _ResultRow
@@ -131,6 +134,7 @@ _DEFAULT_TAB_IDS: tuple[str, ...] = (
     "calculation_description",
     "simulation",
     "flight_explorer",
+    "launch_monitor_analytics",
     "variation",
     "putting",
     "glossary",
@@ -186,6 +190,7 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
         self._simulation_tab = SimulationTab()
         self._simulation_tab.runCompleted.connect(self._plots_tab.set_run)
         self._flight_explorer_tab = FlightExplorerTab()
+        self._launch_monitor_analytics_tab = LaunchMonitorAnalyticsTab()
         self._variation_tab = VariationTab()
         # Variation -> course-view tie-in (#4125 H7b): a completed study
         # overlays its landing scatter on the flight top-down view, where
@@ -230,6 +235,11 @@ class RateOfClosureMainWindow(ThemedWindowMixin, QMainWindow):
             ),
             ("simulation", self._simulation_tab, "Simulation"),
             ("flight_explorer", self._flight_explorer_tab, "Flight Explorer"),
+            (
+                "launch_monitor_analytics",
+                self._launch_monitor_analytics_tab,
+                "Launch Monitor Analytics",
+            ),
             ("variation", self._variation_tab, "Variation"),
             ("putting", self._putting_tab, "Putting"),
             ("glossary", self._glossary_tab, "Glossary"),

--- a/src/rate_of_closure/web/src/App.tsx
+++ b/src/rate_of_closure/web/src/App.tsx
@@ -15,6 +15,7 @@ import { ClubCanvas } from "./components/ClubCanvas";
 import { DecimalInput } from "./components/DecimalInput";
 import { FieldInfo } from "./components/FieldInfo";
 import { FlightExplorerPanel } from "./components/FlightExplorerPanel";
+import { LaunchMonitorAnalyticsPanel } from "./components/LaunchMonitorAnalyticsPanel";
 import { PlotsPanel } from "./components/PlotsPanel";
 import { PuttingPanel } from "./components/PuttingPanel";
 import { PrimaryViewTabs } from "./components/PrimaryViewTabs";
@@ -307,6 +308,8 @@ export default function App() {
         <VariationPanel target={target} distanceUnit={units.distance} />
       ) : tab === "flight" ? (
         <FlightExplorerPanel distanceUnit={units.distance} />
+      ) : tab === "launch-monitor-analytics" ? (
+        <LaunchMonitorAnalyticsPanel />
       ) : tab === "plots" ? (
         // Static loft mirrors the desktop default driver (same note as
         // the Simulation tab; the full club picker joins with P7 WASM).

--- a/src/rate_of_closure/web/src/components/LaunchMonitorAnalyticsPanel.test.tsx
+++ b/src/rate_of_closure/web/src/components/LaunchMonitorAnalyticsPanel.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LaunchMonitorAnalyticsPanel } from "./LaunchMonitorAnalyticsPanel";
+
+describe("LaunchMonitorAnalyticsPanel", () => {
+  it("runs the demonstration analysis and displays lineage", () => {
+    render(<LaunchMonitorAnalyticsPanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Run Analysis" }));
+
+    expect(screen.getByText("Correlations and Multiplicity Control")).toBeInTheDocument();
+    expect(screen.getByText("OLS Coefficients")).toBeInTheDocument();
+    expect(screen.getByText(/SHA-256:/)).toHaveTextContent(/[a-f0-9]{64}/);
+    expect(screen.getByText(/TrackMan-Comparable/, { selector: "option" })).toBeInTheDocument();
+  });
+
+  it("exposes arbitrary numeric variables and an explicit grouping selector", () => {
+    render(<LaunchMonitorAnalyticsPanel />);
+    expect(screen.getAllByRole("option", { name: "carry_distance" }).length).toBeGreaterThan(0);
+    expect(screen.getByTitle("Optionally compute separate results for each group"))
+      .toHaveValue("monitor_vendor");
+    expect(screen.getByLabelText("Predictor Variables")).toHaveAttribute("multiple");
+  });
+});

--- a/src/rate_of_closure/web/src/components/LaunchMonitorAnalyticsPanel.tsx
+++ b/src/rate_of_closure/web/src/components/LaunchMonitorAnalyticsPanel.tsx
@@ -1,0 +1,283 @@
+import { useMemo, useRef, useState } from "react";
+
+import {
+  analyzeLaunchMonitorData,
+  numericLaunchMonitorColumns,
+  parseLaunchMonitorFile,
+  type AnalysisMode,
+  type CorrelationMethod,
+  type LaunchMonitorAnalysisResult,
+  type LaunchMonitorRow,
+  type MissingPolicy,
+} from "../model/launchMonitorAnalysis";
+import {
+  conventionRegistry,
+  PARAMETER_IDS,
+  type ConventionId,
+  type ParameterId,
+} from "../model/launchMonitorConventions";
+
+const DEMO_ROWS: LaunchMonitorRow[] = Array.from({ length: 120 }, (_, index) => {
+  const clubSpeed = 38 + index * 0.11;
+  const attackAngle = -4 + (index % 17) * 0.4;
+  const clubPath = -3 + (index % 13) * 0.5;
+  const faceAngle = clubPath * 0.65 + Math.sin(index * 0.7) * 0.8;
+  const ballSpeed = clubSpeed * 1.46 + attackAngle * 0.08 + Math.sin(index) * 0.25;
+  return {
+    shot_id: `demo-${index + 1}`,
+    session_id: index < 60 ? "demo-a" : "demo-b",
+    monitor_vendor: index % 2 ? "FlightScope" : "TrackMan",
+    observation_kind: "shot",
+    club_speed: clubSpeed,
+    attack_angle: attackAngle,
+    club_path: clubPath,
+    face_angle: faceAngle,
+    ball_speed: ballSpeed,
+    carry_distance: ballSpeed * 3.25 + attackAngle * 0.9,
+  };
+});
+
+const card = "rounded-xl border border-slate-800/80 bg-slate-900/60 p-4 shadow-lg shadow-black/20";
+const field = "w-full rounded border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-slate-100 focus:border-sky-400 focus:outline-none";
+
+const finiteText = (value: number | null | undefined, digits = 4) =>
+  value === null || value === undefined || !Number.isFinite(value) ? "—" : value.toFixed(digits);
+
+const conventionLabel = (id: ConventionId) => ({
+  app_native: "App-Native",
+  trackman_comparable: "TrackMan-Comparable",
+  foresight_comparable: "Foresight-Comparable",
+}[id]);
+
+function download(name: string, payload: unknown) {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = name;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function ScatterPlot({ rows, outcome, predictor }: {
+  rows: LaunchMonitorRow[]; outcome: string; predictor: string;
+}) {
+  const pairs = rows.map((row) => [Number(row[predictor]), Number(row[outcome])])
+    .filter(([x, y]) => Number.isFinite(x) && Number.isFinite(y));
+  if (pairs.length < 2) return <p className="text-sm text-slate-500">Select two populated variables.</p>;
+  const xs = pairs.map(([x]) => x);
+  const ys = pairs.map(([, y]) => y);
+  const xMin = Math.min(...xs); const xMax = Math.max(...xs);
+  const yMin = Math.min(...ys); const yMax = Math.max(...ys);
+  const scale = (value: number, low: number, high: number, start: number, span: number) =>
+    start + (value - low) / Math.max(Number.EPSILON, high - low) * span;
+  return (
+    <svg viewBox="0 0 640 250" role="img" aria-label={`${outcome} versus ${predictor} scatter plot`}
+      className="h-64 w-full rounded-lg border border-slate-800 bg-slate-950">
+      <line x1="52" y1="215" x2="620" y2="215" stroke="#475569" />
+      <line x1="52" y1="18" x2="52" y2="215" stroke="#475569" />
+      {pairs.map(([x, y], index) => (
+        <circle key={index} cx={scale(x, xMin, xMax, 52, 568)}
+          cy={215 - scale(y, yMin, yMax, 0, 197)} r="3" fill="#38bdf8" opacity="0.72" />
+      ))}
+      <text x="336" y="242" textAnchor="middle" fill="#94a3b8" fontSize="12">{predictor}</text>
+      <text x="15" y="116" textAnchor="middle" fill="#94a3b8" fontSize="12"
+        transform="rotate(-90 15 116)">{outcome}</text>
+    </svg>
+  );
+}
+
+export function LaunchMonitorAnalyticsPanel() {
+  const [rows, setRows] = useState<LaunchMonitorRow[]>(DEMO_ROWS);
+  const [sourceName, setSourceName] = useState("Built-In Demonstration Data");
+  const [outcome, setOutcome] = useState("ball_speed");
+  const [predictors, setPredictors] = useState<string[]>(["club_speed", "attack_angle"]);
+  const [mode, setMode] = useState<AnalysisMode>("comprehensive");
+  const [method, setMethod] = useState<CorrelationMethod>("pearson");
+  const [missing, setMissing] = useState<MissingPolicy>("pairwise");
+  const [groupBy, setGroupBy] = useState("monitor_vendor");
+  const [confidence, setConfidence] = useState(0.95);
+  const [minSamples, setMinSamples] = useState(10);
+  const [convention, setConvention] = useState<ConventionId>("app_native");
+  const [result, setResult] = useState<LaunchMonitorAnalysisResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const input = useRef<HTMLInputElement>(null);
+  const numeric = useMemo(() => numericLaunchMonitorColumns(rows), [rows]);
+  const grouping = useMemo(() => {
+    const columns = new Set(rows.flatMap((row) => Object.keys(row)));
+    return [...columns].filter((column) => new Set(rows.map((row) => row[column])).size <= 100).sort();
+  }, [rows]);
+  const parameter = PARAMETER_IDS.includes(outcome as ParameterId) ? outcome as ParameterId : "club_speed";
+  const definition = conventionRegistry().definition(convention, parameter);
+
+  const run = () => {
+    try {
+      setResult(analyzeLaunchMonitorData(rows, {
+        outcome, predictors, analysisMode: mode, correlationMethod: method,
+        missingPolicy: missing, groupBy: groupBy || undefined,
+        confidenceLevel: confidence, minSamples,
+      }));
+      setError(null);
+    } catch (caught) {
+      setResult(null);
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const loadFile = async (file: File) => {
+    try {
+      const next = parseLaunchMonitorFile(file.name, await file.text());
+      const nextNumeric = numericLaunchMonitorColumns(next);
+      if (nextNumeric.length < 2) throw new RangeError("The file needs at least two numeric columns with three values each.");
+      setRows(next);
+      setSourceName(file.name);
+      setOutcome(nextNumeric[0]);
+      setPredictors([nextNumeric[1]]);
+      setResult(null);
+      setError(null);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  return (
+    <section aria-label="Launch Monitor Analytics" className="space-y-5">
+      <div className={card}>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-sky-200">Launch Monitor Analytics</h2>
+            <p className="mt-1 max-w-3xl text-sm text-slate-400">
+              Import CSV or JSON records without dropping source columns, then correlate, regress,
+              stratify, diagnose, and export any compatible numeric variables. Associations and fitted
+              models are not causal evidence.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <input ref={input} type="file" accept=".csv,.json,text/csv,application/json"
+              className="hidden" aria-label="Launch monitor CSV or JSON file"
+              onChange={(event) => { const file = event.target.files?.[0]; if (file) void loadFile(file); }} />
+            <button type="button" title="Import a local CSV or JSON launch-monitor export"
+              onClick={() => input.current?.click()}
+              className="rounded-lg bg-sky-600 px-4 py-2 text-sm font-semibold hover:bg-sky-500">Import Data</button>
+            <button type="button" title="Restore the built-in non-vendor demonstration dataset"
+              onClick={() => { setRows(DEMO_ROWS); setSourceName("Built-In Demonstration Data"); setResult(null); }}
+              className="rounded-lg border border-slate-700 px-4 py-2 text-sm hover:bg-slate-800">Load Demo</button>
+          </div>
+        </div>
+        <p className="mt-3 text-xs text-slate-500">Source: {sourceName} · {rows.length} retained rows · {Object.keys(rows[0] ?? {}).length} source columns</p>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-[340px_1fr]">
+        <div className={`${card} space-y-4`}>
+          <h3 className="font-semibold text-slate-200">Analysis Contract</h3>
+          <label className="block text-sm text-slate-300">Interpretation Convention
+            <select value={convention} title="Choose the documented parameter convention used to interpret canonical names"
+              onChange={(event) => setConvention(event.target.value as ConventionId)} className={`${field} mt-1`}>
+              {(["app_native", "trackman_comparable", "foresight_comparable"] as ConventionId[])
+                .map((id) => <option key={id} value={id}>{conventionLabel(id)}</option>)}
+            </select>
+          </label>
+          <div className="rounded-lg border border-amber-500/30 bg-amber-950/20 p-3 text-xs text-amber-100">
+            <strong>{conventionLabel(convention)}</strong> is a documented comparability frame, not
+            device emulation or certification. {definition.label}: {definition.referencePoint.replace(/_/g, " ")}, {definition.eventTime.replace(/_/g, " ")}.
+            {" "}<a className="underline" href={definition.sourceUrl} target="_blank" rel="noreferrer">Source definition</a>
+          </div>
+          <label className="block text-sm text-slate-300">Outcome
+            <select value={outcome} title="Select the numeric outcome variable"
+              onChange={(event) => setOutcome(event.target.value)} className={`${field} mt-1`}>
+              {numeric.map((column) => <option key={column}>{column}</option>)}
+            </select>
+          </label>
+          <label className="block text-sm text-slate-300">Predictors
+            <select multiple value={predictors} title="Select one or more numeric predictor variables"
+              aria-label="Predictor Variables" onChange={(event) => setPredictors(
+                [...event.currentTarget.selectedOptions].map((option) => option.value),
+              )} className={`${field} mt-1 min-h-36`}>
+              {numeric.filter((column) => column !== outcome).map((column) => <option key={column}>{column}</option>)}
+            </select>
+          </label>
+          <div className="grid grid-cols-2 gap-3">
+            <label className="text-sm text-slate-300">Mode
+              <select value={mode} title="Choose correlation, regression, or both"
+                onChange={(event) => setMode(event.target.value as AnalysisMode)} className={`${field} mt-1`}>
+                <option value="comprehensive">Comprehensive</option><option value="correlation">Correlation</option><option value="regression">Regression</option>
+              </select>
+            </label>
+            <label className="text-sm text-slate-300">Correlation
+              <select value={method} title="Choose the correlation estimator"
+                onChange={(event) => setMethod(event.target.value as CorrelationMethod)} className={`${field} mt-1`}>
+                <option value="pearson">Pearson</option><option value="spearman">Spearman</option><option value="kendall">Kendall</option>
+              </select>
+            </label>
+            <label className="text-sm text-slate-300">Missing Data
+              <select value={missing} title="Choose how missing numeric values are handled"
+                onChange={(event) => setMissing(event.target.value as MissingPolicy)} className={`${field} mt-1`}>
+                <option value="pairwise">Pairwise</option><option value="listwise">Listwise</option><option value="fail">Fail Closed</option>
+              </select>
+            </label>
+            <label className="text-sm text-slate-300">Group By
+              <select value={groupBy} title="Optionally compute separate results for each group"
+                onChange={(event) => setGroupBy(event.target.value)} className={`${field} mt-1`}>
+                <option value="">No Grouping</option>{grouping.map((column) => <option key={column}>{column}</option>)}
+              </select>
+            </label>
+            <label className="text-sm text-slate-300">Confidence
+              <input type="number" min="0.51" max="0.999" step="0.01" value={confidence}
+                title="Set the confidence level for analytical intervals" aria-label="Confidence Level"
+                onChange={(event) => setConfidence(Number(event.target.value))} className={`${field} mt-1`} />
+            </label>
+            <label className="text-sm text-slate-300">Minimum N
+              <input type="number" min="3" step="1" value={minSamples}
+                title="Set the minimum observations per analysis" aria-label="Minimum Sample Count"
+                onChange={(event) => setMinSamples(Number(event.target.value))} className={`${field} mt-1`} />
+            </label>
+          </div>
+          <button type="button" onClick={run} title="Run the selected traceable statistical analysis"
+            className="w-full rounded-lg bg-emerald-600 px-4 py-3 font-semibold hover:bg-emerald-500">Run Analysis</button>
+          {error && <p role="alert" className="rounded border border-red-500/40 bg-red-950/30 p-3 text-sm text-red-200">{error}</p>}
+        </div>
+
+        <div className="space-y-5">
+          <div className={card}>
+            <h3 className="mb-3 font-semibold text-slate-200">Selected Relationship</h3>
+            <ScatterPlot rows={rows} outcome={outcome} predictor={predictors[0] ?? ""} />
+          </div>
+          {!result ? (
+            <div className={`${card} text-center text-slate-500`}>Run the analysis to populate uncertainty, diagnostics, grouping, and lineage.</div>
+          ) : (
+            <>
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <div className={card}><p className="text-xs uppercase text-slate-500">Rows / Complete</p><p className="text-2xl font-semibold">{result.dataset.rowCount} / {result.dataset.completeRowCount}</p></div>
+                <div className={card}><p className="text-xs uppercase text-slate-500">R² / Adjusted</p><p className="text-2xl font-semibold">{finiteText(result.regression?.rSquared)} / {finiteText(result.regression?.adjustedRSquared)}</p></div>
+                <div className={card}><p className="text-xs uppercase text-slate-500">RMSE / MAE</p><p className="text-2xl font-semibold">{finiteText(result.regression?.residualDiagnostics.rmse)} / {finiteText(result.regression?.residualDiagnostics.mae)}</p></div>
+                <div className={card}><p className="text-xs uppercase text-slate-500">Groups</p><p className="text-2xl font-semibold">{result.groups.length || "—"}</p></div>
+              </div>
+              <div className={`${card} overflow-x-auto`}>
+                <h3 className="mb-3 font-semibold text-slate-200">Correlations and Multiplicity Control</h3>
+                <table className="w-full text-left text-sm"><thead className="text-slate-400"><tr><th>Predictor</th><th>r / τ</th><th>p</th><th>BH q</th><th>Confidence Interval</th><th>N</th></tr></thead>
+                  <tbody>{result.correlations.map((item) => <tr key={item.predictor} className="border-t border-slate-800"><td className="py-2">{item.predictor}</td><td>{finiteText(item.coefficient)}</td><td>{finiteText(item.pValue)}</td><td>{finiteText(item.adjustedPValue)}</td><td>[{finiteText(item.ciLower)}, {finiteText(item.ciUpper)}]</td><td>{item.sampleCount}</td></tr>)}</tbody></table>
+              </div>
+              {result.regression && <div className={`${card} overflow-x-auto`}>
+                <h3 className="mb-3 font-semibold text-slate-200">OLS Coefficients</h3>
+                <table className="w-full text-left text-sm"><thead className="text-slate-400"><tr><th>Term</th><th>Estimate</th><th>SE</th><th>t</th><th>p</th><th>Confidence Interval</th></tr></thead>
+                  <tbody>{Object.entries(result.regression.coefficients).map(([name, item]) => <tr key={name} className="border-t border-slate-800"><td className="py-2">{name}</td><td>{finiteText(item.estimate)}</td><td>{finiteText(item.standardError)}</td><td>{finiteText(item.tStatistic)}</td><td>{finiteText(item.pValue)}</td><td>[{finiteText(item.ciLower)}, {finiteText(item.ciUpper)}]</td></tr>)}</tbody></table>
+              </div>}
+              <div className={card}>
+                <h3 className="font-semibold text-slate-200">Traceability</h3>
+                <p className="mt-2 break-all font-mono text-xs text-slate-400">SHA-256: {result.dataset.fingerprintSha256}</p>
+                <p className="mt-2 text-sm text-slate-400">Monitors: {result.dataset.monitorVendors.join(", ") || "unrecorded"} · Sessions: {result.dataset.sessionIds.join(", ") || "unrecorded"} · Contract: {result.contractVersion}</p>
+                {result.warnings.map((warning) => <p key={warning} className="mt-2 text-sm text-amber-200">{warning}</p>)}
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button type="button" title="Download every retained input record as JSON"
+                    onClick={() => download("launch-monitor-records.json", rows)} className="rounded border border-slate-700 px-3 py-2 text-sm hover:bg-slate-800">Export Retained Data</button>
+                  <button type="button" title="Download the complete request, statistics, warnings, and lineage as JSON"
+                    onClick={() => download("launch-monitor-analysis.json", result)} className="rounded border border-slate-700 px-3 py-2 text-sm hover:bg-slate-800">Export Analysis</button>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/rate_of_closure/web/src/components/PrimaryViewTabs.test.tsx
+++ b/src/rate_of_closure/web/src/components/PrimaryViewTabs.test.tsx
@@ -43,6 +43,7 @@ describe("PrimaryViewTabs", () => {
       "calculation",
       "plots",
       "flight",
+      "launch-monitor-analytics",
       "variation",
       "putting",
       "glossary",

--- a/src/rate_of_closure/web/src/components/hoverHints.test.tsx
+++ b/src/rate_of_closure/web/src/components/hoverHints.test.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_TARGET } from "../model/targets";
 import { Derivation } from "./Derivation";
 import { FlightExplorerPanel } from "./FlightExplorerPanel";
 import { GlossaryPanel } from "./GlossaryPanel";
+import { LaunchMonitorAnalyticsPanel } from "./LaunchMonitorAnalyticsPanel";
 import { PlotsPanel } from "./PlotsPanel";
 import { PuttingPanel } from "./PuttingPanel";
 import { SimulationPanel } from "./SimulationPanel";
@@ -82,6 +83,11 @@ describe("hover-hint completeness", () => {
   it("VariationPanel", () => {
     const { container } = render(<VariationPanel />);
     assertHints(container, "VariationPanel");
+  });
+
+  it("LaunchMonitorAnalyticsPanel", () => {
+    const { container } = render(<LaunchMonitorAnalyticsPanel />);
+    assertHints(container, "LaunchMonitorAnalyticsPanel");
   });
 
   it("PlotsPanel", () => {

--- a/src/rate_of_closure/web/src/model/helptext.test.ts
+++ b/src/rate_of_closure/web/src/model/helptext.test.ts
@@ -15,6 +15,7 @@ const TABS = [
   "Simulation",
   "Plots",
   "Flight Explorer",
+  "Launch Monitor Analytics",
   "Variation",
   "Putting",
   "Glossary",

--- a/src/rate_of_closure/web/src/model/helptext.ts
+++ b/src/rate_of_closure/web/src/model/helptext.ts
@@ -104,6 +104,13 @@ export const HELP_TEXTS: Record<string, HelpEntry> = {
         "range and source.",
     ],
   },
+  "Launch Monitor Analytics": {
+    title: "How to Use This Page",
+    paragraphs: [
+      "Import a local CSV or JSON launch-monitor export, or begin with the built-in demonstration data. Every source column stays available. Select any compatible numeric outcome and one or more predictors, choose Pearson, Spearman, or Kendall association, and optionally fit multivariable ordinary least squares. Missing-data behavior, confidence level, minimum sample count, and grouping are explicit controls rather than hidden defaults.",
+      "Results include pair-specific sample counts, multiplicity-adjusted p-values, confidence intervals, OLS coefficient uncertainty, residual diagnostics, grouped estimates, and a deterministic dataset fingerprint. TrackMan-Comparable and Foresight-Comparable labels describe documented interpretation frames only; they do not claim device emulation or certification. Export both retained records and the complete analysis evidence as JSON.",
+    ],
+  },
   Variation: {
     title: "How to Use This Page",
     paragraphs: [

--- a/src/rate_of_closure/web/src/model/launchMonitorAnalysis.test.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorAnalysis.test.ts
@@ -7,23 +7,24 @@ import {
   type LaunchMonitorRow,
 } from "./launchMonitorAnalysis";
 
-const rows = (): LaunchMonitorRow[] => Array.from({ length: 80 }, (_, index) => {
-  const clubSpeed = 35 + index * 0.2;
-  const attackAngle = -3 + (index % 8) * 0.5;
-  return {
-    shot_id: `shot-${index}`,
-    session_id: index < 40 ? "a" : "b",
-    monitor_vendor: index % 2 ? "FlightScope" : "TrackMan",
-    club_speed: clubSpeed,
-    attack_angle: attackAngle,
-    ball_speed: 1.48 * clubSpeed + 0.04 * attackAngle,
-  };
-});
+const rows = (): LaunchMonitorRow[] =>
+  Array.from({ length: 80 }, (_, index) => {
+    const clubSpeed = 35 + index * 0.2;
+    const attackAngle = -3 + (index % 8) * 0.5;
+    return {
+      shot_id: `shot-${index}`,
+      session_id: index < 40 ? "a" : "b",
+      monitor_vendor: index % 2 ? "FlightScope" : "TrackMan",
+      club_speed: clubSpeed,
+      attack_angle: attackAngle,
+      ball_speed: 1.48 * clubSpeed + 0.04 * attackAngle,
+    };
+  });
 
 describe("launch monitor flexible analysis", () => {
   it("uses standards-conformant SHA-256 fingerprints", () => {
     expect(sha256Text("abc")).toBe(
-      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad", // pragma: allowlist secret
     );
   });
 
@@ -43,8 +44,13 @@ describe("launch monitor flexible analysis", () => {
     expect(result.dataset.monitorVendors).toEqual(["FlightScope", "TrackMan"]);
     expect(result.dataset.fingerprintSha256).toMatch(/^[a-f0-9]{64}$/);
     expect(result.regression?.rSquared).toBeGreaterThan(0.999);
-    expect(result.regression?.coefficients.club_speed.estimate).toBeCloseTo(1.48, 8);
-    expect(result.correlations.every((item) => item.sampleCount === 80)).toBe(true);
+    expect(result.regression?.coefficients.club_speed.estimate).toBeCloseTo(
+      1.48,
+      8,
+    );
+    expect(result.correlations.every((item) => item.sampleCount === 80)).toBe(
+      true,
+    );
   });
 
   it("keeps pairwise counts and grouped results explicit", () => {
@@ -62,35 +68,63 @@ describe("launch monitor flexible analysis", () => {
       minSamples: 10,
     });
 
-    expect(Object.fromEntries(result.correlations.map((item) => [item.predictor, item.sampleCount])))
-      .toEqual({ club_speed: 79, attack_angle: 79 });
-    expect(result.groups.map((group) => group.groupValue)).toEqual(["FlightScope", "TrackMan"]);
+    expect(
+      Object.fromEntries(
+        result.correlations.map((item) => [item.predictor, item.sampleCount]),
+      ),
+    ).toEqual({ club_speed: 79, attack_angle: 79 });
+    expect(result.groups.map((group) => group.groupValue)).toEqual([
+      "FlightScope",
+      "TrackMan",
+    ]);
   });
 
   it("blocks aggregate regression and pooled vendor-specific source fields", () => {
-    expect(() => analyzeLaunchMonitorData(rows().map((row) => ({
-      ...row, observation_kind: "aggregate",
-    })), {
-      outcome: "ball_speed", predictors: ["club_speed"], analysisMode: "regression",
-      correlationMethod: "pearson", missingPolicy: "listwise", confidenceLevel: 0.95,
-      minSamples: 10, allowAggregate: true,
-    })).toThrow(/Aggregate observations cannot enter regression/);
+    expect(() =>
+      analyzeLaunchMonitorData(
+        rows().map((row) => ({
+          ...row,
+          observation_kind: "aggregate",
+        })),
+        {
+          outcome: "ball_speed",
+          predictors: ["club_speed"],
+          analysisMode: "regression",
+          correlationMethod: "pearson",
+          missingPolicy: "listwise",
+          confidenceLevel: 0.95,
+          minSamples: 10,
+          allowAggregate: true,
+        },
+      ),
+    ).toThrow(/Aggregate observations cannot enter regression/);
 
-    expect(() => analyzeLaunchMonitorData(rows().map((row, index) => ({
-      ...row, "source::temperature": 20 + index * 0.01,
-    })), {
-      outcome: "ball_speed", predictors: ["source::temperature"], analysisMode: "correlation",
-      correlationMethod: "pearson", missingPolicy: "pairwise", confidenceLevel: 0.95,
-      minSamples: 10,
-    })).toThrow(/source fields.*multiple monitors/);
+    expect(() =>
+      analyzeLaunchMonitorData(
+        rows().map((row, index) => ({
+          ...row,
+          "source::temperature": 20 + index * 0.01,
+        })),
+        {
+          outcome: "ball_speed",
+          predictors: ["source::temperature"],
+          analysisMode: "correlation",
+          correlationMethod: "pearson",
+          missingPolicy: "pairwise",
+          confidenceLevel: 0.95,
+          minSamples: 10,
+        },
+      ),
+    ).toThrow(/source fields.*multiple monitors/);
   });
 
   it("parses quoted CSV and JSON without dropping source columns", () => {
-    const csv = "Shot,Vendor,Comment,Speed\r\n1,TrackMan,\"wind, left\",70\r\n";
+    const csv = 'Shot,Vendor,Comment,Speed\r\n1,TrackMan,"wind, left",70\r\n';
     expect(parseLaunchMonitorFile("shots.csv", csv)).toEqual([
       { Shot: 1, Vendor: "TrackMan", Comment: "wind, left", Speed: 70 },
     ]);
-    expect(parseLaunchMonitorFile("shots.json", JSON.stringify([{ custom: 4.2 }])))
-      .toEqual([{ custom: 4.2 }]);
+    expect(
+      parseLaunchMonitorFile("shots.json", JSON.stringify([{ custom: 4.2 }])),
+    ).toEqual([{ custom: 4.2 }]);
   });
 });

--- a/src/rate_of_closure/web/src/model/launchMonitorAnalysis.test.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorAnalysis.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  analyzeLaunchMonitorData,
+  parseLaunchMonitorFile,
+  sha256Text,
+  type LaunchMonitorRow,
+} from "./launchMonitorAnalysis";
+
+const rows = (): LaunchMonitorRow[] => Array.from({ length: 80 }, (_, index) => {
+  const clubSpeed = 35 + index * 0.2;
+  const attackAngle = -3 + (index % 8) * 0.5;
+  return {
+    shot_id: `shot-${index}`,
+    session_id: index < 40 ? "a" : "b",
+    monitor_vendor: index % 2 ? "FlightScope" : "TrackMan",
+    club_speed: clubSpeed,
+    attack_angle: attackAngle,
+    ball_speed: 1.48 * clubSpeed + 0.04 * attackAngle,
+  };
+});
+
+describe("launch monitor flexible analysis", () => {
+  it("uses standards-conformant SHA-256 fingerprints", () => {
+    expect(sha256Text("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+
+  it("reports traceable correlation and multivariable OLS results", () => {
+    const result = analyzeLaunchMonitorData(rows(), {
+      outcome: "ball_speed",
+      predictors: ["club_speed", "attack_angle"],
+      analysisMode: "comprehensive",
+      correlationMethod: "pearson",
+      missingPolicy: "pairwise",
+      confidenceLevel: 0.95,
+      minSamples: 10,
+    });
+
+    expect(result.contractVersion).toBe("1.0.0");
+    expect(result.dataset.rowCount).toBe(80);
+    expect(result.dataset.monitorVendors).toEqual(["FlightScope", "TrackMan"]);
+    expect(result.dataset.fingerprintSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.regression?.rSquared).toBeGreaterThan(0.999);
+    expect(result.regression?.coefficients.club_speed.estimate).toBeCloseTo(1.48, 8);
+    expect(result.correlations.every((item) => item.sampleCount === 80)).toBe(true);
+  });
+
+  it("keeps pairwise counts and grouped results explicit", () => {
+    const data = rows();
+    data[0].attack_angle = null;
+    data[1].club_speed = null;
+    const result = analyzeLaunchMonitorData(data, {
+      outcome: "ball_speed",
+      predictors: ["club_speed", "attack_angle"],
+      analysisMode: "correlation",
+      correlationMethod: "spearman",
+      missingPolicy: "pairwise",
+      groupBy: "monitor_vendor",
+      confidenceLevel: 0.95,
+      minSamples: 10,
+    });
+
+    expect(Object.fromEntries(result.correlations.map((item) => [item.predictor, item.sampleCount])))
+      .toEqual({ club_speed: 79, attack_angle: 79 });
+    expect(result.groups.map((group) => group.groupValue)).toEqual(["FlightScope", "TrackMan"]);
+  });
+
+  it("blocks aggregate regression and pooled vendor-specific source fields", () => {
+    expect(() => analyzeLaunchMonitorData(rows().map((row) => ({
+      ...row, observation_kind: "aggregate",
+    })), {
+      outcome: "ball_speed", predictors: ["club_speed"], analysisMode: "regression",
+      correlationMethod: "pearson", missingPolicy: "listwise", confidenceLevel: 0.95,
+      minSamples: 10, allowAggregate: true,
+    })).toThrow(/Aggregate observations cannot enter regression/);
+
+    expect(() => analyzeLaunchMonitorData(rows().map((row, index) => ({
+      ...row, "source::temperature": 20 + index * 0.01,
+    })), {
+      outcome: "ball_speed", predictors: ["source::temperature"], analysisMode: "correlation",
+      correlationMethod: "pearson", missingPolicy: "pairwise", confidenceLevel: 0.95,
+      minSamples: 10,
+    })).toThrow(/source fields.*multiple monitors/);
+  });
+
+  it("parses quoted CSV and JSON without dropping source columns", () => {
+    const csv = "Shot,Vendor,Comment,Speed\r\n1,TrackMan,\"wind, left\",70\r\n";
+    expect(parseLaunchMonitorFile("shots.csv", csv)).toEqual([
+      { Shot: 1, Vendor: "TrackMan", Comment: "wind, left", Speed: 70 },
+    ]);
+    expect(parseLaunchMonitorFile("shots.json", JSON.stringify([{ custom: 4.2 }])))
+      .toEqual([{ custom: 4.2 }]);
+  });
+});

--- a/src/rate_of_closure/web/src/model/launchMonitorAnalysis.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorAnalysis.ts
@@ -1,452 +1,77 @@
 /** UI-neutral, provenance-preserving launch-monitor statistical analysis. */
 
-export const LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION = "1.0.0" as const;
+import { canonicalFingerprint, uniqueStrings } from "./launchMonitorFingerprint";
+import { calculateCorrelations, calculateRegression } from "./launchMonitorAnalysisStatistics";
+import {
+  finiteLaunchMonitorScalar,
+  LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION,
+  type GroupAnalysis,
+  type LaunchMonitorAnalysisRequest,
+  type LaunchMonitorAnalysisResult,
+  type LaunchMonitorRow,
+} from "./launchMonitorAnalysisTypes";
 
-export type LaunchMonitorScalar = string | number | boolean | null;
-export type LaunchMonitorRow = Record<string, LaunchMonitorScalar>;
-export type AnalysisMode = "correlation" | "regression" | "comprehensive";
-export type CorrelationMethod = "pearson" | "spearman" | "kendall";
-export type MissingPolicy = "pairwise" | "listwise" | "fail";
-
-export interface LaunchMonitorAnalysisRequest {
-  outcome: string;
-  predictors: string[];
-  analysisMode: AnalysisMode;
-  correlationMethod: CorrelationMethod;
-  missingPolicy: MissingPolicy;
-  groupBy?: string;
-  confidenceLevel: number;
-  minSamples: number;
-  allowAggregate?: boolean;
-}
-
-export interface CorrelationEstimate {
-  predictor: string;
-  coefficient: number | null;
-  pValue: number | null;
-  adjustedPValue: number | null;
-  ciLower: number | null;
-  ciUpper: number | null;
-  sampleCount: number;
-  method: CorrelationMethod;
-}
-
-export interface CoefficientEstimate {
-  estimate: number;
-  standardError: number;
-  tStatistic: number;
-  pValue: number;
-  ciLower: number;
-  ciUpper: number;
-}
-
-export interface RegressionEstimate {
-  sampleCount: number;
-  rSquared: number;
-  adjustedRSquared: number;
-  coefficients: Record<string, CoefficientEstimate>;
-  residualDiagnostics: {
-    rmse: number;
-    mae: number;
-    residualMean: number;
-    residualStd: number;
-    durbinWatson: number | null;
-    influentialCount: number;
-  };
-}
-
-export interface GroupAnalysis {
-  groupValue: string;
-  rowCount: number;
-  correlations: CorrelationEstimate[];
-  regression: RegressionEstimate | null;
-  warnings: string[];
-}
-
-export interface LaunchMonitorAnalysisResult {
-  contractVersion: typeof LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION;
-  request: LaunchMonitorAnalysisRequest;
-  dataset: {
-    rowCount: number;
-    completeRowCount: number;
-    selectedColumns: string[];
-    monitorVendors: string[];
-    sessionIds: string[];
-    observationKinds: string[];
-    fingerprintSha256: string;
-  };
-  correlations: CorrelationEstimate[];
-  regression: RegressionEstimate | null;
-  groups: GroupAnalysis[];
-  warnings: string[];
-}
-
-const finite = (value: LaunchMonitorScalar | undefined): number | null => {
-  if (value === null || value === undefined || value === "" || typeof value === "boolean") return null;
-  const converted = typeof value === "number" ? value : Number(value);
-  return Number.isFinite(converted) ? converted : null;
-};
+export { parseLaunchMonitorFile } from "./launchMonitorFileParsing";
+export { sha256Text } from "./launchMonitorFingerprint";
+export { LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION } from "./launchMonitorAnalysisTypes";
+export type {
+  AnalysisMode,
+  CoefficientEstimate,
+  CorrelationEstimate,
+  CorrelationMethod,
+  GroupAnalysis,
+  LaunchMonitorAnalysisRequest,
+  LaunchMonitorAnalysisResult,
+  LaunchMonitorRow,
+  LaunchMonitorScalar,
+  MissingPolicy,
+  RegressionEstimate,
+} from "./launchMonitorAnalysisTypes";
 
 export function numericLaunchMonitorColumns(rows: LaunchMonitorRow[]): string[] {
   const columns = new Set(rows.flatMap((row) => Object.keys(row)));
-  return [...columns].filter((column) =>
-    rows.reduce((count, row) => count + (finite(row[column]) === null ? 0 : 1), 0) >= 3,
-  ).sort();
+  return [...columns].filter((column) => rows.reduce(
+    (count, row) => count + (finiteLaunchMonitorScalar(row[column]) === null ? 0 : 1), 0,
+  ) >= 3).sort();
 }
-
-const mean = (values: number[]) => values.reduce((sum, value) => sum + value, 0) / values.length;
-
-const variance = (values: number[], degrees = 1): number => {
-  const center = mean(values);
-  return values.reduce((sum, value) => sum + (value - center) ** 2, 0) /
-    Math.max(1, values.length - degrees);
-};
-
-const erf = (value: number): number => {
-  const sign = value < 0 ? -1 : 1;
-  const x = Math.abs(value);
-  const t = 1 / (1 + 0.3275911 * x);
-  const polynomial = (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t -
-    0.284496736) * t + 0.254829592) * t;
-  return sign * (1 - polynomial * Math.exp(-(x ** 2)));
-};
-
-const normalCdf = (value: number) => 0.5 * (1 + erf(value / Math.sqrt(2)));
-
-const logGamma = (value: number): number => {
-  const coefficients = [
-    676.5203681218851, -1259.1392167224028, 771.3234287776531,
-    -176.6150291621406, 12.507343278686905, -0.13857109526572012,
-    9.984369578019572e-6, 1.5056327351493116e-7,
-  ];
-  if (value < 0.5) return Math.log(Math.PI) - Math.log(Math.sin(Math.PI * value)) - logGamma(1 - value);
-  let x = 0.9999999999998099;
-  const shifted = value - 1;
-  coefficients.forEach((coefficient, index) => { x += coefficient / (shifted + index + 1); });
-  const t = shifted + coefficients.length - 0.5;
-  return 0.5 * Math.log(2 * Math.PI) + (shifted + 0.5) * Math.log(t) - t + Math.log(x);
-};
-
-const betaFraction = (a: number, b: number, x: number): number => {
-  const maxIterations = 200;
-  const epsilon = 3e-14;
-  const tiny = 1e-300;
-  const qab = a + b;
-  const qap = a + 1;
-  const qam = a - 1;
-  let c = 1;
-  let d = 1 - qab * x / qap;
-  if (Math.abs(d) < tiny) d = tiny;
-  d = 1 / d;
-  let result = d;
-  for (let iteration = 1; iteration <= maxIterations; iteration += 1) {
-    const twice = 2 * iteration;
-    let aa = iteration * (b - iteration) * x / ((qam + twice) * (a + twice));
-    d = 1 + aa * d;
-    if (Math.abs(d) < tiny) d = tiny;
-    c = 1 + aa / c;
-    if (Math.abs(c) < tiny) c = tiny;
-    d = 1 / d;
-    result *= d * c;
-    aa = -(a + iteration) * (qab + iteration) * x /
-      ((a + twice) * (qap + twice));
-    d = 1 + aa * d;
-    if (Math.abs(d) < tiny) d = tiny;
-    c = 1 + aa / c;
-    if (Math.abs(c) < tiny) c = tiny;
-    d = 1 / d;
-    const delta = d * c;
-    result *= delta;
-    if (Math.abs(delta - 1) < epsilon) break;
-  }
-  return result;
-};
-
-const regularizedBeta = (x: number, a: number, b: number): number => {
-  if (x <= 0) return 0;
-  if (x >= 1) return 1;
-  const front = Math.exp(logGamma(a + b) - logGamma(a) - logGamma(b) +
-    a * Math.log(x) + b * Math.log(1 - x));
-  return x < (a + 1) / (a + b + 2)
-    ? front * betaFraction(a, b, x) / a
-    : 1 - front * betaFraction(b, a, 1 - x) / b;
-};
-
-const studentTwoSidedP = (tStatistic: number, degrees: number): number => {
-  if (!Number.isFinite(tStatistic) || degrees <= 0) return 0;
-  const x = degrees / (degrees + tStatistic ** 2);
-  return Math.min(1, Math.max(0, regularizedBeta(x, degrees / 2, 0.5)));
-};
-
-const normalQuantile = (probability: number): number => {
-  let low = -8;
-  let high = 8;
-  for (let index = 0; index < 80; index += 1) {
-    const middle = (low + high) / 2;
-    if (normalCdf(middle) < probability) low = middle;
-    else high = middle;
-  }
-  return (low + high) / 2;
-};
-
-const studentQuantile = (probability: number, degrees: number): number => {
-  let low = -20;
-  let high = 20;
-  for (let index = 0; index < 90; index += 1) {
-    const middle = (low + high) / 2;
-    const cdf = middle >= 0
-      ? 1 - studentTwoSidedP(middle, degrees) / 2
-      : studentTwoSidedP(middle, degrees) / 2;
-    if (cdf < probability) low = middle;
-    else high = middle;
-  }
-  return (low + high) / 2;
-};
-
-const ranks = (values: number[]): number[] => {
-  const order = values.map((value, index) => ({ value, index }))
-    .sort((left, right) => left.value - right.value);
-  const result = Array(values.length).fill(0) as number[];
-  let start = 0;
-  while (start < order.length) {
-    let end = start + 1;
-    while (end < order.length && order[end].value === order[start].value) end += 1;
-    const rank = (start + end + 1) / 2;
-    for (let index = start; index < end; index += 1) result[order[index].index] = rank;
-    start = end;
-  }
-  return result;
-};
-
-const pearson = (left: number[], right: number[]): number => {
-  const leftMean = mean(left);
-  const rightMean = mean(right);
-  let numerator = 0;
-  let leftSum = 0;
-  let rightSum = 0;
-  left.forEach((value, index) => {
-    const x = value - leftMean;
-    const y = right[index] - rightMean;
-    numerator += x * y;
-    leftSum += x * x;
-    rightSum += y * y;
-  });
-  return numerator / Math.sqrt(leftSum * rightSum);
-};
-
-const kendall = (left: number[], right: number[]): number => {
-  let concordant = 0;
-  let discordant = 0;
-  let leftTies = 0;
-  let rightTies = 0;
-  for (let first = 0; first < left.length; first += 1) {
-    for (let second = first + 1; second < left.length; second += 1) {
-      const dx = Math.sign(left[first] - left[second]);
-      const dy = Math.sign(right[first] - right[second]);
-      if (dx === 0 && dy !== 0) leftTies += 1;
-      else if (dy === 0 && dx !== 0) rightTies += 1;
-      else if (dx * dy > 0) concordant += 1;
-      else if (dx * dy < 0) discordant += 1;
-    }
-  }
-  return (concordant - discordant) /
-    Math.sqrt((concordant + discordant + leftTies) *
-      (concordant + discordant + rightTies));
-};
-
-const correlation = (left: number[], right: number[], method: CorrelationMethod) => {
-  const coefficient = method === "pearson" ? pearson(left, right)
-    : method === "spearman" ? pearson(ranks(left), ranks(right)) : kendall(left, right);
-  const count = left.length;
-  const pValue = method === "kendall"
-    ? 2 * (1 - normalCdf(Math.abs(coefficient) * Math.sqrt(9 * count * (count - 1) /
-      (2 * (2 * count + 5)))))
-    : studentTwoSidedP(coefficient * Math.sqrt((count - 2) /
-      Math.max(Number.EPSILON, 1 - coefficient ** 2)), count - 2);
-  return { coefficient, pValue };
-};
-
-const adjustPValues = (values: Array<number | null>): Array<number | null> => {
-  const ordered = values.map((value, index) => ({ value, index }))
-    .filter((item): item is { value: number; index: number } => item.value !== null)
-    .sort((left, right) => left.value - right.value);
-  const adjusted = Array(values.length).fill(null) as Array<number | null>;
-  let previous = 1;
-  for (let index = ordered.length - 1; index >= 0; index -= 1) {
-    const corrected = Math.min(previous, ordered[index].value * ordered.length / (index + 1));
-    adjusted[ordered[index].index] = Math.min(1, corrected);
-    previous = corrected;
-  }
-  return adjusted;
-};
-
-const inverse = (matrix: number[][]): number[][] => {
-  const size = matrix.length;
-  const augmented = matrix.map((row, rowIndex) => [
-    ...row,
-    ...Array.from({ length: size }, (_, column) => rowIndex === column ? 1 : 0),
-  ]);
-  for (let column = 0; column < size; column += 1) {
-    let pivot = column;
-    for (let row = column + 1; row < size; row += 1) {
-      if (Math.abs(augmented[row][column]) > Math.abs(augmented[pivot][column])) pivot = row;
-    }
-    if (Math.abs(augmented[pivot][column]) < 1e-12) throw new RangeError("Regression design matrix is rank deficient");
-    [augmented[column], augmented[pivot]] = [augmented[pivot], augmented[column]];
-    const divisor = augmented[column][column];
-    augmented[column] = augmented[column].map((value) => value / divisor);
-    for (let row = 0; row < size; row += 1) {
-      if (row === column) continue;
-      const factor = augmented[row][column];
-      augmented[row] = augmented[row].map((value, index) => value - factor * augmented[column][index]);
-    }
-  }
-  return augmented.map((row) => row.slice(size));
-};
-
-const multiply = (left: number[][], right: number[][]): number[][] =>
-  left.map((row) => right[0].map((_, column) =>
-    row.reduce((sum, value, index) => sum + value * right[index][column], 0)));
-
-const transpose = (matrix: number[][]): number[][] =>
-  matrix[0].map((_, column) => matrix.map((row) => row[column]));
-
-const ols = (rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest): RegressionEstimate => {
-  const complete = rows.map((row) => [request.outcome, ...request.predictors]
-    .map((column) => finite(row[column])))
-    .filter((values): values is number[] => values.every((value) => value !== null));
-  const parameterCount = request.predictors.length + 1;
-  if (complete.length < Math.max(request.minSamples, parameterCount + 2)) {
-    throw new RangeError("Too few complete observations for regression");
-  }
-  const y = complete.map((values) => values[0]);
-  const design = complete.map((values) => [1, ...values.slice(1)]);
-  const xt = transpose(design);
-  const xtxInverse = inverse(multiply(xt, design));
-  const beta = multiply(multiply(xtxInverse, xt), y.map((value) => [value])).map((row) => row[0]);
-  const fitted = design.map((row) => row.reduce((sum, value, index) => sum + value * beta[index], 0));
-  const residuals = y.map((value, index) => value - fitted[index]);
-  const residualSum = residuals.reduce((sum, value) => sum + value ** 2, 0);
-  const yMean = mean(y);
-  const totalSum = y.reduce((sum, value) => sum + (value - yMean) ** 2, 0);
-  const rSquared = 1 - residualSum / totalSum;
-  const degrees = complete.length - parameterCount;
-  const sigmaSquared = residualSum / degrees;
-  const critical = studentQuantile(0.5 + request.confidenceLevel / 2, degrees);
-  const names = ["intercept", ...request.predictors];
-  const coefficients = Object.fromEntries(names.map((name, index) => {
-    const standardError = Math.sqrt(Math.max(0, sigmaSquared * xtxInverse[index][index]));
-    const tStatistic = standardError === 0 ? Number.POSITIVE_INFINITY : beta[index] / standardError;
-    return [name, {
-      estimate: beta[index], standardError, tStatistic,
-      pValue: studentTwoSidedP(tStatistic, degrees),
-      ciLower: beta[index] - critical * standardError,
-      ciUpper: beta[index] + critical * standardError,
-    }];
-  }));
-  const leverage = design.map((row) => {
-    const projected = multiply([row], xtxInverse)[0];
-    return projected.reduce((sum, value, index) => sum + value * row[index], 0);
-  });
-  const cooks = residuals.map((residual, index) =>
-    (residual ** 2 / Math.max(Number.EPSILON, parameterCount * sigmaSquared)) *
-    leverage[index] / Math.max(Number.EPSILON, (1 - leverage[index]) ** 2));
-  return {
-    sampleCount: complete.length,
-    rSquared,
-    adjustedRSquared: 1 - (1 - rSquared) * (complete.length - 1) / degrees,
-    coefficients,
-    residualDiagnostics: {
-      rmse: Math.sqrt(residualSum / complete.length),
-      mae: mean(residuals.map(Math.abs)),
-      residualMean: mean(residuals),
-      residualStd: Math.sqrt(variance(residuals, parameterCount)),
-      durbinWatson: residualSum === 0 ? null : residuals.slice(1).reduce((sum, value, index) =>
-        sum + (value - residuals[index]) ** 2, 0) / residualSum,
-      influentialCount: cooks.filter((value) => value > 4 / complete.length).length,
-    },
-  };
-};
-
-// Deterministic SHA-256 keeps browser exports comparable without a server round-trip.
-const sha256 = (input: string): string => {
-  const rightRotate = (value: number, amount: number) => (value >>> amount) | (value << (32 - amount));
-  const powers: number[] = [];
-  for (let candidate = 2; powers.length < 64; candidate += 1) {
-    if (powers.every((prime) => candidate % prime !== 0)) powers.push(candidate);
-  }
-  const initial = powers.slice(0, 8).map((prime) => (Math.sqrt(prime) % 1) * 2 ** 32 | 0);
-  const constants = powers.map((prime) => (Math.cbrt(prime) % 1) * 2 ** 32 | 0);
-  const bytes = new TextEncoder().encode(input);
-  const bitLength = bytes.length * 8;
-  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
-  const padded = new Uint8Array(paddedLength);
-  padded.set(bytes);
-  padded[bytes.length] = 0x80;
-  new DataView(padded.buffer).setUint32(paddedLength - 4, bitLength, false);
-  const hash = [...initial];
-  for (let offset = 0; offset < padded.length; offset += 64) {
-    const words = Array(64).fill(0) as number[];
-    const view = new DataView(padded.buffer, offset, 64);
-    for (let index = 0; index < 16; index += 1) words[index] = view.getUint32(index * 4, false);
-    for (let index = 16; index < 64; index += 1) {
-      const first = rightRotate(words[index - 15], 7) ^ rightRotate(words[index - 15], 18) ^ (words[index - 15] >>> 3);
-      const second = rightRotate(words[index - 2], 17) ^ rightRotate(words[index - 2], 19) ^ (words[index - 2] >>> 10);
-      words[index] = (words[index - 16] + first + words[index - 7] + second) | 0;
-    }
-    let [a, b, c, d, e, f, g, h] = hash;
-    for (let index = 0; index < 64; index += 1) {
-      const sigmaOne = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
-      const choice = (e & f) ^ (~e & g);
-      const first = (h + sigmaOne + choice + constants[index] + words[index]) | 0;
-      const sigmaZero = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
-      const majority = (a & b) ^ (a & c) ^ (b & c);
-      const second = (sigmaZero + majority) | 0;
-      [h, g, f, e, d, c, b, a] = [g, f, e, (d + first) | 0, c, b, a, (first + second) | 0];
-    }
-    [a, b, c, d, e, f, g, h].forEach((value, index) => { hash[index] = (hash[index] + value) | 0; });
-  }
-  return hash.map((value) => (value >>> 0).toString(16).padStart(8, "0")).join("");
-};
-
-export const sha256Text = (input: string): string => sha256(input);
-
-const uniqueStrings = (rows: LaunchMonitorRow[], column: string): string[] =>
-  [...new Set(rows.map((row) => row[column]).filter((value) => value !== null && value !== undefined)
-    .map(String).filter((value) => value.trim()))].sort();
-
-const canonicalFingerprint = (rows: LaunchMonitorRow[], selected: string[]): string => {
-  const identity = ["shot_id", "session_id", "source_row", "monitor_vendor"]
-    .filter((column) => rows.some((row) => column in row) && !selected.includes(column));
-  const columns = [...identity, ...selected];
-  return sha256(JSON.stringify(rows.map((row) => Object.fromEntries(columns.map((column) =>
-    [column, row[column] ?? null])))));
-};
 
 const validate = (rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest): void => {
   if (!rows.length) throw new RangeError("At least one observation is required");
-  if (!request.outcome || !request.predictors.length) throw new RangeError("Select an outcome and predictors");
-  if (request.predictors.includes(request.outcome)) throw new RangeError("outcome cannot also be a predictor");
-  if (new Set(request.predictors).size !== request.predictors.length) throw new RangeError("predictors must be unique");
-  if (!(request.confidenceLevel > 0.5 && request.confidenceLevel < 1)) throw new RangeError("confidenceLevel must be between 0.5 and 1");
+  if (!request.outcome || !request.predictors.length) {
+    throw new RangeError("Select an outcome and predictors");
+  }
+  if (request.predictors.includes(request.outcome)) {
+    throw new RangeError("outcome cannot also be a predictor");
+  }
+  if (new Set(request.predictors).size !== request.predictors.length) {
+    throw new RangeError("predictors must be unique");
+  }
+  if (!(request.confidenceLevel > 0.5 && request.confidenceLevel < 1)) {
+    throw new RangeError("confidenceLevel must be between 0.5 and 1");
+  }
   if (request.minSamples < 3) throw new RangeError("minSamples must be at least 3");
   const selected = [request.outcome, ...request.predictors];
   const missing = [...selected, ...(request.groupBy ? [request.groupBy] : [])]
     .filter((column) => !rows.some((row) => column in row));
-  if (missing.length) throw new RangeError(`Columns not present: ${[...new Set(missing)].join(", ")}`);
-  const constants = selected.filter((column) => new Set(rows.map((row) => finite(row[column]))
+  if (missing.length) {
+    throw new RangeError(`Columns not present: ${[...new Set(missing)].join(", ")}`);
+  }
+  const constants = selected.filter((column) => new Set(rows
+    .map((row) => finiteLaunchMonitorScalar(row[column]))
     .filter((value) => value !== null)).size < 2);
-  if (constants.length) throw new RangeError(`Constant variables cannot be analyzed: ${constants.join(", ")}`);
-  if (request.missingPolicy === "fail" && rows.some((row) => selected.some((column) => finite(row[column]) === null))) {
+  if (constants.length) {
+    throw new RangeError(`Constant variables cannot be analyzed: ${constants.join(", ")}`);
+  }
+  if (request.missingPolicy === "fail" && rows.some((row) => selected.some(
+    (column) => finiteLaunchMonitorScalar(row[column]) === null,
+  ))) {
     throw new RangeError("Selected variables contain missing or non-numeric values");
   }
 };
 
-export function analyzeLaunchMonitorData(
-  rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest,
-): LaunchMonitorAnalysisResult {
-  validate(rows, request);
-  const selected = [request.outcome, ...request.predictors];
+const observationScope = (
+  rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest, selected: string[],
+): { vendors: string[]; observationKinds: string[]; warnings: string[] } => {
   const vendors = uniqueStrings(rows, "monitor_vendor");
   if (selected.some((column) => column.startsWith("source::")) && vendors.length > 1) {
     throw new RangeError("source fields cannot be pooled across multiple monitors");
@@ -457,114 +82,63 @@ export function analyzeLaunchMonitorData(
   if (aggregate && request.analysisMode !== "correlation") {
     throw new RangeError("Aggregate observations cannot enter regression");
   }
-  if (aggregate && !request.allowAggregate) throw new RangeError("Aggregate observations require allowAggregate=true");
+  if (aggregate && !request.allowAggregate) {
+    throw new RangeError("Aggregate observations require allowAggregate=true");
+  }
   const warnings: string[] = [];
-  if (aggregate) warnings.push("Aggregate correlations are descriptive only and may exhibit ecological bias.");
+  if (aggregate) {
+    warnings.push("Aggregate correlations are descriptive only and may exhibit ecological bias.");
+  }
   if (request.correlationMethod !== "pearson" && request.analysisMode !== "regression") {
     warnings.push("Analytical confidence intervals are only reported for Pearson correlation.");
   }
-  const listwiseRows = request.missingPolicy === "listwise"
-    ? rows.filter((row) => selected.every((column) => finite(row[column]) !== null)) : rows;
-  const correlations: CorrelationEstimate[] = request.analysisMode === "regression" ? [] : request.predictors.map((predictor): CorrelationEstimate => {
-    const pairs = listwiseRows.map((row) => [finite(row[request.outcome]), finite(row[predictor])])
-      .filter((pair): pair is [number, number] => pair[0] !== null && pair[1] !== null);
-    if (pairs.length < request.minSamples) return {
-      predictor, coefficient: null, pValue: null, adjustedPValue: null,
-      ciLower: null, ciUpper: null, sampleCount: pairs.length, method: request.correlationMethod,
-    };
-    const result = correlation(pairs.map((pair) => pair[0]), pairs.map((pair) => pair[1]), request.correlationMethod);
-    let ciLower: number | null = null;
-    let ciUpper: number | null = null;
-    if (request.correlationMethod === "pearson" && pairs.length > 3) {
-      const clipped = Math.max(-0.999999, Math.min(0.999999, result.coefficient));
-      const transformed = Math.atanh(clipped);
-      const margin = normalQuantile(0.5 + request.confidenceLevel / 2) / Math.sqrt(pairs.length - 3);
-      ciLower = Math.tanh(transformed - margin);
-      ciUpper = Math.tanh(transformed + margin);
+  return { vendors, observationKinds, warnings };
+};
+
+const groupedAnalyses = (
+  rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest,
+): GroupAnalysis[] => {
+  if (!request.groupBy) return [];
+  return uniqueStrings(rows, request.groupBy).map((value) => {
+    const groupRows = rows.filter((row) => String(row[request.groupBy as string]) === value);
+    try {
+      const result = analyzeLaunchMonitorData(groupRows, { ...request, groupBy: undefined });
+      return { groupValue: value, rowCount: groupRows.length,
+        correlations: result.correlations, regression: result.regression, warnings: result.warnings };
+    } catch (error) {
+      return { groupValue: value, rowCount: groupRows.length, correlations: [], regression: null,
+        warnings: [error instanceof Error ? error.message : String(error)] };
     }
-    return { predictor, coefficient: result.coefficient, pValue: result.pValue,
-      adjustedPValue: null, ciLower, ciUpper, sampleCount: pairs.length,
-      method: request.correlationMethod };
   });
-  const adjusted = adjustPValues(correlations.map((item) => item.pValue));
-  correlations.forEach((item, index) => { item.adjustedPValue = adjusted[index]; });
-  const regression = request.analysisMode === "correlation" ? null : ols(rows, request);
-  const groups: GroupAnalysis[] = [];
-  if (request.groupBy) {
-    const values = uniqueStrings(rows, request.groupBy);
-    values.forEach((value) => {
-      const groupRows = rows.filter((row) => String(row[request.groupBy as string]) === value);
-      try {
-        const result = analyzeLaunchMonitorData(groupRows, { ...request, groupBy: undefined });
-        groups.push({ groupValue: value, rowCount: groupRows.length,
-          correlations: result.correlations, regression: result.regression, warnings: result.warnings });
-      } catch (error) {
-        groups.push({ groupValue: value, rowCount: groupRows.length, correlations: [], regression: null,
-          warnings: [error instanceof Error ? error.message : String(error)] });
-      }
-    });
-  }
+};
+
+export function analyzeLaunchMonitorData(
+  rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest,
+): LaunchMonitorAnalysisResult {
+  validate(rows, request);
+  const selected = [request.outcome, ...request.predictors];
+  const { vendors, observationKinds, warnings } = observationScope(rows, request, selected);
+  const correlations = request.analysisMode === "regression"
+    ? [] : calculateCorrelations(rows, request);
+  const regression = request.analysisMode === "correlation"
+    ? null : calculateRegression(rows, request);
   return {
     contractVersion: LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION,
     request: { ...request, predictors: [...request.predictors] },
     dataset: {
       rowCount: rows.length,
-      completeRowCount: rows.filter((row) => selected.every((column) => finite(row[column]) !== null)).length,
+      completeRowCount: rows.filter((row) => selected.every(
+        (column) => finiteLaunchMonitorScalar(row[column]) !== null,
+      )).length,
       selectedColumns: selected,
       monitorVendors: vendors,
       sessionIds: uniqueStrings(rows, "session_id"),
       observationKinds,
       fingerprintSha256: canonicalFingerprint(rows, selected),
     },
-    correlations, regression, groups, warnings,
+    correlations,
+    regression,
+    groups: groupedAnalyses(rows, request),
+    warnings,
   };
-}
-
-const coerceCell = (value: string): LaunchMonitorScalar => {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  const numeric = Number(trimmed);
-  return Number.isFinite(numeric) ? numeric : trimmed;
-};
-
-const parseCsvRows = (text: string): string[][] => {
-  const rows: string[][] = [];
-  let row: string[] = [];
-  let cell = "";
-  let quoted = false;
-  for (let index = 0; index < text.length; index += 1) {
-    const character = text[index];
-    if (character === '"') {
-      if (quoted && text[index + 1] === '"') { cell += '"'; index += 1; }
-      else quoted = !quoted;
-    } else if (character === "," && !quoted) {
-      row.push(cell); cell = "";
-    } else if ((character === "\n" || character === "\r") && !quoted) {
-      if (character === "\r" && text[index + 1] === "\n") index += 1;
-      row.push(cell); cell = "";
-      if (row.some((value) => value.length)) rows.push(row);
-      row = [];
-    } else cell += character;
-  }
-  if (cell.length || row.length) { row.push(cell); rows.push(row); }
-  if (quoted) throw new RangeError("CSV contains an unterminated quoted field");
-  return rows;
-};
-
-export function parseLaunchMonitorFile(fileName: string, text: string): LaunchMonitorRow[] {
-  if (fileName.toLowerCase().endsWith(".json")) {
-    const parsed: unknown = JSON.parse(text);
-    if (!Array.isArray(parsed) || parsed.some((row) => !row || typeof row !== "object" || Array.isArray(row))) {
-      throw new RangeError("JSON launch-monitor data must be an array of record objects");
-    }
-    return parsed as LaunchMonitorRow[];
-  }
-  const parsed = parseCsvRows(text);
-  if (parsed.length < 2) throw new RangeError("CSV must contain a header and at least one row");
-  const headers = parsed[0].map((header) => header.trim());
-  if (headers.some((header) => !header) || new Set(headers).size !== headers.length) {
-    throw new RangeError("CSV headers must be non-empty and unique");
-  }
-  return parsed.slice(1).map((values) => Object.fromEntries(headers.map((header, index) =>
-    [header, coerceCell(values[index] ?? "")]))) as LaunchMonitorRow[];
 }

--- a/src/rate_of_closure/web/src/model/launchMonitorAnalysis.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorAnalysis.ts
@@ -1,0 +1,570 @@
+/** UI-neutral, provenance-preserving launch-monitor statistical analysis. */
+
+export const LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION = "1.0.0" as const;
+
+export type LaunchMonitorScalar = string | number | boolean | null;
+export type LaunchMonitorRow = Record<string, LaunchMonitorScalar>;
+export type AnalysisMode = "correlation" | "regression" | "comprehensive";
+export type CorrelationMethod = "pearson" | "spearman" | "kendall";
+export type MissingPolicy = "pairwise" | "listwise" | "fail";
+
+export interface LaunchMonitorAnalysisRequest {
+  outcome: string;
+  predictors: string[];
+  analysisMode: AnalysisMode;
+  correlationMethod: CorrelationMethod;
+  missingPolicy: MissingPolicy;
+  groupBy?: string;
+  confidenceLevel: number;
+  minSamples: number;
+  allowAggregate?: boolean;
+}
+
+export interface CorrelationEstimate {
+  predictor: string;
+  coefficient: number | null;
+  pValue: number | null;
+  adjustedPValue: number | null;
+  ciLower: number | null;
+  ciUpper: number | null;
+  sampleCount: number;
+  method: CorrelationMethod;
+}
+
+export interface CoefficientEstimate {
+  estimate: number;
+  standardError: number;
+  tStatistic: number;
+  pValue: number;
+  ciLower: number;
+  ciUpper: number;
+}
+
+export interface RegressionEstimate {
+  sampleCount: number;
+  rSquared: number;
+  adjustedRSquared: number;
+  coefficients: Record<string, CoefficientEstimate>;
+  residualDiagnostics: {
+    rmse: number;
+    mae: number;
+    residualMean: number;
+    residualStd: number;
+    durbinWatson: number | null;
+    influentialCount: number;
+  };
+}
+
+export interface GroupAnalysis {
+  groupValue: string;
+  rowCount: number;
+  correlations: CorrelationEstimate[];
+  regression: RegressionEstimate | null;
+  warnings: string[];
+}
+
+export interface LaunchMonitorAnalysisResult {
+  contractVersion: typeof LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION;
+  request: LaunchMonitorAnalysisRequest;
+  dataset: {
+    rowCount: number;
+    completeRowCount: number;
+    selectedColumns: string[];
+    monitorVendors: string[];
+    sessionIds: string[];
+    observationKinds: string[];
+    fingerprintSha256: string;
+  };
+  correlations: CorrelationEstimate[];
+  regression: RegressionEstimate | null;
+  groups: GroupAnalysis[];
+  warnings: string[];
+}
+
+const finite = (value: LaunchMonitorScalar | undefined): number | null => {
+  if (value === null || value === undefined || value === "" || typeof value === "boolean") return null;
+  const converted = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(converted) ? converted : null;
+};
+
+export function numericLaunchMonitorColumns(rows: LaunchMonitorRow[]): string[] {
+  const columns = new Set(rows.flatMap((row) => Object.keys(row)));
+  return [...columns].filter((column) =>
+    rows.reduce((count, row) => count + (finite(row[column]) === null ? 0 : 1), 0) >= 3,
+  ).sort();
+}
+
+const mean = (values: number[]) => values.reduce((sum, value) => sum + value, 0) / values.length;
+
+const variance = (values: number[], degrees = 1): number => {
+  const center = mean(values);
+  return values.reduce((sum, value) => sum + (value - center) ** 2, 0) /
+    Math.max(1, values.length - degrees);
+};
+
+const erf = (value: number): number => {
+  const sign = value < 0 ? -1 : 1;
+  const x = Math.abs(value);
+  const t = 1 / (1 + 0.3275911 * x);
+  const polynomial = (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t -
+    0.284496736) * t + 0.254829592) * t;
+  return sign * (1 - polynomial * Math.exp(-(x ** 2)));
+};
+
+const normalCdf = (value: number) => 0.5 * (1 + erf(value / Math.sqrt(2)));
+
+const logGamma = (value: number): number => {
+  const coefficients = [
+    676.5203681218851, -1259.1392167224028, 771.3234287776531,
+    -176.6150291621406, 12.507343278686905, -0.13857109526572012,
+    9.984369578019572e-6, 1.5056327351493116e-7,
+  ];
+  if (value < 0.5) return Math.log(Math.PI) - Math.log(Math.sin(Math.PI * value)) - logGamma(1 - value);
+  let x = 0.9999999999998099;
+  const shifted = value - 1;
+  coefficients.forEach((coefficient, index) => { x += coefficient / (shifted + index + 1); });
+  const t = shifted + coefficients.length - 0.5;
+  return 0.5 * Math.log(2 * Math.PI) + (shifted + 0.5) * Math.log(t) - t + Math.log(x);
+};
+
+const betaFraction = (a: number, b: number, x: number): number => {
+  const maxIterations = 200;
+  const epsilon = 3e-14;
+  const tiny = 1e-300;
+  const qab = a + b;
+  const qap = a + 1;
+  const qam = a - 1;
+  let c = 1;
+  let d = 1 - qab * x / qap;
+  if (Math.abs(d) < tiny) d = tiny;
+  d = 1 / d;
+  let result = d;
+  for (let iteration = 1; iteration <= maxIterations; iteration += 1) {
+    const twice = 2 * iteration;
+    let aa = iteration * (b - iteration) * x / ((qam + twice) * (a + twice));
+    d = 1 + aa * d;
+    if (Math.abs(d) < tiny) d = tiny;
+    c = 1 + aa / c;
+    if (Math.abs(c) < tiny) c = tiny;
+    d = 1 / d;
+    result *= d * c;
+    aa = -(a + iteration) * (qab + iteration) * x /
+      ((a + twice) * (qap + twice));
+    d = 1 + aa * d;
+    if (Math.abs(d) < tiny) d = tiny;
+    c = 1 + aa / c;
+    if (Math.abs(c) < tiny) c = tiny;
+    d = 1 / d;
+    const delta = d * c;
+    result *= delta;
+    if (Math.abs(delta - 1) < epsilon) break;
+  }
+  return result;
+};
+
+const regularizedBeta = (x: number, a: number, b: number): number => {
+  if (x <= 0) return 0;
+  if (x >= 1) return 1;
+  const front = Math.exp(logGamma(a + b) - logGamma(a) - logGamma(b) +
+    a * Math.log(x) + b * Math.log(1 - x));
+  return x < (a + 1) / (a + b + 2)
+    ? front * betaFraction(a, b, x) / a
+    : 1 - front * betaFraction(b, a, 1 - x) / b;
+};
+
+const studentTwoSidedP = (tStatistic: number, degrees: number): number => {
+  if (!Number.isFinite(tStatistic) || degrees <= 0) return 0;
+  const x = degrees / (degrees + tStatistic ** 2);
+  return Math.min(1, Math.max(0, regularizedBeta(x, degrees / 2, 0.5)));
+};
+
+const normalQuantile = (probability: number): number => {
+  let low = -8;
+  let high = 8;
+  for (let index = 0; index < 80; index += 1) {
+    const middle = (low + high) / 2;
+    if (normalCdf(middle) < probability) low = middle;
+    else high = middle;
+  }
+  return (low + high) / 2;
+};
+
+const studentQuantile = (probability: number, degrees: number): number => {
+  let low = -20;
+  let high = 20;
+  for (let index = 0; index < 90; index += 1) {
+    const middle = (low + high) / 2;
+    const cdf = middle >= 0
+      ? 1 - studentTwoSidedP(middle, degrees) / 2
+      : studentTwoSidedP(middle, degrees) / 2;
+    if (cdf < probability) low = middle;
+    else high = middle;
+  }
+  return (low + high) / 2;
+};
+
+const ranks = (values: number[]): number[] => {
+  const order = values.map((value, index) => ({ value, index }))
+    .sort((left, right) => left.value - right.value);
+  const result = Array(values.length).fill(0) as number[];
+  let start = 0;
+  while (start < order.length) {
+    let end = start + 1;
+    while (end < order.length && order[end].value === order[start].value) end += 1;
+    const rank = (start + end + 1) / 2;
+    for (let index = start; index < end; index += 1) result[order[index].index] = rank;
+    start = end;
+  }
+  return result;
+};
+
+const pearson = (left: number[], right: number[]): number => {
+  const leftMean = mean(left);
+  const rightMean = mean(right);
+  let numerator = 0;
+  let leftSum = 0;
+  let rightSum = 0;
+  left.forEach((value, index) => {
+    const x = value - leftMean;
+    const y = right[index] - rightMean;
+    numerator += x * y;
+    leftSum += x * x;
+    rightSum += y * y;
+  });
+  return numerator / Math.sqrt(leftSum * rightSum);
+};
+
+const kendall = (left: number[], right: number[]): number => {
+  let concordant = 0;
+  let discordant = 0;
+  let leftTies = 0;
+  let rightTies = 0;
+  for (let first = 0; first < left.length; first += 1) {
+    for (let second = first + 1; second < left.length; second += 1) {
+      const dx = Math.sign(left[first] - left[second]);
+      const dy = Math.sign(right[first] - right[second]);
+      if (dx === 0 && dy !== 0) leftTies += 1;
+      else if (dy === 0 && dx !== 0) rightTies += 1;
+      else if (dx * dy > 0) concordant += 1;
+      else if (dx * dy < 0) discordant += 1;
+    }
+  }
+  return (concordant - discordant) /
+    Math.sqrt((concordant + discordant + leftTies) *
+      (concordant + discordant + rightTies));
+};
+
+const correlation = (left: number[], right: number[], method: CorrelationMethod) => {
+  const coefficient = method === "pearson" ? pearson(left, right)
+    : method === "spearman" ? pearson(ranks(left), ranks(right)) : kendall(left, right);
+  const count = left.length;
+  const pValue = method === "kendall"
+    ? 2 * (1 - normalCdf(Math.abs(coefficient) * Math.sqrt(9 * count * (count - 1) /
+      (2 * (2 * count + 5)))))
+    : studentTwoSidedP(coefficient * Math.sqrt((count - 2) /
+      Math.max(Number.EPSILON, 1 - coefficient ** 2)), count - 2);
+  return { coefficient, pValue };
+};
+
+const adjustPValues = (values: Array<number | null>): Array<number | null> => {
+  const ordered = values.map((value, index) => ({ value, index }))
+    .filter((item): item is { value: number; index: number } => item.value !== null)
+    .sort((left, right) => left.value - right.value);
+  const adjusted = Array(values.length).fill(null) as Array<number | null>;
+  let previous = 1;
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    const corrected = Math.min(previous, ordered[index].value * ordered.length / (index + 1));
+    adjusted[ordered[index].index] = Math.min(1, corrected);
+    previous = corrected;
+  }
+  return adjusted;
+};
+
+const inverse = (matrix: number[][]): number[][] => {
+  const size = matrix.length;
+  const augmented = matrix.map((row, rowIndex) => [
+    ...row,
+    ...Array.from({ length: size }, (_, column) => rowIndex === column ? 1 : 0),
+  ]);
+  for (let column = 0; column < size; column += 1) {
+    let pivot = column;
+    for (let row = column + 1; row < size; row += 1) {
+      if (Math.abs(augmented[row][column]) > Math.abs(augmented[pivot][column])) pivot = row;
+    }
+    if (Math.abs(augmented[pivot][column]) < 1e-12) throw new RangeError("Regression design matrix is rank deficient");
+    [augmented[column], augmented[pivot]] = [augmented[pivot], augmented[column]];
+    const divisor = augmented[column][column];
+    augmented[column] = augmented[column].map((value) => value / divisor);
+    for (let row = 0; row < size; row += 1) {
+      if (row === column) continue;
+      const factor = augmented[row][column];
+      augmented[row] = augmented[row].map((value, index) => value - factor * augmented[column][index]);
+    }
+  }
+  return augmented.map((row) => row.slice(size));
+};
+
+const multiply = (left: number[][], right: number[][]): number[][] =>
+  left.map((row) => right[0].map((_, column) =>
+    row.reduce((sum, value, index) => sum + value * right[index][column], 0)));
+
+const transpose = (matrix: number[][]): number[][] =>
+  matrix[0].map((_, column) => matrix.map((row) => row[column]));
+
+const ols = (rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest): RegressionEstimate => {
+  const complete = rows.map((row) => [request.outcome, ...request.predictors]
+    .map((column) => finite(row[column])))
+    .filter((values): values is number[] => values.every((value) => value !== null));
+  const parameterCount = request.predictors.length + 1;
+  if (complete.length < Math.max(request.minSamples, parameterCount + 2)) {
+    throw new RangeError("Too few complete observations for regression");
+  }
+  const y = complete.map((values) => values[0]);
+  const design = complete.map((values) => [1, ...values.slice(1)]);
+  const xt = transpose(design);
+  const xtxInverse = inverse(multiply(xt, design));
+  const beta = multiply(multiply(xtxInverse, xt), y.map((value) => [value])).map((row) => row[0]);
+  const fitted = design.map((row) => row.reduce((sum, value, index) => sum + value * beta[index], 0));
+  const residuals = y.map((value, index) => value - fitted[index]);
+  const residualSum = residuals.reduce((sum, value) => sum + value ** 2, 0);
+  const yMean = mean(y);
+  const totalSum = y.reduce((sum, value) => sum + (value - yMean) ** 2, 0);
+  const rSquared = 1 - residualSum / totalSum;
+  const degrees = complete.length - parameterCount;
+  const sigmaSquared = residualSum / degrees;
+  const critical = studentQuantile(0.5 + request.confidenceLevel / 2, degrees);
+  const names = ["intercept", ...request.predictors];
+  const coefficients = Object.fromEntries(names.map((name, index) => {
+    const standardError = Math.sqrt(Math.max(0, sigmaSquared * xtxInverse[index][index]));
+    const tStatistic = standardError === 0 ? Number.POSITIVE_INFINITY : beta[index] / standardError;
+    return [name, {
+      estimate: beta[index], standardError, tStatistic,
+      pValue: studentTwoSidedP(tStatistic, degrees),
+      ciLower: beta[index] - critical * standardError,
+      ciUpper: beta[index] + critical * standardError,
+    }];
+  }));
+  const leverage = design.map((row) => {
+    const projected = multiply([row], xtxInverse)[0];
+    return projected.reduce((sum, value, index) => sum + value * row[index], 0);
+  });
+  const cooks = residuals.map((residual, index) =>
+    (residual ** 2 / Math.max(Number.EPSILON, parameterCount * sigmaSquared)) *
+    leverage[index] / Math.max(Number.EPSILON, (1 - leverage[index]) ** 2));
+  return {
+    sampleCount: complete.length,
+    rSquared,
+    adjustedRSquared: 1 - (1 - rSquared) * (complete.length - 1) / degrees,
+    coefficients,
+    residualDiagnostics: {
+      rmse: Math.sqrt(residualSum / complete.length),
+      mae: mean(residuals.map(Math.abs)),
+      residualMean: mean(residuals),
+      residualStd: Math.sqrt(variance(residuals, parameterCount)),
+      durbinWatson: residualSum === 0 ? null : residuals.slice(1).reduce((sum, value, index) =>
+        sum + (value - residuals[index]) ** 2, 0) / residualSum,
+      influentialCount: cooks.filter((value) => value > 4 / complete.length).length,
+    },
+  };
+};
+
+// Deterministic SHA-256 keeps browser exports comparable without a server round-trip.
+const sha256 = (input: string): string => {
+  const rightRotate = (value: number, amount: number) => (value >>> amount) | (value << (32 - amount));
+  const powers: number[] = [];
+  for (let candidate = 2; powers.length < 64; candidate += 1) {
+    if (powers.every((prime) => candidate % prime !== 0)) powers.push(candidate);
+  }
+  const initial = powers.slice(0, 8).map((prime) => (Math.sqrt(prime) % 1) * 2 ** 32 | 0);
+  const constants = powers.map((prime) => (Math.cbrt(prime) % 1) * 2 ** 32 | 0);
+  const bytes = new TextEncoder().encode(input);
+  const bitLength = bytes.length * 8;
+  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  new DataView(padded.buffer).setUint32(paddedLength - 4, bitLength, false);
+  const hash = [...initial];
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    const words = Array(64).fill(0) as number[];
+    const view = new DataView(padded.buffer, offset, 64);
+    for (let index = 0; index < 16; index += 1) words[index] = view.getUint32(index * 4, false);
+    for (let index = 16; index < 64; index += 1) {
+      const first = rightRotate(words[index - 15], 7) ^ rightRotate(words[index - 15], 18) ^ (words[index - 15] >>> 3);
+      const second = rightRotate(words[index - 2], 17) ^ rightRotate(words[index - 2], 19) ^ (words[index - 2] >>> 10);
+      words[index] = (words[index - 16] + first + words[index - 7] + second) | 0;
+    }
+    let [a, b, c, d, e, f, g, h] = hash;
+    for (let index = 0; index < 64; index += 1) {
+      const sigmaOne = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
+      const choice = (e & f) ^ (~e & g);
+      const first = (h + sigmaOne + choice + constants[index] + words[index]) | 0;
+      const sigmaZero = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const second = (sigmaZero + majority) | 0;
+      [h, g, f, e, d, c, b, a] = [g, f, e, (d + first) | 0, c, b, a, (first + second) | 0];
+    }
+    [a, b, c, d, e, f, g, h].forEach((value, index) => { hash[index] = (hash[index] + value) | 0; });
+  }
+  return hash.map((value) => (value >>> 0).toString(16).padStart(8, "0")).join("");
+};
+
+export const sha256Text = (input: string): string => sha256(input);
+
+const uniqueStrings = (rows: LaunchMonitorRow[], column: string): string[] =>
+  [...new Set(rows.map((row) => row[column]).filter((value) => value !== null && value !== undefined)
+    .map(String).filter((value) => value.trim()))].sort();
+
+const canonicalFingerprint = (rows: LaunchMonitorRow[], selected: string[]): string => {
+  const identity = ["shot_id", "session_id", "source_row", "monitor_vendor"]
+    .filter((column) => rows.some((row) => column in row) && !selected.includes(column));
+  const columns = [...identity, ...selected];
+  return sha256(JSON.stringify(rows.map((row) => Object.fromEntries(columns.map((column) =>
+    [column, row[column] ?? null])))));
+};
+
+const validate = (rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest): void => {
+  if (!rows.length) throw new RangeError("At least one observation is required");
+  if (!request.outcome || !request.predictors.length) throw new RangeError("Select an outcome and predictors");
+  if (request.predictors.includes(request.outcome)) throw new RangeError("outcome cannot also be a predictor");
+  if (new Set(request.predictors).size !== request.predictors.length) throw new RangeError("predictors must be unique");
+  if (!(request.confidenceLevel > 0.5 && request.confidenceLevel < 1)) throw new RangeError("confidenceLevel must be between 0.5 and 1");
+  if (request.minSamples < 3) throw new RangeError("minSamples must be at least 3");
+  const selected = [request.outcome, ...request.predictors];
+  const missing = [...selected, ...(request.groupBy ? [request.groupBy] : [])]
+    .filter((column) => !rows.some((row) => column in row));
+  if (missing.length) throw new RangeError(`Columns not present: ${[...new Set(missing)].join(", ")}`);
+  const constants = selected.filter((column) => new Set(rows.map((row) => finite(row[column]))
+    .filter((value) => value !== null)).size < 2);
+  if (constants.length) throw new RangeError(`Constant variables cannot be analyzed: ${constants.join(", ")}`);
+  if (request.missingPolicy === "fail" && rows.some((row) => selected.some((column) => finite(row[column]) === null))) {
+    throw new RangeError("Selected variables contain missing or non-numeric values");
+  }
+};
+
+export function analyzeLaunchMonitorData(
+  rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest,
+): LaunchMonitorAnalysisResult {
+  validate(rows, request);
+  const selected = [request.outcome, ...request.predictors];
+  const vendors = uniqueStrings(rows, "monitor_vendor");
+  if (selected.some((column) => column.startsWith("source::")) && vendors.length > 1) {
+    throw new RangeError("source fields cannot be pooled across multiple monitors");
+  }
+  const observationKinds = uniqueStrings(rows, "observation_kind");
+  if (!observationKinds.length) observationKinds.push("shot");
+  const aggregate = observationKinds.some((kind) => kind.toLowerCase() !== "shot");
+  if (aggregate && request.analysisMode !== "correlation") {
+    throw new RangeError("Aggregate observations cannot enter regression");
+  }
+  if (aggregate && !request.allowAggregate) throw new RangeError("Aggregate observations require allowAggregate=true");
+  const warnings: string[] = [];
+  if (aggregate) warnings.push("Aggregate correlations are descriptive only and may exhibit ecological bias.");
+  if (request.correlationMethod !== "pearson" && request.analysisMode !== "regression") {
+    warnings.push("Analytical confidence intervals are only reported for Pearson correlation.");
+  }
+  const listwiseRows = request.missingPolicy === "listwise"
+    ? rows.filter((row) => selected.every((column) => finite(row[column]) !== null)) : rows;
+  const correlations: CorrelationEstimate[] = request.analysisMode === "regression" ? [] : request.predictors.map((predictor): CorrelationEstimate => {
+    const pairs = listwiseRows.map((row) => [finite(row[request.outcome]), finite(row[predictor])])
+      .filter((pair): pair is [number, number] => pair[0] !== null && pair[1] !== null);
+    if (pairs.length < request.minSamples) return {
+      predictor, coefficient: null, pValue: null, adjustedPValue: null,
+      ciLower: null, ciUpper: null, sampleCount: pairs.length, method: request.correlationMethod,
+    };
+    const result = correlation(pairs.map((pair) => pair[0]), pairs.map((pair) => pair[1]), request.correlationMethod);
+    let ciLower: number | null = null;
+    let ciUpper: number | null = null;
+    if (request.correlationMethod === "pearson" && pairs.length > 3) {
+      const clipped = Math.max(-0.999999, Math.min(0.999999, result.coefficient));
+      const transformed = Math.atanh(clipped);
+      const margin = normalQuantile(0.5 + request.confidenceLevel / 2) / Math.sqrt(pairs.length - 3);
+      ciLower = Math.tanh(transformed - margin);
+      ciUpper = Math.tanh(transformed + margin);
+    }
+    return { predictor, coefficient: result.coefficient, pValue: result.pValue,
+      adjustedPValue: null, ciLower, ciUpper, sampleCount: pairs.length,
+      method: request.correlationMethod };
+  });
+  const adjusted = adjustPValues(correlations.map((item) => item.pValue));
+  correlations.forEach((item, index) => { item.adjustedPValue = adjusted[index]; });
+  const regression = request.analysisMode === "correlation" ? null : ols(rows, request);
+  const groups: GroupAnalysis[] = [];
+  if (request.groupBy) {
+    const values = uniqueStrings(rows, request.groupBy);
+    values.forEach((value) => {
+      const groupRows = rows.filter((row) => String(row[request.groupBy as string]) === value);
+      try {
+        const result = analyzeLaunchMonitorData(groupRows, { ...request, groupBy: undefined });
+        groups.push({ groupValue: value, rowCount: groupRows.length,
+          correlations: result.correlations, regression: result.regression, warnings: result.warnings });
+      } catch (error) {
+        groups.push({ groupValue: value, rowCount: groupRows.length, correlations: [], regression: null,
+          warnings: [error instanceof Error ? error.message : String(error)] });
+      }
+    });
+  }
+  return {
+    contractVersion: LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION,
+    request: { ...request, predictors: [...request.predictors] },
+    dataset: {
+      rowCount: rows.length,
+      completeRowCount: rows.filter((row) => selected.every((column) => finite(row[column]) !== null)).length,
+      selectedColumns: selected,
+      monitorVendors: vendors,
+      sessionIds: uniqueStrings(rows, "session_id"),
+      observationKinds,
+      fingerprintSha256: canonicalFingerprint(rows, selected),
+    },
+    correlations, regression, groups, warnings,
+  };
+}
+
+const coerceCell = (value: string): LaunchMonitorScalar => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const numeric = Number(trimmed);
+  return Number.isFinite(numeric) ? numeric : trimmed;
+};
+
+const parseCsvRows = (text: string): string[][] => {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (character === '"') {
+      if (quoted && text[index + 1] === '"') { cell += '"'; index += 1; }
+      else quoted = !quoted;
+    } else if (character === "," && !quoted) {
+      row.push(cell); cell = "";
+    } else if ((character === "\n" || character === "\r") && !quoted) {
+      if (character === "\r" && text[index + 1] === "\n") index += 1;
+      row.push(cell); cell = "";
+      if (row.some((value) => value.length)) rows.push(row);
+      row = [];
+    } else cell += character;
+  }
+  if (cell.length || row.length) { row.push(cell); rows.push(row); }
+  if (quoted) throw new RangeError("CSV contains an unterminated quoted field");
+  return rows;
+};
+
+export function parseLaunchMonitorFile(fileName: string, text: string): LaunchMonitorRow[] {
+  if (fileName.toLowerCase().endsWith(".json")) {
+    const parsed: unknown = JSON.parse(text);
+    if (!Array.isArray(parsed) || parsed.some((row) => !row || typeof row !== "object" || Array.isArray(row))) {
+      throw new RangeError("JSON launch-monitor data must be an array of record objects");
+    }
+    return parsed as LaunchMonitorRow[];
+  }
+  const parsed = parseCsvRows(text);
+  if (parsed.length < 2) throw new RangeError("CSV must contain a header and at least one row");
+  const headers = parsed[0].map((header) => header.trim());
+  if (headers.some((header) => !header) || new Set(headers).size !== headers.length) {
+    throw new RangeError("CSV headers must be non-empty and unique");
+  }
+  return parsed.slice(1).map((values) => Object.fromEntries(headers.map((header, index) =>
+    [header, coerceCell(values[index] ?? "")]))) as LaunchMonitorRow[];
+}

--- a/src/rate_of_closure/web/src/model/launchMonitorAnalysisStatistics.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorAnalysisStatistics.ts
@@ -1,0 +1,361 @@
+/** Statistical primitives for launch-monitor analysis. */
+
+import {
+  finiteLaunchMonitorScalar,
+  type CorrelationEstimate,
+  type CorrelationMethod,
+  type LaunchMonitorAnalysisRequest,
+  type LaunchMonitorRow,
+  type RegressionEstimate,
+} from "./launchMonitorAnalysisTypes";
+
+interface RegressionWork {
+  count: number;
+  parameterCount: number;
+  outcome: number[];
+  design: number[][];
+  beta: number[];
+  residuals: number[];
+  inverseInformation: number[][];
+}
+
+const mean = (values: number[]) =>
+  values.reduce((sum, value) => sum + value, 0) / values.length;
+
+const variance = (values: number[], degrees = 1): number => {
+  const center = mean(values);
+  return values.reduce((sum, value) => sum + (value - center) ** 2, 0) /
+    Math.max(1, values.length - degrees);
+};
+
+const erf = (value: number): number => {
+  const sign = value < 0 ? -1 : 1;
+  const x = Math.abs(value);
+  const t = 1 / (1 + 0.3275911 * x);
+  const polynomial = (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t -
+    0.284496736) * t + 0.254829592) * t;
+  return sign * (1 - polynomial * Math.exp(-(x ** 2)));
+};
+
+const normalCdf = (value: number) => 0.5 * (1 + erf(value / Math.sqrt(2)));
+
+const logGamma = (value: number): number => {
+  const coefficients = [
+    676.5203681218851, -1259.1392167224028, 771.3234287776531,
+    -176.6150291621406, 12.507343278686905, -0.13857109526572012,
+    9.984369578019572e-6, 1.5056327351493116e-7,
+  ];
+  if (value < 0.5) {
+    return Math.log(Math.PI) - Math.log(Math.sin(Math.PI * value)) - logGamma(1 - value);
+  }
+  let x = 0.9999999999998099;
+  const shifted = value - 1;
+  coefficients.forEach((coefficient, index) => {
+    x += coefficient / (shifted + index + 1);
+  });
+  const t = shifted + coefficients.length - 0.5;
+  return 0.5 * Math.log(2 * Math.PI) + (shifted + 0.5) * Math.log(t) - t + Math.log(x);
+};
+
+const betaFraction = (a: number, b: number, x: number): number => {
+  const maxIterations = 200;
+  const epsilon = 3e-14;
+  const tiny = 1e-300;
+  const qab = a + b;
+  const qap = a + 1;
+  const qam = a - 1;
+  let c = 1;
+  let d = 1 - qab * x / qap;
+  if (Math.abs(d) < tiny) d = tiny;
+  d = 1 / d;
+  let result = d;
+  for (let iteration = 1; iteration <= maxIterations; iteration += 1) {
+    const twice = 2 * iteration;
+    let aa = iteration * (b - iteration) * x / ((qam + twice) * (a + twice));
+    d = 1 + aa * d;
+    if (Math.abs(d) < tiny) d = tiny;
+    c = 1 + aa / c;
+    if (Math.abs(c) < tiny) c = tiny;
+    d = 1 / d;
+    result *= d * c;
+    aa = -(a + iteration) * (qab + iteration) * x / ((a + twice) * (qap + twice));
+    d = 1 + aa * d;
+    if (Math.abs(d) < tiny) d = tiny;
+    c = 1 + aa / c;
+    if (Math.abs(c) < tiny) c = tiny;
+    d = 1 / d;
+    const delta = d * c;
+    result *= delta;
+    if (Math.abs(delta - 1) < epsilon) break;
+  }
+  return result;
+};
+
+const regularizedBeta = (x: number, a: number, b: number): number => {
+  if (x <= 0) return 0;
+  if (x >= 1) return 1;
+  const front = Math.exp(logGamma(a + b) - logGamma(a) - logGamma(b) +
+    a * Math.log(x) + b * Math.log(1 - x));
+  return x < (a + 1) / (a + b + 2)
+    ? front * betaFraction(a, b, x) / a
+    : 1 - front * betaFraction(b, a, 1 - x) / b;
+};
+
+const studentTwoSidedP = (tStatistic: number, degrees: number): number => {
+  if (!Number.isFinite(tStatistic) || degrees <= 0) return 0;
+  const x = degrees / (degrees + tStatistic ** 2);
+  return Math.min(1, Math.max(0, regularizedBeta(x, degrees / 2, 0.5)));
+};
+
+const normalQuantile = (probability: number): number => {
+  let low = -8;
+  let high = 8;
+  for (let index = 0; index < 80; index += 1) {
+    const middle = (low + high) / 2;
+    if (normalCdf(middle) < probability) low = middle;
+    else high = middle;
+  }
+  return (low + high) / 2;
+};
+
+const studentQuantile = (probability: number, degrees: number): number => {
+  let low = -20;
+  let high = 20;
+  for (let index = 0; index < 90; index += 1) {
+    const middle = (low + high) / 2;
+    const cdf = middle >= 0
+      ? 1 - studentTwoSidedP(middle, degrees) / 2
+      : studentTwoSidedP(middle, degrees) / 2;
+    if (cdf < probability) low = middle;
+    else high = middle;
+  }
+  return (low + high) / 2;
+};
+
+const ranks = (values: number[]): number[] => {
+  const order = values.map((value, index) => ({ value, index }))
+    .sort((left, right) => left.value - right.value);
+  const result = Array(values.length).fill(0) as number[];
+  let start = 0;
+  while (start < order.length) {
+    let end = start + 1;
+    while (end < order.length && order[end].value === order[start].value) end += 1;
+    const rank = (start + end + 1) / 2;
+    for (let index = start; index < end; index += 1) result[order[index].index] = rank;
+    start = end;
+  }
+  return result;
+};
+
+const pearson = (left: number[], right: number[]): number => {
+  const leftMean = mean(left);
+  const rightMean = mean(right);
+  let numerator = 0;
+  let leftSum = 0;
+  let rightSum = 0;
+  left.forEach((value, index) => {
+    const x = value - leftMean;
+    const y = right[index] - rightMean;
+    numerator += x * y;
+    leftSum += x * x;
+    rightSum += y * y;
+  });
+  return numerator / Math.sqrt(leftSum * rightSum);
+};
+
+const kendall = (left: number[], right: number[]): number => {
+  let concordant = 0;
+  let discordant = 0;
+  let leftTies = 0;
+  let rightTies = 0;
+  for (let first = 0; first < left.length; first += 1) {
+    for (let second = first + 1; second < left.length; second += 1) {
+      const dx = Math.sign(left[first] - left[second]);
+      const dy = Math.sign(right[first] - right[second]);
+      if (dx === 0 && dy !== 0) leftTies += 1;
+      else if (dy === 0 && dx !== 0) rightTies += 1;
+      else if (dx * dy > 0) concordant += 1;
+      else if (dx * dy < 0) discordant += 1;
+    }
+  }
+  return (concordant - discordant) / Math.sqrt(
+    (concordant + discordant + leftTies) * (concordant + discordant + rightTies),
+  );
+};
+
+const correlation = (
+  left: number[], right: number[], method: CorrelationMethod,
+): { coefficient: number; pValue: number } => {
+  const coefficient = method === "pearson" ? pearson(left, right)
+    : method === "spearman" ? pearson(ranks(left), ranks(right)) : kendall(left, right);
+  const count = left.length;
+  const pValue = method === "kendall"
+    ? 2 * (1 - normalCdf(Math.abs(coefficient) * Math.sqrt(
+      9 * count * (count - 1) / (2 * (2 * count + 5)),
+    )))
+    : studentTwoSidedP(
+      coefficient * Math.sqrt((count - 2) / Math.max(Number.EPSILON, 1 - coefficient ** 2)),
+      count - 2,
+    );
+  return { coefficient, pValue };
+};
+
+const adjustPValues = (values: Array<number | null>): Array<number | null> => {
+  const ordered = values.map((value, index) => ({ value, index }))
+    .filter((item): item is { value: number; index: number } => item.value !== null)
+    .sort((left, right) => left.value - right.value);
+  const adjusted = Array(values.length).fill(null) as Array<number | null>;
+  let previous = 1;
+  for (let index = ordered.length - 1; index >= 0; index -= 1) {
+    const corrected = Math.min(previous, ordered[index].value * ordered.length / (index + 1));
+    adjusted[ordered[index].index] = Math.min(1, corrected);
+    previous = corrected;
+  }
+  return adjusted;
+};
+
+export const calculateCorrelations = (
+  rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest,
+): CorrelationEstimate[] => {
+  const selected = [request.outcome, ...request.predictors];
+  const candidates = request.missingPolicy === "listwise"
+    ? rows.filter((row) => selected.every((column) => finiteLaunchMonitorScalar(row[column]) !== null))
+    : rows;
+  const estimates = request.predictors.map((predictor) =>
+    correlationForPredictor(candidates, request, predictor));
+  const adjusted = adjustPValues(estimates.map((item) => item.pValue));
+  return estimates.map((item, index) => ({ ...item, adjustedPValue: adjusted[index] }));
+};
+
+const correlationForPredictor = (
+  rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest, predictor: string,
+): CorrelationEstimate => {
+  const pairs = rows.map((row) => [
+    finiteLaunchMonitorScalar(row[request.outcome]), finiteLaunchMonitorScalar(row[predictor]),
+  ]).filter((pair): pair is [number, number] => pair[0] !== null && pair[1] !== null);
+  if (pairs.length < request.minSamples) {
+    return { predictor, coefficient: null, pValue: null, adjustedPValue: null,
+      ciLower: null, ciUpper: null, sampleCount: pairs.length, method: request.correlationMethod };
+  }
+  const result = correlation(
+    pairs.map((pair) => pair[0]), pairs.map((pair) => pair[1]), request.correlationMethod,
+  );
+  const [ciLower, ciUpper] = pearsonInterval(result.coefficient, pairs.length, request);
+  return { predictor, ...result, adjustedPValue: null, ciLower, ciUpper,
+    sampleCount: pairs.length, method: request.correlationMethod };
+};
+
+const pearsonInterval = (
+  coefficient: number, count: number, request: LaunchMonitorAnalysisRequest,
+): [number | null, number | null] => {
+  if (request.correlationMethod !== "pearson" || count <= 3) return [null, null];
+  const clipped = Math.max(-0.999999, Math.min(0.999999, coefficient));
+  const transformed = Math.atanh(clipped);
+  const margin = normalQuantile(0.5 + request.confidenceLevel / 2) / Math.sqrt(count - 3);
+  return [Math.tanh(transformed - margin), Math.tanh(transformed + margin)];
+};
+
+const inverse = (matrix: number[][]): number[][] => {
+  const size = matrix.length;
+  const augmented = matrix.map((row, rowIndex) => [
+    ...row, ...Array.from({ length: size }, (_, column) => rowIndex === column ? 1 : 0),
+  ]);
+  for (let column = 0; column < size; column += 1) {
+    let pivot = column;
+    for (let row = column + 1; row < size; row += 1) {
+      if (Math.abs(augmented[row][column]) > Math.abs(augmented[pivot][column])) pivot = row;
+    }
+    if (Math.abs(augmented[pivot][column]) < 1e-12) {
+      throw new RangeError("Regression design matrix is rank deficient");
+    }
+    [augmented[column], augmented[pivot]] = [augmented[pivot], augmented[column]];
+    const divisor = augmented[column][column];
+    augmented[column] = augmented[column].map((value) => value / divisor);
+    for (let row = 0; row < size; row += 1) {
+      if (row === column) continue;
+      const factor = augmented[row][column];
+      augmented[row] = augmented[row].map(
+        (value, index) => value - factor * augmented[column][index],
+      );
+    }
+  }
+  return augmented.map((row) => row.slice(size));
+};
+
+const multiply = (left: number[][], right: number[][]): number[][] =>
+  left.map((row) => right[0].map((_, column) =>
+    row.reduce((sum, value, index) => sum + value * right[index][column], 0)));
+
+const transpose = (matrix: number[][]): number[][] =>
+  matrix[0].map((_, column) => matrix.map((row) => row[column]));
+
+export const calculateRegression = (
+  rows: LaunchMonitorRow[], request: LaunchMonitorAnalysisRequest,
+): RegressionEstimate => {
+  const complete = rows.map((row) => [request.outcome, ...request.predictors]
+    .map((column) => finiteLaunchMonitorScalar(row[column])))
+    .filter((values): values is number[] => values.every((value) => value !== null));
+  const parameterCount = request.predictors.length + 1;
+  if (complete.length < Math.max(request.minSamples, parameterCount + 2)) {
+    throw new RangeError("Too few complete observations for regression");
+  }
+  const outcome = complete.map((values) => values[0]);
+  const design = complete.map((values) => [1, ...values.slice(1)]);
+  const inverseInformation = inverse(multiply(transpose(design), design));
+  const beta = multiply(
+    multiply(inverseInformation, transpose(design)), outcome.map((value) => [value]),
+  ).map((row) => row[0]);
+  const residuals = outcome.map((value, index) => value - design[index]
+    .reduce((sum, item, betaIndex) => sum + item * beta[betaIndex], 0));
+  return regressionResult({
+    count: complete.length,
+    parameterCount,
+    outcome,
+    design,
+    beta,
+    residuals,
+    inverseInformation,
+  }, request);
+};
+
+const regressionResult = (
+  work: RegressionWork,
+  request: LaunchMonitorAnalysisRequest,
+): RegressionEstimate => {
+  const residualSum = work.residuals.reduce((sum, value) => sum + value ** 2, 0);
+  const totalSum = work.outcome.reduce(
+    (sum, value) => sum + (value - mean(work.outcome)) ** 2, 0,
+  );
+  const rSquared = 1 - residualSum / totalSum;
+  const degrees = work.count - work.parameterCount;
+  const sigmaSquared = residualSum / degrees;
+  const critical = studentQuantile(0.5 + request.confidenceLevel / 2, degrees);
+  const names = ["intercept", ...request.predictors];
+  const coefficients = Object.fromEntries(names.map((name, index) => {
+    const standardError = Math.sqrt(
+      Math.max(0, sigmaSquared * work.inverseInformation[index][index]),
+    );
+    const estimate = work.beta[index];
+    const tStatistic = standardError === 0 ? Number.POSITIVE_INFINITY : estimate / standardError;
+    return [name, { estimate, standardError, tStatistic,
+      pValue: studentTwoSidedP(tStatistic, degrees),
+      ciLower: estimate - critical * standardError,
+      ciUpper: estimate + critical * standardError }];
+  }));
+  const leverage = work.design.map((row) => multiply([row], work.inverseInformation)[0]
+    .reduce((sum, value, index) => sum + value * row[index], 0));
+  const cooks = work.residuals.map((residual, index) =>
+    (residual ** 2 / Math.max(Number.EPSILON, work.parameterCount * sigmaSquared)) *
+    leverage[index] / Math.max(Number.EPSILON, (1 - leverage[index]) ** 2));
+  return { sampleCount: work.count, rSquared,
+    adjustedRSquared: 1 - (1 - rSquared) * (work.count - 1) / degrees, coefficients,
+    residualDiagnostics: {
+      rmse: Math.sqrt(residualSum / work.count), mae: mean(work.residuals.map(Math.abs)),
+      residualMean: mean(work.residuals),
+      residualStd: Math.sqrt(variance(work.residuals, work.parameterCount)),
+      durbinWatson: residualSum === 0 ? null : work.residuals.slice(1)
+        .reduce((sum, value, index) => sum + (value - work.residuals[index]) ** 2, 0) /
+        residualSum,
+      influentialCount: cooks.filter((value) => value > 4 / work.count).length,
+    } };
+};

--- a/src/rate_of_closure/web/src/model/launchMonitorAnalysisTypes.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorAnalysisTypes.ts
@@ -1,0 +1,92 @@
+/** Shared contracts for browser launch-monitor statistical analysis. */
+
+export const LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION = "1.0.0" as const;
+
+export type LaunchMonitorScalar = string | number | boolean | null;
+export type LaunchMonitorRow = Record<string, LaunchMonitorScalar>;
+export type AnalysisMode = "correlation" | "regression" | "comprehensive";
+export type CorrelationMethod = "pearson" | "spearman" | "kendall";
+export type MissingPolicy = "pairwise" | "listwise" | "fail";
+
+export interface LaunchMonitorAnalysisRequest {
+  outcome: string;
+  predictors: string[];
+  analysisMode: AnalysisMode;
+  correlationMethod: CorrelationMethod;
+  missingPolicy: MissingPolicy;
+  groupBy?: string;
+  confidenceLevel: number;
+  minSamples: number;
+  allowAggregate?: boolean;
+}
+
+export interface CorrelationEstimate {
+  predictor: string;
+  coefficient: number | null;
+  pValue: number | null;
+  adjustedPValue: number | null;
+  ciLower: number | null;
+  ciUpper: number | null;
+  sampleCount: number;
+  method: CorrelationMethod;
+}
+
+export interface CoefficientEstimate {
+  estimate: number;
+  standardError: number;
+  tStatistic: number;
+  pValue: number;
+  ciLower: number;
+  ciUpper: number;
+}
+
+export interface RegressionEstimate {
+  sampleCount: number;
+  rSquared: number;
+  adjustedRSquared: number;
+  coefficients: Record<string, CoefficientEstimate>;
+  residualDiagnostics: {
+    rmse: number;
+    mae: number;
+    residualMean: number;
+    residualStd: number;
+    durbinWatson: number | null;
+    influentialCount: number;
+  };
+}
+
+export interface GroupAnalysis {
+  groupValue: string;
+  rowCount: number;
+  correlations: CorrelationEstimate[];
+  regression: RegressionEstimate | null;
+  warnings: string[];
+}
+
+export interface LaunchMonitorAnalysisResult {
+  contractVersion: typeof LAUNCH_MONITOR_ANALYSIS_CONTRACT_VERSION;
+  request: LaunchMonitorAnalysisRequest;
+  dataset: {
+    rowCount: number;
+    completeRowCount: number;
+    selectedColumns: string[];
+    monitorVendors: string[];
+    sessionIds: string[];
+    observationKinds: string[];
+    fingerprintSha256: string;
+  };
+  correlations: CorrelationEstimate[];
+  regression: RegressionEstimate | null;
+  groups: GroupAnalysis[];
+  warnings: string[];
+}
+
+export const finiteLaunchMonitorScalar = (
+  value: LaunchMonitorScalar | undefined,
+): number | null => {
+  if (value === null || value === undefined || value === "" || typeof value === "boolean") {
+    return null;
+  }
+  const converted = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(converted) ? converted : null;
+};

--- a/src/rate_of_closure/web/src/model/launchMonitorFileParsing.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorFileParsing.ts
@@ -1,0 +1,61 @@
+/** CSV and JSON ingestion for launch-monitor analysis. */
+
+import type { LaunchMonitorRow, LaunchMonitorScalar } from "./launchMonitorAnalysisTypes";
+
+const coerceCell = (value: string): LaunchMonitorScalar => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const numeric = Number(trimmed);
+  return Number.isFinite(numeric) ? numeric : trimmed;
+};
+
+const parseCsvRows = (text: string): string[][] => {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let quoted = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    if (character === '"') {
+      if (quoted && text[index + 1] === '"') {
+        cell += '"';
+        index += 1;
+      } else quoted = !quoted;
+    } else if (character === "," && !quoted) {
+      row.push(cell);
+      cell = "";
+    } else if ((character === "\n" || character === "\r") && !quoted) {
+      if (character === "\r" && text[index + 1] === "\n") index += 1;
+      row.push(cell);
+      cell = "";
+      if (row.some((value) => value.length)) rows.push(row);
+      row = [];
+    } else cell += character;
+  }
+  if (cell.length || row.length) {
+    row.push(cell);
+    rows.push(row);
+  }
+  if (quoted) throw new RangeError("CSV contains an unterminated quoted field");
+  return rows;
+};
+
+export function parseLaunchMonitorFile(fileName: string, text: string): LaunchMonitorRow[] {
+  if (fileName.toLowerCase().endsWith(".json")) {
+    const parsed: unknown = JSON.parse(text);
+    if (!Array.isArray(parsed) || parsed.some((row) =>
+      !row || typeof row !== "object" || Array.isArray(row))) {
+      throw new RangeError("JSON launch-monitor data must be an array of record objects");
+    }
+    return parsed as LaunchMonitorRow[];
+  }
+  const parsed = parseCsvRows(text);
+  if (parsed.length < 2) throw new RangeError("CSV must contain a header and at least one row");
+  const headers = parsed[0].map((header) => header.trim());
+  if (headers.some((header) => !header) || new Set(headers).size !== headers.length) {
+    throw new RangeError("CSV headers must be non-empty and unique");
+  }
+  return parsed.slice(1).map((values) => Object.fromEntries(headers.map(
+    (header, index) => [header, coerceCell(values[index] ?? "")],
+  ))) as LaunchMonitorRow[];
+}

--- a/src/rate_of_closure/web/src/model/launchMonitorFingerprint.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorFingerprint.ts
@@ -1,0 +1,62 @@
+/** Deterministic provenance fingerprints for browser analysis exports. */
+
+import type { LaunchMonitorRow } from "./launchMonitorAnalysisTypes";
+
+const sha256 = (input: string): string => {
+  const rotate = (value: number, amount: number) =>
+    (value >>> amount) | (value << (32 - amount));
+  const primes: number[] = [];
+  for (let candidate = 2; primes.length < 64; candidate += 1) {
+    if (primes.every((prime) => candidate % prime !== 0)) primes.push(candidate);
+  }
+  const hash = primes.slice(0, 8).map((prime) => (Math.sqrt(prime) % 1) * 2 ** 32 | 0);
+  const constants = primes.map((prime) => (Math.cbrt(prime) % 1) * 2 ** 32 | 0);
+  const bytes = new TextEncoder().encode(input);
+  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  new DataView(padded.buffer).setUint32(paddedLength - 4, bytes.length * 8, false);
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    const words = Array(64).fill(0) as number[];
+    const view = new DataView(padded.buffer, offset, 64);
+    for (let index = 0; index < 16; index += 1) words[index] = view.getUint32(index * 4, false);
+    for (let index = 16; index < 64; index += 1) {
+      const first = rotate(words[index - 15], 7) ^ rotate(words[index - 15], 18) ^
+        (words[index - 15] >>> 3);
+      const second = rotate(words[index - 2], 17) ^ rotate(words[index - 2], 19) ^
+        (words[index - 2] >>> 10);
+      words[index] = (words[index - 16] + first + words[index - 7] + second) | 0;
+    }
+    let [a, b, c, d, e, f, g, h] = hash;
+    for (let index = 0; index < 64; index += 1) {
+      const sigmaOne = rotate(e, 6) ^ rotate(e, 11) ^ rotate(e, 25);
+      const choice = (e & f) ^ (~e & g);
+      const first = (h + sigmaOne + choice + constants[index] + words[index]) | 0;
+      const sigmaZero = rotate(a, 2) ^ rotate(a, 13) ^ rotate(a, 22);
+      const majority = (a & b) ^ (a & c) ^ (b & c);
+      const second = (sigmaZero + majority) | 0;
+      [h, g, f, e, d, c, b, a] = [g, f, e, (d + first) | 0, c, b, a, (first + second) | 0];
+    }
+    [a, b, c, d, e, f, g, h].forEach((value, index) => {
+      hash[index] = (hash[index] + value) | 0;
+    });
+  }
+  return hash.map((value) => (value >>> 0).toString(16).padStart(8, "0")).join("");
+};
+
+export const sha256Text = (input: string): string => sha256(input);
+
+export const uniqueStrings = (rows: LaunchMonitorRow[], column: string): string[] =>
+  [...new Set(rows.map((row) => row[column])
+    .filter((value) => value !== null && value !== undefined)
+    .map(String).filter((value) => value.trim()))].sort();
+
+export const canonicalFingerprint = (rows: LaunchMonitorRow[], selected: string[]): string => {
+  const identity = ["shot_id", "session_id", "source_row", "monitor_vendor"]
+    .filter((column) => rows.some((row) => column in row) && !selected.includes(column));
+  const columns = [...identity, ...selected];
+  return sha256(JSON.stringify(rows.map((row) => Object.fromEntries(
+    columns.map((column) => [column, row[column] ?? null]),
+  ))));
+};

--- a/src/rate_of_closure/web/src/model/viewPreferences.test.ts
+++ b/src/rate_of_closure/web/src/model/viewPreferences.test.ts
@@ -47,6 +47,7 @@ describe("primary view preferences", () => {
     const loaded = loadPrimaryViewState(storage);
     expect(loaded.order.slice(0, 2)).toEqual(["plots", "simulation"]);
     expect(new Set(loaded.order)).toEqual(new Set(PRIMARY_VIEW_IDS));
+    expect(loaded.order).toContain("launch-monitor-analytics");
   });
 
   it("round-trips a valid reordered state", () => {

--- a/src/rate_of_closure/web/src/model/viewPreferences.ts
+++ b/src/rate_of_closure/web/src/model/viewPreferences.ts
@@ -6,6 +6,7 @@ export const PRIMARY_VIEWS = [
   { id: "simulation", label: "Simulation" },
   { id: "plots", label: "Plots" },
   { id: "flight", label: "Flight Explorer" },
+  { id: "launch-monitor-analytics", label: "Launch Monitor Analytics" },
   { id: "variation", label: "Variation" },
   { id: "putting", label: "Putting" },
   { id: "glossary", label: "Glossary" },

--- a/tests/rate_of_closure/test_launch_monitor_analysis.py
+++ b/tests/rate_of_closure/test_launch_monitor_analysis.py
@@ -1,0 +1,83 @@
+"""Parity and safety contracts for desktop launch-monitor analytics."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from rate_of_closure.launch_monitor_analysis import (
+    AnalysisRequest,
+    analyze_launch_monitor_data,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+def _frame() -> pd.DataFrame:
+    count = 80
+    index = np.arange(count)
+    club_speed = 35.0 + index * 0.2
+    attack_angle = -3.0 + (index % 8) * 0.5
+    return pd.DataFrame(
+        {
+            "shot_id": [f"shot-{item}" for item in index],
+            "session_id": np.where(index < 40, "a", "b"),
+            "monitor_vendor": np.where(index % 2, "FlightScope", "TrackMan"),
+            "club_speed": club_speed,
+            "attack_angle": attack_angle,
+            "ball_speed": 1.48 * club_speed + 0.04 * attack_angle,
+        }
+    )
+
+
+def test_analysis_reports_uncertainty_diagnostics_groups_and_lineage() -> None:
+    result = analyze_launch_monitor_data(
+        _frame(),
+        AnalysisRequest(
+            outcome="ball_speed",
+            predictors=("club_speed", "attack_angle"),
+            group_by="monitor_vendor",
+        ),
+    )
+
+    assert result.contract_version == "1.0.0"
+    assert result.dataset.row_count == 80
+    assert result.dataset.monitor_vendors == ("FlightScope", "TrackMan")
+    assert len(result.dataset.fingerprint_sha256) == 64
+    assert result.regression is not None
+    assert result.regression.r_squared > 0.999
+    assert result.regression.coefficients["club_speed"].estimate == pytest.approx(1.48)
+    assert [group.group_value for group in result.groups] == ["FlightScope", "TrackMan"]
+    assert result.to_wire()["contractVersion"] == "1.0.0"
+
+
+def test_pairwise_missingness_and_fail_closed_boundaries() -> None:
+    frame = _frame()
+    frame.loc[0, "attack_angle"] = np.nan
+    result = analyze_launch_monitor_data(
+        frame,
+        AnalysisRequest(
+            outcome="ball_speed",
+            predictors=("club_speed", "attack_angle"),
+            analysis_mode="correlation",
+        ),
+    )
+    assert {item.predictor: item.sample_count for item in result.correlations} == {
+        "club_speed": 80,
+        "attack_angle": 79,
+    }
+
+    aggregate = _frame().assign(observation_kind="aggregate")
+    with pytest.raises(
+        ValueError, match="Aggregate observations cannot enter regression"
+    ):
+        analyze_launch_monitor_data(
+            aggregate,
+            AnalysisRequest(
+                outcome="ball_speed",
+                predictors=("club_speed",),
+                analysis_mode="regression",
+                allow_aggregate=True,
+            ),
+        )

--- a/tests/rate_of_closure/test_launch_monitor_analytics_tab.py
+++ b/tests/rate_of_closure/test_launch_monitor_analytics_tab.py
@@ -1,0 +1,49 @@
+"""Desktop presentation tests for the Launch Monitor Analytics tab."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("PyQt6")
+pytest.importorskip("pytestqt")
+
+from rate_of_closure.ui.pyqt6.launch_monitor_analytics_tab import (  # noqa: E402
+    LaunchMonitorAnalyticsTab,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+def test_demo_analysis_populates_results_and_traceability(qtbot) -> None:  # type: ignore[no-untyped-def]
+    tab = LaunchMonitorAnalyticsTab()
+    qtbot.addWidget(tab)
+
+    result = tab.run_analysis()
+
+    assert result.dataset.row_count == 120
+    assert tab.result_table.rowCount() >= 3
+    assert result.dataset.fingerprint_sha256 in tab.details.toPlainText()
+    assert tab.export_result_button.isEnabled()
+
+
+def test_every_interactive_control_has_accessible_help(qtbot) -> None:  # type: ignore[no-untyped-def]
+    tab = LaunchMonitorAnalyticsTab()
+    qtbot.addWidget(tab)
+    controls = (
+        tab.import_button,
+        tab.demo_button,
+        tab.export_data_button,
+        tab.export_result_button,
+        tab.convention_combo,
+        tab.outcome_combo,
+        tab.predictor_list,
+        tab.mode_combo,
+        tab.method_combo,
+        tab.missing_combo,
+        tab.group_combo,
+        tab.confidence_spin,
+        tab.min_samples_spin,
+        tab.run_button,
+    )
+    assert all(control.accessibleName() for control in controls)
+    assert all(control.toolTip() for control in controls)

--- a/tests/rate_of_closure/test_primary_navigation.py
+++ b/tests/rate_of_closure/test_primary_navigation.py
@@ -91,3 +91,17 @@ def test_legacy_or_partial_order_is_sanitized(qtbot, settings) -> None:  # type:
 def test_default_qsettings_namespace_is_application_specific() -> None:
     assert _NAVIGATION_SETTINGS_ORG == "D-sorganization"
     assert _NAVIGATION_SETTINGS_APP == "RateOfClosureImpactExplorer"
+
+
+def test_launch_monitor_tab_is_registered_once(qtbot, settings) -> None:  # type: ignore[no-untyped-def]
+    window = RateOfClosureMainWindow(navigation_settings=settings)
+    qtbot.addWidget(window)
+    try:
+        assert window.primary_tab_ids().count("launch_monitor_analytics") == 1
+        assert window._tabs.indexOf(window._launch_monitor_analytics_tab) >= 0
+        assert (
+            window._launch_monitor_analytics_tab.outcome_combo.currentText()
+            == "ball_speed"
+        )
+    finally:
+        window.close()


### PR DESCRIPTION
## Summary
- add **Launch Monitor Analytics** as a persistent primary tab in the Rate of Closure PyQt6 and React/Vite applications
- retain every imported CSV/JSON source column and allow arbitrary numeric outcomes with multiple predictors
- provide Pearson/Spearman/Kendall association, BH correction, multivariable OLS uncertainty, residual diagnostics, grouping, scatter visualization, SHA-256 lineage, and JSON exports
- consume the #4203 Python/TypeScript convention registries and retain **TrackMan-Comparable** / **Foresight-Comparable** language without device-emulation or certification claims
- preserve old persisted tab orders by appending the stable new tab ID automatically

## Stack
This draft intentionally targets `feat/4181-launch-monitor-registry` (#4203), the authoritative shared convention/provenance foundation identified for the active Impact Zone Model stack.

## Verification
- `python -m pytest tests/rate_of_closure -q` — 583 passed
- focused Ruff — passed
- focused MyPy — passed
- `npm test` — 374 passed
- `npm run type-check` — passed
- `npm run lint` — passed
- `npm run build` — passed
- in-app rendered layout and Run Analysis interaction — passed with no console errors

Relates to D-sorganization/UpstreamDrift#8364
Closes #4205