### PR TITLE
⚡ Bolt: Replace Array.from in CSV indexing to eliminate closure overhead

### DIFF
--- a/src/p1am_control_system/frontend/src/components/data_explorer/DataExplorer.tsx
+++ b/src/p1am_control_system/frontend/src/components/data_explorer/DataExplorer.tsx
@@ -123,7 +123,15 @@ export const DataExplorer: React.FC<DataExplorerProps> = ({ triggerNotification 
       } else {
         if (!csv) throw new Error("No CSV loaded");
         const n = csv.columns[0]?.values.length ?? 0;
-        const index = csv.index ?? Array.from({ length: n }, (_, i) => i);
+
+        // ⚡ Bolt Optimization: Avoid Array.from({ length: n }) in data-intensive paths
+        // which incurs iterator and closure overhead per element.
+        let index = csv.index;
+        if (!index) {
+          index = new Array(n);
+          for (let i = 0; i < n; i++) index[i] = i;
+        }
+
         req = {
           inline: { index, columns: csv.columns },
           resample: pipeline.resample ?? undefined,


### PR DESCRIPTION
* 💡 What: Replaced `Array.from({ length: n })` with a pre-allocated `new Array(n)` and a standard `for` loop for default CSV index generation in `DataExplorer.tsx`.
* 🎯 Why: In V8, `Array.from` on an object with a `length` property creates an iterator and executes a callback for every element. For large datasets (like importing 100k+ row CSVs), this causes significant CPU and GC overhead compared to a basic loop.
* 📊 Impact: Substantially reduces main-thread blocking time and garbage collection pressure when loading large CSV files without explicit time columns.
* 🔬 Measurement: Profile the main thread in Chrome DevTools while importing a 100k+ row CSV with no time column; observe the reduced execution time and memory allocation during the `buildDataset` preparation phase.

---
*PR created automatically by Jules for task [8732981744710152070](https://jules.google.com/task/8732981744710152070) started by @dieterolson*