### PR TITLE
🎨 Palette: Add focus-visible states to core buttons

### DIFF
--- a/src/p1am_control_system/frontend/src/index.css
+++ b/src/p1am_control_system/frontend/src/index.css
@@ -267,6 +267,11 @@ body {
   border-color: var(--text-muted);
 }
 
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--panel-bg), 0 0 0 4px var(--accent-cyan);
+}
+
 .btn-primary {
   background: var(--accent-cyan);
   border-color: var(--accent-cyan);
@@ -399,6 +404,12 @@ body {
 .tab-button.active-tab {
   color: var(--accent-cyan);
   border-bottom-color: var(--accent-cyan);
+}
+
+.tab-btn:focus-visible {
+  outline: none;
+  background: var(--cell-hover-bg);
+  border-radius: 4px;
 }
 
 /* --- Tuning & Comparison Grid --- */


### PR DESCRIPTION
💡 What: Added `focus-visible` styling to `.btn` and `.tab-btn` classes in `index.css`.
🎯 Why: To ensure that core interactive elements have clear visual focus indicators when navigated via keyboard, improving accessibility for keyboard-only users.
📸 Before/After: N/A (CSS style addition)
♿ Accessibility: Resolves an accessibility issue where standard buttons utilizing the `.btn` and `.tab-btn` utility classes lacked focus ring accessibility, despite inputs and other tabs being styled properly.

---
*PR created automatically by Jules for task [14866957424878358747](https://jules.google.com/task/14866957424878358747) started by @dieterolson*