### PR TITLE
🎨 Palette: Add ARIA labels to dynamic matrix grids

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -49,3 +49,6 @@
 ## 2024-05-31 - Tab Roles vs aria-pressed
 **Learning:** When implementing custom tab components in React, use `role="tab"` paired strictly with `aria-selected` (not `aria-pressed`, which is intended for toggle buttons) and ensure `aria-controls` points to a valid `role="tabpanel"` container whose `aria-labelledby` points back to the tab.
 **Action:** When adding accessible properties to custom tabs, replace `aria-pressed` with `aria-selected`, ensure a `role="tablist"` wrapper is present, and correctly cross-reference `aria-controls` with the tab panel IDs.
+## 2024-08-12 - ARIA Labels for Dynamic Matrix Grids
+**Learning:** When creating dynamic input grids (e.g., mathematical matrices or vectors) where explicit `<label>` elements per cell are impractical, screen readers are left without contextual associations for each input field.
+**Action:** Always assign descriptive, context-aware `aria-label` attributes to the inputs (e.g., `aria-label={\`Row \${i + 1}, Column \${j + 1}\`}`) to ensure screen reader accessibility without breaking the visual density of the grid.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -49,6 +49,6 @@
 ## 2024-05-31 - Tab Roles vs aria-pressed
 **Learning:** When implementing custom tab components in React, use `role="tab"` paired strictly with `aria-selected` (not `aria-pressed`, which is intended for toggle buttons) and ensure `aria-controls` points to a valid `role="tabpanel"` container whose `aria-labelledby` points back to the tab.
 **Action:** When adding accessible properties to custom tabs, replace `aria-pressed` with `aria-selected`, ensure a `role="tablist"` wrapper is present, and correctly cross-reference `aria-controls` with the tab panel IDs.
-## 2024-08-12 - ARIA Labels for Dynamic Matrix Grids
+## 2026-08-12 - ARIA Labels for Dynamic Matrix Grids
 **Learning:** When creating dynamic input grids (e.g., mathematical matrices or vectors) where explicit `<label>` elements per cell are impractical, screen readers are left without contextual associations for each input field.
 **Action:** Always assign descriptive, context-aware `aria-label` attributes to the inputs (e.g., `aria-label={\`Row \${i + 1}, Column \${j + 1}\`}`) to ensure screen reader accessibility without breaking the visual density of the grid.

--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -1,7 +1,23 @@
 # AGENT_HANDOFF — Tools (monorepo root)
 
 > **Update this file with every PR and every push to main.**
-> Last updated: 2026-08-04
+> Last updated: 2026-08-12
+
+## 2026-08-12 — PR #4389 Rotation-Converter Accessible Input Names
+
+Open PR #4389 on `palette-aria-labels-matrices-3953280844180552522`
+targets `main` with accessible names for every dense rotation and
+reference-frame numeric input. The continuation corrects the Palette note's
+date, replaces screen-reader-hostile Greek and Lie-algebra abbreviations with
+plain-language twist and rotation-vector names, and explicitly associates the
+operation, input-type, and Euler-convention labels with their controls. It also
+adds focused React contracts covering every conditional input family.
+
+Local exact-branch evidence: five focused component tests pass, including the
+initial red accessibility-name case; TypeScript, zero-warning ESLint, and the
+29-module production build pass. Human review is approved, but the final
+handoff head still requires fresh protected checks and ordinary non-admin merge
+behavior. No Rate of Closure behavior or public numerical contract changes.
 
 ## Where This Repo Is Headed
 

--- a/src/rotation_converter/AGENT_HANDOFF.md
+++ b/src/rotation_converter/AGENT_HANDOFF.md
@@ -1,7 +1,22 @@
 # AGENT_HANDOFF — rotation_converter
 
 > **Update this file with every PR and every push to main.**
-> Last updated: 2026-08-04
+> Last updated: 2026-08-12
+
+## 2026-08-12 — PR #4389 Accessible Input Names
+
+Open PR #4389 on `palette-aria-labels-matrices-3953280844180552522`
+targets `main`. Every dynamic rotation, transform-matrix, twist, translation,
+and rotation-vector number field now has a descriptive accessible name.
+Symbolic twist labels are expanded to angular/linear velocity plus axis, and
+the operation, input-type, and Euler-convention visible labels are explicitly
+bound to their controls. The Palette learning date is corrected to 2026.
+
+TDD evidence: the new accessibility query failed against the original
+symbolic names, then all five focused React tests passed after the production
+labels were clarified. TypeScript, zero-warning ESLint, and the 29-module Vite
+production build pass. Human review is approved, but fresh final-head protected
+checks and ordinary non-admin merge behavior remain mandatory.
 
 ## Where This Tool Is Headed
 

--- a/src/rotation_converter/web/src/components/ReferenceFrameConverter.test.tsx
+++ b/src/rotation_converter/web/src/components/ReferenceFrameConverter.test.tsx
@@ -99,4 +99,40 @@ describe("ReferenceFrameConverter", () => {
       assertPayloadContainsOnlyExpectedFields("so3_so3_maps", ["so3_vector"]);
     });
   });
+
+  it("gives every dense numeric input a descriptive accessible name", () => {
+    render(<ReferenceFrameConverter />);
+
+    expect(screen.getByRole("combobox", { name: "Operation" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("spinbutton", {
+        name: "Transform matrix row 1, column 1",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("spinbutton", { name: "Twist angular velocity x" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("spinbutton", { name: "Twist linear velocity z" }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Operation" }), {
+      target: { value: "homogeneous_transform" },
+    });
+    expect(
+      screen.getByRole("spinbutton", {
+        name: "Rotation matrix row 3, column 3",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("spinbutton", { name: "Translation component y" }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Operation" }), {
+      target: { value: "so3_so3_maps" },
+    });
+    expect(
+      screen.getByRole("spinbutton", { name: "Rotation vector component z" }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/rotation_converter/web/src/components/ReferenceFrameConverter.tsx
+++ b/src/rotation_converter/web/src/components/ReferenceFrameConverter.tsx
@@ -105,6 +105,7 @@ export function ReferenceFrameConverter() {
                     key={`${i}-${j}`}
                     type="number"
                     value={entry}
+                    aria-label={`Transform matrix row ${i + 1}, column ${j + 1}`}
                     onChange={(event) => updateMatrix(setTransform, transform, i, j, Number(event.target.value))}
                     className="bg-slate-700 rounded px-2 py-1 text-sm border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   />
@@ -118,6 +119,7 @@ export function ReferenceFrameConverter() {
                   key={i}
                   type="number"
                   value={entry}
+                  aria-label={`Twist component ${['ωx', 'ωy', 'ωz', 'vx', 'vy', 'vz'][i]}`}
                   onChange={(event) => {
                     const next = [...twist];
                     next[i] = Number(event.target.value);
@@ -140,6 +142,7 @@ export function ReferenceFrameConverter() {
                     key={`${i}-${j}`}
                     type="number"
                     value={entry}
+                    aria-label={`Rotation matrix row ${i + 1}, column ${j + 1}`}
                     onChange={(event) =>
                       updateMatrix(setRotationMatrix, rotationMatrix, i, j, Number(event.target.value))
                     }
@@ -155,6 +158,7 @@ export function ReferenceFrameConverter() {
                   key={i}
                   type="number"
                   value={entry}
+                  aria-label={`Translation component ${['x', 'y', 'z'][i]}`}
                   onChange={(event) => {
                     const next = [...translation];
                     next[i] = Number(event.target.value);
@@ -176,6 +180,7 @@ export function ReferenceFrameConverter() {
                   key={i}
                   type="number"
                   value={entry}
+                  aria-label={`so(3) vector component ${['x', 'y', 'z'][i]}`}
                   onChange={(event) => {
                     const next = [...so3Vector];
                     next[i] = Number(event.target.value);

--- a/src/rotation_converter/web/src/components/ReferenceFrameConverter.tsx
+++ b/src/rotation_converter/web/src/components/ReferenceFrameConverter.tsx
@@ -22,6 +22,17 @@ const IDENTITY_3X3 = [
   [0, 0, 1],
 ];
 
+const TWIST_ACCESSIBLE_LABELS = [
+  "Twist angular velocity x",
+  "Twist angular velocity y",
+  "Twist angular velocity z",
+  "Twist linear velocity x",
+  "Twist linear velocity y",
+  "Twist linear velocity z",
+] as const;
+
+const AXES = ["x", "y", "z"] as const;
+
 export function ReferenceFrameConverter() {
   const [operation, setOperation] = useState<Operation>("twist_frame_conversion");
   const [transform, setTransform] = useState<number[][]>(IDENTITY_4X4);
@@ -80,11 +91,14 @@ export function ReferenceFrameConverter() {
           Reference-Frame Operations
         </h2>
 
-        {error && <div className="bg-red-900/40 border border-red-500 rounded p-3 text-red-200">{error}</div>}
+        {error && <div role="alert" className="bg-red-900/40 border border-red-500 rounded p-3 text-red-200">{error}</div>}
 
         <div>
-          <label className="block text-sm text-slate-300 mb-1">Operation</label>
+          <label htmlFor="reference-frame-operation" className="block text-sm text-slate-300 mb-1">
+            Operation
+          </label>
           <select
+            id="reference-frame-operation"
             value={operation}
             onChange={(event) => setOperation(event.target.value as Operation)}
             className="w-full bg-slate-700 rounded px-3 py-2 border border-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
@@ -119,7 +133,7 @@ export function ReferenceFrameConverter() {
                   key={i}
                   type="number"
                   value={entry}
-                  aria-label={`Twist component ${['ωx', 'ωy', 'ωz', 'vx', 'vy', 'vz'][i]}`}
+                  aria-label={TWIST_ACCESSIBLE_LABELS[i]}
                   onChange={(event) => {
                     const next = [...twist];
                     next[i] = Number(event.target.value);
@@ -158,7 +172,7 @@ export function ReferenceFrameConverter() {
                   key={i}
                   type="number"
                   value={entry}
-                  aria-label={`Translation component ${['x', 'y', 'z'][i]}`}
+                  aria-label={`Translation component ${AXES[i]}`}
                   onChange={(event) => {
                     const next = [...translation];
                     next[i] = Number(event.target.value);
@@ -180,7 +194,7 @@ export function ReferenceFrameConverter() {
                   key={i}
                   type="number"
                   value={entry}
-                  aria-label={`so(3) vector component ${['x', 'y', 'z'][i]}`}
+                  aria-label={`Rotation vector component ${AXES[i]}`}
                   onChange={(event) => {
                     const next = [...so3Vector];
                     next[i] = Number(event.target.value);

--- a/src/rotation_converter/web/src/components/RotationConverter.test.tsx
+++ b/src/rotation_converter/web/src/components/RotationConverter.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RotationConverter } from "./RotationConverter";
+
+describe("RotationConverter", () => {
+  it("gives every rotation input a descriptive accessible name", () => {
+    render(<RotationConverter />);
+
+    expect(
+      screen.getByRole("spinbutton", { name: "Quaternion component W" }),
+    ).toBeInTheDocument();
+
+    const inputType = screen.getByRole("combobox", { name: "Input Type" });
+    fireEvent.change(inputType, { target: { value: "euler" } });
+    expect(screen.getByRole("textbox", { name: "Convention" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("spinbutton", { name: "Euler angle axis 3" }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(inputType, { target: { value: "axis_angle" } });
+    expect(
+      screen.getByRole("spinbutton", {
+        name: "Axis-angle component angle (rad)",
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(inputType, { target: { value: "rodrigues" } });
+    expect(
+      screen.getByRole("spinbutton", {
+        name: "Rodrigues vector component rz",
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/rotation_converter/web/src/components/RotationConverter.tsx
+++ b/src/rotation_converter/web/src/components/RotationConverter.tsx
@@ -80,8 +80,9 @@ export function RotationConverter() {
                 )}
 
                 <div>
-                    <label className="block text-sm text-slate-300 mb-1">Input Type</label>
+                    <label htmlFor="rotation-input-type" className="block text-sm text-slate-300 mb-1">Input Type</label>
                     <select
+                        id="rotation-input-type"
                         value={inputType}
                         onChange={(e) => setInputType(e.target.value)}
                         className="w-full bg-slate-700 rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
@@ -118,8 +119,9 @@ export function RotationConverter() {
                 {inputType === 'euler' && (
                     <div className="space-y-4">
                         <div>
-                            <label className="block text-sm text-slate-300 mb-1">Convention</label>
+                            <label htmlFor="euler-convention" className="block text-sm text-slate-300 mb-1">Convention</label>
                             <input
+                                id="euler-convention"
                                 type="text"
                                 value={eulerConvention}
                                 onChange={(e) => setEulerConvention(e.target.value)}

--- a/src/rotation_converter/web/src/components/RotationConverter.tsx
+++ b/src/rotation_converter/web/src/components/RotationConverter.tsx
@@ -101,6 +101,7 @@ export function RotationConverter() {
                                 <input
                                     type="number"
                                     value={quaternion[i]}
+                                    aria-label={`Quaternion component ${axis.toUpperCase()}`}
                                     onChange={(e) => {
                                         const newQ = [...quaternion];
                                         newQ[i] = Number(e.target.value);
@@ -133,6 +134,7 @@ export function RotationConverter() {
                                     <input
                                         type="number"
                                         value={euler[i]}
+                                        aria-label={`Euler angle axis ${i + 1}`}
                                         onChange={(e) => {
                                             const newE = [...euler];
                                             newE[i] = Number(e.target.value);
@@ -155,6 +157,7 @@ export function RotationConverter() {
                                 <input
                                     type="number"
                                     value={axisAngle[i]}
+                                    aria-label={`Axis-angle component ${label}`}
                                     onChange={(e) => {
                                         const newA = [...axisAngle];
                                         newA[i] = Number(e.target.value);
@@ -176,6 +179,7 @@ export function RotationConverter() {
                                 <input
                                     type="number"
                                     value={rodrigues[i]}
+                                    aria-label={`Rodrigues vector component ${label}`}
                                     onChange={(e) => {
                                         const newR = [...rodrigues];
                                         newR[i] = Number(e.target.value);


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to the matrix and vector input fields in `ReferenceFrameConverter.tsx` and `RotationConverter.tsx`.
🎯 Why: Dynamic input grids are completely inaccessible to screen reader users without explicit labels for each cell. Because standard `<label>` elements are impractical for dense matrix layouts, `aria-label` provides the necessary context.
📸 Before/After: Inputs for matrices and vectors had no screen reader announcements. Now they clearly announce their mathematical component (e.g. "Transform matrix row 1, column 1", "Twist component ωx", or "Quaternion component W").
♿ Accessibility: Significantly improves screen reader navigation by explicitly associating matrix cells and vector elements with their contextual meaning.

---
*PR created automatically by Jules for task [3953280844180552522](https://jules.google.com/task/3953280844180552522) started by @dieterolson*