### PR TITLE
⚡ Bolt: Optimize CSV generation to reduce GC overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -89,3 +89,6 @@
 ## 2025-05-18 - Avoid array methods for small static arrays in frequently called initializers
 **Learning:** Using `.reduce()` or `.map()` on static arrays like tabs definitions inside frequently called functions (e.g. state initializers or local storage hydration) incurs unnecessary closure and function call overhead.
 **Action:** Replace `.reduce()` and `.map()` with single-pass `for` loops in simple data transformation functions (like `defaultTabVisibility`) to eliminate closure allocations.
+## 2026-08-13 - Replace chained .map().join() in CSV generation
+**Learning:** Using chained array methods like `.map().join()` for large data serialization (like CSV exports) allocates intermediate arrays for every row, putting immense pressure on the garbage collector and stalling the main thread.
+**Action:** Replace chained array map/join operations in data serialization hot paths with single-pass `for` loops and string concatenation to eliminate intermediate allocations.

--- a/src/p1am_control_system/frontend/src/lib/chartSnapshot.ts
+++ b/src/p1am_control_system/frontend/src/lib/chartSnapshot.ts
@@ -287,11 +287,25 @@ export function downloadCsv(
     throw new TypeError("downloadCsv: rows must be an array of arrays");
   }
   assertNonEmptyString(filename, "downloadCsv", "filename");
-  const lines = [headers.map(escapeCsvValue).join(",")];
-  for (const row of rows) {
-    lines.push(row.map(escapeCsvValue).join(","));
+
+  // ⚡ Bolt Optimization: Replace intermediate array allocations (.map().join())
+  // with a single-pass string concatenation loop to reduce garbage collection
+  // overhead during large CSV exports.
+  let csvString = "";
+  for (let i = 0; i < headers.length; i++) {
+    if (i > 0) csvString += ",";
+    csvString += escapeCsvValue(headers[i]);
   }
-  const blob = new Blob([lines.join("\r\n")], {
+  for (let i = 0; i < rows.length; i++) {
+    csvString += "\r\n";
+    const row = rows[i];
+    for (let j = 0; j < row.length; j++) {
+      if (j > 0) csvString += ",";
+      csvString += escapeCsvValue(row[j]);
+    }
+  }
+
+  const blob = new Blob([csvString], {
     type: "text/csv;charset=utf-8",
   });
   triggerDownload(blob, filename);


### PR DESCRIPTION
💡 What: Replaced `.map().join()` with string concatenation inside `downloadCsv`.
🎯 Why: `.map().join()` allocates an intermediate array of strings for every row during export, causing massive garbage collection overhead for large datasets.
📊 Impact: Eliminates O(N) array allocations per CSV export, significantly reducing memory pressure and potential main-thread stalling.
🔬 Measurement: Run a large data export profile to verify decreased Heap growth and GC pauses.

---
*PR created automatically by Jules for task [2480763301857704012](https://jules.google.com/task/2480763301857704012) started by @dieterolson*