### PR TITLE
fix(ci): reconcile the cross-repo sparse-scope mirror and the sandboxed exit test

### DIFF
--- a/.github/workflows/cross-repo-python-integration.yml
+++ b/.github/workflows/cross-repo-python-integration.yml
@@ -92,11 +92,7 @@ jobs:
             test_command: xvfb-run --auto-servernum pytest tests/shared_contracts/ --timeout=60 --timeout-method=thread -v --tb=short
             env_name: REQUIRE_REAL_TOOLS_REPO
             sparse_checkout: |
-              src/chat
-              src/contracts.py
-              src/python/src/utils
               src/shared
-              src/sidekick
               tests/shared_contracts
               tests/support
 

--- a/tests/ops/test_cross_repo_python_integration.py
+++ b/tests/ops/test_cross_repo_python_integration.py
@@ -14,12 +14,10 @@ REQUIRED_SPARSE_PATHS = {
         "tests/shared_contracts",
     },
     "D-sorganization/UpstreamDrift": {
-        "chat",
-        "contracts.py",
-        "python/src/utils",
-        "shared",
-        "sidekick",
-        "src/shared/python",
+        # UpstreamDrift moved its consumed packages under src/shared/python, so
+        # this is the narrow root that carries them. Deliberately NOT bare `src`
+        # -- see the assertions in the test below.
+        "src/shared",
         "tests/shared_contracts",
         "tests/support",
     },
@@ -75,13 +73,11 @@ def test_upstream_scope_includes_every_release_build_package_root() -> None:
     )
 
     scope = set(upstream["sparse_checkout"].splitlines())
-    assert {
-        "chat",
-        "contracts.py",
-        "python/src/utils",
-        "shared",
-        "sidekick",
-    } <= scope
+    # `src/shared` is the package root that actually carries the code this repo
+    # provides to UpstreamDrift; `pip install -e .` there resolves through
+    # hatchling's `packages = ["src"]`, and cone-mode sparse checkout gives it a
+    # populated `src/shared` without pulling all of `src`.
+    assert {"src/shared"} <= scope
 
 
 def test_downstream_checkout_keeps_sparse_checkout_authoritative() -> None:

--- a/tests/rotation_converter/test_scripting_env.py
+++ b/tests/rotation_converter/test_scripting_env.py
@@ -112,7 +112,10 @@ class TestConsoleEnvironment(unittest.TestCase):
             self.env.set_user_library_path(user_lib_path)
 
             # Save code that raises SystemExit
-            self.env.save_user_code("import sys; sys.exit(1)")
+            # `import sys` is blocked by the scripting sandbox, so importing it to
+            # reach sys.exit never raises. SystemExit is a builtin, so raise it
+            # directly to test what this case is actually about: propagation.
+            self.env.save_user_code("raise SystemExit(1)")
 
             # Should propagate instead of being caught and logged
             with self.assertRaises(SystemExit):


### PR DESCRIPTION
Three tests fail on `main` at `edfeae684` **today**, before this PR. They are invisible because neither file lands in `main`'s changed-file set, so delta CI never runs them. The practical effect is that the first branch to touch either file inherits the failures and appears to have caused them — which is what happened to #4447.

```
tests/ops/test_cross_repo_python_integration.py
  ::test_each_downstream_declares_its_required_sparse_scope
  ::test_upstream_scope_includes_every_release_build_package_root
tests/rotation_converter/test_scripting_env.py
  ::TestConsoleEnvironment::test_refresh_user_functions_system_exit_propagates
```

Reproduce on a clean checkout of `main`:

```bash
git worktree add --detach /tmp/probe origin/main
cd /tmp/probe && pytest tests/ops/test_cross_repo_python_integration.py \
  tests/rotation_converter/test_scripting_env.py
# 3 failed
```

## 1-2. The cross-repo sparse scope and its mirror test drifted apart

The workflow declares UpstreamDrift's scope as `src/chat`, `src/contracts.py`, `src/python/src/utils`, `src/shared`, `src/sidekick`, `tests/shared_contracts`, `tests/support`. The test asserts the pre-`src/` names — `chat`, `contracts.py`, `python/src/utils`, `shared`, `sidekick` — plus `src/shared/python`. Both are relics of an UpstreamDrift reorganization that neither side fully followed.

I checked every candidate against **UpstreamDrift's default branch via the API**, not a local clone:

| path | exists on UD `main`? |
|---|---|
| `src/shared`, `tests/shared_contracts`, `tests/support` | yes |
| `shared`, `src/shared/python` | yes |
| `chat`, `sidekick`, `contracts.py`, `python/src/utils` | **no — in neither form** |

Four declared paths match nothing at all. **Removed rather than replaced with a guess** — a sparse entry that resolves to nothing is the same vacuous-gate family as #4477.

Which side should move was the real question, and the test answers it itself:

```python
assert "src" not in upstream_scope
assert "ui" not in upstream_scope
```

Narrowness is a **deliberate constraint, not drift**. So declaring bare `src` was not available to me, even though UpstreamDrift's hatchling config says `packages = ["src"]` and that would have been the simplest way to make the mirror agree. `src/shared` is the narrow root that actually carries the packages this repo provides — UD's own `test_tools_vendoring.py` resolves from `src/shared/python`, and cone-mode sparse checkout populates `src/shared` without pulling all of `src`. **The workflow was the closer side, so the test's expectation is what moved.**

Resulting scope:

```
D-sorganization/Gasification_Model -> src, tests/shared_contracts
D-sorganization/UpstreamDrift      -> src/shared, tests/shared_contracts, tests/support
```

**Left out deliberately**, so this stays reviewable and does not collide with work in flight:
- `vendor/ud-tools` and the pinned-submodule init step are added by **#4447**.
- `tests/fixtures` exists on UD and its vendoring test seeds it onto `sys.path`, so it may be a further gap — flagged, not fixed here.

**Context a reviewer should have:** the Cross-Repo Python Integration workflow's last *completed* run on `main` was a **failure** (2026-08-06). So the previously declared path set cannot be assumed to have been the working configuration either. This PR makes the declaration honest about what exists; it does **not** claim the cross-repo job is green end to end.

## 3. The sandboxed SystemExit test

The scripting sandbox now blocks `import sys` — `Error loading user library: import of 'sys' is blocked in the scripting sandbox` — so the test's `import sys; sys.exit(1)` never reaches `sys.exit` and no `SystemExit` is raised.

The sandbox is correct behaviour; the test is stale against a good security change. The payload is now `raise SystemExit(1)`: `SystemExit` is a builtin, needs no import, and the test goes back to checking what its name says — that it **propagates** rather than being caught and logged.

## Why this is a separate PR

These are `main`'s defects, not any one branch's. Fixing them here unblocks #4447, #4446 and every future branch that touches these files, instead of one; and it keeps a 34-PR consolidation from absorbing unrelated repairs.

## Verification

- **15 passed** across both test files on Python 3.11 (was 3 failed).
- `ruff check` and `ruff format --check` clean on both changed test files.
- Changed-test assertion gate passes.
- Workflow still parses as valid YAML; both jobs intact.
- All three files keep their existing line endings (the workflow is CRLF on `main` and stays CRLF, so the diff is content only).

Part of #4460
Part of #4481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

