### PR TITLE
fix(shared): upstream three fixes orphaned in consumers' vendored copies

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -6115,3 +6115,7 @@ The command injection check logic in `cli_tools.py` has been fortified. The inpu
 - Removed chained array maps and reduces in the parseVariableAssignments function within `src/web_applications/calculator/static/app.js`.
 - Improved execution speed by using standard single pass for loop and string `indexOf` / `substring` techniques.
 - **2026-10-27**: Replaced inline `Array.from` with `new Array` + `for` loops in `Histogram.tsx` and `DataExplorer.tsx` to eliminate iterator and closure execution overhead during UI drag/zoom events.
+
+## 2026-08-15: Upstream three orphaned shared fixes from consumers
+
+- **2026-08-15**: fix(shared) — Upstreamed three fixes from consumers' vendored trees: (1) `data_processor_io.rust_engine.filter_export` now validates predicates with `validate_pandas_formula` to block code injection before `DataFrame.query`; (2) `SharedImportAliasFinder.find_spec` skips `<root>.tests.<...>` module names so package internal test modules resolve correctly; (3) `theme.zoom._coerce_percent` catches `ValueError` and falls back to the configured default on malformed persisted zoom settings.

--- a/src/shared/python/data_processor_io/rust_engine.py
+++ b/src/shared/python/data_processor_io/rust_engine.py
@@ -30,6 +30,8 @@ from typing import Any, cast
 
 import pandas as pd
 
+from shared.python.safe_pandas_eval import validate_pandas_formula
+
 logger = logging.getLogger(__name__)
 
 
@@ -482,6 +484,13 @@ def filter_export(
         df = pd.read_parquet(p)
 
     df = _select_columns(df, columns)
+    # ``df.query`` runs the predicate through pandas eval, so an unvalidated
+    # predicate is a code-injection vector. Restrict it to the shared
+    # numeric/boolean allow-list grammar before it is evaluated.
+    try:
+        validate_pandas_formula(predicate, allowed_columns=df.columns)
+    except ValueError as error:
+        raise ValueError(f"Invalid predicate: {error}") from error
     filtered = df.query(predicate)
 
     if active_token.is_cancelled():

--- a/src/shared/python/import_aliases.py
+++ b/src/shared/python/import_aliases.py
@@ -221,6 +221,11 @@ class SharedImportAliasFinder(MetaPathFinder):
     ) -> ModuleSpec | None:
         if fullname == "shared.python" or fullname.startswith("shared.python."):
             return None
+        # A shared package's own ``tests`` subtree is imported directly by
+        # downstream suites (e.g. ``sidekick.tests.calculators...``). Aliasing
+        # those names resolves them to the wrong module object, so decline them.
+        if ".tests." in fullname or fullname.endswith(".tests"):
+            return None
         root, suffix = self._parse(fullname)
         if root is None:
             return None

--- a/src/shared/python/theme/zoom.py
+++ b/src/shared/python/theme/zoom.py
@@ -228,7 +228,10 @@ def _coerce_percent(value: object, default: int) -> int:
     if isinstance(value, int):
         return value
     if isinstance(value, str):
-        return int(value)
+        try:
+            return int(value)
+        except ValueError:
+            return default
     return default
 
 

--- a/tests/architecture/test_shared_import_aliases_3316.py
+++ b/tests/architecture/test_shared_import_aliases_3316.py
@@ -77,6 +77,51 @@ def test_canonical_alias_loader_delegates_runpy_code_lookup() -> None:
     assert requested == [canonical_name]
 
 
+def test_finder_does_not_redirect_internal_test_modules() -> None:
+    """``<root>.tests.<...>`` must load normally instead of being aliased.
+
+    Downstream repos import the shared packages' own test modules directly
+    (e.g. ``from sidekick.tests.calculators.conversion.test_conversion import
+    ...``). Redirecting those names through the alias machinery resolves them
+    to the wrong module object, so the finder must decline them outright.
+    """
+    finder = import_aliases.SharedImportAliasFinder()
+
+    declined = (
+        "sidekick.tests",
+        "sidekick.tests.calculators",
+        "sidekick.tests.calculators.conversion.test_conversion",
+        "upstream_drift_tools.tests.test_data_io",
+        "src.shared.python.sidekick.tests.test_data_io",
+    )
+    for fullname in declined:
+        assert finder.find_spec(fullname) is None, fullname
+
+
+def test_finder_still_redirects_non_test_submodules() -> None:
+    """The ``.tests`` carve-out must not disable ordinary alias redirection."""
+    finder = import_aliases.SharedImportAliasFinder()
+
+    for fullname in (
+        "sidekick.process_calculators",
+        "sidekick.ui.tools_sidebar.registry",
+    ):
+        assert finder.find_spec(fullname) is not None, fullname
+
+
+def test_internal_test_package_imports_under_alias_root() -> None:
+    """A shared package's own ``tests`` subpackage is importable, not aliased."""
+    install_shared_import_aliases()
+
+    module = importlib.import_module("sidekick.tests")
+
+    assert module.__name__ == "sidekick.tests"
+    canonical_root = Path(
+        importlib.import_module("shared.python.sidekick").__file__ or ""
+    ).parent
+    assert Path(module.__file__ or "").parent == canonical_root / "tests"
+
+
 def test_sidekick_aliases_share_one_registry_module() -> None:
     install_shared_import_aliases()
 

--- a/tests/data_processor_io/test_rust_engine_contract.py
+++ b/tests/data_processor_io/test_rust_engine_contract.py
@@ -385,6 +385,81 @@ class TestFilterExport:
             filter_export("missing.csv", tmp_path / "out.csv", "force > 0")
 
 
+# ── filter_export predicate validation ────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.contract
+class TestFilterExportPredicateValidation:
+    """``filter_export`` must not hand an unvalidated predicate to pandas eval.
+
+    ``pd.DataFrame.query`` evaluates the predicate, so an attacker-controlled
+    predicate is a code-injection vector. The predicate must go through
+    ``validate_pandas_formula`` before it reaches ``df.query``.
+    """
+
+    @pytest.mark.parametrize(
+        "predicate",
+        [
+            "force.__class__ > 0",
+            "force.__class__.__mro__[1].__subclasses__() > 0",
+            "__import__('os').system('echo pwned') > 0",
+            "@force > 0",
+            "abs(force) > 0",
+        ],
+    )
+    def test_injection_predicate_rejected(
+        self, csv_file: Path, tmp_path: Path, predicate: str
+    ) -> None:
+        dst = tmp_path / "out.csv"
+
+        with pytest.raises(ValueError, match="Invalid predicate"):
+            filter_export(csv_file, dst, predicate)
+
+        assert not dst.exists()
+
+    @pytest.mark.parametrize(
+        "predicate",
+        [
+            "unknown_column > 0",
+            "note == 'start'",
+        ],
+    )
+    def test_predicate_outside_allowed_grammar_rejected(
+        self, csv_file: Path, tmp_path: Path, predicate: str
+    ) -> None:
+        """The allow-list grammar is numeric/boolean only, as elsewhere in Tools.
+
+        String comparison and unknown names are refused rather than evaluated,
+        matching ``shared.python.data_processing.processor``.
+        """
+        dst = tmp_path / "out.csv"
+
+        with pytest.raises(ValueError, match="Invalid predicate"):
+            filter_export(csv_file, dst, predicate)
+
+        assert not dst.exists()
+
+    def test_legitimate_predicate_still_filters(
+        self, csv_file: Path, tmp_path: Path
+    ) -> None:
+        dst = tmp_path / "out.csv"
+
+        n = filter_export(csv_file, dst, "force > 10.0 and time < 0.15")
+
+        assert n == 2
+        assert len(pd.read_csv(dst)) == 2
+
+    def test_validation_uses_projected_columns(
+        self, csv_file: Path, tmp_path: Path
+    ) -> None:
+        """A column dropped by ``columns=`` is no longer a valid predicate name."""
+        dst = tmp_path / "out.csv"
+
+        with pytest.raises(ValueError, match="Invalid predicate"):
+            filter_export(csv_file, dst, "force > 10.0", columns=["time", "note"])
+
+
 # ── cancel ────────────────────────────────────────────────────────────────────
 
 

--- a/tests/shared/python/theme/test_zoom.py
+++ b/tests/shared/python/theme/test_zoom.py
@@ -101,6 +101,24 @@ def test_coerce_percent_accepts_int_and_string_defaults_other_values() -> None:
     assert _coerce_percent(None, 100) == 100
 
 
+@pytest.mark.parametrize("stored", ["", "  ", "abc", "1.5", "120%", "0x7b"])
+def test_coerce_percent_falls_back_when_stored_string_is_malformed(
+    stored: str,
+) -> None:
+    """A corrupt persisted setting must not crash application start-up."""
+    assert _coerce_percent(stored, 100) == 100
+
+
+def test_controller_recovers_from_malformed_persisted_zoom(
+    qapp: QApplication,
+) -> None:
+    settings = MemorySettings("not-a-number")
+
+    controller = ApplicationZoomController(qapp, settings=settings)
+
+    assert controller.zoom_percent == ZoomConfig().default_percent
+
+
 def test_point_size_uses_float_size_when_available() -> None:
     font = QFont()
     font.setPointSizeF(11.5)


### PR DESCRIPTION
## What this is

Three fixes that were made **in the wrong repository**. Each one was written into a
consumer's vendored/shadow copy of this repo's `src/shared/python/` tree, never
upstreamed here, and is therefore destroyed the next time that consumer re-syncs from
Tools. These are **recoveries, not new features** — the code already runs in production
downstream; this PR makes Tools the place it lives.

Tools is the source of truth for `src/shared/python/**`. Edits made in UpstreamDrift's or
Gasification_Model's copies are silently lost on the next update.

---

### Fix 1 — `filter_export` passed an unvalidated predicate to pandas eval (security)

`src/shared/python/data_processor_io/rust_engine.py::filter_export`

The pandas fallback did `filtered = df.query(predicate)` with no validation.
`DataFrame.query` runs the string through pandas eval, so a caller-controlled predicate is
a code-injection vector (`force.__class__.__mro__[1].__subclasses__()`, `@`-injection,
arbitrary calls).

The helper to fix it **already existed upstream** — `src/shared/python/safe_pandas_eval.py`,
with tests at `tests/shared/python/test_safe_pandas_eval.py`. Two sibling modules in this
repo already route through it (`shared/python/data_processing/processor.py` and
`shared/python/sidekick/data_processing/core.py`). Only this call site was left unguarded.

- **Orphan found in:** UpstreamDrift's copy of `src/shared/python/data_processor_io/rust_engine.py`,
  which has carried the guard (importing the validator as `src.shared.python.safe_pandas_eval`).
- **Never upstreamed:** `origin/main` here still had the bare `df.query(predicate)`.
- **Consumes it:** re-exported from `shared.python.data_processor_io.__init__`; the bulk-I/O
  contract surface used by the data-processor tooling.

Ported with the import spelling Tools' own siblings use (`shared.python.safe_pandas_eval`),
verified importable both as `data_processor_io.rust_engine` and as
`shared.python.data_processor_io.rust_engine`.

**Behaviour narrowing reviewers should note:** the shared validator's grammar is
numeric/boolean only — column names, numeric/bool constants, arithmetic, comparisons.
String-literal predicates (`note == 'ready'`) and function calls are now refused with
`ValueError("Invalid predicate: ...")` instead of being evaluated. This is the same
restriction the two sibling call sites have already been under, and it is deliberate: the
allow-list is what makes the eval safe. Tests cover both the rejection and the fact that
legitimate numeric predicates still filter.

**Known limitation, faithfully ported:** the guard sits in the pandas fallback only. The
native-Rust branch above it forwards the predicate to `py_filter_export` (Polars), which
does not evaluate Python; validation there would require reading the file for its columns
first. This matches the downstream original.

### Fix 2 — alias finder hijacked `<root>.tests.<...>` module names (load-bearing today)

`src/shared/python/import_aliases.py::SharedImportAliasFinder.find_spec`

`SharedImportAliasFinder` redirects legacy spellings (`sidekick.…`, `theme.…`,
`src.shared.python.…`) onto canonical `shared.python.…` module objects. It also caught a
shared package's **own test subtree** — `sidekick.tests.calculators.conversion.test_conversion`
resolved to an aliased module object rather than the real one.

- **Orphan found in:** UpstreamDrift's copy of `src/shared/python/import_aliases.py`.
- **Never upstreamed:** this repo's `find_spec` had only the `shared.python` guard.
- **Consumes it:** UpstreamDrift's `tests/unit/sidekick/test_internal_test_modules.py`
  imports `TestUnitConversion`, `TestElectricalModel` and `TestTRCGeometryEngine` straight
  out of `sidekick.tests.calculators.…`. Those three classes carry 5 + 11 + 16 = 32 test
  methods, plus 3 importability assertions in the module itself — **35 UpstreamDrift tests
  pass only because of this edit.** They break the moment UpstreamDrift re-syncs its shared
  tree from Tools.

The carve-out is deliberately narrow (`".tests." in fullname or fullname.endswith(".tests")`)
and a companion test asserts ordinary submodules such as `sidekick.process_calculators` and
`sidekick.ui.tools_sidebar.registry` are still redirected.

### Fix 3 — malformed persisted zoom crashed start-up

`src/shared/python/theme/zoom.py::_coerce_percent`

`_coerce_percent` called bare `int(value)` on a string read back from `QSettings`. A corrupt
or hand-edited setting (`""`, `"1.5"`, `"120%"`, `"abc"`) raised `ValueError` out of
`ApplicationZoomController.__init__` — i.e. the app failed to start because of a bad
preference. Now it falls back to the configured default.

- **Orphan found in:** Gasification_Model's vendored copy, commit `d8b34e7a6`
  *"fix(ui): harden application zoom persistence"* (their #3632).
- **Never upstreamed:** this repo still raised.
- **Consumes it:** every fleet PyQt6 app that calls `install_application_zoom`.

⚠️ **This file forks both ways.** Tools is *ahead* of the Gasification_Model shadow in other
hunks, so only the `try/except ValueError` guard is ported — the file was deliberately **not**
synced wholesale, which would have reverted upstream work.

---

## Explicitly out of scope

A fourth orphan exists in `shared_scripts/fleet_hooks.py::check_root_clutter`. It adds a
catch-all that would reject 30–40 already-tracked root files (`.gitattributes`, `.gitmodules`,
`.dockerignore`, …) in every fleet repo. It is **not** in this PR and is being handled
separately.

## Tests

Every fix has a test that fails without it (verified red first, then green):

| Fix | Test | Red without the fix |
| --- | ---- | ------------------- |
| 1 | `tests/data_processor_io/test_rust_engine_contract.py::TestFilterExportPredicateValidation` — 5 injection payloads, 2 out-of-grammar predicates, a legitimate-predicate regression, and a column-projection case; each rejection also asserts **no output file is written** | 8 failed (payloads reached `df.query` and raised `TypeError` / `UndefinedVariableError`, or silently succeeded) |
| 2 | `tests/architecture/test_shared_import_aliases_3316.py::test_finder_does_not_redirect_internal_test_modules`, `::test_internal_test_package_imports_under_alias_root`, plus `::test_finder_still_redirects_non_test_submodules` as an over-reach guard | 2 failed (`sidekick.tests` got an alias spec; `sidekick.tests` imported as `shared.python.sidekick.tests`) |
| 3 | `tests/shared/python/theme/test_zoom.py::test_coerce_percent_falls_back_when_stored_string_is_malformed` (6 malformed values) and `::test_controller_recovers_from_malformed_persisted_zoom` | 7 failed (`ValueError: invalid literal for int()`) |

Local gates: `ruff check` and `ruff format --check` clean on all changed files; `mypy` clean
on the three changed source files (the two `redundant-cast` errors it reports come from the
untouched `theme/theme_manager.py` and pre-date this branch).
