### PR TITLE
fix(tests): stop the codemap conftest from skipping the entire test session (#4497)

### DIFF
--- a/.github/workflows/full-suite-nightly.yml
+++ b/.github/workflows/full-suite-nightly.yml
@@ -150,6 +150,13 @@ jobs:
           if total < 500:
               print(f"Full suite collected only {total} tests (<500) — collection broken (issue #3324).", file=sys.stderr)
               sys.exit(1)
+          # `total` counts skipped tests, so an all-skipped session sails past
+          # the collection floor above while executing nothing. A single
+          # conftest hook did exactly that: 8411 collected, 8411 skipped,
+          # exit 0 (issue #4497). Require a floor on tests that actually ran.
+          if passed < 500:
+              print(f"Full suite executed only {passed} tests ({skipped} skipped of {total} collected) — the suite is being silenced (issue #4497).", file=sys.stderr)
+              sys.exit(1)
           PYEOF
           echo "### Tail of test output" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/test_assertion_allowlist.txt
+++ b/scripts/test_assertion_allowlist.txt
@@ -9,6 +9,12 @@ tests/shared/python/ai/integrations/_bootstrap.py
 tests/rust_bindings/_tools_core_import.py
 tests/helpers/numerical.py
 tests/shared/python/ai/integrations/_bootstrap.py
+# Support module, not a test: detects the optional codemap (tree-sitter) deps
+# and exports the skipif marker the codemap test modules apply via
+# `pytestmark`. It holds no test functions, so it has nothing to assert about.
+# The skip lives here rather than in a conftest hook because a hook receives
+# the whole session's items and silenced the entire suite (issue #4497).
+tests/helpers/codemap_optional_deps.py
 # Vendored Movement Optimizer sub-app support files (migrated from D-sorganization/Movement_Optimizer; Tools#3407)
 src/movement_optimizer/tests/__init__.py
 src/movement_optimizer/tests/conftest.py

--- a/tests/architecture/test_no_session_wide_skip_leak_4497.py
+++ b/tests/architecture/test_no_session_wide_skip_leak_4497.py
@@ -23,6 +23,7 @@ against, so the guard has to observe real pytest outcomes.
 from __future__ import annotations
 
 import ast
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -129,6 +130,39 @@ def test_no_conftest_skips_items_it_does_not_own() -> None:
         + ". Prefer a module-level `pytestmark = pytest.mark.skipif(...)` in "
         "the affected test modules, which structurally cannot reach outside "
         "its own file."
+    )
+
+
+def test_codemap_tests_keep_real_assertions_despite_being_skipped() -> None:
+    """Being skipped must not become licence to hollow the tests out.
+
+    The codemap modules are skipped in CI (the ``codemap`` extra is never
+    installed), so nothing would notice if their bodies decayed into
+    assertion-free stubs -- the same "check that silently does nothing"
+    failure mode as #4497 itself. Reuses the repo's own gate implementation
+    rather than a second copy of the rule.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_check_test_assertions_4497",
+        REPO_ROOT / "scripts" / "check_test_assertions.py",
+    )
+    assert spec is not None and spec.loader is not None
+    gate = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gate)
+
+    modules = sorted(CODEMAP_TESTS.glob("test_*.py"))
+    assert modules, "no codemap test modules found -- the suite was deleted"
+
+    hollow = [
+        module.relative_to(REPO_ROOT).as_posix()
+        for module in modules
+        if not gate.has_behavioral_assertion(module.read_text(encoding="utf-8"))
+    ]
+
+    assert not hollow, (
+        "These codemap test modules no longer contain any behavioral "
+        "assertion: " + ", ".join(hollow) + ". They are skipped in CI, so a "
+        "stubbed-out body would never be noticed."
     )
 
 

--- a/tests/architecture/test_no_session_wide_skip_leak_4497.py
+++ b/tests/architecture/test_no_session_wide_skip_leak_4497.py
@@ -1,0 +1,154 @@
+"""Guards against a conftest silencing tests it does not own (issue #4497).
+
+``tests/unit/codemap/conftest.py`` used to implement
+``pytest_collection_modifyitems`` and mark **every item in the session**
+skipped when the optional tree-sitter stack was absent. That hook receives
+the whole session's items, not just the ones under its own directory, so
+co-collecting the codemap directory with anything else silenced the entire
+run:
+
+    pytest tests/shared/python/theme                    -> 107 passed
+    pytest tests/shared/python/theme tests/unit/codemap -> 198 skipped, 0 passed
+
+A full-suite run reported 8411 skipped and zero passed while still exiting 0.
+Skips are not failures and junit is still written, so every existing
+"vacuous run" guard (#3324, #3325, #3567) reported green.
+
+The tests below are deliberately *meta*: they assert that the suite still
+executes tests, rather than asserting anything about a particular feature.
+A check that silently does nothing is the failure mode being defended
+against, so the guard has to observe real pytest outcomes.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CODEMAP_TESTS = REPO_ROOT / "tests" / "unit" / "codemap"
+
+# Any test module that is skipped wholesale for missing optional deps must do
+# so in a way that cannot reach outside its own file. Directories listed here
+# are co-collected with a sentinel to prove they do not leak.
+OPTIONAL_DEP_TEST_DIRS = ("tests/unit/codemap",)
+
+
+def _run_pytest(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run pytest in a subprocess with repo addopts neutralised where needed."""
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            *args,
+            "-q",
+            "--no-header",
+            "-p",
+            "no:cacheprovider",
+            "-n",
+            "0",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+@pytest.mark.parametrize("optional_dir", OPTIONAL_DEP_TEST_DIRS)
+def test_optional_dep_skips_do_not_leak_outside_their_directory(
+    tmp_path: Path, optional_dir: str
+) -> None:
+    """Co-collecting an optional-dep suite must not skip unrelated tests.
+
+    This is the direct regression test for #4497. The sentinel lives outside
+    the repository test tree entirely, so the only way it can be skipped is a
+    hook reaching across the whole session.
+    """
+    sentinel = tmp_path / "test_sentinel_4497.py"
+    sentinel.write_text(
+        "def test_sentinel_must_execute():\n    assert True\n",
+        encoding="utf-8",
+    )
+
+    result = _run_pytest([str(sentinel), str(REPO_ROOT / optional_dir)])
+    combined = result.stdout + result.stderr
+
+    assert "1 passed" in combined or " passed" in combined, (
+        f"Co-collecting {optional_dir} with an unrelated sentinel test "
+        f"executed nothing. A conftest in that tree is skipping items it "
+        f"does not own (issue #4497).\n\n{combined[-3000:]}"
+    )
+    assert "skipped" not in combined.split("=")[-1] or " passed" in combined, (
+        f"Sentinel test was skipped by {optional_dir}'s conftest.\n\n{combined[-3000:]}"
+    )
+
+
+def test_no_conftest_skips_items_it_does_not_own() -> None:
+    """No conftest may blanket-mark session items without a path filter.
+
+    ``pytest_collection_modifyitems`` is handed every item in the session.
+    A hook that iterates those items and adds a marker without inspecting
+    each item's path silences unrelated directories.
+    """
+    offenders: list[str] = []
+
+    for conftest in REPO_ROOT.joinpath("tests").rglob("conftest.py"):
+        try:
+            tree = ast.parse(conftest.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):  # pragma: no cover - unreadable file
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if node.name != "pytest_collection_modifyitems":
+                continue
+
+            source = ast.dump(node)
+            adds_marker = "add_marker" in source
+            # A compliant hook must consult each item's location before
+            # deciding to skip it.
+            filters_by_path = any(
+                token in source
+                for token in ("path", "fspath", "nodeid", "location", "module")
+            )
+            if adds_marker and not filters_by_path:
+                offenders.append(str(conftest.relative_to(REPO_ROOT)))
+
+    assert not offenders, (
+        "These conftest files add markers to every collected item without "
+        "filtering by path, which silences tests they do not own (#4497): "
+        + ", ".join(offenders)
+        + ". Prefer a module-level `pytestmark = pytest.mark.skipif(...)` in "
+        "the affected test modules, which structurally cannot reach outside "
+        "its own file."
+    )
+
+
+def test_full_suite_nightly_enforces_a_floor_on_executed_tests() -> None:
+    """The nightly guard must count *passed*, not merely *collected*.
+
+    The existing guard rejects ``total < 500``, but ``total`` includes
+    skipped tests. An all-skipped session (8411 collected, 8411 skipped)
+    sails past it. The workflow computes ``passed`` already; it has to
+    assert on it.
+    """
+    workflow = REPO_ROOT / ".github" / "workflows" / "full-suite-nightly.yml"
+    body = workflow.read_text(encoding="utf-8")
+
+    # Parse to confirm the workflow is still valid YAML after editing.
+    assert yaml.safe_load(body), "full-suite-nightly.yml failed to parse"
+
+    assert "passed < " in body, (
+        "full-suite-nightly.yml does not enforce a floor on executed "
+        "(non-skipped) tests. A session where every test is skipped still "
+        "writes junit, exits 0, and clears the `total < 500` collection "
+        "floor (issue #4497)."
+    )

--- a/tests/helpers/codemap_optional_deps.py
+++ b/tests/helpers/codemap_optional_deps.py
@@ -1,0 +1,77 @@
+"""Optional-dependency detection for the codemap test modules (issue #4497).
+
+The codemap parsers need the optional ``codemap`` extra (a tree-sitter stack
+that CI never installs). Those tests must therefore be skipped when the stack
+is absent -- but the skip has to be scoped to the codemap test modules.
+
+``tests/unit/codemap/conftest.py`` previously did this with a
+``pytest_collection_modifyitems`` hook. That hook is handed **every item in
+the session**, not just the ones under its own directory, so co-collecting
+the codemap directory with anything else silenced the whole run (8411
+collected, 8411 skipped, exit 0).
+
+Exporting a marker that each module applies via ``pytestmark`` keeps the skip
+inside the file that opts into it: a module-level marker structurally cannot
+reach another module.
+
+This module lives in ``tests/helpers`` (a real package) rather than beside the
+codemap tests because CI runs pytest with ``--import-mode=importlib``, under
+which a bare sibling import such as ``from _optional_deps import ...`` raises
+``ModuleNotFoundError``.
+
+Usage::
+
+    from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+    pytestmark = CODEMAP_DEPS_SKIP
+"""
+
+from __future__ import annotations
+
+import pytest
+
+#: Every distribution provided by the ``codemap`` extra that the parser
+#: stack imports at runtime.
+CODEMAP_DEP_MODULES: tuple[str, ...] = (
+    "tree_sitter",
+    "tree_sitter_python",
+    "tree_sitter_javascript",
+    "tree_sitter_typescript",
+    "tree_sitter_rust",
+    "tree_sitter_markdown",
+    "pydantic",
+)
+
+
+def missing_codemap_deps() -> list[str]:
+    """Return the codemap optional dependencies that cannot be imported."""
+    missing: list[str] = []
+    for name in CODEMAP_DEP_MODULES:
+        try:
+            __import__(name)
+        except ImportError:
+            missing.append(name)
+    return missing
+
+
+MISSING_CODEMAP_DEPS: list[str] = missing_codemap_deps()
+
+CODEMAP_SKIP_REASON = (
+    "codemap optional deps missing: "
+    + ", ".join(MISSING_CODEMAP_DEPS)
+    + " (install with: pip install -e '.[codemap]')"
+    if MISSING_CODEMAP_DEPS
+    else "codemap optional deps present"
+)
+
+#: Apply with ``pytestmark = CODEMAP_DEPS_SKIP`` at module scope.
+#:
+#: Deliberately a ``skipif`` marker rather than ``pytest.importorskip``: the
+#: CI lane asserts that ``tests/unit/codemap`` collects at least one test
+#: (the "no vacuous core test" guard from #3324). ``importorskip`` raises at
+#: import time and collects zero items, which would trip that guard; a marker
+#: collects every test and reports it skipped.
+CODEMAP_DEPS_SKIP = pytest.mark.skipif(
+    bool(MISSING_CODEMAP_DEPS),
+    reason=CODEMAP_SKIP_REASON,
+)

--- a/tests/unit/codemap/conftest.py
+++ b/tests/unit/codemap/conftest.py
@@ -1,47 +1,28 @@
-"""Skip every codemap unit test when tree-sitter (or any per-language pkg)
-isn't installed. The CI test lane runs on a stock Python that doesn't
-install the optional `codemap` extra; tests would otherwise spuriously
-fail because the parsers return empty results.
+"""Codemap test package configuration.
 
-The mandatory unit-test contract is satisfied by collection; the tests
-just no-op when the parser stack isn't available.
+This file intentionally defines **no** ``pytest_collection_modifyitems`` hook.
+
+It used to. The hook marked every item it was handed as skipped when the
+optional tree-sitter stack was missing, and pytest hands that hook the whole
+session's items -- not just the ones under this directory. Co-collecting this
+directory with any other tests silenced them all::
+
+    pytest tests/shared/python/theme                    -> 107 passed
+    pytest tests/shared/python/theme tests/unit/codemap -> 198 skipped, 0 passed
+
+The nightly full-suite lane reported 8411 collected / 8411 skipped and still
+exited 0, because skips are not failures and junit is written either way.
+See issue #4497.
+
+The optional-dependency skip now lives on each test module as::
+
+    from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+    pytestmark = CODEMAP_DEPS_SKIP
+
+which cannot affect any module other than the one that declares it.
+``tests/architecture/test_no_session_wide_skip_leak_4497.py`` fails if a
+session-wide skip hook is reintroduced anywhere under ``tests/``.
 """
 
 from __future__ import annotations
-
-import pytest
-
-
-def _missing_deps() -> list[str]:
-    missing: list[str] = []
-    for name in (
-        "tree_sitter",
-        "tree_sitter_python",
-        "tree_sitter_javascript",
-        "tree_sitter_typescript",
-        "tree_sitter_rust",
-        "tree_sitter_markdown",
-        "pydantic",
-    ):
-        try:
-            __import__(name)
-        except ImportError:
-            missing.append(name)
-    return missing
-
-
-_MISSING = _missing_deps()
-
-
-def pytest_collection_modifyitems(config, items):  # noqa: ARG001
-    if not _MISSING:
-        return
-    skip_marker = pytest.mark.skip(
-        reason=(
-            "codemap optional deps missing: "
-            + ", ".join(_MISSING)
-            + " (install with: pip install -e '.[codemap]')"
-        )
-    )
-    for item in items:
-        item.add_marker(skip_marker)

--- a/tests/unit/codemap/test_codemap_api.py
+++ b/tests/unit/codemap/test_codemap_api.py
@@ -7,6 +7,11 @@ import subprocess
 from pathlib import Path
 
 from codemap import api, db
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 def _insert_file(

--- a/tests/unit/codemap/test_codemap_cli.py
+++ b/tests/unit/codemap/test_codemap_cli.py
@@ -6,6 +6,11 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from codemap import cli, db
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 def _insert_symbol(repo: Path) -> None:

--- a/tests/unit/codemap/test_codemap_db.py
+++ b/tests/unit/codemap/test_codemap_db.py
@@ -4,6 +4,11 @@ import sqlite3
 from pathlib import Path
 
 from codemap import db as codemap_db
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 def test_path_helpers_use_canonical_codemap_locations(tmp_path: Path) -> None:

--- a/tests/unit/codemap/test_codemap_indexer.py
+++ b/tests/unit/codemap/test_codemap_indexer.py
@@ -12,6 +12,11 @@ from codemap._ts_common import ParsedSymbol, ParseResult
 
 from codemap import db as codemap_db
 from codemap import indexer
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 def _python_result(path: str | Path, _source: bytes | str) -> ParseResult:

--- a/tests/unit/codemap/test_codemap_js_parser.py
+++ b/tests/unit/codemap/test_codemap_js_parser.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass, field
 from codemap._ts_common import ParsedSymbol
 
 from codemap import _lang_js as js_parser
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 def test_extract_javascript_emits_imports_and_symbols(monkeypatch) -> None:

--- a/tests/unit/codemap/test_codemap_markdown_parser.py
+++ b/tests/unit/codemap/test_codemap_markdown_parser.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass, field
 from codemap._ts_common import ParsedSymbol
 
 from codemap import _lang_markdown as markdown
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 def test_extract_emits_atx_headings_with_truncated_symbol_fields(monkeypatch) -> None:

--- a/tests/unit/codemap/test_codemap_mcp_server.py
+++ b/tests/unit/codemap/test_codemap_mcp_server.py
@@ -7,6 +7,11 @@ from collections.abc import Callable
 from typing import Any
 
 from codemap import mcp_server
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 class _Dumpable:

--- a/tests/unit/codemap/test_codemap_parsers.py
+++ b/tests/unit/codemap/test_codemap_parsers.py
@@ -6,6 +6,11 @@ import pytest
 from codemap._ts_common import ParsedSymbol, ParseResult
 
 from codemap import parsers
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/codemap/test_codemap_python_parser.py
+++ b/tests/unit/codemap/test_codemap_python_parser.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass, field
 from codemap._ts_common import ParsedSymbol
 
 from codemap import _lang_python as python_parser
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 def test_extract_emits_imports_symbols_docstrings_signatures_and_calls(

--- a/tests/unit/codemap/test_codemap_rust_parser.py
+++ b/tests/unit/codemap/test_codemap_rust_parser.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass, field
 from codemap._ts_common import ParsedSymbol
 
 from codemap import _lang_rust as rust_parser
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 def test_extract_emits_imports_functions_structs_modules_and_impls(

--- a/tests/unit/codemap/test_codemap_ts_common.py
+++ b/tests/unit/codemap/test_codemap_ts_common.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass, field
 import pytest
 
 from codemap import _ts_common as ts_common
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/codemap/test_codemap_watcher.py
+++ b/tests/unit/codemap/test_codemap_watcher.py
@@ -9,6 +9,11 @@ from types import SimpleNamespace
 import pytest
 
 from codemap import watcher
+from tests.helpers.codemap_optional_deps import CODEMAP_DEPS_SKIP
+
+# Scoped to this module only; a session-wide skip hook silenced the whole
+# suite here once already (issue #4497).
+pytestmark = CODEMAP_DEPS_SKIP
 
 
 class _BaseEventHandler:


### PR DESCRIPTION
Fixes #4497.

## Headline: CI never installs the `codemap` extra, so the skip always fired

I checked every workflow. **No workflow installs `.[codemap]`** — `tree-sitter*` appears only in `pyproject.toml`'s `codemap` optional-dependency group and in no install step anywhere under `.github/`. So `_MISSING` was non-empty on every CI run and the hook fired every time.

## The bug

`tests/unit/codemap/conftest.py` defined `pytest_collection_modifyitems` and marked **every item it was handed** skipped. pytest hands that hook the *whole session's* items, not just the ones under its own directory:

```
pytest tests/shared/python/theme                    -> 107 passed
pytest tests/shared/python/theme tests/unit/codemap -> 198 skipped, 0 passed
```

The sentinel used in the new regression test lives outside the repo test tree entirely and was still skipped.

### Blast radius per lane

| Lane | Installs codemap extra? | Collects `tests/unit/codemap`? | Effect |
|---|---|---|---|
| `full-suite-nightly` (`pytest tests/ src/`) | no | always | **entire suite silenced**: 8411 collected, 8411 skipped, 0 passed, exit 0 |
| `ci-standard` PR lane | no | only when `src/shared/python/codemap/**` changed | silences that PR's whole changed-test set, since the directory is appended to the same pytest invocation |

The PR lane is changed-files-scoped, so the everyday gate was not universally vacuous — but it self-silenced precisely on PRs touching codemap, and the nightly full-suite lane was silenced unconditionally.

### Why every existing guard read green

The repo already has anti-vacuous guards (#3324, #3325, #3567). All of them missed this, because **skips are not failures**: pytest exits 0, junit is still written, and the nightly floor check tests `total < 500` where `total` *includes* skipped tests. 8411 skipped sails past a 500-test floor. The workflow computed `passed` and never asserted on it.

## Fix

- Optional-dep detection moves to `tests/helpers/codemap_optional_deps.py`; each codemap module applies it with `pytestmark = CODEMAP_DEPS_SKIP`. A module-level marker structurally cannot reach another module.
- Kept as a `skipif` marker rather than `pytest.importorskip` on purpose: `importorskip` raises at import time and collects **zero** items, which would trip CI's "every core-test entry must collect ≥1 test" guard (#3324). The marker collects all 91 and reports them skipped.
- The helper lives in `tests/helpers` (a real package) rather than beside the codemap tests because CI runs with `--import-mode=importlib`, under which a bare sibling import raises `ModuleNotFoundError`. Verified both ways before choosing.
- `full-suite-nightly.yml` now enforces a floor on *executed* tests, not just collected ones.

## Regression tests

`tests/architecture/test_no_session_wide_skip_leak_4497.py` — a meta-guard, since "a check that silently does nothing" is the failure mode:

1. **Behavioural leak probe** — a sentinel test written outside the repo tree must still execute when `tests/unit/codemap` is co-collected. This is the direct #4497 regression test and fails without the fix.
2. **Structural scan** — no conftest under `tests/` may add a marker to every collected item without filtering by path. Catches reintroduction anywhere, not just in codemap.
3. **Workflow contract** — the nightly lane must assert on `passed`, not merely `total`.

All three fail on the parent commit and pass here.

## Verification

```
pytest tests/shared/python/theme                    -> 107 passed
pytest tests/shared/python/theme tests/unit/codemap -> 107 passed, 91 skipped
pytest tests/unit/codemap --collect-only            -> 91 tests collected  (CI guard satisfied)
```

Full suite, before -> after: **8411 skipped / 0 passed -> 8196 passed, 151 skipped, 78 failed, 10 errors.**

Those 78 failures and 10 errors are pre-existing breakage this hook was hiding, not regressions from this PR — the diff touches only the codemap test modules, the new helper, the new architecture test, and the nightly workflow. They are unrelated to codemap (Windows path assumptions, missing optional modules, sidekick API drift) and want separate triage.

## Follow-up worth deciding separately

Since CI never installs the `codemap` extra, these 91 tests have **never actually executed in CI** — they are collected and skipped. Making them real coverage means adding `.[codemap]` to an install step. That is a scope call for the maintainer, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
