### PR TITLE
🎨 Palette: Add focus-visible states to ODE Solver inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -52,3 +52,8 @@
 ## 2024-05-31 - React `useId()` for Input Labels
 **Learning:** When improving accessibility for React form inputs where explicit IDs are missing, using hardcoded IDs can cause conflicts if components render multiple times.
 **Action:** When improving accessibility for React form inputs where explicit IDs are missing, use the `useId()` hook to safely generate unique, deterministic identifiers for reliably mapping `<label htmlFor={...}>` to `<input id={...}>` elements.
+
+## 2026-08-16 - Focus Rings on ODE Solver Inputs
+**Learning:** Found an accessibility issue pattern where inputs and textareas in ODE Solver have `focus:outline-none` but lack focus indicators, making keyboard navigation difficult.
+**Action:** Replace `focus:outline-none` with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500` to preserve keyboard accessibility while styling interactive elements.
+

--- a/src/ode_solver/web/src/components/ODESolverCalculator.tsx
+++ b/src/ode_solver/web/src/components/ODESolverCalculator.tsx
@@ -327,7 +327,7 @@ export function ODESolverCalculator() {
             <select
               value={preset}
               onChange={(e) => handlePresetChange(e.target.value)}
-              className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus:outline-none"
+              className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
             >
               <option value="Custom">Custom</option>
               {Object.keys(ODE_PRESETS).map((name) => (
@@ -355,7 +355,7 @@ export function ODESolverCalculator() {
                   onChange={(e) => setDerivativesText(e.target.value)}
                   rows={3}
                   placeholder="y: -k*y"
-                  className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus:outline-none font-mono text-sm"
+                  className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 font-mono text-sm"
                   spellCheck="false"
                   autoCorrect="off"
                   autoCapitalize="none"
@@ -371,7 +371,7 @@ export function ODESolverCalculator() {
                   onChange={(e) => setParametersText(e.target.value)}
                   rows={3}
                   placeholder="k: 0.1"
-                  className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus:outline-none font-mono text-sm"
+                  className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 font-mono text-sm"
                   spellCheck="false"
                   autoCorrect="off"
                   autoCapitalize="none"
@@ -387,7 +387,7 @@ export function ODESolverCalculator() {
                   onChange={(e) => setInitialText(e.target.value)}
                   rows={3}
                   placeholder="y: 100"
-                  className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus:outline-none font-mono text-sm"
+                  className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 font-mono text-sm"
                   spellCheck="false"
                   autoCorrect="off"
                   autoCapitalize="none"
@@ -408,7 +408,7 @@ export function ODESolverCalculator() {
                     type="number"
                     value={tStart}
                     onChange={(e) => setTStart(Number(e.target.value))}
-                    className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus:outline-none"
+                    className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   />
                 </div>
                 <div>
@@ -418,7 +418,7 @@ export function ODESolverCalculator() {
                     type="number"
                     value={tEnd}
                     onChange={(e) => setTEnd(Number(e.target.value))}
-                    className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus:outline-none"
+                    className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                   />
                 </div>
               </div>
@@ -431,7 +431,7 @@ export function ODESolverCalculator() {
                   onChange={(e) => setNumPoints(Number(e.target.value))}
                   min={10}
                   max={10000}
-                  className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus:outline-none"
+                  className="w-full bg-slate-700 text-white rounded px-3 py-2 border border-slate-600 focus:border-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
                 />
               </div>
             </div>


### PR DESCRIPTION
💡 What: Added `focus-visible:ring-2 focus-visible:ring-blue-500` to select, textarea, and input elements in the ODE Solver calculator.
🎯 Why: Elements previously used `focus:outline-none`, breaking standard browser focus rings and making keyboard navigation difficult.
♿ Accessibility: Ensures keyboard users have clear visual feedback when interacting with form inputs.

---
*PR created automatically by Jules for task [16824102473839334850](https://jules.google.com/task/16824102473839334850) started by @dieterolson*