### PR TITLE
ci: raise the tests job timeout 90 -> 150 minutes (the required check is at its cap)

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -446,7 +446,7 @@ jobs:
   tests:
     # The required 3.11 lane must survive a first-use Python download plus
     # dependency installation, Rust-wheel build, and the actual test suite.
-    timeout-minutes: 90
+    timeout-minutes: 150
     # Parallelized: tests do not consume any quality-gate outputs (quality-gate
     # declares no `outputs:` block, and no step in this job references
     # `needs.quality-gate.*`). Fanning out after pick-runner removes the


### PR DESCRIPTION
ci: raise the tests job timeout 90 -> 150 minutes

`tests (3.11)` is one of only two required status checks on `main`, and its
runtime has grown into its own 90-minute cap. Measured across the last ten
completed `CI Standard` runs:

  success    77.7 min   <- the ONLY pass, at 86% of the budget
  cancelled  93.5 min   <- timeout kill
  cancelled  91.8 min   <- timeout kill
  cancelled  91.2 min   <- timeout kill
  cancelled  90.5 min   <- timeout kill
  cancelled  52.3 / 27.7 / 13.7 min
  failure    26.2 / 10.0 min

One pass in ten. The runs at 90+ minutes record **zero failed steps** — they are
timeout kills, not test failures, so a healthy run has roughly twelve minutes of
headroom and any contention on a shared runner consumes it.

Demonstrated concretely by PR #4525, a four-file formatting-only change whose
reformat was proven AST-identical: its `tests (3.11)` was cancelled at 90.0
minutes, re-run, and cancelled again at 90.3 minutes. No change to that PR can
make it pass. Combined with `strict = true` — which forces PRs to merge one at a
time and re-run CI after every sibling merge — a ~10% pass rate on the required
check makes a queue effectively unlandable without repeated luck.

This is a STOPGAP, deliberately reversible, and it does not pretend to be the
fix. 150 minutes is ~2x the observed successful run and ~1.6x the observed
maximum, which is headroom rather than a new ceiling to grow into.

The actual remedies are tracked in #4532: shard the suite across parallel jobs so
the required context no longer has a single-point timeout, scope the required
lane to the contract-critical set, and run `--durations` first to establish
whether this is broad growth or a handful of slow modules. One known contributor
is that `addopts` carries `-n auto --dist loadscope`, so Qt tests with 15-second
`waitUntil` timeouts are load-sensitive and wall-clock varies with the runner.

Worth noting what this is NOT: #4487 already cached the `tools_core` Rust wheel
so the lane stops installing a Rust toolchain and rebuilding the wheel per job,
and every measurement above is from AFTER that merged. The remaining runtime is
the test suite itself, not the toolchain.

Only `jobs.tests.timeout-minutes` changes. `quality-gate` (60) and
`rust-quality-gate` (15) are untouched. Verified with the repo's own gates:
`scripts/validate_workflows.py`, `scripts/check_workflow_pinning.py` and
`scripts/check_blocking_quality_gates.py` all pass, and the tests job still
parses to its full 27 steps.

Part of #4532

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
