### PR TITLE
fix(rate-of-closure, shared): disable static sourcemaps and add contracts to downstream alias roots

### DIFF
--- a/src/rate_of_closure/web/vite.config.ts
+++ b/src/rate_of_closure/web/vite.config.ts
@@ -28,7 +28,7 @@ export default defineConfig(({ mode }) => {
   },
   build: {
     outDir: "dist",
-    sourcemap: process.env.ROC_RELEASE_REVISION === undefined,
+    sourcemap: false,
     rollupOptions: {
       output: {
         manualChunks(id) {

--- a/src/shared/python/import_aliases.py
+++ b/src/shared/python/import_aliases.py
@@ -51,7 +51,9 @@ _SHARED_ROOTS = frozenset(
         "upstream_drift_tools",
     }
 )
-_DOWNSTREAM_SRC_ALIAS_ROOTS = frozenset({"chat", "sidekick", "upstream_drift_tools"})
+_DOWNSTREAM_SRC_ALIAS_ROOTS = frozenset(
+    {"chat", "contracts", "sidekick", "upstream_drift_tools"}
+)
 _TOOLS_SRC_ROOT = Path(__file__).resolve().parents[2]
 
 


### PR DESCRIPTION
### Summary
This PR fixes two CI workflow failures:
1. **Rate of Closure Web Distribution**: In `src/rate_of_closure/web/vite.config.ts`, disable sourcemap generation for static builds so that `.map` files are not output into `dist/assets/`, complying with `releaseArtifactContract.mjs` which strictly rejects `.map` release assets.
2. **Cross-Repo Python Integration (UpstreamDrift vendoring contracts)**: In `src/shared/python/import_aliases.py`, added `contracts` to `_DOWNSTREAM_SRC_ALIAS_ROOTS` so that `src.shared.python.contracts` is recognized and aliased across downstream consumer workspaces.

### Verification
- `npm run build:release` in `src/rate_of_closure/web` passed with exit code 0.
- `pytest tests/shared_contracts/` in `UpstreamDrift` passed 100% (7/7 tests passing).
- `python -m ruff check .` and `python -m ruff format --check .` passed cleanly.
- `python -m mypy src/shared/python/import_aliases.py` passed with 0 errors.
