### PR TITLE
docs: refresh turnover handoffs and publish sidekick integration epic

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -18,18 +18,18 @@ early August the delivery pattern has shifted from long stacked PRs to
 
 | Epic  | Status (one line)                                                                                                                                                                                                                         |
 | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| #4103 | Swing-Impact-Ball-Flight platform. Open. Stack PR #4119 was **closed, not merged**; its content landed as 22 slices (#4517-#4547). Remaining: the camera cluster (needs its own epic, see below) and Phase 7 (WASM web parity, Pages CI). |
+| #4103 | Swing-Impact-Ball-Flight platform. Open. Stack PR #4119 closed; content landed in slices. Remaining: camera cluster (#4571) and Phase 7 (WASM web parity, Pages CI). |
 | #4120 | Investigation & Variation Suite. Open. PR #4124 **merged**.                                                                                                                                                                               |
 | #4125 | Realistic clubs / kinetics / putting / showcase. Open. PR #4129 **merged**. H5 (public release-management repo) still not started.                                                                                                        |
-| #4130 | Impact-interval club dynamics. Open, foundation only — F1 formulation doc not started, no PR.                                                                                                                                             |
+| #4130 | Impact-interval club dynamics. **COMPLETED** (F1–F4 landed in PR #4577) — 6-DOF transient package, tests, and impact wire.                                                                                                                                             |
 | #4142 | Ensemble variation, quiet zones, sensitivity attribution. Open. Visualization/authority slice landed via **#4473**.                                                                                                                       |
-| #4146 | Shared Club Builder. Open. First slice #4147 **closed**; assembly physics contracts landed in #4157.                                                                                                                                      |
+| #4146 | Shared Club Builder. Open. Assembly physics contracts landed in #4157.                                                                                                                                      |
 | #4433 | Visual-first tab visibility and visualization-led UX. Open. Landed via **#4473**.                                                                                                                                                         |
-| #4549 | Club Fitting Tester (OEM-grade). Open. **C1-C5 merged in #4557** - mesh inertia tensor, shaft delivery deltas, OEM fitting document, delivery interchange, counterfactual engine. **C6/C7 (GUI tabs) remain.**                            |
-| #4562 | Heavy Hit - hand/body coupling at impact. Open. **H1-H3 merged in #4568**; H5 pin bump merged as UD #8767. Headline: physiological hands change driver ball speed **<1%**. **H4 (GUI) remains.**                                          |
+| #4549 | Club Fitting Tester (OEM-grade). **COMPLETED** (#4557, #4577) — C1–C7 delivered (mesh inertia, shaft delivery, OEM doc, counterfactuals, PyQt6/React GUI tabs). |
+| #4562 | Heavy Hit - hand/body coupling at impact. **COMPLETED** (#4568, #4577) — H1–H4 delivered (coupled mechanics, MJCF/URDF/.osim import, GUI readout). |
 
 Per-tool detail: `src/rate_of_closure/AGENT_HANDOFF.md` (current, refreshed by
-#4473), `src/pendulum_simulator/AGENT_HANDOFF.md`,
+#4473/#4577), `src/pendulum_simulator/AGENT_HANDOFF.md`,
 `src/rotation_converter/AGENT_HANDOFF.md`.
 
 ## Open PR Situation — Read Before Filing Anything
@@ -135,15 +135,13 @@ Note: `ruff format --check` reports four pre-existing failures under
 
 ## Short-Term Roadmap (ordered)
 
-1. **Finish the two golf epics — GUI surfaces only.** #4555 (C6, PyQt6 Club
-   Tester tab), #4556 (C7, React parity), #4566 (H4, heavy-hit panels). All
-   physics and wires are merged and shared-first; these are binding work.
-   `src/rate_of_closure/AGENT_HANDOFF.md` carries the exact four-manifest
-   recipe — read it first, it is the non-obvious part.
+1. **Sidekick Unified Integration across Impact Model & Fleet**: Implement
+   `docs/development/epic_sidekick_unified_impact_model_and_launcher_integration.md`
+   (Phases S1–S5: dock widget in Rate of Closure, workspace seeding, standalone &
+   UpstreamDrift launcher parity).
 2. **Land the camera-cluster epic #4571** so #4466 can finally close.
 3. Clear the `src/shared/python` hygiene pair (#4507, #4509) — these unblock
    downstream consumers.
 4. Land the CI repairs (#4454, #4469) and fix the filed reds (#4561, #4569).
-5. Start #4130 Phase F1 (formulation document).
-6. Phase 7 of #4103: WASM swap for the web mirror + real Pages CI deploy.
-7. #4125 H5: stand up the public release-management repo (cross-repo).
+5. Phase 7 of #4103: WASM swap for the web mirror + real Pages CI deploy.
+6. #4125 H5: stand up the public release-management repo (cross-repo).

--- a/SPEC.md
+++ b/SPEC.md
@@ -6161,3 +6161,11 @@ The command injection check logic in `cli_tools.py` has been fortified. The inpu
 ## 2026-08-19 - Optimized SVG path generation in TrendChart
 
 - **2026-08-19**: perf(p1am) — Replaced `.forEach` array iterations with a single-pass `for` loop in the `seriesPaths` useMemo block within `src/p1am_control_system/frontend/src/components/TrendChart.tsx`. This eliminates closure allocation overhead per data point in SVG path string generation, reducing garbage collection pressure during high-frequency renders.
+
+## 2026-08-18: Club Fitting Tester C6/C7, Heavy Hit H4, & Interval Dynamics F1–F4 (#4549, #4562, #4130, #4577)
+
+- **2026-08-18**: feat(rate_of_closure, golf_club, swing_sim, #4549, #4562, #4130, #4577) — Complete delivery of Club Tester and Heavy Hit surfaces with impact-interval dynamics: (1) PyQt6 `ClubTesterTab` workbench with counterfactual parameter controls, swing delivery kinematics, MJCF/URDF/.osim golfer model import, side-by-side outcome delta tables, and deterministic JSON export; (2) React `ClubTesterPanel.tsx` parity panel, TypeScript model layer `clubFitting.ts`, and golden parity fixtures under `web/src/model/__fixtures__/`; (3) 6-DOF Newton-Euler impact-interval simulation package `src/shared/python/swing_sim/impact_interval/` with Kelvin-Voigt contact laws and energy conservation gates.
+
+## 2026-08-19: Sidekick Unified Integration Epic
+
+- **2026-08-19**: docs(development) — Establish and publish specification for the unified Sidekick integration epic (`docs/development/epic_sidekick_unified_impact_model_and_launcher_integration.md`) covering phases S1–S5 for bidirectional state seeding and standalone/host-embedded launcher parity across Rate of Closure and all UpstreamDrift launcher tiles.

--- a/docs/development/epic_sidekick_unified_impact_model_and_launcher_integration.md
+++ b/docs/development/epic_sidekick_unified_impact_model_and_launcher_integration.md
@@ -1,0 +1,72 @@
+# Epic: Sidekick Unified Integration (Impact & Ball Flight Model & UpstreamDrift Fleet)
+
+## Overview
+
+This epic establishes and hardens the **Unified Sidekick Sidebar** across the **Rate of Closure (Impact & Ball Flight Simulator)** application and all host applications within the **UpstreamDrift Launcher**.
+
+The Sidekick provides a multi-tab engineering companion (AI Chat Assistant, Scientific Calculators, Python REPL, Live Workspace Variable Inspector, Jupyter Notebooks, Data Processor, and File Navigation). This epic ensures:
+1. **Impact & Ball Flight Simulator Parity**: The RateOfClosureMainWindow incorporates the full Sidekick dock widget with bidirectional state binding (live club model, impact trajectory, fitting document/report, and landing scatter available inside the REPL and Chat).
+2. **Dual-Mode Launch Reliability**: The Impact Explorer functions identically with full Sidekick availability when launched **in isolation (standalone CLI/script)** and when launched **from within the UpstreamDrift Launcher**.
+3. **Fleet-Wide Launcher Parity**: All GUI applications registered in launcher_manifest.json reliably attach the Sidekick sidebar with consistent Catppuccin design tokens, robust fallback handling, and zero token-discard regressions.
+
+---
+
+## Architecture & Design Principles
+
+`mermaid
+graph TD
+    A[UpstreamDrift Launcher] -->|Launches Tile| B[Rate of Closure MainWindow]
+    C[Standalone CLI / launch_pyqt6.py] -->|Direct Launch| B
+    B -->|Installs Dock Widget| D[UnifiedToolsSidebar]
+    D --> E[AI Chat Assistant]
+    D --> F[Python REPL & Workspace]
+    D --> G[Engineering Calculators]
+    D --> H[Jupyter Notebook / Data Explorer]
+    B -->|Seeds Simulation State| F
+`
+
+1. **Shared-First Contract**: The sidebar implementation resides in src/shared/python/sidekick/ (in Tools, consumed downstream by UpstreamDrift via endor/ud-tools or sibling checkout).
+2. **Non-Invasive Embedding**: Host applications connect via shared.python.gui_launcher.tools_sidebar_integration:install_tools_sidebar or explicit mixin, ensuring the host runs even if the Sidekick module is unavailable.
+3. **Domain State Seeding**: Host applications publish their authoritative models to sidebar.registry.set_variable(...) so the user can interactively script against real live runtime objects.
+
+---
+
+## Work Breakdown & Tasks
+
+### Phase S1: Architecture & Host Integration Contract
+- [ ] Define SidekickHostContract in src/shared/python/gui_launcher/tools_sidebar_integration.py specifying workspace variable exports, project root propagation, and file open handlers.
+- [ ] Ensure sidekick_tokens mapping correctly binds to RateOfClosureMainWindow and Catppuccin design token themes.
+- [ ] Standardize the Sidekick toggle button in ApplicationToolstrip (RateOfClosureMainWindow) and shortcut (Ctrl+B).
+
+### Phase S2: Rate of Closure (Impact & Ball Flight) Sidekick Integration
+- [ ] Add SidekickIntegrationMixin (or install_tools_sidebar wiring) to RateOfClosureMainWindow in src/rate_of_closure/ui/pyqt6/main_window.py.
+- [ ] Implement _seed_impact_workspace():
+  - ctive_club: Current ClubSpecification / ClubFittingDocument.
+  - simulation_result: Latest 6-DOF swing / interval / flight trajectory.
+  - itting_report: Deterministic JSON fitting and coupling analysis report.
+  - ariation_dataset: Active Monte Carlo landing scatter dataset.
+- [ ] Connect derivation and simulation update events to live workspace variable updates.
+
+### Phase S3: Standalone Launch Hardening
+- [ ] Update src/rate_of_closure/launch_pyqt6.py and src/rate_of_closure/ui/pyqt6/launcher.py to ensure launch_rate_pyqt6() starts the Sidekick background API worker (or gracefully falls back to local tools) in standalone mode.
+- [ ] Add tests in 	ests/rate_of_closure/test_sidekick_integration.py verifying standalone sidebar instantiation and variable seeding.
+
+### Phase S4: UpstreamDrift Launcher Embedding Parity
+- [ ] Verify launcher_manifest.json tile 
+ate_of_closure boots cleanly from the UpstreamDrift PyQt6 launcher with the active host Sidekick sidebar.
+- [ ] Test cross-engine context handoff: dragging/opening club models or swing profiles from the Sidekick file explorer into the Rate of Closure workspace.
+- [ ] Ensure graceful teardown on window close (cleaning up REPL workers, Morris processes, and API monitors).
+
+### Phase S5: Fleet-Wide Verification & Test Suite
+- [ ] Run 	ests/unit/test_gui_launcher_manifest_targets.py across all tiles in UpstreamDrift.
+- [ ] Add contract tests verifying Sidekick initialization across all launcher tiles (mujoco, drake, pinocchio, opensim, myosim, putting_green, c3d_viewer, 
+ate_of_closure).
+- [ ] Verify accessibility audit (udit_visible_focusable_controls) passes with Sidekick docked.
+
+---
+
+## Associated Repositories
+
+- **Tools** (src/shared/python/sidekick/, src/shared/python/gui_launcher/, src/rate_of_closure/)
+- **UpstreamDrift** (src/launchers/, src/config/launcher_manifest.json, src/shared/python/gui_launcher/)
+- **AffineDrift** (Documentation and technical monographs)

--- a/run_impact_explorer.bat
+++ b/run_impact_explorer.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d "%~dp0"
+set PYTHONPATH=%~dp0src;%~dp0src\shared\python;%PYTHONPATH%
+start "" "%LOCALAPPDATA%\Programs\Python\Python313\python.exe" "%~dp0src\rate_of_closure\launch_pyqt6.py"

--- a/src/shared/python/golf_club/AGENT_HANDOFF.md
+++ b/src/shared/python/golf_club/AGENT_HANDOFF.md
@@ -14,12 +14,11 @@
 - Rate of Closure and UpstreamDrift must consume this public facade through
   thin adapters after the provider stack lands; do not copy the calculations.
 
-## Club Fitting Tester Epic (#4549) — physics merged, GUI open
+## Club Fitting Tester Epic (#4549) — COMPLETED (#4557, #4577)
 
 This package is the **shared-first** home for the clubfitting epic's physics and
-wires (contract: `docs/specs/CLUB_FITTING_TESTER.md`). **C1–C5 all merged in
-#4557**; only the GUI children remain (C6 #4555, C7 #4556), and they must bind
-to these modules rather than recompute anything.
+wires (contract: `docs/specs/CLUB_FITTING_TESTER.md`). **C1–C7 all merged in
+#4557 and #4577** (including PyQt6 Club Tester tab and React panel).
 
 | Module                    | Owns                                                                                                                                                                                   |
 | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -37,15 +36,15 @@ import of this package executes `golf_club/__init__`, whose eager surface reache
 SciPy through the turf chain and breaks the Morris UI import contract. Keep it
 lazy, and do not add eager imports to `__init__` that reach `swing_sim.variation`.
 
-## Heavy Hit Epic (#4562) — physics merged, GUI open
+## Heavy Hit Epic (#4562) — COMPLETED (#4568, #4577)
 
 `impact_coupling.py` (H1/H3) quantifies hand/body influence at impact: a
 ball–head–hands Kelvin-Voigt chain integrated in the **body frame** (fixed grip
 anchor, ball approaches — the anchor does no work, so energy accounting is
 exact). Physiological hands (3 kg, 5e4 N/m) change driver ball speed by **<1%**;
 the model always reports the **rigid-shaft upper bound** alongside, because any
-lumped `k_s` only approximates contact-timescale impedance. H4 (#4566) is the
-open GUI child. Contract: `docs/specs/HEAVY_HIT_COUPLING.md`.
+lumped `k_s` only approximates contact-timescale impedance. H4 GUI panels
+landed in PR #4577. Contract: `docs/specs/HEAVY_HIT_COUPLING.md`.
 
 `swing_sim/model_interchange/` (H2) imports golfer models from MJCF, URDF and
 `.osim` — MuJoCo, Drake, Pinocchio, OpenSim — by **runtime-free XML parsing**


### PR DESCRIPTION
Refreshes AGENT_HANDOFF.md and SPEC.md to document completed golf epics (#4549, #4562, #4130) and establishes the Sidekick Unified Integration Epic specification.