### PR TITLE
🎨 Palette: Add ARIA labels to TrendChart buttons

### DIFF
--- a/src/p1am_control_system/frontend/src/components/TrendChart.tsx
+++ b/src/p1am_control_system/frontend/src/components/TrendChart.tsx
@@ -479,6 +479,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({ history, tagValues }) =>
             className="btn"
             style={{ padding: "0.25rem 0.5rem", fontSize: "0.75rem" }}
             title={view.paused ? "Resume Live Stream" : "Pause / Freeze Plot"}
+            aria-label={view.paused ? "Resume live stream" : "Pause / freeze plot"}
           >
             {view.paused ? <Play size={12} color="var(--color-success)" /> : <Pause size={12} />}
             <span>{view.paused ? "Live" : "Freeze"}</span>
@@ -489,6 +490,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({ history, tagValues }) =>
             className="btn"
             style={{ padding: "0.25rem 0.5rem" }}
             title="Scroll back in time (older)"
+            aria-label="Scroll back in time (older)"
           >
             <ChevronLeft size={12} />
           </button>
@@ -498,6 +500,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({ history, tagValues }) =>
             className="btn"
             style={{ padding: "0.25rem 0.5rem" }}
             title="Scroll toward now (newer)"
+            aria-label="Scroll toward now (newer)"
           >
             <ChevronRight size={12} />
           </button>
@@ -507,6 +510,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({ history, tagValues }) =>
             className="btn"
             style={{ padding: "0.25rem 0.5rem" }}
             title="Reset Plot Zoom/Pan Settings"
+            aria-label="Reset Plot Zoom/Pan Settings"
           >
             <RotateCcw size={12} />
           </button>
@@ -521,6 +525,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({ history, tagValues }) =>
             className="btn"
             style={{ padding: "0.25rem 0.5rem" }}
             title="Zoom In"
+            aria-label="Zoom In"
           >
             <ZoomIn size={12} />
           </button>
@@ -530,6 +535,7 @@ export const TrendChart: React.FC<TrendChartProps> = ({ history, tagValues }) =>
             className="btn"
             style={{ padding: "0.25rem 0.5rem" }}
             title="Zoom Out"
+            aria-label="Zoom Out"
           >
             <ZoomOut size={12} />
           </button>


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to the playback/pan and zoom buttons in the `TrendChart` component.

### 🎯 Why
These buttons only contain SVG icons (`Play`, `Pause`, `ChevronLeft`, `ChevronRight`, `RotateCcw`, `ZoomIn`, `ZoomOut`) without any inner text. While they had `title` attributes for sighted users, adding `aria-label`s makes their function clear to screen reader users, improving the overall accessibility of the interface. This brings `TrendChart` in line with the accessible patterns used in `PowerSupplyTrend` and `TemperatureTrend`.

### 📸 Before/After
*(Visuals remain unchanged. Accessibility tree is updated.)*

### ♿ Accessibility
*   Added `aria-label` to the "Pause / freeze plot" toggle button.
*   Added `aria-label` to the "Scroll back in time" button.
*   Added `aria-label` to the "Scroll toward now" button.
*   Added `aria-label` to the "Reset Plot Zoom/Pan Settings" button.
*   Added `aria-label` to the "Zoom In" button.
*   Added `aria-label` to the "Zoom Out" button.

---
*PR created automatically by Jules for task [11125073481814506891](https://jules.google.com/task/11125073481814506891) started by @dieterolson*