### PR TITLE
⚡ Bolt: Optimize large dataset CSV serialization memory overhead

### DIFF
--- a/src/rate_of_closure/web/src/model/launchMonitorWorkspace.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorWorkspace.ts
@@ -126,8 +126,23 @@ const csvCell = (value: unknown): string => {
 
 const rowsToCsv = (rows: LaunchMonitorRow[]): string => {
   const columns = [...new Set(rows.flatMap((row) => Object.keys(row)))];
-  return `${[columns, ...rows.map((row) => columns.map((column) => row[column]))]
-    .map((row) => row.map(csvCell).join(",")).join("\n")}\n`;
+  // ⚡ Bolt Optimization: Replace chained .map().join() with a single-pass loop
+  // to eliminate intermediate array allocations during large CSV serializations.
+  let result = "";
+  for (let j = 0; j < columns.length; j++) {
+    if (j > 0) result += ",";
+    result += csvCell(columns[j]);
+  }
+  result += "\n";
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    for (let j = 0; j < columns.length; j++) {
+      if (j > 0) result += ",";
+      result += csvCell(row[columns[j]]);
+    }
+    result += "\n";
+  }
+  return result;
 };
 
 export async function createAnalysisExportBundle(


### PR DESCRIPTION
💡 What
Replaced the chained `.map().join()` implementation in `rowsToCsv` with a standard `for` loop and direct string concatenation when exporting the `LaunchMonitorRow` datasets to CSV strings.

🎯 Why
When exporting large datasets, `.map()` creates a new array for every single row, and then another nested array mapping inside, creating a massive explosion of intermediate array objects. V8 handles string accumulation natively and much more efficiently than allocating millions of ephemeral objects waiting for a final `.join()`. Eliminating the intermediate arrays significantly cuts down garbage collection overhead and prevents memory spikes during data exports.

📊 Impact
Dramatically reduces heap allocations and garbage collection pauses when running `createAnalysisExportBundle`, allowing massive datasets to be serialized smoothly on the frontend main thread.

🔬 Measurement
Review heap snapshots before and after calling `rowsToCsv` on a 100k+ row dataset, comparing the total number of short-lived `Array` allocations. Time-to-string conversion speed will also measurably decrease for large sets.

---
*PR created automatically by Jules for task [11685277979104783701](https://jules.google.com/task/11685277979104783701) started by @dieterolson*