### PR TITLE
feat(rate-of-closure): consume canonical analytics v2

### DIFF
--- a/AGENT_HANDOFF.md
+++ b/AGENT_HANDOFF.md
@@ -27,7 +27,7 @@ early August the delivery pattern has shifted from long stacked PRs to
 | #4433 | Visual-first tab visibility and visualization-led UX. Open. Landed via **#4473**.                                                                                                                                                         |
 | #4549 | Club Fitting Tester (OEM-grade). **COMPLETED** (#4557, #4577) — C1–C7 delivered (mesh inertia, shaft delivery, OEM doc, counterfactuals, PyQt6/React GUI tabs). |
 | #4562 | Heavy Hit - hand/body coupling at impact. **COMPLETED** (#4568, #4577) — H1–H4 delivered (coupled mechanics, MJCF/URDF/.osim import, GUI readout). |
-| #4583 | Professional launch-monitor program. Release A and canonical source-backed SG #4584/#4599 are merged. #4600 is the post-merge PyQt visual-baseline approval. Release B physical collection remains external and open. |
+| #4583 | Professional launch-monitor program. Release A and source-backed SG are merged; #4603 adds canonical dataset/covariation consumers through the ordinary protected flow. Release B physical collection remains external and open. |
 
 Per-tool detail: `src/rate_of_closure/AGENT_HANDOFF.md` (current, refreshed by
 #4473/#4577), `src/pendulum_simulator/AGENT_HANDOFF.md`,

--- a/SPEC.md
+++ b/SPEC.md
@@ -27,12 +27,21 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | 1.17.10                                    |
-| **Spec Version**        | 1.17.74                                    |
+| **Spec Version**        | 1.17.76                                    |
 | **Last Spec Update**    | 2026-08-20                                 |
 
 ## 2. Purpose & Mission
 
 ### Governed Launch-Monitor Analytics Release
+
+Version 1.17.76 migrates the player/population workspace to the canonical
+UpstreamDrift authorities pinned at `453346806a2950354f5b72cc46c2646e66459c8c`.
+PyQt6 and React now share strict dataset-job and player-covariation contracts,
+an immutable authorized-corpus selector, reference-only persistence, bounded
+submit/status/result clients, and evidence/claim validation. Canonical inline
+covariation fails closed above 20,000 rows; larger private corpora use only
+server-authorized aggregate jobs. The embedded estimators remain available as
+explicitly versioned offline compatibility, never as silent canonical results.
 
 Version 1.17.74 keeps the trusted React dependency install locked through
 `npm ci` while disabling `setup-node`'s package-manager cache in that
@@ -5075,6 +5084,7 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-20 | 1.17.76 | feat(rate-of-closure): consume canonical Upstream immutable dataset jobs and evidence-bearing player covariation through strict Python/TypeScript clients; add parity authorized-corpus selection, reference-only persistence, bounded aggregate refresh, and explicit 20,000-row inline limits while retaining local estimators only as labelled offline compatibility. | #4603 |
 | 2026-08-20 | 1.17.75 | fix(rate-of-closure, tests): make the isolated PyQt Variation rendered probe stop its worker, close and deferred-delete its window, drain posted Qt ownership, and quit the application after writing evidence; preserve the 60-second suite timeout and every approved baseline, accessibility, and performance budget. | #4613 |
 | 2026-08-20 | 1.17.74 | fix(rate-of-closure, ci): disable only the trusted self-hosted setup-node npm cache hook after its 2.0 GB post-job upload exhausted the unchanged job timeout and prevented independent PyQt evidence; retain npm ci, all budgets, artifacts, and failure semantics. | #4607 |
 | 2026-08-20 | 1.17.73 | fix(rate-of-closure, ci): transfer React visual-baseline candidates to an independent non-cancelled PyQt evidence job so protected render and baseline authorities still execute after React performance failure, without weakening either job's budgets or overall workflow failure semantics. | #4610 |

--- a/docs/rate_of_closure/LAUNCH_MONITOR_PLAYER_WORKSPACE_V2.md
+++ b/docs/rate_of_closure/LAUNCH_MONITOR_PLAYER_WORKSPACE_V2.md
@@ -59,6 +59,11 @@ Contract `2.0.0` project documents contain only:
 - explicit identity binding; and
 - selected variables and uncertainty settings.
 
+They may additionally pin a canonical authorized-corpus reference containing
+only an opaque server root alias, repository, 40-character commit, manifest
+and content SHA-256 values, and expected row count. Filesystem paths and rows
+are rejected from this reference.
+
 Rows are intentionally absent. Loading a project against a different dataset
 fingerprint fails closed.
 
@@ -70,15 +75,28 @@ where that bundle may be stored.
 
 ## Calculation authority and current limitations
 
-UpstreamDrift contract v2 is the canonical cross-service envelope for generic
-launch-monitor analytics, evidence lineage, backing records, and typed
-unavailable states. Tools currently owns the specialized grouped estimators
-described in [WITHIN_PLAYER_COVARIATION.md](WITHIN_PLAYER_COVARIATION.md) and
-[LONGITUDINAL_PLAYER_ANALYSIS.md](LONGITUDINAL_PLAYER_ANALYSIS.md). Python is the
-desktop calculation authority; the React implementation is a tested browser
-twin with the same eligibility, formula, unit, warning, and export contracts.
-This is an explicit local release boundary, not a claim that the grouped
-operations are already part of the UpstreamDrift v2 API.
+UpstreamDrift commit `453346806a2950354f5b72cc46c2646e66459c8c` is the
+canonical cross-service authority for immutable dataset jobs and evidence-
+bearing selected-pair/player-population covariation. Both clients validate the
+same pinned golden, identity evidence, backing lineage, safe claims, page
+bounds, and contract versions before displaying results. Dataset jobs accept
+only server-authorized references and return aggregates; they never return shot
+rows. Inline canonical covariation accepts at most 20,000 rows. The 261,666-row
+authority therefore remains eligible for reference-only aggregate jobs but not
+for an inline browser covariation request.
+
+The shared qualification golden pins the private dataset repository at
+`d469b8a427418fa00e99b0ad488e4310b067697d`, its Parquet manifest at SHA-256
+`b45fd9100e6786d32dce229224ed901f02c20ef5c44962769faf6cc94700c299`, and
+the sorted path-plus-content corpus digest at SHA-256
+`7bedf88ba473c947db2d4d078a73ee0ccd3512ffa182b751ea0a23298d1ab10c`.
+
+The embedded Python and React estimators described in
+[WITHIN_PLAYER_COVARIATION.md](WITHIN_PLAYER_COVARIATION.md) and
+[LONGITUDINAL_PLAYER_ANALYSIS.md](LONGITUDINAL_PLAYER_ANALYSIS.md) remain
+explicitly labelled `offline compatibility`. They do not replace or silently
+impersonate the canonical service when its URL, identity evidence, or row
+eligibility is unavailable.
 
 The released grouped surface includes player-mean-centered pooled effects,
 between-player decomposition, per-player correlations and regressions,
@@ -95,7 +113,8 @@ The remaining unavailable or deliberately bounded capabilities are:
   released summary and DerSimonian--Laird synthesis;
 - clustered or repeated-measures confidence limits for the centered pooled
   correlation;
-- out-of-core private-corpus querying from the browser client;
+- out-of-core shot-row querying from the browser client (bounded canonical
+  aggregate jobs are available);
 - vendor-model training when the capability manifest denies eligibility; and
 - causal improvement, swing-mechanism, or device-certification claims.
 

--- a/src/rate_of_closure/AGENT_HANDOFF.md
+++ b/src/rate_of_closure/AGENT_HANDOFF.md
@@ -44,9 +44,9 @@ React now share explicit-identity projects, arbitrary-variable analysis,
 dispersion/target-error, attested session summaries, persistence/export, and a
 safe capability-driven Neural Model Lab. The desktop client can load all
 261,666 manifest-verified private-authority rows from an explicitly authorized
-local root while its plot stays bounded. UpstreamDrift v2 is the canonical
-contract; embedded calculations are labeled compatibility/offline. The current
-#4277 slice adds identity-attested pooled, player-centered, between-player,
+local root while its plot stays bounded. #4603 adds parity clients for canonical
+dataset jobs/player covariation, a 20,000-row cap, and no private rows/paths in
+projects; embedded calculations remain labelled offline compatibility. The #4277 slice adds pooled, player-centered, between-player,
 per-player and random-effects covariation plus exploratory all-pairs scans to
 both clients, with unit-labelled plots and complete backing exports. The next
 performance slice adds hash-verified, user-authorized expected-strokes baseline

--- a/src/rate_of_closure/launch_monitor_canonical_v2.py
+++ b/src/rate_of_closure/launch_monitor_canonical_v2.py
@@ -1,0 +1,397 @@
+"""Strict public-client types generated from pinned Upstream v2 schemas."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from re import fullmatch
+from typing import Any
+
+DATASET_JOB_CONTRACT_VERSION = "launch-monitor-dataset-job/1.0.0"
+PLAYER_COVARIATION_CONTRACT_VERSION = "launch-monitor-player-covariation/1.0.0"
+MAX_CANONICAL_INLINE_RECORDS = 20_000
+MAX_DATASET_JOB_PAGE_SIZE = 200
+CANONICAL_DATASET_METRICS = frozenset(
+    {
+        "club_speed",
+        "ball_speed",
+        "smash_factor",
+        "launch_angle",
+        "launch_direction",
+        "spin_rate",
+        "back_spin",
+        "side_spin",
+        "spin_axis",
+        "attack_angle",
+        "club_path",
+        "face_angle",
+        "carry_distance",
+        "total_distance",
+        "descent_angle",
+        "lateral_carry",
+        "flight_time",
+    }
+)
+_SHA256_PATTERN = r"[0-9a-f]{64}"
+_COMMIT_PATTERN = r"[0-9a-f]{40}"
+_ROOT_ID_PATTERN = r"[a-z][a-z0-9-]{0,62}"
+_REPOSITORY_PATTERN = r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+"
+_PRIVATE_ROW_KEYS = frozenset({"shot_id", "source_row", "row_index"})
+_STATUS_KEYS = frozenset(
+    {
+        "contract_version",
+        "job_id",
+        "status",
+        "submitted_at_utc",
+        "completed_at_utc",
+        "input_row_count",
+        "result_item_count",
+        "unavailable",
+    }
+)
+_PAGE_KEYS = frozenset(
+    {
+        "contract_version",
+        "job_id",
+        "offset",
+        "limit",
+        "total_items",
+        "next_offset",
+        "items",
+    }
+)
+_AGGREGATE_KEYSETS = frozenset(
+    {
+        frozenset(
+            {
+                "source_id",
+                "row_count",
+                "vendor_key",
+                "redistribution_status",
+                "license_spdx",
+                "backing_repository",
+                "backing_commit",
+                "backing_object_digests",
+            }
+        ),
+        frozenset(
+            {
+                "group_by",
+                "group",
+                "metric",
+                "n",
+                "mean",
+                "standard_deviation",
+                "minimum",
+                "maximum",
+            }
+        ),
+        frozenset(
+            {
+                "group_by",
+                "group",
+                "left_metric",
+                "right_metric",
+                "n",
+                "correlation",
+            }
+        ),
+    }
+)
+
+
+@dataclass(frozen=True)
+class CanonicalDatasetReference:
+    """Immutable server-authorized dataset reference without a filesystem path."""
+
+    root_id: str
+    repository: str
+    commit: str
+    manifest_sha256: str
+    content_sha256: str
+    expected_row_count: int
+
+    def to_wire(self) -> dict[str, object]:
+        """Return the exact Upstream dataset-reference wire shape."""
+
+        return {
+            "root_id": self.root_id,
+            "repository": self.repository,
+            "commit": self.commit,
+            "manifest_sha256": self.manifest_sha256,
+            "content_sha256": self.content_sha256,
+            "expected_row_count": self.expected_row_count,
+        }
+
+
+def _strict_object(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def _matched_text(value: object, pattern: str, label: str) -> str:
+    if not isinstance(value, str) or fullmatch(pattern, value) is None:
+        raise ValueError(f"{label} is invalid")
+    return value
+
+
+def validate_job_id(value: object) -> str:
+    """Return one canonical opaque dataset job identifier."""
+
+    return _matched_text(value, r"[0-9a-f]{32}", "job_id")
+
+
+def load_canonical_dataset_reference(value: object) -> CanonicalDatasetReference:
+    """Validate a user-authorized opaque reference; paths are never accepted."""
+
+    item = _strict_object(value, "dataset reference")
+    required = {
+        "root_id",
+        "repository",
+        "commit",
+        "manifest_sha256",
+        "content_sha256",
+        "expected_row_count",
+    }
+    if set(item) != required:
+        raise ValueError("dataset reference has missing or unknown fields")
+    row_count = item["expected_row_count"]
+    if (
+        not isinstance(row_count, int)
+        or isinstance(row_count, bool)
+        or not (1 <= row_count <= 10_000_000)
+    ):
+        raise ValueError("expected_row_count is outside the canonical bounds")
+    return CanonicalDatasetReference(
+        root_id=_matched_text(item["root_id"], _ROOT_ID_PATTERN, "root_id"),
+        repository=_matched_text(item["repository"], _REPOSITORY_PATTERN, "repository"),
+        commit=_matched_text(item["commit"], _COMMIT_PATTERN, "commit"),
+        manifest_sha256=_matched_text(
+            item["manifest_sha256"], _SHA256_PATTERN, "manifest_sha256"
+        ),
+        content_sha256=_matched_text(
+            item["content_sha256"], _SHA256_PATTERN, "content_sha256"
+        ),
+        expected_row_count=row_count,
+    )
+
+
+def build_dataset_job_request(
+    reference: CanonicalDatasetReference,
+    kind: str,
+    *,
+    metrics: tuple[str, ...] = (),
+    group_by: str | None = None,
+    minimum_group_rows: int = 10,
+) -> dict[str, object]:
+    """Build one allow-listed aggregate job; arbitrary query text is forbidden."""
+
+    if kind not in {"source_summary", "metric_summary", "correlation"}:
+        raise ValueError("dataset operation kind is unsupported")
+    if group_by not in {None, "source_id", "monitor", "club"}:
+        raise ValueError("dataset operation group_by is unsupported")
+    if minimum_group_rows < 10:
+        raise ValueError("minimum_group_rows must be at least 10")
+    if (
+        len(metrics) > 12
+        or len(set(metrics)) != len(metrics)
+        or not set(metrics).issubset(CANONICAL_DATASET_METRICS)
+    ):
+        raise ValueError("metrics must be unique canonical dataset metrics")
+    if kind == "source_summary" and (metrics or group_by is not None):
+        raise ValueError("source_summary does not accept metrics or group_by")
+    if kind == "metric_summary" and not metrics:
+        raise ValueError("metric_summary requires metrics")
+    if kind == "correlation" and len(metrics) < 2:
+        raise ValueError("correlation requires at least two metrics")
+    return {
+        "contract_version": DATASET_JOB_CONTRACT_VERSION,
+        "dataset": reference.to_wire(),
+        "operation": {
+            "kind": kind,
+            "metrics": list(metrics),
+            "group_by": group_by,
+            "minimum_group_rows": minimum_group_rows,
+        },
+    }
+
+
+def validate_dataset_job_status(value: object) -> dict[str, Any]:
+    """Validate data-free asynchronous job state from the canonical authority."""
+
+    item = _strict_object(value, "dataset job status")
+    if set(item) != _STATUS_KEYS:
+        raise ValueError("dataset job status has missing or unknown fields")
+    if item.get("contract_version") != DATASET_JOB_CONTRACT_VERSION:
+        raise ValueError("dataset job status has an unsupported contract version")
+    validate_job_id(item.get("job_id"))
+    if item.get("status") not in {
+        "queued",
+        "running",
+        "completed",
+        "unavailable",
+        "failed",
+    }:
+        raise ValueError("dataset job status is invalid")
+    for key in ("input_row_count", "result_item_count"):
+        if not isinstance(item.get(key), int) or item[key] < 0:
+            raise ValueError(f"dataset job {key} is invalid")
+    return item
+
+
+def validate_dataset_job_page(value: object) -> dict[str, Any]:
+    """Validate a bounded aggregate page and reject observation-shaped items."""
+
+    item = _strict_object(value, "dataset job result page")
+    if set(item) != _PAGE_KEYS:
+        raise ValueError("dataset job page has missing or unknown fields")
+    if item.get("contract_version") != DATASET_JOB_CONTRACT_VERSION:
+        raise ValueError("dataset job page has an unsupported contract version")
+    validate_job_id(item.get("job_id"))
+    for key in ("offset", "total_items"):
+        if (
+            not isinstance(item.get(key), int)
+            or isinstance(item[key], bool)
+            or item[key] < 0
+        ):
+            raise ValueError(f"dataset job page {key} is invalid")
+    next_offset = item.get("next_offset")
+    if next_offset is not None and (
+        not isinstance(next_offset, int)
+        or isinstance(next_offset, bool)
+        or next_offset < 0
+    ):
+        raise ValueError("dataset job page next_offset is invalid")
+    limit = item.get("limit")
+    if (
+        not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or not 1 <= limit <= MAX_DATASET_JOB_PAGE_SIZE
+    ):
+        raise ValueError("dataset job page limit is invalid")
+    items = item.get("items")
+    if not isinstance(items, list) or len(items) > limit:
+        raise ValueError("dataset job page items are invalid")
+    for entry in items:
+        if not isinstance(entry, dict) or _PRIVATE_ROW_KEYS.intersection(entry):
+            raise ValueError("dataset job pages cannot expose private rows")
+        if frozenset(entry) not in _AGGREGATE_KEYSETS:
+            raise ValueError("dataset job page item does not match an aggregate schema")
+    return item
+
+
+def build_player_covariation_payload(
+    records: list[dict[str, object]],
+    *,
+    player_column: str,
+    x_column: str,
+    y_column: str,
+    min_samples: int,
+    confidence_level: float,
+) -> dict[str, object]:
+    """Build the canonical inline request and fail closed above its hard limit."""
+
+    if not 1 <= len(records) <= MAX_CANONICAL_INLINE_RECORDS:
+        raise ValueError("canonical player covariation accepts at most 20,000 rows")
+    if len({player_column, x_column, y_column}) != 3 or not all(
+        value.strip() for value in (player_column, x_column, y_column)
+    ):
+        raise ValueError("player, x, and y columns must be distinct and non-empty")
+    if min_samples < 4 or not 0.5 < confidence_level < 1:
+        raise ValueError("canonical covariation options are invalid")
+    return {
+        "records": records,
+        "request": {
+            "x_column": x_column,
+            "y_column": y_column,
+            "player_column": player_column,
+            "min_samples": min_samples,
+            "confidence_level": confidence_level,
+        },
+        "context": {
+            "player_identity": {
+                "trust_level": "explicit_user_attested",
+                "identifier_column": player_column,
+                "evidence": (
+                    f"Dataset owner attested {player_column} in this client session."
+                ),
+            }
+        },
+    }
+
+
+def validate_player_covariation_response(value: object) -> dict[str, Any]:
+    """Validate the canonical evidence envelope before either UI consumes it."""
+
+    item = _strict_object(value, "player covariation response")
+    if item.get("contract_version") != PLAYER_COVARIATION_CONTRACT_VERSION:
+        raise ValueError("player covariation response has an unsupported contract")
+    common = {
+        "analysis_kind",
+        "contract_version",
+        "status",
+        "request",
+        "lineage",
+        "player_identity",
+        "vendor_provenance",
+        "claims",
+        "warnings",
+    }
+    selected = common | {
+        "pooled",
+        "within_player",
+        "between_player",
+        "per_player",
+        "meta_analysis",
+        "missingness",
+        "units",
+        "availability",
+        "uncertainty",
+        "definitions",
+    }
+    scan = common | {
+        "pair_count",
+        "available_pair_count",
+        "unavailable_pair_count",
+        "ranking",
+        "method_description",
+    }
+    expected = selected if item.get("analysis_kind") == "selected_pair" else scan
+    if set(item) != expected:
+        raise ValueError("player covariation response is missing required fields")
+    if item["analysis_kind"] not in {"selected_pair", "pair_scan"}:
+        raise ValueError("player covariation analysis_kind is invalid")
+    lineage = _strict_object(item["lineage"], "covariation lineage")
+    if not isinstance(lineage.get("backing_records"), list):
+        raise ValueError("player covariation backing lineage is invalid")
+    identity = _strict_object(item["player_identity"], "player identity")
+    if identity.get("trust_level") not in {
+        "explicit_user_attested",
+        "pseudonymous_stable",
+        "verified_external",
+    }:
+        raise ValueError("player covariation requires trusted identity evidence")
+    claims = _strict_object(item["claims"], "covariation claims")
+    if any(
+        claims.get(name) is not False
+        for name in ("device_emulation", "device_certification", "causal_inference")
+    ):
+        raise ValueError("player covariation response makes an unsupported claim")
+    return item
+
+
+__all__ = [
+    "DATASET_JOB_CONTRACT_VERSION",
+    "CANONICAL_DATASET_METRICS",
+    "MAX_CANONICAL_INLINE_RECORDS",
+    "MAX_DATASET_JOB_PAGE_SIZE",
+    "PLAYER_COVARIATION_CONTRACT_VERSION",
+    "CanonicalDatasetReference",
+    "build_dataset_job_request",
+    "build_player_covariation_payload",
+    "load_canonical_dataset_reference",
+    "validate_dataset_job_page",
+    "validate_dataset_job_status",
+    "validate_job_id",
+    "validate_player_covariation_response",
+]

--- a/src/rate_of_closure/launch_monitor_canonical_v2_golden.json
+++ b/src/rate_of_closure/launch_monitor_canonical_v2_golden.json
@@ -1,0 +1,56 @@
+{
+  "authority": {
+    "repository": "D-sorganization/UpstreamDrift",
+    "commit": "453346806a2950354f5b72cc46c2646e66459c8c",
+    "dataset_jobs_merge": "9cdc724e61bf7e5ebb4c741118875fcc03ca0913",
+    "player_covariation_merge": "453346806a2950354f5b72cc46c2646e66459c8c",
+    "dataset_repository_commit": "d469b8a427418fa00e99b0ad488e4310b067697d"
+  },
+  "dataset_reference": {
+    "root_id": "launch-monitor-authority",
+    "repository": "D-sorganization/Launch-Monitor-Flight-Model-Campaign",
+    "commit": "d469b8a427418fa00e99b0ad488e4310b067697d",
+    "manifest_sha256": "b45fd9100e6786d32dce229224ed901f02c20ef5c44962769faf6cc94700c299",
+    "content_sha256": "7bedf88ba473c947db2d4d078a73ee0ccd3512ffa182b751ea0a23298d1ab10c",
+    "expected_row_count": 261666
+  },
+  "dataset_job_request": {
+    "contract_version": "launch-monitor-dataset-job/1.0.0",
+    "dataset": {
+      "root_id": "launch-monitor-authority",
+      "repository": "D-sorganization/Launch-Monitor-Flight-Model-Campaign",
+      "commit": "d469b8a427418fa00e99b0ad488e4310b067697d",
+      "manifest_sha256": "b45fd9100e6786d32dce229224ed901f02c20ef5c44962769faf6cc94700c299",
+      "content_sha256": "7bedf88ba473c947db2d4d078a73ee0ccd3512ffa182b751ea0a23298d1ab10c",
+      "expected_row_count": 261666
+    },
+    "operation": {
+      "kind": "source_summary",
+      "metrics": [],
+      "group_by": null,
+      "minimum_group_rows": 10
+    }
+  },
+  "player_covariation_request": {
+    "records": [
+      {"player_id": "p1", "face_angle": 1.0, "club_path": 0.5},
+      {"player_id": "p1", "face_angle": 2.0, "club_path": 1.5},
+      {"player_id": "p1", "face_angle": 3.0, "club_path": 2.5},
+      {"player_id": "p1", "face_angle": 4.0, "club_path": 3.5}
+    ],
+    "request": {
+      "x_column": "face_angle",
+      "y_column": "club_path",
+      "player_column": "player_id",
+      "min_samples": 4,
+      "confidence_level": 0.95
+    },
+    "context": {
+      "player_identity": {
+        "trust_level": "explicit_user_attested",
+        "identifier_column": "player_id",
+        "evidence": "Dataset owner attested player_id in this client session."
+      }
+    }
+  }
+}

--- a/src/rate_of_closure/launch_monitor_v2_client.py
+++ b/src/rate_of_closure/launch_monitor_v2_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlencode, urlparse
 from urllib.request import Request, urlopen
 
@@ -193,18 +193,17 @@ class UpstreamV2Client:
         """Submit a verified-reference aggregate job without inline observations."""
 
         value = self._post("/tools/launch-monitor-analytics/v2/dataset-jobs", payload)
-        return cast(dict[str, Any], validate_dataset_job_status(value))
+        validated: dict[str, Any] = validate_dataset_job_status(value)
+        return validated
 
     def dataset_job_status(self, job_id: str) -> dict[str, Any]:
         """Fetch one data-free canonical dataset-job status."""
 
         validate_job_id(job_id)
-        return cast(
-            dict[str, Any],
-            validate_dataset_job_status(
-                self._get(f"/tools/launch-monitor-analytics/v2/dataset-jobs/{job_id}")
-            ),
+        validated: dict[str, Any] = validate_dataset_job_status(
+            self._get(f"/tools/launch-monitor-analytics/v2/dataset-jobs/{job_id}")
         )
+        return validated
 
     def dataset_job_results(
         self, job_id: str, *, offset: int = 0, limit: int = 100
@@ -216,7 +215,8 @@ class UpstreamV2Client:
         value = self._get(
             f"/tools/launch-monitor-analytics/v2/dataset-jobs/{job_id}/results?{query}"
         )
-        return cast(dict[str, Any], validate_dataset_job_page(value))
+        validated: dict[str, Any] = validate_dataset_job_page(value)
+        return validated
 
     def player_covariation(self, payload: dict[str, object]) -> dict[str, Any]:
         """Run canonical selected-pair covariation through UpstreamDrift."""
@@ -224,7 +224,8 @@ class UpstreamV2Client:
         value = self._post(
             "/tools/launch-monitor-analytics/v2/player-covariation", payload
         )
-        return cast(dict[str, Any], validate_player_covariation_response(value))
+        validated: dict[str, Any] = validate_player_covariation_response(value)
+        return validated
 
     def _get(self, path: str) -> object:
         request = Request(f"{self.base_url}{path}", method="GET")

--- a/src/rate_of_closure/launch_monitor_v2_client.py
+++ b/src/rate_of_closure/launch_monitor_v2_client.py
@@ -1,12 +1,28 @@
-"""Validated HTTP client seam for the canonical UpstreamDrift v2 contract."""
+"""Validated HTTP client seam for canonical UpstreamDrift analytics contracts."""
 
 from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any
-from urllib.parse import urlparse
+from typing import Any, cast
+from urllib.parse import urlencode, urlparse
 from urllib.request import Request, urlopen
+
+from rate_of_closure.launch_monitor_canonical_v2 import (
+    CANONICAL_DATASET_METRICS,
+    DATASET_JOB_CONTRACT_VERSION,
+    MAX_CANONICAL_INLINE_RECORDS,
+    MAX_DATASET_JOB_PAGE_SIZE,
+    PLAYER_COVARIATION_CONTRACT_VERSION,
+    CanonicalDatasetReference,
+    build_dataset_job_request,
+    build_player_covariation_payload,
+    load_canonical_dataset_reference,
+    validate_dataset_job_page,
+    validate_dataset_job_status,
+    validate_job_id,
+    validate_player_covariation_response,
+)
 
 
 @dataclass(frozen=True)
@@ -34,6 +50,8 @@ class StrokesGainedResponseV1:
 
 
 def validate_v2_response(value: object) -> AnalysisResponseV2:
+    """Validate the general evidence-bearing analysis envelope."""
+
     if not isinstance(value, dict) or value.get("contract_version") != "2.0.0":
         raise ValueError(
             "Upstream analysis response has an unsupported contract version"
@@ -171,6 +189,49 @@ class UpstreamV2Client:
         value = self._post("/tools/launch-monitor-analytics/v2/strokes-gained", payload)
         return validate_strokes_gained_response(value)
 
+    def submit_dataset_job(self, payload: dict[str, object]) -> dict[str, Any]:
+        """Submit a verified-reference aggregate job without inline observations."""
+
+        value = self._post("/tools/launch-monitor-analytics/v2/dataset-jobs", payload)
+        return cast(dict[str, Any], validate_dataset_job_status(value))
+
+    def dataset_job_status(self, job_id: str) -> dict[str, Any]:
+        """Fetch one data-free canonical dataset-job status."""
+
+        validate_job_id(job_id)
+        return cast(
+            dict[str, Any],
+            validate_dataset_job_status(
+                self._get(f"/tools/launch-monitor-analytics/v2/dataset-jobs/{job_id}")
+            ),
+        )
+
+    def dataset_job_results(
+        self, job_id: str, *, offset: int = 0, limit: int = 100
+    ) -> dict[str, Any]:
+        """Fetch one bounded aggregate page; private observation rows are rejected."""
+
+        validate_job_id(job_id)
+        query = urlencode({"offset": offset, "limit": limit})
+        value = self._get(
+            f"/tools/launch-monitor-analytics/v2/dataset-jobs/{job_id}/results?{query}"
+        )
+        return cast(dict[str, Any], validate_dataset_job_page(value))
+
+    def player_covariation(self, payload: dict[str, object]) -> dict[str, Any]:
+        """Run canonical selected-pair covariation through UpstreamDrift."""
+
+        value = self._post(
+            "/tools/launch-monitor-analytics/v2/player-covariation", payload
+        )
+        return cast(dict[str, Any], validate_player_covariation_response(value))
+
+    def _get(self, path: str) -> object:
+        request = Request(f"{self.base_url}{path}", method="GET")
+        with urlopen(request, timeout=self.timeout_seconds) as response:  # nosec B310
+            value: Any = json.loads(response.read().decode("utf-8"))
+        return value
+
     def _post(self, path: str, payload: dict[str, object]) -> object:
         request = Request(
             f"{self.base_url}{path}",
@@ -178,7 +239,6 @@ class UpstreamV2Client:
             headers={"Content-Type": "application/json"},
             method="POST",
         )
-        # The constructor admits only HTTP(S) authorities; file/custom schemes fail.
         with urlopen(request, timeout=self.timeout_seconds) as response:  # nosec B310
             value: Any = json.loads(response.read().decode("utf-8"))
         return value
@@ -186,9 +246,21 @@ class UpstreamV2Client:
 
 __all__ = [
     "AnalysisResponseV2",
+    "CanonicalDatasetReference",
+    "CANONICAL_DATASET_METRICS",
+    "DATASET_JOB_CONTRACT_VERSION",
+    "MAX_CANONICAL_INLINE_RECORDS",
+    "MAX_DATASET_JOB_PAGE_SIZE",
+    "PLAYER_COVARIATION_CONTRACT_VERSION",
     "ResidualAvailability",
     "StrokesGainedResponseV1",
     "UpstreamV2Client",
+    "build_dataset_job_request",
+    "build_player_covariation_payload",
+    "load_canonical_dataset_reference",
+    "validate_dataset_job_page",
+    "validate_dataset_job_status",
+    "validate_player_covariation_response",
     "validate_strokes_gained_response",
     "validate_v2_response",
 ]

--- a/src/rate_of_closure/launch_monitor_workspace.py
+++ b/src/rate_of_closure/launch_monitor_workspace.py
@@ -17,6 +17,10 @@ from typing import Any
 import pandas as pd
 
 from rate_of_closure.application.atomic_text_files import write_utf8_text_atomic
+from rate_of_closure.launch_monitor_v2_client import (
+    CanonicalDatasetReference,
+    load_canonical_dataset_reference,
+)
 
 CONTRACT_VERSION = "2.0.0"
 
@@ -96,6 +100,7 @@ class LaunchMonitorProject:
     dataset: DatasetReference
     identity: PlayerIdentityBinding
     selection: AnalysisSelection
+    canonical_dataset: CanonicalDatasetReference | None = None
     contract_version: str = CONTRACT_VERSION
 
     def __post_init__(self) -> None:
@@ -108,7 +113,10 @@ class LaunchMonitorProject:
     def to_wire(self) -> dict[str, Any]:
         """Return the snake-case backend and persistence representation."""
 
-        return asdict(self)
+        payload = asdict(self)
+        if self.canonical_dataset is None:
+            payload.pop("canonical_dataset")
+        return payload
 
 
 def build_player_covariation_request(project: LaunchMonitorProject) -> dict[str, Any]:
@@ -166,14 +174,19 @@ def load_project(source: str | Path) -> LaunchMonitorProject:
     payload = json.loads(Path(source).read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError("launch-monitor project must be a JSON object")
-    allowed = {"name", "dataset", "identity", "selection", "contract_version"}
-    if set(payload) != allowed:
+    required = {"name", "dataset", "identity", "selection", "contract_version"}
+    allowed = required | {"canonical_dataset"}
+    if not required.issubset(payload) or not set(payload).issubset(allowed):
         raise ValueError("launch-monitor project has missing or unknown fields")
+    canonical = payload.get("canonical_dataset")
     return LaunchMonitorProject(
         name=str(payload["name"]),
         dataset=DatasetReference(**payload["dataset"]),
         identity=PlayerIdentityBinding(**payload["identity"]),
         selection=AnalysisSelection(**payload["selection"]),
+        canonical_dataset=(
+            None if canonical is None else load_canonical_dataset_reference(canonical)
+        ),
         contract_version=str(payload["contract_version"]),
     )
 

--- a/src/rate_of_closure/ui/pyqt6/launch_monitor_canonical_workspace_mixin.py
+++ b/src/rate_of_closure/ui/pyqt6/launch_monitor_canonical_workspace_mixin.py
@@ -1,0 +1,176 @@
+"""Reference-only canonical authority actions for the PyQt player workspace."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from PyQt6.QtWidgets import (
+    QFileDialog,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QWidget,
+)
+
+from rate_of_closure.launch_monitor_v2_client import (
+    CanonicalDatasetReference,
+    UpstreamV2Client,
+    build_dataset_job_request,
+    build_player_covariation_payload,
+    load_canonical_dataset_reference,
+)
+from rate_of_closure.launch_monitor_workspace import LaunchMonitorProject
+
+
+class CanonicalWorkspaceMixin:
+    """Keep private-reference transport separate from local statistics/UI layout."""
+
+    authority_url: QLineEdit
+    status: QLabel
+    corpus_reference_button: QPushButton
+    inspect_corpus_button: QPushButton
+    refresh_corpus_button: QPushButton
+    canonical_covariation_button: QPushButton
+    canonical_limit: QLabel
+    _frame: pd.DataFrame
+    _canonical_reference: CanonicalDatasetReference | None
+    _canonical_job_id: str | None
+    _export_payload: dict[str, object]
+
+    def project(self) -> LaunchMonitorProject:
+        """Return the host workspace project."""
+
+        raise NotImplementedError
+
+    def _refresh_enabled(self) -> None:
+        """Refresh host controls after authority state changes."""
+
+        raise NotImplementedError
+
+    def _host_widget(self) -> QWidget:
+        if not isinstance(self, QWidget):
+            raise TypeError("canonical workspace mixin requires a QWidget host")
+        return self
+
+    def _build_canonical_controls(self) -> None:
+        """Create the shared canonical authority controls for the host layout."""
+
+        self.authority_url = QLineEdit()
+        self.authority_url.setPlaceholderText("https://authorized-upstream.example")
+        self.corpus_reference_button = QPushButton(
+            "Load Authorized Corpus Reference..."
+        )
+        self.inspect_corpus_button = QPushButton("Inspect Authorized Corpus")
+        self.refresh_corpus_button = QPushButton("Refresh Corpus Job")
+        self.canonical_covariation_button = QPushButton(
+            "Run Canonical Player Covariation"
+        )
+        self.canonical_limit = QLabel(
+            "Canonical inline limit is 20,000 rows. Larger authorized corpora "
+            "use reference-only aggregate jobs; private rows are never persisted."
+        )
+        self.canonical_limit.setWordWrap(True)
+
+    def load_corpus_reference_dialog(self) -> None:
+        """Load an immutable reference selected by the user, never corpus rows."""
+
+        selected, _ = QFileDialog.getOpenFileName(
+            self._host_widget(),
+            "Load Authorized Corpus Reference",
+            "",
+            "JSON (*.json)",
+        )
+        if not selected:
+            return
+        try:
+            payload = json.loads(Path(selected).read_text(encoding="utf-8"))
+            self._canonical_reference = load_canonical_dataset_reference(payload)
+            row_count = self._canonical_reference.expected_row_count
+            self.status.setText(
+                f"Authorized reference loaded: {row_count:,} rows; no rows were loaded."
+            )
+        except (OSError, ValueError) as error:
+            QMessageBox.warning(
+                self._host_widget(), "Corpus Reference Not Loaded", str(error)
+            )
+        self._refresh_enabled()
+
+    def submit_corpus_job_safely(self) -> None:
+        """Submit a reference-only source summary to the configured authority."""
+
+        try:
+            if self._canonical_reference is None:
+                raise ValueError("Load an authorized corpus reference first")
+            client = UpstreamV2Client(self.authority_url.text())
+            response = client.submit_dataset_job(
+                build_dataset_job_request(self._canonical_reference, "source_summary")
+            )
+            self._canonical_job_id = str(response["job_id"])
+            self.status.setText(
+                f"Canonical corpus job {self._canonical_job_id} is "
+                f"{response['status']}."
+            )
+        except (OSError, ValueError) as error:
+            QMessageBox.warning(
+                self._host_widget(), "Corpus Job Not Submitted", str(error)
+            )
+        self._refresh_enabled()
+
+    def refresh_corpus_job_safely(self) -> None:
+        """Fetch bounded aggregate results only after canonical completion."""
+
+        try:
+            if self._canonical_job_id is None:
+                raise ValueError("No canonical corpus job has been submitted")
+            client = UpstreamV2Client(self.authority_url.text())
+            response = client.dataset_job_status(self._canonical_job_id)
+            if response["status"] == "completed":
+                page = client.dataset_job_results(self._canonical_job_id)
+                self._export_payload = page
+                self.status.setText(
+                    "Canonical corpus job completed with "
+                    f"{page['total_items']} bounded aggregate items."
+                )
+            else:
+                self.status.setText(f"Canonical corpus job is {response['status']}.")
+        except (OSError, ValueError) as error:
+            QMessageBox.warning(
+                self._host_widget(), "Corpus Job Not Refreshed", str(error)
+            )
+        self._refresh_enabled()
+
+    def run_canonical_covariation_safely(self) -> None:
+        """Submit inline rows only within the canonical 20,000-row boundary."""
+
+        try:
+            project = self.project()
+            records: list[dict[str, Any]] = [
+                {str(key): value for key, value in row.items()}
+                for row in self._frame.to_dict(orient="records")
+            ]
+            payload = build_player_covariation_payload(
+                records,
+                player_column=project.identity.column,
+                x_column=project.selection.x,
+                y_column=project.selection.y,
+                min_samples=max(4, project.selection.min_samples),
+                confidence_level=project.selection.confidence_level,
+            )
+            client = UpstreamV2Client(self.authority_url.text())
+            self._export_payload = client.player_covariation(payload)
+            self.status.setText(
+                "Canonical Upstream player covariation completed with "
+                "evidence-bearing lineage."
+            )
+        except (OSError, ValueError) as error:
+            QMessageBox.warning(
+                self._host_widget(), "Canonical Covariation Not Run", str(error)
+            )
+        self._refresh_enabled()
+
+
+__all__ = ["CanonicalWorkspaceMixin"]

--- a/src/rate_of_closure/ui/pyqt6/launch_monitor_player_workspace.py
+++ b/src/rate_of_closure/ui/pyqt6/launch_monitor_player_workspace.py
@@ -27,6 +27,10 @@ from rate_of_closure.launch_monitor_analysis import (
     analyze_launch_monitor_data,
     numeric_columns,
 )
+from rate_of_closure.launch_monitor_v2_client import (
+    MAX_CANONICAL_INLINE_RECORDS,
+    CanonicalDatasetReference,
+)
 from rate_of_closure.launch_monitor_workspace import (
     AnalysisSelection,
     LaunchMonitorProject,
@@ -43,12 +47,15 @@ from rate_of_closure.player_covariation import (
     analyze_player_covariation,
     scan_covariation_pairs,
 )
+from rate_of_closure.ui.pyqt6.launch_monitor_canonical_workspace_mixin import (
+    CanonicalWorkspaceMixin,
+)
 from rate_of_closure.ui.pyqt6.launch_monitor_covariation_view import (
     LaunchMonitorCovariationView,
 )
 
 
-class LaunchMonitorPlayerWorkspace(QWidget):
+class LaunchMonitorPlayerWorkspace(CanonicalWorkspaceMixin, QWidget):
     """Run delegated per-player covariation with explicit identity consent."""
 
     def __init__(self, parent: QWidget | None = None) -> None:
@@ -58,6 +65,8 @@ class LaunchMonitorPlayerWorkspace(QWidget):
         self._result: AnalysisResult | None = None
         self.covariation_result: PlayerCovariationAnalysis | None = None
         self._export_payload: dict[str, object] = {}
+        self._canonical_reference: CanonicalDatasetReference | None = None
+        self._canonical_job_id: str | None = None
         self._build_ui()
 
     def _build_ui(self) -> None:
@@ -77,6 +86,7 @@ class LaunchMonitorPlayerWorkspace(QWidget):
             "I attest this column identifies a player; it was not inferred "
             "from session, club, or row order."
         )
+        self._build_canonical_controls()
         self.run_button = QPushButton("Run Offline Compatibility Covariation")
         self.scan_button = QPushButton("Rank Variable Pairs")
         self.save_button = QPushButton("Save Project...")
@@ -92,6 +102,14 @@ class LaunchMonitorPlayerWorkspace(QWidget):
             (self.min_samples_spin, "Minimum pairwise-complete shots per player"),
             (self.confidence_spin, "Pearson confidence level"),
             (self.attestation, "Explicit player identity attestation"),
+            (self.authority_url, "Canonical Upstream authority URL"),
+            (self.corpus_reference_button, "Load authorized corpus reference"),
+            (self.inspect_corpus_button, "Inspect authorized corpus aggregates"),
+            (self.refresh_corpus_button, "Refresh canonical corpus job"),
+            (
+                self.canonical_covariation_button,
+                "Run canonical Upstream player covariation for at most 20,000 rows",
+            ),
             (
                 self.run_button,
                 "Run local v1 compatibility calculation; canonical v2 is preferred",
@@ -118,8 +136,14 @@ class LaunchMonitorPlayerWorkspace(QWidget):
         form.addRow("Minimum N/player:", self.min_samples_spin)
         form.addRow("Confidence:", self.confidence_spin)
         form.addRow(self.attestation)
+        form.addRow("Canonical authority:", self.authority_url)
+        form.addRow(self.corpus_reference_button)
+        form.addRow(self.canonical_limit)
         buttons = QHBoxLayout()
         for button in (
+            self.inspect_corpus_button,
+            self.refresh_corpus_button,
+            self.canonical_covariation_button,
             self.run_button,
             self.scan_button,
             self.save_button,
@@ -152,6 +176,13 @@ class LaunchMonitorPlayerWorkspace(QWidget):
         self.save_button.clicked.connect(self.save_dialog)
         self.load_button.clicked.connect(self.load_dialog)
         self.export_button.clicked.connect(self.export_dialog)
+        self.corpus_reference_button.clicked.connect(self.load_corpus_reference_dialog)
+        self.inspect_corpus_button.clicked.connect(self.submit_corpus_job_safely)
+        self.refresh_corpus_button.clicked.connect(self.refresh_corpus_job_safely)
+        self.canonical_covariation_button.clicked.connect(
+            self.run_canonical_covariation_safely
+        )
+        self.authority_url.textChanged.connect(self._refresh_enabled)
         self._refresh_enabled()
 
     def set_dataset(
@@ -187,10 +218,22 @@ class LaunchMonitorPlayerWorkspace(QWidget):
 
     def _refresh_enabled(self) -> None:
         ready = bool(self.identity_combo.currentText()) and self.attestation.isChecked()
+        authority_ready = bool(self.authority_url.text().strip())
         self.run_button.setEnabled(ready)
         self.scan_button.setEnabled(ready)
         self.save_button.setEnabled(ready)
-        self.export_button.setEnabled(ready and self._result is not None)
+        self.export_button.setEnabled(ready and bool(self._export_payload))
+        self.inspect_corpus_button.setEnabled(
+            authority_ready and self._canonical_reference is not None
+        )
+        self.refresh_corpus_button.setEnabled(
+            authority_ready and self._canonical_job_id is not None
+        )
+        self.canonical_covariation_button.setEnabled(
+            ready
+            and authority_ready
+            and 0 < len(self._frame) <= MAX_CANONICAL_INLINE_RECORDS
+        )
 
     def project(self) -> LaunchMonitorProject:
         """Return validated reference-only state for the current controls."""
@@ -207,6 +250,7 @@ class LaunchMonitorPlayerWorkspace(QWidget):
                 self.min_samples_spin.value(),
                 self.confidence_spin.value(),
             ),
+            canonical_dataset=self._canonical_reference,
         )
 
     def run_player_analysis(self) -> AnalysisResult:
@@ -335,11 +379,13 @@ class LaunchMonitorPlayerWorkspace(QWidget):
             self.min_samples_spin.setValue(project.selection.min_samples)
             self.confidence_spin.setValue(project.selection.confidence_level)
             self.attestation.setChecked(project.identity.user_attested)
+            self._canonical_reference = project.canonical_dataset
+            self._refresh_enabled()
         except (OSError, ValueError) as error:
             QMessageBox.warning(self, "Project Not Loaded", str(error))
 
     def export_dialog(self) -> None:
-        if self._result is None:
+        if not self._export_payload:
             return
         selected = QFileDialog.getExistingDirectory(self, "Choose Full Export Parent")
         if selected:

--- a/src/rate_of_closure/web/src/components/LaunchMonitorPlayerWorkspace.test.tsx
+++ b/src/rate_of_closure/web/src/components/LaunchMonitorPlayerWorkspace.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { LaunchMonitorRow } from "../model/launchMonitorAnalysisTypes";
 import { LaunchMonitorPlayerWorkspace } from "./LaunchMonitorPlayerWorkspace";
@@ -12,6 +12,8 @@ const rows: LaunchMonitorRow[] = Array.from({ length: 12 }, (_, index) => ({
 }));
 
 describe("LaunchMonitorPlayerWorkspace", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   it("fails closed until a player identity column is explicitly attested", async () => {
     render(<LaunchMonitorPlayerWorkspace rows={rows} sourceName="test.csv" />);
     expect(screen.getByRole("button", { name: /run offline compatibility covariation/i })).toBeDisabled();
@@ -41,5 +43,48 @@ describe("LaunchMonitorPlayerWorkspace", () => {
     expect(screen.getByLabelText("Covariation player column")).toHaveValue("player_id");
     expect(screen.getByLabelText("Covariation player column")).toBeDisabled();
     expect(screen.getByRole("button", { name: "Analyze Player Covariation" })).toHaveAttribute("title");
+  });
+
+  it("offers fail-closed canonical authority and authorized corpus controls", () => {
+    render(<LaunchMonitorPlayerWorkspace rows={rows} sourceName="test.csv" />);
+    expect(screen.getByLabelText("Canonical Upstream authority URL")).toBeInTheDocument();
+    expect(screen.getByLabelText("Load authorized corpus reference")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /inspect authorized corpus/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /run canonical player covariation/i })).toBeDisabled();
+    expect(screen.getByText(/canonical inline limit is 20,000 rows/i)).toBeInTheDocument();
+  });
+
+  it("makes validated canonical evidence inspectable and exportable", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        contract_version: "launch-monitor-player-covariation/1.0.0",
+        analysis_kind: "selected_pair",
+        status: "available",
+        request: {},
+        pooled: {},
+        within_player: {},
+        between_player: {},
+        per_player: [],
+        meta_analysis: {},
+        missingness: {},
+        units: {},
+        lineage: { backing_records: rows.map((_, index) => ({ row_index: index })) },
+        availability: [],
+        uncertainty: {},
+        player_identity: { trust_level: "explicit_user_attested" },
+        vendor_provenance: {},
+        claims: { device_emulation: false, device_certification: false, causal_inference: false },
+        definitions: {},
+        warnings: [],
+      }),
+    })));
+    render(<LaunchMonitorPlayerWorkspace rows={rows} sourceName="test.csv" />);
+    fireEvent.change(screen.getByLabelText("Canonical Upstream authority URL"), { target: { value: "https://upstream.example" } });
+    fireEvent.change(screen.getByLabelText("Player identity column"), { target: { value: "player_id" } });
+    fireEvent.click(screen.getByLabelText(/I attest/i));
+    fireEvent.click(screen.getByRole("button", { name: /run canonical player covariation/i }));
+    expect(await screen.findByLabelText("Canonical player covariation evidence")).toHaveTextContent("explicit_user_attested");
+    expect(screen.getByRole("button", { name: /export full bundle/i })).toBeEnabled();
   });
 });

--- a/src/rate_of_closure/web/src/components/LaunchMonitorPlayerWorkspace.tsx
+++ b/src/rate_of_closure/web/src/components/LaunchMonitorPlayerWorkspace.tsx
@@ -10,6 +10,14 @@ import {
   type LaunchMonitorProject,
 } from "../model/launchMonitorWorkspace";
 import { LaunchMonitorCovariation } from "./LaunchMonitorCovariation";
+import {
+  MAX_CANONICAL_INLINE_RECORDS,
+  buildDatasetJobRequest,
+  buildPlayerCovariationPayload,
+  createCanonicalLaunchMonitorClient,
+  parseCanonicalDatasetReference,
+  type CanonicalDatasetReference,
+} from "../model/launchMonitorV2Client";
 
 interface Props { rows: LaunchMonitorRow[]; sourceName: string }
 
@@ -34,13 +42,19 @@ export function LaunchMonitorPlayerWorkspace({ rows, sourceName }: Props) {
   const [datasetSha, setDatasetSha] = useState("");
   const [result, setResult] = useState<LaunchMonitorAnalysisResult | null>(null);
   const [message, setMessage] = useState("Select and attest an explicit player identity column.");
+  const [authorityUrl, setAuthorityUrl] = useState("");
+  const [canonicalReference, setCanonicalReference] = useState<CanonicalDatasetReference | null>(null);
+  const [canonicalJobId, setCanonicalJobId] = useState("");
+  const [canonicalResult, setCanonicalResult] = useState<Record<string, unknown> | null>(null);
   const loadInput = useRef<HTMLInputElement>(null);
+  const corpusInput = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setDatasetSha(fingerprintLaunchMonitorRows(rows));
     setAttested(false);
     setIdentity("");
     setResult(null);
+    setCanonicalResult(null);
   }, [rows]);
 
   const project = (): LaunchMonitorProject => ({
@@ -52,8 +66,54 @@ export function LaunchMonitorPlayerWorkspace({ rows, sourceName }: Props) {
     },
     playerIdentity: { column: identity, userAttested: attested },
     selection: { x, y, minSamples: 10, confidenceLevel: 0.95 },
+    ...(canonicalReference ? { canonicalDataset: canonicalReference } : {}),
   });
   const ready = Boolean(identity && attested && x && y && x !== y && datasetSha);
+  const canonicalReady = ready && Boolean(authorityUrl.trim()) && rows.length <= MAX_CANONICAL_INLINE_RECORDS;
+
+  const loadCorpusReference = async (file: File) => {
+    try {
+      const reference = parseCanonicalDatasetReference(JSON.parse(await file.text()));
+      setCanonicalReference(reference);
+      setCanonicalJobId("");
+      setMessage(`Authorized reference loaded: ${reference.expected_row_count.toLocaleString()} rows; no private rows were loaded.`);
+    } catch (caught) {
+      setCanonicalReference(null);
+      setMessage(caught instanceof Error ? caught.message : String(caught));
+    }
+  };
+
+  const inspectCorpus = async () => {
+    if (!canonicalReference) return;
+    try {
+      const client = createCanonicalLaunchMonitorClient(authorityUrl);
+      const status = await client.submitDatasetJob(buildDatasetJobRequest(canonicalReference, "source_summary"));
+      setCanonicalJobId(String(status.job_id));
+      setMessage(`Canonical corpus job ${String(status.job_id)} is ${String(status.status)}.`);
+    } catch (caught) { setMessage(caught instanceof Error ? caught.message : String(caught)); }
+  };
+
+  const refreshCorpus = async () => {
+    if (!canonicalJobId) return;
+    try {
+      const client = createCanonicalLaunchMonitorClient(authorityUrl);
+      const status = await client.datasetJobStatus(canonicalJobId);
+      if (status.status === "completed") {
+        const page = await client.datasetJobResults(canonicalJobId);
+        setMessage(`Canonical corpus job completed with ${String(page.total_items)} bounded aggregate items.`);
+      } else setMessage(`Canonical corpus job is ${String(status.status)}.`);
+    } catch (caught) { setMessage(caught instanceof Error ? caught.message : String(caught)); }
+  };
+
+  const runCanonical = async () => {
+    try {
+      const payload = buildPlayerCovariationPayload(rows, { playerColumn: identity, xColumn: x, yColumn: y, minSamples: 10, confidenceLevel: 0.95 });
+      const response = await createCanonicalLaunchMonitorClient(authorityUrl).playerCovariation(payload);
+      setResult(null);
+      setCanonicalResult(response);
+      setMessage(`Canonical Upstream player covariation completed (${String(response.status)}) with evidence-bearing lineage.`);
+    } catch (caught) { setMessage(caught instanceof Error ? caught.message : String(caught)); }
+  };
 
   const run = () => {
     try {
@@ -63,6 +123,7 @@ export function LaunchMonitorPlayerWorkspace({ rows, sourceName }: Props) {
         groupBy: identity, confidenceLevel: 0.95, minSamples: 10,
       });
       setResult(next);
+      setCanonicalResult(null);
       setMessage(`${next.groups.length} player groups analyzed. Associations are not causal; no player identity was inferred.`);
     } catch (caught) {
       setResult(null);
@@ -78,6 +139,7 @@ export function LaunchMonitorPlayerWorkspace({ rows, sourceName }: Props) {
       setAttested(saved.playerIdentity.userAttested);
       setX(saved.selection.x);
       setY(saved.selection.y);
+      setCanonicalReference(saved.canonicalDataset ?? null);
       setMessage("Saved project settings restored against the matching dataset fingerprint.");
     } catch (caught) {
       setMessage(caught instanceof Error ? caught.message : String(caught));
@@ -85,37 +147,58 @@ export function LaunchMonitorPlayerWorkspace({ rows, sourceName }: Props) {
   };
 
   const exportBundle = async () => {
-    if (!result) return;
-    const bundle = await createAnalysisExportBundle(project(), result as unknown as Record<string, unknown>, rows);
+    const analysis = result as unknown as Record<string, unknown> | null ?? canonicalResult;
+    if (!analysis) return;
+    const bundle = await createAnalysisExportBundle(project(), analysis, rows);
     download("launch-monitor-analysis-bundle.json", JSON.stringify(bundle, null, 2));
   };
 
   return <section aria-label="Player analytics workspace" className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
     <h3 className="font-semibold text-slate-200">Player Covariation Workspace</h3>
     <p className="mt-1 text-xs text-slate-400">Identity is never inferred from session, club, filename, or row order. The replaceable client validates canonical UpstreamDrift v2 responses. With no authority URL configured in this standalone build, Run is explicitly the local v1 compatibility/offline calculation; row-aligned residuals are unavailable.</p>
+    <div className="mt-3 rounded border border-slate-700 p-3">
+      <label className="text-sm text-slate-300">Canonical authority URL
+        <input className={`${field} mt-1`} type="url" aria-label="Canonical Upstream authority URL"
+          title="Authorized HTTP(S) UpstreamDrift analytics authority; private filesystem paths are not accepted"
+          value={authorityUrl} onChange={(event) => { setAuthorityUrl(event.target.value); setCanonicalJobId(""); setCanonicalResult(null); }} />
+      </label>
+      <p className="mt-2 text-xs text-slate-400">Canonical inline limit is 20,000 rows. Larger authorized corpora use immutable reference-only aggregate jobs; private rows are never stored in browser projects.</p>
+      <input ref={corpusInput} type="file" accept=".json,application/json" className="hidden"
+        aria-label="Load authorized corpus reference" onChange={(event) => { const file = event.target.files?.[0]; if (file) void loadCorpusReference(file); }} />
+      <div className="mt-2 flex flex-wrap gap-2">
+        <button type="button" title="Load an opaque root alias and immutable hashes, never a private path or row"
+          onClick={() => corpusInput.current?.click()} className="rounded border border-slate-700 px-3 py-2 text-sm">Select Authorized Corpus Reference</button>
+        <button type="button" disabled={!canonicalReference || !authorityUrl.trim()} title="Submit a source-summary job using only the immutable authorized reference"
+          onClick={() => void inspectCorpus()} className="rounded border border-slate-700 px-3 py-2 text-sm disabled:opacity-40">Inspect Authorized Corpus</button>
+        <button type="button" disabled={!canonicalJobId} title="Refresh the data-free job state and fetch bounded aggregates after completion"
+          onClick={() => void refreshCorpus()} className="rounded border border-slate-700 px-3 py-2 text-sm disabled:opacity-40">Refresh Corpus Job</button>
+        <button type="button" disabled={!canonicalReady} title={rows.length > MAX_CANONICAL_INLINE_RECORDS ? "Unavailable: canonical inline covariation accepts at most 20,000 rows" : "Run the canonical evidence-bearing player covariation endpoint"}
+          onClick={() => void runCanonical()} className="rounded bg-sky-700 px-3 py-2 text-sm disabled:opacity-40">Run Canonical Player Covariation</button>
+      </div>
+    </div>
     <div className="mt-3 grid gap-3 sm:grid-cols-3">
       <label className="text-sm text-slate-300">Player identity
         <select aria-label="Player identity column" title="Choose a real player identifier supplied by the dataset owner" value={identity}
-          onChange={(event) => { setIdentity(event.target.value); setAttested(false); setResult(null); }} className={`${field} mt-1`}>
+          onChange={(event) => { setIdentity(event.target.value); setAttested(false); setResult(null); setCanonicalResult(null); }} className={`${field} mt-1`}>
           <option value="">Select column</option>{columns.map((column) => <option key={column}>{column}</option>)}
         </select>
       </label>
       <label className="text-sm text-slate-300">X variable
         <select aria-label="Player covariation X variable" title="Choose the first covariation variable" value={x}
-          onChange={(event) => { setX(event.target.value); setResult(null); }} className={`${field} mt-1`}>
+          onChange={(event) => { setX(event.target.value); setResult(null); setCanonicalResult(null); }} className={`${field} mt-1`}>
           {numeric.map((column) => <option key={column}>{column}</option>)}
         </select>
       </label>
       <label className="text-sm text-slate-300">Y variable
         <select aria-label="Player covariation Y variable" title="Choose the second covariation variable" value={y}
-          onChange={(event) => { setY(event.target.value); setResult(null); }} className={`${field} mt-1`}>
+          onChange={(event) => { setY(event.target.value); setResult(null); setCanonicalResult(null); }} className={`${field} mt-1`}>
           {numeric.map((column) => <option key={column}>{column}</option>)}
         </select>
       </label>
     </div>
     <label className="mt-3 flex items-start gap-2 text-sm text-amber-100">
       <input type="checkbox" aria-label="I attest this column identifies a player" title="Required identity-safety attestation"
-        checked={attested} disabled={!identity} onChange={(event) => { setAttested(event.target.checked); setResult(null); }} />
+        checked={attested} disabled={!identity} onChange={(event) => { setAttested(event.target.checked); setResult(null); setCanonicalResult(null); }} />
       I attest this column identifies a player; it was not inferred from session, club, filename, or row order.
     </label>
     <div className="mt-3 flex flex-wrap gap-2">
@@ -128,10 +211,16 @@ export function LaunchMonitorPlayerWorkspace({ rows, sourceName }: Props) {
         onChange={(event) => { const file = event.target.files?.[0]; if (file) void load(file); }} />
       <button type="button" title="Load settings from a saved project after fingerprint verification" onClick={() => loadInput.current?.click()}
         className="rounded border border-slate-700 px-3 py-2 text-sm">Load Project</button>
-      <button type="button" disabled={!result} title="Export the project, result, manifest, hashes, and explicit backing rows"
+      <button type="button" disabled={!result && !canonicalResult} title="Export the project, result, manifest, hashes, and explicit backing rows"
         onClick={() => void exportBundle()} className="rounded border border-slate-700 px-3 py-2 text-sm disabled:opacity-40">Export Full Bundle</button>
     </div>
     <p role="status" className="mt-3 text-sm text-slate-400">{message}</p>
+    {canonicalResult && <details className="mt-3 rounded border border-slate-700 p-3">
+      <summary className="cursor-pointer text-sm text-slate-200">Canonical player covariation evidence</summary>
+      <pre aria-label="Canonical player covariation evidence" className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap text-xs text-slate-300">
+        {JSON.stringify(canonicalResult, null, 2)}
+      </pre>
+    </details>}
     {identity && attested && <div className="mt-5 border-t border-slate-800 pt-5">
       <LaunchMonitorCovariation rows={rows} lockedPlayerColumn={identity}
         savedSettings={{

--- a/src/rate_of_closure/web/src/model/launchMonitorV2Client.test.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorV2Client.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { validateLaunchMonitorStrokesGainedResponse, validateLaunchMonitorV2Response } from "./launchMonitorV2Client";
+import { describe, expect, it, vi } from "vitest";
+import golden from "../../../launch_monitor_canonical_v2_golden.json";
+import {
+  buildDatasetJobRequest,
+  buildPlayerCovariationPayload,
+  createCanonicalLaunchMonitorClient,
+  parseCanonicalDatasetReference,
+  validateDatasetJobPage,
+  validateLaunchMonitorStrokesGainedResponse,
+  validateLaunchMonitorV2Response,
+  validatePlayerCovariationResponse,
+} from "./launchMonitorV2Client";
 
 const response = { contract_version: "2.0.0", status: "available", analysis: {}, units: {},
   lineage: { dataset_fingerprint_sha256: "a".repeat(64), backing_records: [] },
@@ -13,6 +23,65 @@ describe("Upstream v2 client", () => {
   it("rejects unsafe claims", () => {
     expect(() => validateLaunchMonitorV2Response({ ...response, claims: { ...response.claims, device_emulation: true } }))
       .toThrow(/emulation/i);
+  });
+});
+
+describe("canonical dataset jobs and player covariation", () => {
+  it("shares the immutable dataset-reference golden with Python", () => {
+    const reference = parseCanonicalDatasetReference(golden.dataset_reference);
+    expect(buildDatasetJobRequest(reference, "source_summary")).toEqual(golden.dataset_job_request);
+    expect(() => parseCanonicalDatasetReference({ ...golden.dataset_reference, root_id: "../private" })).toThrow(/root_id/i);
+    expect(() => buildDatasetJobRequest(reference, "metric_summary", ["bogus"])).toThrow(/canonical dataset metrics/i);
+  });
+
+  it("rejects row-like dataset-job pages and oversized inline covariation", () => {
+    expect(() => validateDatasetJobPage({
+      contract_version: "launch-monitor-dataset-job/1.0.0", job_id: "a".repeat(32),
+      offset: 0, limit: 100, total_items: 1, next_offset: null,
+      items: [{ shot_id: "secret", ball_speed: 170 }],
+    })).toThrow(/private rows/i);
+    expect(() => validateDatasetJobPage({
+      contract_version: "launch-monitor-dataset-job/1.0.0", job_id: "a".repeat(32),
+      offset: 0, limit: 100, total_items: 1, next_offset: null,
+      items: [{ ball_speed: 170 }],
+    })).toThrow(/aggregate schema/i);
+    expect(() => buildPlayerCovariationPayload(Array.from({ length: 20_001 }, () => ({})), {
+      playerColumn: "player_id", xColumn: "face_angle", yColumn: "club_path",
+      minSamples: 4, confidenceLevel: 0.95,
+    })).toThrow(/20,000/);
+  });
+
+  it("validates safe evidence-bearing covariation responses", () => {
+    const result = {
+      contract_version: "launch-monitor-player-covariation/1.0.0", analysis_kind: "selected_pair",
+      status: "available", request: {}, pooled: {}, within_player: {}, between_player: {},
+      per_player: [], meta_analysis: {}, missingness: {}, units: {}, lineage: { backing_records: [] },
+      availability: [], uncertainty: {}, player_identity: { trust_level: "explicit_user_attested", identifier_column: "player_id" },
+      vendor_provenance: [], claims: { device_emulation: false, device_certification: false, causal_inference: false }, definitions: {}, warnings: [],
+    };
+    expect(validatePlayerCovariationResponse(result).status).toBe("available");
+    expect(() => validatePlayerCovariationResponse({ ...result, claims: { ...result.claims, causal_inference: true } })).toThrow(/claim/i);
+  });
+
+  it("calls the canonical immutable dataset-job routes", async () => {
+    const status = { contract_version: "launch-monitor-dataset-job/1.0.0", job_id: "a".repeat(32),
+      status: "queued", submitted_at_utc: "2026-08-21T00:00:00Z", completed_at_utc: null,
+      input_row_count: 0, result_item_count: 0, unavailable: null };
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => status });
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createCanonicalLaunchMonitorClient("https://authority.example/");
+    await client.submitDatasetJob({ contract_version: "test" });
+    await client.datasetJobStatus("a".repeat(32));
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://authority.example/tools/launch-monitor-analytics/v2/dataset-jobs",
+      `https://authority.example/tools/launch-monitor-analytics/v2/dataset-jobs/${"a".repeat(32)}`,
+    ]);
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects filesystem and custom-scheme authorities", () => {
+    expect(() => createCanonicalLaunchMonitorClient("file:///private/corpus")).toThrow(/HTTP/i);
+    expect(() => createCanonicalLaunchMonitorClient("not-a-url")).toThrow(/HTTP/i);
   });
 });
 

--- a/src/rate_of_closure/web/src/model/launchMonitorV2Client.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorV2Client.ts
@@ -3,11 +3,144 @@
 export interface ResidualAvailability { state: "available" | "unavailable"; reason: string; rows?: Record<string, unknown>[] }
 export interface LaunchMonitorV2Response { contractVersion: "2.0.0"; payload: Record<string, unknown>; rowAlignedResiduals: ResidualAvailability }
 export interface LaunchMonitorStrokesGainedResponse { status: string; count: number; mean: number | null; payload: Record<string, unknown> }
+export const DATASET_JOB_CONTRACT_VERSION = "launch-monitor-dataset-job/1.0.0" as const;
+export const PLAYER_COVARIATION_CONTRACT_VERSION = "launch-monitor-player-covariation/1.0.0" as const;
+export const MAX_CANONICAL_INLINE_RECORDS = 20_000;
+export const MAX_DATASET_JOB_PAGE_SIZE = 200;
+export const CANONICAL_DATASET_METRICS = new Set([
+  "club_speed", "ball_speed", "smash_factor", "launch_angle", "launch_direction",
+  "spin_rate", "back_spin", "side_spin", "spin_axis", "attack_angle", "club_path",
+  "face_angle", "carry_distance", "total_distance", "descent_angle", "lateral_carry",
+  "flight_time",
+]);
+
+export interface CanonicalDatasetReference {
+  root_id: string; repository: string; commit: string; manifest_sha256: string;
+  content_sha256: string; expected_row_count: number;
+}
+
+export interface CovariationOptions {
+  playerColumn: string; xColumn: string; yColumn: string;
+  minSamples: number; confidenceLevel: number;
+}
 
 const object = (value: unknown, label: string): Record<string, unknown> => {
   if (!value || typeof value !== "object" || Array.isArray(value)) throw new RangeError(`${label} must be an object`);
   return value as Record<string, unknown>;
 };
+
+const matchedText = (value: unknown, pattern: RegExp, label: string): string => {
+  if (typeof value !== "string" || !pattern.test(value)) throw new RangeError(`${label} is invalid`);
+  return value;
+};
+
+export function parseCanonicalDatasetReference(value: unknown): CanonicalDatasetReference {
+  const root = object(value, "dataset reference");
+  const required = ["root_id", "repository", "commit", "manifest_sha256", "content_sha256", "expected_row_count"];
+  if (Object.keys(root).length !== required.length || required.some((key) => !(key in root))) {
+    throw new RangeError("dataset reference has missing or unknown fields");
+  }
+  const expected = root.expected_row_count;
+  if (!Number.isSafeInteger(expected) || !(Number(expected) >= 1 && Number(expected) <= 10_000_000)) {
+    throw new RangeError("expected_row_count is outside the canonical bounds");
+  }
+  return {
+    root_id: matchedText(root.root_id, /^[a-z][a-z0-9-]{0,62}$/, "root_id"),
+    repository: matchedText(root.repository, /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/, "repository"),
+    commit: matchedText(root.commit, /^[0-9a-f]{40}$/, "commit"),
+    manifest_sha256: matchedText(root.manifest_sha256, /^[0-9a-f]{64}$/, "manifest_sha256"),
+    content_sha256: matchedText(root.content_sha256, /^[0-9a-f]{64}$/, "content_sha256"),
+    expected_row_count: expected as number,
+  };
+}
+
+export function buildDatasetJobRequest(
+  reference: CanonicalDatasetReference,
+  kind: "source_summary" | "metric_summary" | "correlation",
+  metrics: string[] = [],
+  groupBy: "source_id" | "monitor" | "club" | null = null,
+  minimumGroupRows = 10,
+) {
+  parseCanonicalDatasetReference(reference);
+  if (minimumGroupRows < 10) throw new RangeError("minimum_group_rows must be at least 10");
+  if (metrics.length > 12 || new Set(metrics).size !== metrics.length || metrics.some((metric) => !CANONICAL_DATASET_METRICS.has(metric))) {
+    throw new RangeError("metrics must be unique canonical dataset metrics");
+  }
+  if (kind === "source_summary" && (metrics.length || groupBy !== null)) throw new RangeError("source_summary does not accept options");
+  if (kind === "metric_summary" && !metrics.length) throw new RangeError("metric_summary requires metrics");
+  if (kind === "correlation" && metrics.length < 2) throw new RangeError("correlation requires two metrics");
+  return { contract_version: DATASET_JOB_CONTRACT_VERSION, dataset: reference,
+    operation: { kind, metrics, group_by: groupBy, minimum_group_rows: minimumGroupRows } };
+}
+
+export function validateDatasetJobStatus(value: unknown): Record<string, unknown> {
+  const root = object(value, "dataset job status");
+  const keys = ["contract_version", "job_id", "status", "submitted_at_utc", "completed_at_utc", "input_row_count", "result_item_count", "unavailable"];
+  if (Object.keys(root).length !== keys.length || keys.some((key) => !(key in root))) throw new RangeError("dataset job status has missing or unknown fields");
+  if (root.contract_version !== DATASET_JOB_CONTRACT_VERSION) throw new RangeError("Unsupported dataset job contract");
+  matchedText(root.job_id, /^[0-9a-f]{32}$/, "job_id");
+  if (!["queued", "running", "completed", "unavailable", "failed"].includes(String(root.status))) throw new RangeError("dataset job status is invalid");
+  for (const key of ["input_row_count", "result_item_count"]) {
+    if (!Number.isSafeInteger(root[key]) || Number(root[key]) < 0) throw new RangeError(`dataset job ${key} is invalid`);
+  }
+  return root;
+}
+
+export function validateDatasetJobPage(value: unknown): Record<string, unknown> {
+  const root = object(value, "dataset job page");
+  const keys = ["contract_version", "job_id", "offset", "limit", "total_items", "next_offset", "items"];
+  if (Object.keys(root).length !== keys.length || keys.some((key) => !(key in root))) throw new RangeError("dataset job page has missing or unknown fields");
+  if (root.contract_version !== DATASET_JOB_CONTRACT_VERSION) throw new RangeError("Unsupported dataset job contract");
+  matchedText(root.job_id, /^[0-9a-f]{32}$/, "job_id");
+  for (const key of ["offset", "total_items"]) {
+    if (!Number.isSafeInteger(root[key]) || Number(root[key]) < 0) throw new RangeError(`dataset job page ${key} is invalid`);
+  }
+  if (root.next_offset !== null && (!Number.isSafeInteger(root.next_offset) || Number(root.next_offset) < 0)) throw new RangeError("dataset job page next_offset is invalid");
+  if (!Number.isSafeInteger(root.limit) || Number(root.limit) < 1 || Number(root.limit) > MAX_DATASET_JOB_PAGE_SIZE) throw new RangeError("dataset job page limit is invalid");
+  if (!Array.isArray(root.items) || root.items.length > Number(root.limit)) throw new RangeError("dataset job page items are invalid");
+  const privateKeys = new Set(["shot_id", "source_row", "row_index"]);
+  const aggregateKeysets = [
+    ["source_id", "row_count", "vendor_key", "redistribution_status", "license_spdx", "backing_repository", "backing_commit", "backing_object_digests"],
+    ["group_by", "group", "metric", "n", "mean", "standard_deviation", "minimum", "maximum"],
+    ["group_by", "group", "left_metric", "right_metric", "n", "correlation"],
+  ].map((keys) => [...keys].sort().join("\u001f"));
+  for (const item of root.items) {
+    const aggregate = object(item, "dataset job aggregate");
+    if (Object.keys(aggregate).some((key) => privateKeys.has(key))) throw new RangeError("dataset job pages cannot expose private rows");
+    if (!aggregateKeysets.includes(Object.keys(aggregate).sort().join("\u001f"))) throw new RangeError("dataset job page item does not match an aggregate schema");
+  }
+  return root;
+}
+
+export function buildPlayerCovariationPayload(records: Record<string, unknown>[], options: CovariationOptions) {
+  if (records.length < 1 || records.length > MAX_CANONICAL_INLINE_RECORDS) throw new RangeError("canonical player covariation accepts at most 20,000 rows");
+  const columns = [options.playerColumn, options.xColumn, options.yColumn];
+  if (columns.some((value) => !value.trim()) || new Set(columns).size !== 3) throw new RangeError("player, x, and y columns must be distinct and non-empty");
+  if (!Number.isSafeInteger(options.minSamples) || options.minSamples < 4 || !(options.confidenceLevel > 0.5 && options.confidenceLevel < 1)) throw new RangeError("canonical covariation options are invalid");
+  return { records, request: { x_column: options.xColumn, y_column: options.yColumn,
+    player_column: options.playerColumn, min_samples: options.minSamples,
+    confidence_level: options.confidenceLevel }, context: { player_identity: {
+      trust_level: "explicit_user_attested", identifier_column: options.playerColumn,
+      evidence: `Dataset owner attested ${options.playerColumn} in this client session.`,
+    } } };
+}
+
+export function validatePlayerCovariationResponse(value: unknown): Record<string, unknown> {
+  const root = object(value, "player covariation response");
+  if (root.contract_version !== PLAYER_COVARIATION_CONTRACT_VERSION) throw new RangeError("Unsupported player covariation contract");
+  const common = ["analysis_kind", "contract_version", "status", "request", "lineage", "player_identity", "vendor_provenance", "claims", "warnings"];
+  const selected = [...common, "pooled", "within_player", "between_player", "per_player", "meta_analysis", "missingness", "units", "availability", "uncertainty", "definitions"];
+  const scan = [...common, "pair_count", "available_pair_count", "unavailable_pair_count", "ranking", "method_description"];
+  const expected = root.analysis_kind === "selected_pair" ? selected : scan;
+  if (Object.keys(root).length !== expected.length || expected.some((key) => !(key in root))) throw new RangeError("player covariation response is missing required fields");
+  if (!["selected_pair", "pair_scan"].includes(String(root.analysis_kind))) throw new RangeError("player covariation analysis kind is invalid");
+  if (!Array.isArray(object(root.lineage, "lineage").backing_records)) throw new RangeError("player covariation backing lineage is invalid");
+  const trust = object(root.player_identity, "player identity").trust_level;
+  if (!["explicit_user_attested", "pseudonymous_stable", "verified_external"].includes(String(trust))) throw new RangeError("player covariation requires trusted identity evidence");
+  const claims = object(root.claims, "claims");
+  if (claims.device_emulation !== false || claims.device_certification !== false || claims.causal_inference !== false) throw new RangeError("player covariation response makes an unsupported claim");
+  return root;
+}
 
 export function validateLaunchMonitorV2Response(value: unknown): LaunchMonitorV2Response {
   const root = object(value, "Upstream v2 response");
@@ -57,5 +190,35 @@ export function createLaunchMonitorStrokesGainedClient(baseUrl: string) {
       headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
     if (!response.ok) throw new Error(`Upstream strokes-gained analysis failed (${response.status})`);
     return validateLaunchMonitorStrokesGainedResponse(await response.json());
+  };
+}
+
+const requestJson = async (url: string, init?: RequestInit): Promise<unknown> => {
+  const response = await fetch(url, init);
+  if (!response.ok) throw new Error(`Upstream launch-monitor request failed (${response.status})`);
+  return response.json();
+};
+
+export function createCanonicalLaunchMonitorClient(baseUrl: string) {
+  let authority: URL;
+  try { authority = new URL(baseUrl); } catch { throw new RangeError("Canonical authority must be an HTTP(S) URL"); }
+  if (!["http:", "https:"].includes(authority.protocol) || !authority.host) throw new RangeError("Canonical authority must be an HTTP(S) URL");
+  const root = baseUrl.replace(/\/$/, "");
+  const endpoint = `${root}/tools/launch-monitor-analytics/v2`;
+  return {
+    submitDatasetJob: async (payload: Record<string, unknown>) => validateDatasetJobStatus(await requestJson(`${endpoint}/dataset-jobs`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+    })),
+    datasetJobStatus: async (jobId: string) => {
+      matchedText(jobId, /^[0-9a-f]{32}$/, "job_id");
+      return validateDatasetJobStatus(await requestJson(`${endpoint}/dataset-jobs/${jobId}`));
+    },
+    datasetJobResults: async (jobId: string, offset = 0, limit = 100) => {
+      matchedText(jobId, /^[0-9a-f]{32}$/, "job_id");
+      return validateDatasetJobPage(await requestJson(`${endpoint}/dataset-jobs/${jobId}/results?offset=${offset}&limit=${limit}`));
+    },
+    playerCovariation: async (payload: Record<string, unknown>) => validatePlayerCovariationResponse(await requestJson(`${endpoint}/player-covariation`, {
+      method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload),
+    })),
   };
 }

--- a/src/rate_of_closure/web/src/model/launchMonitorWorkspace.test.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorWorkspace.test.ts
@@ -53,6 +53,18 @@ describe("launch monitor workspace v2", () => {
     expect(parseLaunchMonitorProject(serialized)).toEqual(project);
   });
 
+  it("persists an authorized corpus reference without a private path", () => {
+    const canonical = { ...project, canonicalDataset: {
+      root_id: "launch-monitor-authority",
+      repository: "D-sorganization/Launch-Monitor-Flight-Model-Campaign",
+      commit: "7".repeat(40), manifest_sha256: "8".repeat(64),
+      content_sha256: "9".repeat(64), expected_row_count: 261666,
+    } };
+    const serialized = serializeLaunchMonitorProject(canonical);
+    expect(parseLaunchMonitorProject(serialized)).toEqual(canonical);
+    expect(serialized).not.toContain("privatePath");
+  });
+
   it("delegates computation to the injected authoritative backend", async () => {
     const backend = vi.fn().mockResolvedValue({ contract_version: "2.0.0", result: { ok: true } });
     await expect(runPlayerCovariation(backend, project)).resolves.toEqual({

--- a/src/rate_of_closure/web/src/model/launchMonitorWorkspace.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorWorkspace.ts
@@ -2,6 +2,7 @@
 
 import type { LaunchMonitorRow } from "./launchMonitorAnalysisTypes";
 import { sha256Text } from "./launchMonitorFingerprint";
+import { parseCanonicalDatasetReference, type CanonicalDatasetReference } from "./launchMonitorV2Client";
 
 export const LAUNCH_MONITOR_WORKSPACE_CONTRACT_VERSION = "2.0.0" as const;
 
@@ -20,6 +21,7 @@ export interface LaunchMonitorProject {
   dataset: DatasetReference;
   playerIdentity: { column: string; userAttested: boolean };
   selection: { x: string; y: string; minSamples: number; confidenceLevel: number };
+  canonicalDataset?: CanonicalDatasetReference;
 }
 
 export interface PlayerCovariationRequest {
@@ -70,6 +72,7 @@ function validateProject(project: LaunchMonitorProject): void {
   if (!(project.selection.confidenceLevel > 0.5 && project.selection.confidenceLevel < 1)) {
     throw new RangeError("Confidence level must be between 0.5 and 1");
   }
+  if (project.canonicalDataset) parseCanonicalDatasetReference(project.canonicalDataset);
 }
 
 export function buildPlayerCovariationRequest(project: LaunchMonitorProject): PlayerCovariationRequest {

--- a/tests/rate_of_closure/test_launch_monitor_v2_client.py
+++ b/tests/rate_of_closure/test_launch_monitor_v2_client.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
 from rate_of_closure.launch_monitor_v2_client import (
+    MAX_CANONICAL_INLINE_RECORDS,
     UpstreamV2Client,
+    build_dataset_job_request,
+    build_player_covariation_payload,
+    load_canonical_dataset_reference,
+    validate_dataset_job_page,
+    validate_dataset_job_status,
+    validate_player_covariation_response,
     validate_strokes_gained_response,
     validate_v2_response,
+)
+
+GOLDEN = (
+    Path(__file__).resolve().parents[2]
+    / "src/rate_of_closure/launch_monitor_canonical_v2_golden.json"
 )
 
 
@@ -135,3 +150,170 @@ def test_strokes_gained_client_validates_scoring_contract_and_claims() -> None:
     unsafe["claims"] = {**unsafe["claims"], "source_backed": False}  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="source-backed"):
         validate_strokes_gained_response(unsafe)
+
+
+def test_canonical_dataset_reference_and_job_contract_match_shared_golden() -> None:
+    golden = json.loads(GOLDEN.read_text(encoding="utf-8"))
+    reference = load_canonical_dataset_reference(golden["dataset_reference"])
+
+    assert reference.expected_row_count == 261_666
+    assert (
+        build_dataset_job_request(reference, "source_summary")
+        == golden["dataset_job_request"]
+    )
+    with pytest.raises(ValueError, match="root_id"):
+        load_canonical_dataset_reference(
+            {**golden["dataset_reference"], "root_id": "../private/path"}
+        )
+    with pytest.raises(ValueError, match="canonical dataset metrics"):
+        build_dataset_job_request(reference, "metric_summary", metrics=("bogus",))
+
+
+def test_dataset_job_responses_are_versioned_bounded_and_data_free() -> None:
+    status = validate_dataset_job_status(
+        {
+            "contract_version": "launch-monitor-dataset-job/1.0.0",
+            "job_id": "a" * 32,
+            "status": "completed",
+            "submitted_at_utc": "2026-08-21T00:00:00Z",
+            "completed_at_utc": "2026-08-21T00:00:01Z",
+            "input_row_count": 261_666,
+            "result_item_count": 1,
+            "unavailable": None,
+        }
+    )
+    assert status["input_row_count"] == 261_666
+    page = validate_dataset_job_page(
+        {
+            "contract_version": "launch-monitor-dataset-job/1.0.0",
+            "job_id": "a" * 32,
+            "offset": 0,
+            "limit": 100,
+            "total_items": 1,
+            "next_offset": None,
+            "items": [
+                {
+                    "source_id": "trackman",
+                    "row_count": 11_699,
+                    "vendor_key": "trackman",
+                    "redistribution_status": "restricted",
+                    "license_spdx": "NOASSERTION",
+                    "backing_repository": "owner/repository",
+                    "backing_commit": "b" * 40,
+                    "backing_object_digests": [],
+                }
+            ],
+        }
+    )
+    assert page["items"][0]["row_count"] == 11_699
+    with pytest.raises(ValueError, match="private rows"):
+        validate_dataset_job_page(
+            {**page, "items": [{"shot_id": "secret", "ball_speed": 170.0}]}
+        )
+    with pytest.raises(ValueError, match="aggregate schema"):
+        validate_dataset_job_page({**page, "items": [{"ball_speed": 170.0}]})
+
+
+def test_player_covariation_payload_enforces_inline_limit_and_identity() -> None:
+    golden = json.loads(GOLDEN.read_text(encoding="utf-8"))
+    payload = build_player_covariation_payload(
+        golden["player_covariation_request"]["records"],
+        player_column="player_id",
+        x_column="face_angle",
+        y_column="club_path",
+        min_samples=4,
+        confidence_level=0.95,
+    )
+    assert payload == golden["player_covariation_request"]
+    with pytest.raises(ValueError, match="20,000"):
+        build_player_covariation_payload(
+            [{}] * (MAX_CANONICAL_INLINE_RECORDS + 1),
+            player_column="player_id",
+            x_column="face_angle",
+            y_column="club_path",
+            min_samples=4,
+            confidence_level=0.95,
+        )
+
+
+def test_player_covariation_response_rejects_unsafe_or_unbacked_results() -> None:
+    response = {
+        "contract_version": "launch-monitor-player-covariation/1.0.0",
+        "analysis_kind": "selected_pair",
+        "status": "available",
+        "request": {},
+        "pooled": {},
+        "within_player": {},
+        "between_player": {},
+        "per_player": [],
+        "meta_analysis": {},
+        "missingness": {},
+        "units": {},
+        "lineage": {"backing_records": []},
+        "availability": [],
+        "uncertainty": {},
+        "player_identity": {
+            "trust_level": "explicit_user_attested",
+            "identifier_column": "player_id",
+        },
+        "vendor_provenance": [],
+        "claims": {
+            "device_emulation": False,
+            "device_certification": False,
+            "causal_inference": False,
+        },
+        "definitions": {},
+        "warnings": [],
+    }
+    assert validate_player_covariation_response(response)["status"] == "available"
+    unsafe = {**response, "claims": {**response["claims"], "causal_inference": True}}
+    with pytest.raises(ValueError, match="claim"):
+        validate_player_covariation_response(unsafe)
+
+
+def test_client_uses_canonical_dataset_and_covariation_routes(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[tuple[str, str]] = []
+    status = {
+        "contract_version": "launch-monitor-dataset-job/1.0.0",
+        "job_id": "a" * 32,
+        "status": "queued",
+        "submitted_at_utc": "2026-08-21T00:00:00Z",
+        "completed_at_utc": None,
+        "input_row_count": 0,
+        "result_item_count": 0,
+        "unavailable": None,
+    }
+
+    class Response:
+        def __enter__(self):  # type: ignore[no-untyped-def]
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps(status).encode("utf-8")
+
+    def fake_urlopen(request, timeout):  # type: ignore[no-untyped-def]
+        assert timeout == 30.0
+        calls.append((request.method, request.full_url))
+        return Response()
+
+    monkeypatch.setattr(
+        "rate_of_closure.launch_monitor_v2_client.urlopen", fake_urlopen
+    )
+    client = UpstreamV2Client("https://authority.example")
+    client.submit_dataset_job({"contract_version": "test"})
+    client.dataset_job_status("a" * 32)
+
+    assert calls == [
+        (
+            "POST",
+            "https://authority.example/tools/launch-monitor-analytics/v2/dataset-jobs",
+        ),
+        (
+            "GET",
+            "https://authority.example/tools/launch-monitor-analytics/v2/dataset-jobs/"
+            + "a" * 32,
+        ),
+    ]

--- a/tests/rate_of_closure/test_launch_monitor_workspace.py
+++ b/tests/rate_of_closure/test_launch_monitor_workspace.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from rate_of_closure.launch_monitor_v2_client import CanonicalDatasetReference
 from rate_of_closure.launch_monitor_workspace import (
     AnalysisSelection,
     DatasetReference,
@@ -71,6 +72,29 @@ def test_project_round_trip_keeps_reference_but_never_embeds_rows(
     assert payload["dataset"]["revision"] == "97f3ecf"
     assert "rows" not in payload
     assert load_project(destination) == _project()
+
+
+def test_project_round_trip_can_pin_authorized_corpus_without_private_path(
+    tmp_path: Path,
+) -> None:
+    canonical = CanonicalDatasetReference(
+        root_id="launch-monitor-authority",
+        repository="D-sorganization/Launch-Monitor-Flight-Model-Campaign",
+        commit="7" * 40,
+        manifest_sha256="8" * 64,
+        content_sha256="9" * 64,
+        expected_row_count=261_666,
+    )
+    project = LaunchMonitorProject(
+        **{**_project().__dict__, "canonical_dataset": canonical}
+    )
+    destination = tmp_path / "canonical.lmproject.json"
+    save_project(destination, project)
+    payload = json.loads(destination.read_text(encoding="utf-8"))
+
+    assert payload["canonical_dataset"]["root_id"] == "launch-monitor-authority"
+    assert "path" not in payload["canonical_dataset"]
+    assert load_project(destination) == project
 
 
 def test_full_export_contains_project_result_backing_rows_and_hashes(
@@ -147,6 +171,39 @@ def test_pyqt_player_workspace_runs_grouped_analysis_only_after_attestation(
     panel.run_pair_scan()
     assert panel._export_payload["mode"] == "exploratory_pair_scan"
     assert panel.covariation_view.table.rowCount() > 0
+
+
+def test_pyqt_player_workspace_exposes_fail_closed_canonical_controls(qtbot) -> None:  # type: ignore[no-untyped-def]
+    from rate_of_closure.ui.pyqt6.launch_monitor_player_workspace import (
+        LaunchMonitorPlayerWorkspace,
+    )
+
+    panel = LaunchMonitorPlayerWorkspace()
+    qtbot.addWidget(panel)
+
+    assert panel.authority_url.accessibleName() == "Canonical Upstream authority URL"
+    assert panel.corpus_reference_button.accessibleName() == (
+        "Load authorized corpus reference"
+    )
+    assert not panel.canonical_covariation_button.isEnabled()
+    assert not panel.inspect_corpus_button.isEnabled()
+    assert "20,000" in panel.canonical_limit.text()
+
+    panel.set_dataset(
+        pd.DataFrame(
+            {
+                "player_id": ["p1"] * 4,
+                "face_angle": [0.0, 1.0, 2.0, 3.0],
+                "club_path": [0.0, 0.5, 1.0, 1.5],
+            }
+        ),
+        "canonical-test.csv",
+    )
+    panel.identity_combo.setCurrentText("player_id")
+    panel.attestation.setChecked(True)
+    panel._export_payload = {"contract_version": "canonical-test"}
+    panel._refresh_enabled()
+    assert panel.export_button.isEnabled()
 
 
 def test_workspace_documentation_matches_released_grouped_analytics() -> None:


### PR DESCRIPTION
Closes #4603.

## Outcome

- consumes the pinned UpstreamDrift immutable dataset-job and player-covariation v2 authorities through strict Python and TypeScript clients
- adds user-authorized opaque corpus references, bounded aggregate submit/status/results, and explicit trusted-identity inline covariation in PyQt6 and React
- persists only aliases, repository/commit identities, hashes, and row counts; private paths and corpus rows are excluded from projects/browser storage
- validates exact aggregate/result schemas, safe claims, lineage, page bounds, and the 20,000-row inline limit
- keeps embedded estimators distinctly labelled Offline Compatibility
- makes canonical results inspectable and exportable with PyQt/React parity

## Pinned authorities

- UpstreamDrift: 453346806a2950354f5b72cc46c2646e66459c8c
- dataset-jobs merge: 9cdc724e61bf7e5ebb4c741118875fcc03ca0913
- player-covariation merge: 453346806a2950354f5b72cc46c2646e66459c8c
- private dataset authority: d469b8a427418fa00e99b0ad488e4310b067697d
- manifest SHA-256: b45fd9100e6786d32dce229224ed901f02c20ef5c44962769faf6cc94700c299
- content SHA-256: 7bedf88ba473c947db2d4d078a73ee0ccd3512ffa182b751ea0a23298d1ab10c

## Local validation

- Python focused: 18 passed
- React launch-monitor: 73 passed
- React focused contracts/workspace: 19 passed
- mypy: 5 changed production modules clean
- Ruff check/format, changed-test assertion check, ESLint, TypeScript typecheck, and git diff check: passed
- production build: passed, 244 modules; existing chunk-size advisory only