### PR TITLE
⚡ Bolt: Optimize large SVG path generation in LaunchMonitorLinkedScatter

### DIFF
--- a/src/rate_of_closure/web/src/components/LaunchMonitorLinkedScatter.tsx
+++ b/src/rate_of_closure/web/src/components/LaunchMonitorLinkedScatter.tsx
@@ -58,7 +58,15 @@ export function LaunchMonitorLinkedScatter({
   );
   const plotted = useMemo(() => coordinates(plan), [plan]);
   const selected = plotted.find(({ point }) => point.rawIndex === selectedRawIndex) ?? null;
-  const path = plotted.map(({ cx, cy }) => `M${cx.toFixed(2)} ${cy.toFixed(2)}l0.01 0`).join("");
+  // ⚡ Bolt Optimization: Wrap path generation in useMemo and use a single-pass loop
+  // to eliminate intermediate array allocations during large SVG path string generation.
+  const path = useMemo(() => {
+    let d = "";
+    for (let i = 0; i < plotted.length; i++) {
+      d += `M${plotted[i].cx.toFixed(2)} ${plotted[i].cy.toFixed(2)}l0.01 0`;
+    }
+    return d;
+  }, [plotted]);
   const chooseNearest = (event: PointerEvent<SVGSVGElement>) => {
     const bounds = event.currentTarget.getBoundingClientRect();
     const x = (event.clientX - bounds.left) * WIDTH / bounds.width;


### PR DESCRIPTION
### 💡 What
Wrapped the large SVG path generation in `src/rate_of_closure/web/src/components/LaunchMonitorLinkedScatter.tsx` in a `useMemo` hook and replaced `.map().join()` with a single-pass `for` loop.

### 🎯 Why
When navigating the linked scatter plot points (using the pointer or keyboard), the component re-renders to update `selectedRawIndex`. Previously, this forced a full recalculation and reallocation of the underlying static SVG path string on every selection change.

### 📊 Impact
Eliminates intermediate array allocations for large path strings and prevents `O(N)` string generation overhead during selection/hover events where `N` is the number of plotted data points, significantly reducing GC pressure.

### 🔬 Measurement
Load a large dataset into the Launch Monitor workspace and observe reduced main thread blocking and memory allocation during rapid point selection or keyboard navigation in the Linked Scatter Plot view.

---
*PR created automatically by Jules for task [12954647328402800249](https://jules.google.com/task/12954647328402800249) started by @dieterolson*