### PR TITLE
⚡ Bolt: [performance improvement] optimize downloadCsv serialization

### DIFF
--- a/src/rate_of_closure/web/src/model/launchMonitorDownloads.ts
+++ b/src/rate_of_closure/web/src/model/launchMonitorDownloads.ts
@@ -16,12 +16,20 @@ export function downloadJson(name: string, payload: unknown) {
 export function downloadCsv<T extends object>(name: string, rows: T[]) {
   const headers = [...new Set(rows.flatMap((row) => Object.keys(row)))];
   const quote = (value: unknown) => `"${String(value ?? "").replace(/"/g, '""')}"`;
-  const lines = [headers, ...rows.map((row) => headers.map(
-    (key) => (row as Record<string, unknown>)[key],
-  ))];
-  downloadBlob(name, new Blob([
-    lines.map((line) => line.map(quote).join(",")).join("\n"),
-  ], { type: "text/csv;charset=utf-8" }));
+
+  // ⚡ Bolt Optimization: Replace chained array .map().join() with a single-pass loop
+  // to eliminate intermediate array allocations and reduce GC pressure for large dataset exports.
+  let csv = headers.map(quote).join(",");
+  for (let i = 0; i < rows.length; i++) {
+    csv += "\n";
+    const row = rows[i] as Record<string, unknown>;
+    for (let j = 0; j < headers.length; j++) {
+      if (j > 0) csv += ",";
+      csv += quote(row[headers[j]]);
+    }
+  }
+
+  downloadBlob(name, new Blob([csv], { type: "text/csv;charset=utf-8" }));
 }
 
 export function downloadSvg(name: string, id: string) {


### PR DESCRIPTION
💡 What: Replaced chained array mapping and joining with a single-pass `for` loop in `downloadCsv` in `src/rate_of_closure/web/src/model/launchMonitorDownloads.ts`.
🎯 Why: Chained array operations (`.map().join()`) create massive amounts of intermediate arrays for large datasets (e.g., thousands of CSV rows). This stalls the main thread and causes severe garbage collection pressure.
📊 Impact: Eliminates O(N) array allocations per CSV download row. Transforms intermediate allocations to an O(1) array footprint using fast JS string concatenation.
🔬 Measurement: Export a dataset with 20,000+ rows; observe the absence of GC spikes and memory stalls during generation compared to the prior `.map().join()` implementation.

---
*PR created automatically by Jules for task [9542305947993740986](https://jules.google.com/task/9542305947993740986) started by @dieterolson*