### PR TITLE
fix(theme): enforce icon_utils input contracts with typed exceptions (#4488)

### DIFF
--- a/.github/workflows/cross-repo-python-integration.yml
+++ b/.github/workflows/cross-repo-python-integration.yml
@@ -239,6 +239,9 @@ jobs:
             tests/support
           touch src/shared/python/__init__.py vendor/ud-tools/src/shared/python/__init__.py
           touch tests/__init__.py tests/support/__init__.py
+          if [ ! -f tests/conftest.py ]; then
+            touch tests/conftest.py
+          fi
           touch src/shared/python/contracts.py vendor/ud-tools/src/shared/python/contracts.py
           if [ ! -f tests/support/suite_markers.py ]; then
             python -c "

--- a/src/shared/python/theme/icon_utils.py
+++ b/src/shared/python/theme/icon_utils.py
@@ -4,6 +4,7 @@
 # templating contract used downstream. Lint suppressed at module level.
 
 import re
+from collections.abc import Mapping
 from pathlib import Path
 
 from PyQt6.QtCore import QByteArray
@@ -54,6 +55,29 @@ SVG_REGISTRY = {
 }
 
 
+def validate_icon_name(name: object) -> str:
+    """Validate that the icon name is a string, raising TypeError if not."""
+    if not isinstance(name, str):
+        raise TypeError("name must be a string")
+    return name
+
+
+def validate_icon_color(color: object) -> str:
+    """Validate that the icon color is a string, raising TypeError if not."""
+    if not isinstance(color, str):
+        raise TypeError("color must be a string")
+    return color
+
+
+def get_registered_svg(registry: Mapping[str, str], name: object) -> str:
+    """Retrieve an SVG template by name from the registry, validating input contract."""
+    icon_name = validate_icon_name(name)
+    svg_content = registry.get(icon_name)
+    if not svg_content:
+        raise ValueError(f"Icon '{icon_name}' is not registered in SVG_REGISTRY.")
+    return svg_content
+
+
 class IconColorizer:
     @staticmethod
     def get_icon(name: str, color: str) -> QIcon:
@@ -64,14 +88,10 @@ class IconColorizer:
             - name must be a registered icon string.
             - color must be a valid hex string or color name.
         """
-        assert isinstance(name, str), "name must be a string"
-        assert isinstance(color, str), "color must be a string"
+        svg_content = get_registered_svg(SVG_REGISTRY, name)
+        valid_color = validate_icon_color(color)
 
-        svg_content = SVG_REGISTRY.get(name)
-        if not svg_content:
-            raise ValueError(f"Icon '{name}' is not registered in SVG_REGISTRY.")
-
-        colored_svg = svg_content.replace("{color}", color)
+        colored_svg = svg_content.replace("{color}", valid_color)
         pixmap = QPixmap()
         pixmap.loadFromData(QByteArray(colored_svg.encode("utf-8")))
         return QIcon(pixmap)
@@ -85,7 +105,7 @@ class IconColorizer:
             - path must be a valid, existing file path.
             - color must be a valid hex string or color name.
         """
-        assert isinstance(color, str), "color must be a string"
+        valid_color = validate_icon_color(color)
 
         path = Path(path)
         if not path.exists():
@@ -94,8 +114,8 @@ class IconColorizer:
         with open(path, encoding="utf-8") as f:
             svg_content = f.read()
 
-        svg_content = re.sub(r'fill="[^"]+"', f'fill="{color}"', svg_content)
-        svg_content = re.sub(r'stroke="[^"]+"', f'stroke="{color}"', svg_content)
+        svg_content = re.sub(r'fill="[^"]+"', f'fill="{valid_color}"', svg_content)
+        svg_content = re.sub(r'stroke="[^"]+"', f'stroke="{valid_color}"', svg_content)
 
         pixmap = QPixmap()
         pixmap.loadFromData(QByteArray(svg_content.encode("utf-8")))

--- a/tests/shared/python/theme/test_icon_utils.py
+++ b/tests/shared/python/theme/test_icon_utils.py
@@ -55,10 +55,35 @@ def test_get_icon_rejects_unknown_icon_name(icon_utils):
         icon_utils.IconColorizer.get_icon("missing", "#fff")
 
 
+def test_validate_icon_name(icon_utils):
+    assert icon_utils.validate_icon_name("home") == "home"
+    with pytest.raises(TypeError, match="name must be a string"):
+        icon_utils.validate_icon_name(None)
+    with pytest.raises(TypeError, match="name must be a string"):
+        icon_utils.validate_icon_name(123)
+
+
+def test_validate_icon_color(icon_utils):
+    assert icon_utils.validate_icon_color("#ff0000") == "#ff0000"
+    with pytest.raises(TypeError, match="color must be a string"):
+        icon_utils.validate_icon_color(None)
+    with pytest.raises(TypeError, match="color must be a string"):
+        icon_utils.validate_icon_color(42)
+
+
+def test_get_registered_svg(icon_utils):
+    reg = {"test": "<svg>{color}</svg>"}
+    assert icon_utils.get_registered_svg(reg, "test") == "<svg>{color}</svg>"
+    with pytest.raises(TypeError, match="name must be a string"):
+        icon_utils.get_registered_svg(reg, None)
+    with pytest.raises(ValueError, match="Icon 'missing' is not registered"):
+        icon_utils.get_registered_svg(reg, "missing")
+
+
 def test_get_icon_validates_argument_types(icon_utils):
-    with pytest.raises(AssertionError, match="name must be a string"):
+    with pytest.raises(TypeError, match="name must be a string"):
         icon_utils.IconColorizer.get_icon(None, "#fff")
-    with pytest.raises(AssertionError, match="color must be a string"):
+    with pytest.raises(TypeError, match="color must be a string"):
         icon_utils.IconColorizer.get_icon("home", None)
 
 
@@ -84,5 +109,5 @@ def test_colorize_svg_file_validates_color_type(icon_utils, tmp_path):
     svg_path = tmp_path / "glyph.svg"
     svg_path.write_text("<svg />", encoding="utf-8")
 
-    with pytest.raises(AssertionError, match="color must be a string"):
+    with pytest.raises(TypeError, match="color must be a string"):
         icon_utils.IconColorizer.colorize_svg_file(svg_path, None)


### PR DESCRIPTION
Closes #4488. Replaces bare assert statements in theme/icon_utils.py with validate_icon_name, validate_icon_color, and get_registered_svg functions that raise TypeError and ValueError.