### PR TITLE
fix(codemap): hoist splitlines in per-symbol loop and narrow blake3 fallback (#4492)

### DIFF
--- a/src/shared/python/codemap/indexer.py
+++ b/src/shared/python/codemap/indexer.py
@@ -35,11 +35,11 @@ logger = logging.getLogger(__name__)
 
 def _hash_bytes(data: bytes) -> str:
     try:
-        import blake3
-
-        return str(blake3.blake3(data).hexdigest())
-    except Exception:
+        import blake3  # type: ignore[import-not-found]
+    except ImportError:
         return hashlib.blake2b(data, digest_size=16).hexdigest()
+
+    return str(blake3.blake3(data).hexdigest())
 
 
 # ---------------------------------------------------------------------------
@@ -257,8 +257,12 @@ def _process_file(
         ),
     )
 
+    # Split the file once and reuse the lines for every symbol slice.
+    # Splitting inside the loop re-scans the whole file per symbol, which is
+    # quadratic for large, symbol-dense files.
+    source_lines = data.splitlines()
     for sym in parsed.symbols:
-        slice_bytes = b"\n".join(data.splitlines()[sym.start_line - 1 : sym.end_line])
+        slice_bytes = b"\n".join(source_lines[sym.start_line - 1 : sym.end_line])
         sym_hash = _hash_bytes(slice_bytes)
         cur.execute(
             "INSERT INTO symbols(path, kind, name, qualified, sig, docstring, "

--- a/tests/unit/codemap/test_codemap_indexer.py
+++ b/tests/unit/codemap/test_codemap_indexer.py
@@ -329,6 +329,28 @@ def test_hash_bytes_uses_blake3_when_available(
     assert indexer._hash_bytes(b"payload") == "fake-blake3"
 
 
+def test_hash_bytes_fallback_when_blake3_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(sys.modules, "blake3", None)
+    import hashlib
+
+    expected = hashlib.blake2b(b"payload", digest_size=16).hexdigest()
+    assert indexer._hash_bytes(b"payload") == expected
+
+
+def test_hash_bytes_raises_when_blake3_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def bad_blake3(data: bytes) -> None:
+        raise RuntimeError("Corrupt memory")
+
+    fake_blake3 = SimpleNamespace(blake3=bad_blake3)
+    monkeypatch.setitem(sys.modules, "blake3", fake_blake3)
+    with pytest.raises(RuntimeError, match="Corrupt memory"):
+        indexer._hash_bytes(b"payload")
+
+
 def test_gitignore_loader_uses_simple_fallback_when_pathspec_is_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes #4492. Hoists data.splitlines() out of the per-symbol iteration loop in codemap indexer and narrows blake3 exception handling to ImportError so real hash errors propagate.