### PR TITLE
⚡ Bolt: Optimize fixed-size array rendering in RotationConverter

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -101,3 +101,6 @@
 ## 2025-02-12 - CSV Export Overhead
 **Learning:** Chained array methods (.map().join()) in data-intensive hot paths (like exporting thousands of LaunchMonitor rows) create massive numbers of intermediate arrays, increasing GC pressure and memory consumption.
 **Action:** Always replace chained declarative array operations with single-pass `for`-loops and string concatenation when generating large text payloads to bypass unnecessary memory allocations.
+## 2024-11-20 - Avoid .map().join() overhead for fixed-size arrays in JSX
+**Learning:** In React components rendering mathematical data (e.g. `RotationConverter`), using `.map(n => n.toFixed(4)).join(', ')` on tiny fixed-size vectors or matrices allocates multiple intermediate arrays on every render, adding GC pressure.
+**Action:** Unroll the loops and manually format the strings for tiny fixed-size arrays (like 3D vectors or quaternions) directly in the JSX.

--- a/SPEC.md
+++ b/SPEC.md
@@ -6438,3 +6438,7 @@ The command injection check logic in `cli_tools.py` has been fortified. The inpu
 ## 2026-08-23: Palette Micro-UX Improvement in Rate of Closure
 
 - **2026-08-23**: fix(ux) — Add accessible focus indicators (`focus-visible:ring-2`, `focus-visible:ring-blue-500` or equivalent) in place of `outline-none` across inputs, selects, and buttons in the `rate_of_closure` app to ensure keyboard-only and screen-reader users can visually track their current element focus.
+
+## 2026-11-20 - Bolt Performance Optimization
+
+- **Performance**: Replaced chained array methods (`.map().join()`) with manually formatted JSX string structures for small fixed-size math arrays in `RotationConverter.tsx`.

--- a/src/rotation_converter/web/src/components/RotationConverter.tsx
+++ b/src/rotation_converter/web/src/components/RotationConverter.tsx
@@ -222,7 +222,7 @@ export function RotationConverter() {
                         <div className="bg-slate-700/50 p-3 rounded">
                             <p className="text-xs text-slate-400 mb-1">Quaternion (w, x, y, z)</p>
                             <p className="font-mono text-sm">
-                                [{results.quaternion.map(n => n.toFixed(4)).join(', ')}]
+                                [{results.quaternion[0].toFixed(4)}, {results.quaternion[1].toFixed(4)}, {results.quaternion[2].toFixed(4)}, {results.quaternion[3].toFixed(4)}]
                             </p>
                         </div>
 
@@ -230,7 +230,7 @@ export function RotationConverter() {
                         <div className="bg-slate-700/50 p-3 rounded">
                             <p className="text-xs text-slate-400 mb-1">Euler Angles ({results.euler_convention})</p>
                             <p className="font-mono text-sm">
-                                [{results.euler.map(n => n.toFixed(4)).join(', ')}]
+                                [{results.euler[0].toFixed(4)}, {results.euler[1].toFixed(4)}, {results.euler[2].toFixed(4)}]
                             </p>
                         </div>
 
@@ -238,7 +238,7 @@ export function RotationConverter() {
                         <div className="bg-slate-700/50 p-3 rounded">
                             <p className="text-xs text-slate-400 mb-1">Axis-Angle</p>
                             <p className="font-mono text-sm">
-                                Axis: [{results.axis_angle.axis.map(n => n.toFixed(4)).join(', ')}]
+                                Axis: [{results.axis_angle.axis[0].toFixed(4)}, {results.axis_angle.axis[1].toFixed(4)}, {results.axis_angle.axis[2].toFixed(4)}]
                             </p>
                             <p className="font-mono text-sm">
                                 Angle: {results.axis_angle.angle.toFixed(4)} rad
@@ -249,7 +249,7 @@ export function RotationConverter() {
                         <div className="bg-slate-700/50 p-3 rounded">
                             <p className="text-xs text-slate-400 mb-1">Rodrigues Vector</p>
                             <p className="font-mono text-sm">
-                                [{results.rodrigues.map(n => n.toFixed(4)).join(', ')}]
+                                [{results.rodrigues[0].toFixed(4)}, {results.rodrigues[1].toFixed(4)}, {results.rodrigues[2].toFixed(4)}]
                             </p>
                         </div>
 
@@ -257,9 +257,15 @@ export function RotationConverter() {
                         <div className="bg-slate-700/50 p-3 rounded overflow-x-auto">
                             <p className="text-xs text-slate-400 mb-1">Rotation Matrix (3x3)</p>
                             <pre className="font-mono text-sm bg-slate-900/50 p-2 rounded">
-                                {results.rotation_matrix.map(row =>
-                                    `[ ${row.map(n => n.toFixed(4).padStart(7, ' ')).join(', ')} ]`
-                                ).join('\n')}
+                                {(() => {
+                                    // ⚡ Bolt Optimization: Replace chained array .map().join() with manual string construction
+                                    // for fixed 3x3 matrices to eliminate intermediate array allocations per render.
+                                    const m = results.rotation_matrix;
+                                    const r0 = `[ ${m[0][0].toFixed(4).padStart(7, ' ')}, ${m[0][1].toFixed(4).padStart(7, ' ')}, ${m[0][2].toFixed(4).padStart(7, ' ')} ]`;
+                                    const r1 = `[ ${m[1][0].toFixed(4).padStart(7, ' ')}, ${m[1][1].toFixed(4).padStart(7, ' ')}, ${m[1][2].toFixed(4).padStart(7, ' ')} ]`;
+                                    const r2 = `[ ${m[2][0].toFixed(4).padStart(7, ' ')}, ${m[2][1].toFixed(4).padStart(7, ' ')}, ${m[2][2].toFixed(4).padStart(7, ' ')} ]`;
+                                    return `${r0}\n${r1}\n${r2}`;
+                                })()}
                             </pre>
                         </div>
 


### PR DESCRIPTION
💡 What: Replaced chained `.map().join()` methods with manually unrolled string interpolation for small, fixed-size mathematical arrays (quaternions, Euler angles, etc.) in `RotationConverter.tsx`.

🎯 Why: In React components rendering mathematical data, chained array methods like `.map().join()` allocate multiple intermediate arrays on every render. For fixed-size vectors (length 3 or 4), unrolling these loops significantly reduces Garbage Collection (GC) pressure.

📊 Impact: Eliminates O(N) intermediate array allocations and closure executions per re-render for statically sized mathematical outputs (quaternions, Euler angles, axis-angles, Rodrigues vectors, and 3x3 rotation matrices).

🔬 Measurement: Review the codebase (particularly `src/rotation_converter/web/src/components/RotationConverter.tsx`). Run `pnpm run test` in `/app/src/rotation_converter/web` to verify regressions. Tests continue to pass.

---
*PR created automatically by Jules for task [7451343314095210888](https://jules.google.com/task/7451343314095210888) started by @dieterolson*