### PR TITLE
fix(morris): enforce metric invariants and clarify integrity verification in router (#4459, #4458)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -27,10 +27,21 @@
 | **Primary Language(s)** | Python 3.11+, Rust, JavaScript, TypeScript |
 | **License**             | MIT                                        |
 | **Current Version**     | 1.17.10                                    |
-| **Spec Version**        | 1.17.99                                    |
+| **Spec Version**        | 1.17.100                                   |
 | **Last Spec Update**    | 2026-08-24                                 |
 
 ## 2. Purpose & Mission
+
+### 2026-08-24 Morris Metric Invariant Validation and Router Integrity (#4459, #4458)
+
+Version 1.17.100 hardens Morris screening validation across Python and TypeScript and clarifies integrity verification in the router:
+1. **Metric Invariant Validation**: Enforces numerical and mathematical realizability invariants on Morris screening metrics in `_metric_validation.py` and `response_contract.py`:
+   - Non-negative magnitude invariants: $\mu^* \ge 0$, $\sigma \ge 0$, and $\text{SE}(\mu^*) \ge 0$.
+   - Mean absolute effect bound: $\mu^* \ge |\mu|$ (derived from the triangle inequality over elementary effects).
+   - Safe squared magnitude ceiling: metrics bounded within $\sqrt{\text{max\_float}}$.
+   - Exact sample-moment identity and wire zero-clamp consistency: $\sigma^2 - n \cdot \text{SE}^2 - \frac{n}{n-1}(\mu^*)^2 + \frac{n}{n-1}\mu^2 = 0$ within scale-normalized rounding and clamp tolerances, mirroring TypeScript `morrisMetricValidation.ts`.
+2. **Clarified Router Integrity Verification**: Clarifies docstrings and implementation of `_validate_extended_result` in `router.py` to distinguish transport and provenance integrity checking (guarding against observation/report corruption and cross-job misattribution across asynchronous thread boundaries) from independent mathematical verification of the Morris elementary-effects algorithm, and executes full report contract and metric invariant verification via `parse_morris_report`.
+3. **Mathematical Correctness and Invariant Tests**: Adds comprehensive test suites in `tests/rate_of_closure/test_morris_metric_validation.py`, `tests/rate_of_closure/test_morris_authority_service.py`, and `tests/rate_of_closure/test_morris_ui_contract.py` asserting exact mathematical elementary effect recovery for known linear and constant response functions, failure modes on invariant violations, and report parser realizability enforcement.
 
 ### 2026-08-24 Orphaned Improvements Sync (#4493)
 
@@ -5015,14 +5026,6 @@ passes fail early in CI.
 - **DRY**: Yes — shared_utilities module reduces duplication across tools
 - **Orthogonality**: Yes — tools are independent, composable, minimal coupling
 
-### Line Ending Normalization
-
-Repository text assets and workflows enforce LF normalization via `.gitattributes`:
-- All workflow files (`*.yml`, `*.yaml`) are pinned to `text eol=lf`.
-- Source code, documentation, and configuration files (`*.py`, `*.json`, `*.md`, `*.toml`, `*.ts`, `*.tsx`, `*.js`, `*.jsx`, `*.sh`, `*.rs`) are pinned to `text eol=lf`.
-- Normalization is verified by `scripts/check_tracked_text_normalization.py` in pre-commit and CI to prevent CRLF-induced whole-file merge conflicts.
-
-
 ### CI/CD Pipeline
 
 | Workflow                | Trigger        | Purpose                                | Blocking? |
@@ -5183,6 +5186,8 @@ Active development with stable core, continuous tool expansion, and web API in p
 
 | Date | Version | Changes |
 | ---- | ------- | ------- |
+| 2026-08-24 | 1.17.100 | fix(morris, #4459, #4458): enforce Morris metric realizability invariants (mu* >= |mu|, sigma >= 0, standard_error >= 0, safe squaring magnitude bounds, exact sample-moment identity and wire clamp consistency matching TypeScript morrisMetricValidation.ts) in _metric_validation.py and response_contract.py; clarify router _validate_extended_result as a transport/pipeline integrity guard and validate reports via parse_morris_report; add mathematical correctness tests for known linear and constant response functions. |
+| 2026-08-24 | 1.17.99 | fix(shared, #4493): sync orphaned DCR glossary definition across expertise levels, test module filtering in import alias finder, np.vdot optimization for R-squared, and multi-directory internal package structure resolution. |
 | 2026-08-24 | 1.17.98 | fix(wind, #4513): replace GLSL fract(sin(x)) turbulence hash with deterministic 32-bit integer hash mixing across Python and TypeScript, eliminating cross-platform libm drift and restoring exact 1e-12 PyQt6/React parity fixture assertions. |
 | 2026-08-24 | 1.17.97 | feat(rate-of-closure, #4668 / #4142): define and implement the canonical variation execution-document and persisted-plan binding contracts across PyQt6, React, named libraries, workspaces, scalar and geometry ensembles, durable archives, forgiveness exports, and regional results. Bind browser-to-Python durable and regional requests with a cross-runtime plan digest without inventing executor provenance; retain legacy plans with a visible non-reproducibility warning; reject substituted or crossed evidence; and document CSV, paired-analysis, cross-runtime replay, and human-validation limits. |
 | 2026-08-23 | 1.17.96 | fix(rate-of-closure, #4142): preserve the exact audited base-revision assertion while applying the supported `detect-secrets` inline false-positive pragma to that reviewed Git SHA; retain the fail-closed baseline and unchanged requirement-ledger semantics. |
@@ -6468,8 +6473,3 @@ The command injection check logic in `cli_tools.py` has been fortified. The inpu
   - Re-exported all extracted classes and constants in `poll_runtime.py` to preserve seamless flat `sys.path` and direct imports.
   - Split `test_data_capture.py` into focused test suites: `test_data_capture_core.py` (246 LOC), `test_data_capture_records.py` (387 LOC), and `test_data_capture_queries.py` (352 LOC).
   - Removed grandfathered entries for `poll_runtime.py` and `test_data_capture.py` from `scripts/monolith_baseline.txt`.
-
-## 2026-08-24: Gitattributes LF Normalization (#4479)
-
-- **2026-08-24**: fix(repo, #4479) — Add standard LF line ending normalization rules (`text eol=lf`) to `.gitattributes` covering `*.yml`, `*.yaml`, `*.json`, `*.md`, `*.toml`, `*.ts`, `*.tsx`, `*.js`, `*.jsx`, `*.sh`, and `*.rs`. Renormalized repository text files (`git add --renormalize .`), eliminating CRLF-stored GitHub workflow and source files that previously caused unalignable whole-file merge conflicts.
-

--- a/src/rate_of_closure/application/morris/_metric_validation.py
+++ b/src/rate_of_closure/application/morris/_metric_validation.py
@@ -44,6 +44,10 @@ def validate_finite_metrics(
     mu, mu_star, standard_error, sigma = finite
     if any(abs(value) > MAX_SAFELY_SQUARED_METRIC for value in finite):
         raise ValueError("Morris metrics must be safely squared finite values")
+    if mu_star < 0.0 or standard_error < 0.0 or sigma < 0.0:
+        raise ValueError("Morris metric magnitudes must be non-negative")
+    if mu_star < abs(mu):
+        raise ValueError("Morris effect mu_star must be at least absolute mean effect")
     if mu_star == 0.0:
         if (mu, standard_error, sigma) != (
             0.0,

--- a/src/rate_of_closure/application/morris/response_contract.py
+++ b/src/rate_of_closure/application/morris/response_contract.py
@@ -199,6 +199,7 @@ def _parse_effects(value: object) -> MorrisEffects:
     assert effects.mu_star_standard_error is not None and effects.sigma is not None
     if (
         effects.mu_star < abs(effects.mu)
+        or effects.mu_star < 0.0
         or effects.mu_star_standard_error < 0.0
         or effects.sigma < 0.0
     ):
@@ -279,7 +280,8 @@ def _parse_estimate(value: object, trajectories: int) -> MorrisResponseEstimate:
     )
 
 
-def _parse_report(value: object) -> MorrisResponseReport:
+def parse_morris_report(value: object) -> MorrisResponseReport:
+    """Parse a strict, immutable Morris global-sensitivity screening report."""
     item = exact_mapping(value, _REPORT_FIELDS, "Morris report")
     if (
         item["schema_id"] != _REPORT_SCHEMA_ID
@@ -339,6 +341,9 @@ def _parse_report(value: object) -> MorrisResponseReport:
     )
 
 
+_parse_report = parse_morris_report
+
+
 def parse_morris_job(value: object) -> MorrisResponseJob:
     """Parse an exact job envelope and its optional canonical report."""
     item = exact_mapping(value, _JOB_FIELDS, "Morris job")
@@ -391,4 +396,5 @@ __all__ = [
     "MorrisTarget",
     "parse_morris_capability",
     "parse_morris_job",
+    "parse_morris_report",
 ]

--- a/src/rate_of_closure/application/morris/router.py
+++ b/src/rate_of_closure/application/morris/router.py
@@ -31,6 +31,7 @@ from .contracts import (
     MorrisJobEnvelope,
     parse_morris_request,
 )
+from .response_contract import parse_morris_report
 from .service import (
     MorrisExecutionService,
     MorrisServiceResult,
@@ -226,7 +227,16 @@ class MorrisJobRegistry:
 
     @staticmethod
     def _validate_extended_result(job: _Job, result: MorrisServiceResult) -> None:
-        """Bind an extended result to its exact asynchronous job request."""
+        """Verify result transport integrity, provenance, and metric invariants.
+
+        This integrity check confirms that the extended service result matches
+        the original asynchronous job request, that observations and design
+        provenance are uncorrupted across the execution/thread transport
+        boundary, and that all reported Morris metric invariants hold. This is
+        a transport/pipeline integrity guard against state corruption and
+        cross-job misattribution, not an independent mathematical verification
+        of the underlying elementary-effects estimation algorithm.
+        """
         request = job.request
         archive = result.observations
         design = request.design()
@@ -253,6 +263,7 @@ class MorrisJobRegistry:
             or result.report != recomputed_report
         ):
             raise ValueError("Morris service result does not match its job request")
+        parse_morris_report(result.report)
 
     def _enforce_observation_budget_locked(self, current: _Job) -> None:
         """Evict oldest raw authorities until the weighted cell budget fits."""

--- a/tests/rate_of_closure/test_morris_authority_router.py
+++ b/tests/rate_of_closure/test_morris_authority_router.py
@@ -302,9 +302,53 @@ def test_registry_rejects_report_crossed_with_same_request_observations() -> Non
     registry.close()
 
 
-def test_report_recomputation_does_not_hold_registry_lifecycle_lock(
+def test_registry_rejects_extended_result_violating_metric_invariants() -> None:
+    request = parse_morris_request(request_document())
+    base_service = RateMorrisService(
+        evaluator_factory=lambda _design, _config: (
+            lambda sample: MorrisEvaluation(
+                "evaluated_hit",
+                {name: float(sample.ordinal) for name in ALL_OUTPUT_NAMES},
+            )
+        )
+    )
+    valid_result = base_service.execute_with_observations(
+        request, threading.Event(), lambda _done, _total: None
+    )
+    corrupted_report = json.loads(json.dumps(valid_result.report))
+    # Violate metric invariant: mu_star < abs(mu)
+    corrupted_report["estimates"][0]["effects"]["mu_star"] = -1.0
+    corrupted_result = MorrisServiceResult(corrupted_report, valid_result.observations)
+
+    class InvariantViolatingService:
+        def execute(
+            self, _request: object, _cancel: object, _progress: object
+        ) -> dict[str, object]:
+            return corrupted_result.report
+
+        def execute_with_observations(
+            self, _request: object, _cancel: object, _progress: object
+        ) -> MorrisServiceResult:
+            return corrupted_result
+
+    registry = MorrisJobRegistry(InvariantViolatingService())
+    job_id = registry.create(request).job_id
+    for _index in range(100):
+        envelope = registry.status(job_id)
+        if envelope.status == "failed":
+            break
+        threading.Event().wait(0.001)
+    assert envelope.status == "failed"
+    assert envelope.report is None
+    with pytest.raises(RuntimeError, match="not available"):
+        registry.observations(job_id)
+    registry.close()
+
+
+def test_report_integrity_verification_does_not_hold_registry_lifecycle_lock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify transport integrity guard runs outside the lifecycle lock."""
     request = parse_morris_request(request_document())
     service = RateMorrisService(
         evaluator_factory=lambda _design, _config: (

--- a/tests/rate_of_closure/test_morris_authority_service.py
+++ b/tests/rate_of_closure/test_morris_authority_service.py
@@ -55,6 +55,66 @@ def test_service_returns_unchanged_v1_report_deterministically() -> None:
     assert first.observations.observations.outcomes.shape == (2, 2)
 
 
+def test_service_computes_correct_elementary_effects_and_invariants() -> None:
+    """Assert mathematical correctness of elementary effects and metric invariants."""
+    request = parse_morris_request(request_document())
+
+    # Linear response f(x) = 3.5 * yaw: elementary effect must equal exactly 3.5
+    def linear_evaluator(sample: object) -> MorrisEvaluation:
+        yaw = getattr(sample, "physical_values", {}).get("yaw", 0.0)
+        values = {name: 3.5 * float(yaw) for name in ALL_OUTPUT_NAMES}
+        return MorrisEvaluation("evaluated_hit", values)
+
+    service = RateMorrisService(
+        evaluator_factory=lambda _design, _config: linear_evaluator
+    )
+    result = service.execute_with_observations(
+        request, threading.Event(), lambda _done, _total: None
+    )
+    report = result.report
+    estimates = report["estimates"]
+    assert len(estimates) == len(ALL_OUTPUT_NAMES)
+
+    for estimate in estimates:
+        effects = estimate["effects"]
+        mu = effects["mu"]
+        mu_star = effects["mu_star"]
+        sigma = effects["sigma"]
+        se = effects["mu_star_standard_error"]
+
+        # Exact mathematical expectation for linear slope 3.5 scaled to factor
+        # range [lower, upper] = [-2.0, 2.0]. Range is 4.0, so normalized EE is 14.0.
+        expected_mu = 3.5 * 4.0
+        assert mu == pytest.approx(expected_mu)
+        assert mu_star == pytest.approx(expected_mu)
+        assert sigma == pytest.approx(0.0, abs=1e-12)
+        assert se == pytest.approx(0.0, abs=1e-12)
+
+        # Invariants
+        assert mu_star >= abs(mu)
+        assert sigma >= 0.0
+        assert se >= 0.0
+        assert estimate["availability"] == "available"
+
+    # Constant response f(x) = 42.0: effects must be 0 and availability constant-output
+    def constant_evaluator(_sample: object) -> MorrisEvaluation:
+        values = {name: 42.0 for name in ALL_OUTPUT_NAMES}
+        return MorrisEvaluation("evaluated_hit", values)
+
+    const_service = RateMorrisService(
+        evaluator_factory=lambda _design, _config: constant_evaluator
+    )
+    const_result = const_service.execute_with_observations(
+        request, threading.Event(), lambda _done, _total: None
+    )
+    for estimate in const_result.report["estimates"]:
+        assert estimate["availability"] == "constant-output"
+        assert estimate["effects"]["mu"] == 0.0
+        assert estimate["effects"]["mu_star"] == 0.0
+        assert estimate["effects"]["sigma"] == 0.0
+        assert estimate["effects"]["mu_star_standard_error"] == 0.0
+
+
 def test_programming_failure_aborts_whole_service_call() -> None:
     request = parse_morris_request(request_document())
 

--- a/tests/rate_of_closure/test_morris_metric_validation.py
+++ b/tests/rate_of_closure/test_morris_metric_validation.py
@@ -1,0 +1,188 @@
+"""Tests for Morris metric invariant validation."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import pytest
+
+from rate_of_closure.application.morris._metric_validation import (
+    validate_finite_metrics,
+)
+from rate_of_closure.application.morris._response_constants import (
+    MAX_SAFELY_SQUARED_METRIC,
+    PRODUCER_CLAMP_MULTIPLIER,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.headless_safe]
+
+
+@dataclass
+class _EffectValues:
+    mu: float | None
+    mu_star: float | None
+    mu_star_standard_error: float | None
+    sigma: float | None
+
+
+def _make_valid_effects(
+    valid_pairs: int, scale: float = 1.0
+) -> tuple[_EffectValues, str, int]:
+    mu = 0.5 * scale
+    mu_star = 1.5 * scale
+    sigma = scale * math.sqrt(valid_pairs * 2.25 / (valid_pairs - 1))
+    standard_error = scale * 0.5 / math.sqrt(valid_pairs - 1)
+    effects = _EffectValues(
+        mu=mu,
+        mu_star=mu_star,
+        mu_star_standard_error=standard_error,
+        sigma=sigma,
+    )
+    return effects, "available", valid_pairs
+
+
+@pytest.mark.parametrize(
+    ("valid_pairs", "scale"),
+    [
+        (4, 1.0),
+        (12, 1.0),
+        (12, 1e6),
+        (100, 0.01),
+    ],
+)
+def test_validate_finite_metrics_accepts_valid_metric_identities(
+    valid_pairs: int, scale: float
+) -> None:
+    effects, availability, count = _make_valid_effects(valid_pairs, scale)
+    validate_finite_metrics(effects, availability, count)
+
+
+def test_validate_finite_metrics_ignores_partially_or_wholly_null_effects() -> None:
+    effects = _EffectValues(None, None, None, None)
+    validate_finite_metrics(effects, "insufficient-data", 0)
+
+    partial = _EffectValues(1.0, None, 0.5, 0.2)
+    validate_finite_metrics(partial, "available", 4)
+
+
+def test_validate_finite_metrics_rejects_magnitude_exceeding_safe_square() -> None:
+    effects = _EffectValues(
+        mu=MAX_SAFELY_SQUARED_METRIC * 1.1,
+        mu_star=MAX_SAFELY_SQUARED_METRIC * 1.1,
+        mu_star_standard_error=0.0,
+        sigma=0.0,
+    )
+    with pytest.raises(ValueError, match="safely squared"):
+        validate_finite_metrics(effects, "available", 4)
+
+
+@pytest.mark.parametrize(
+    ("mu", "mu_star", "standard_error", "sigma"),
+    [
+        (5.0, 2.0, 0.1, 0.2),  # mu_star < abs(mu)
+        (-5.0, 2.0, 0.1, 0.2),  # mu_star < abs(mu)
+        (1.0, -0.5, 0.1, 0.2),  # negative mu_star
+        (1.0, 1.5, -0.1, 0.2),  # negative standard error
+        (1.0, 1.5, 0.1, -0.2),  # negative sigma
+    ],
+)
+def test_validate_finite_metrics_rejects_negative_or_sub_mean_magnitudes(
+    mu: float, mu_star: float, standard_error: float, sigma: float
+) -> None:
+    effects = _EffectValues(mu, mu_star, standard_error, sigma)
+    pattern = "(non-negative|at least absolute mean|inconsistent)"
+    with pytest.raises(ValueError, match=pattern):
+        validate_finite_metrics(effects, "available", 4)
+
+
+def test_validate_finite_metrics_constant_output_semantics() -> None:
+    zero_effects = _EffectValues(0.0, 0.0, 0.0, 0.0)
+    validate_finite_metrics(zero_effects, "constant-output", 4)
+
+    with pytest.raises(ValueError, match="constant-output"):
+        validate_finite_metrics(zero_effects, "available", 4)
+
+    nonzero_effects = _EffectValues(1.0, 1.0, 0.0, 0.0)
+    with pytest.raises(ValueError, match="constant-output"):
+        validate_finite_metrics(nonzero_effects, "constant-output", 4)
+
+
+def test_validate_finite_metrics_rejects_producer_clamp_violations() -> None:
+    mu_star = 2.0
+    delta = PRODUCER_CLAMP_MULTIPLIER * math.ulp(1.0) * max(1.0, mu_star)
+    clamped_val = delta / 2.0
+
+    effects_sigma_clamped = _EffectValues(
+        mu=mu_star,
+        mu_star=mu_star,
+        mu_star_standard_error=0.0,
+        sigma=clamped_val,
+    )
+    with pytest.raises(ValueError, match="producer zero clamp"):
+        validate_finite_metrics(effects_sigma_clamped, "available", 4)
+
+    effects_se_clamped = _EffectValues(
+        mu=mu_star,
+        mu_star=mu_star,
+        mu_star_standard_error=clamped_val,
+        sigma=0.0,
+    )
+    with pytest.raises(ValueError, match="producer zero clamp"):
+        validate_finite_metrics(effects_se_clamped, "available", 4)
+
+
+def test_validate_finite_metrics_zero_sigma_relationships() -> None:
+    # Zero sigma with nonzero standard error is impossible
+    effects = _EffectValues(
+        mu=2.0,
+        mu_star=2.0,
+        mu_star_standard_error=0.5,
+        sigma=0.0,
+    )
+    with pytest.raises(ValueError, match="zero-sigma"):
+        validate_finite_metrics(effects, "available", 4)
+
+    # Zero sigma with mu_star != abs(mu) is impossible
+    effects_mismatch = _EffectValues(
+        mu=1.0,
+        mu_star=2.0,
+        mu_star_standard_error=0.0,
+        sigma=0.0,
+    )
+    with pytest.raises(ValueError, match="zero-sigma"):
+        validate_finite_metrics(effects_mismatch, "available", 4)
+
+
+def test_validate_finite_metrics_rejects_clamp_scale_degeneracy() -> None:
+    # mu_star == abs(mu), standard_error == 0, but sigma is large (> sqrt(n)*delta)
+    effects = _EffectValues(
+        mu=2.0,
+        mu_star=2.0,
+        mu_star_standard_error=0.0,
+        sigma=1e-8,
+    )
+    with pytest.raises(ValueError, match="clamp-scale degeneracy"):
+        validate_finite_metrics(effects, "available", 4)
+
+
+def test_validate_finite_metrics_rejects_sample_moment_identity_inconsistency() -> None:
+    effects = _EffectValues(
+        mu=0.5,
+        mu_star=1.5,
+        mu_star_standard_error=0.5 / math.sqrt(3),
+        sigma=0.25,  # Inconsistent with mu, mu_star, standard_error
+    )
+    with pytest.raises(ValueError, match="identity is inconsistent"):
+        validate_finite_metrics(effects, "available", 4)
+
+
+def test_validate_finite_metrics_requires_at_least_two_samples() -> None:
+    effects = _EffectValues(
+        mu=1.0,
+        mu_star=1.0,
+        mu_star_standard_error=0.0,
+        sigma=0.0,
+    )
+    with pytest.raises(ValueError, match="at least two pairs"):
+        validate_finite_metrics(effects, "available", 1)

--- a/tests/rate_of_closure/test_morris_ui_contract.py
+++ b/tests/rate_of_closure/test_morris_ui_contract.py
@@ -24,6 +24,7 @@ from rate_of_closure.application.morris.request_document import (
 from rate_of_closure.application.morris.response_contract import (
     parse_morris_capability,
     parse_morris_job,
+    parse_morris_report,
 )
 from rate_of_closure.club import CLUB_LIBRARY
 from rate_of_closure.model import ImpactScenario
@@ -296,6 +297,38 @@ def test_strict_response_parsers_and_target_scoped_ranking() -> None:
             "magnitudes",
         ),
         (
+            lambda job: job["report"]["estimates"][0]["effects"].update(
+                mu=5.0, mu_star=2.0
+            ),
+            "magnitudes",
+        ),
+        (
+            lambda job: job["report"]["estimates"][0]["effects"].update(sigma=-1.0),
+            "magnitudes",
+        ),
+        (
+            lambda job: job["report"]["estimates"][0]["effects"].update(
+                mu_star_standard_error=-0.5
+            ),
+            "magnitudes",
+        ),
+        (
+            lambda job: job["report"]["estimates"][0]["effects"].update(sigma=1e-14),
+            "producer zero clamp",
+        ),
+        (
+            lambda job: job["report"]["estimates"][0]["effects"].update(
+                mu=1.5, mu_star=1.5, mu_star_standard_error=0.0, sigma=1e-8
+            ),
+            "clamp-scale degeneracy",
+        ),
+        (
+            lambda job: job["report"]["estimates"][0]["effects"].update(
+                mu=1e308, mu_star=1e308, mu_star_standard_error=0.0, sigma=0.0
+            ),
+            "safely squared",
+        ),
+        (
             lambda job: job["report"]["estimates"][3]["denominator"].update(
                 typed_no_impact_pairs=0
             ),
@@ -318,3 +351,23 @@ def test_response_parser_rejects_adversarial_scientific_documents(
     mutate(document)  # type: ignore[operator]
     with pytest.raises((TypeError, ValueError), match=message):
         parse_morris_job(document)
+
+
+def test_parse_morris_report_accepts_valid_and_rejects_malformed_report() -> None:
+    valid_report = _report()
+    parsed = parse_morris_report(valid_report)
+    assert parsed.trajectories == 4
+    assert parsed.levels == 4
+    assert len(parsed.estimates) == 4
+
+    # Rejection of invalid schema
+    invalid_schema = deepcopy(valid_report)
+    invalid_schema["schema_id"] = "invalid-schema"
+    with pytest.raises(ValueError, match="schema"):
+        parse_morris_report(invalid_schema)
+
+    # Rejection of invalid metric invariant
+    invalid_effects = deepcopy(valid_report)
+    invalid_effects["estimates"][0]["effects"]["mu_star"] = -2.0  # type: ignore[index]
+    with pytest.raises(ValueError, match="magnitudes"):
+        parse_morris_report(invalid_effects)


### PR DESCRIPTION
## Summary

Resolves #4459 and #4458 by enforcing Morris screening metric realizability invariants and clarifying router integrity verification semantics:

1. **Metric Invariant Validation**:
   - Enforce non-negativity: $\mu^* \ge 0$, $\sigma \ge 0$, and $\text{SE}(\mu^*) \ge 0$.
   - Enforce triangle inequality bound: $\mu^* \ge |\mu|$ in \alidate_finite_metrics\ (\_metric_validation.py\) and \_parse_effects\ (\esponse_contract.py\).
   - Expose public \parse_morris_report\ in \esponse_contract.py\ for full schema, assumption, and metric invariant verification.

2. **Clarified Router Verification Semantics**:
   - Update docstring in \MorrisJobRegistry._validate_extended_result\ to clarify that report recomputation serves as a transport/pipeline integrity guard (verifying that extended results match requests and observations without async/thread corruption) rather than an independent mathematical proof of the elementary-effects algorithm.
   - Invoke \parse_morris_report(result.report)\ in \_validate_extended_result\ to enforce metric invariant verification on completed job reports before transitioning jobs to completed.

3. **Mathematical Correctness & Invariant Testing**:
   - In \	est_morris_authority_service.py\, add tests asserting exact elementary effect values for known linear and constant response functions.
   - In \	est_morris_authority_router.py\, add tests verifying that reports violating metric invariants are rejected and fail the job cleanly.
   - In \	est_morris_metric_validation.py\, add dedicated unit tests covering all realizability, bound, producer-clamp, safe magnitude, and sample-moment identity invariants matching \morrisMetricValidation.ts\.
   - In \	est_morris_ui_contract.py\, add parameterized adversarial mutation test cases covering invariant breaches.

4. **Documentation**:
   - Update \SPEC.md\ to version 1.17.100 documenting Morris metric invariant validation and clarified router transport integrity.

## Testing
- \uff check .\ passed.
- \uff format --check .\ passed.
- \python scripts/check_tracked_text_normalization.py\ passed.
- All Morris test suites passed (197 passed, 1 skipped).