### PR TITLE
docs: rebuild the public-facing landing page and repair the license

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Tool catalog
+    url: https://github.com/D-sorganization/Tools#tool-catalog
+    about: Every application in this repository and what each one does.
+  - name: Troubleshooting
+    url: https://github.com/D-sorganization/Tools/blob/main/docs/help/troubleshooting.md
+    about: Installation failures, launcher problems, MATLAB setup, and test collection errors.
+  - name: User manual
+    url: https://github.com/D-sorganization/Tools/blob/main/docs/USER_MANUAL.md
+    about: Per-tool operating instructions.
+  - name: Security vulnerabilities
+    url: https://github.com/D-sorganization/Tools/blob/main/SECURITY.md
+    about: Report vulnerabilities privately. Do not open a public issue.

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,21 @@
 MIT License
 
-Copyright (c) 2025
+Copyright (c) 2025-2026 D-sorganization
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to do so, subject to the following conditions:
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,158 +1,179 @@
-# Tools Monorepo 🛠️
+# Tools
 
 [![CI Standard](https://github.com/D-sorganization/Tools/actions/workflows/ci-standard.yml/badge.svg)](https://github.com/D-sorganization/Tools/actions/workflows/ci-standard.yml)
-[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-Welcome to the **Tools Monorepo**. This repository houses a comprehensive collection of utility tools for data processing, file management, scientific computing, and project automation. It features Python-based utilities, MATLAB scientific tools, and web-based interfaces.
+A monorepo of engineering and scientific desktop applications, shared Python
+libraries, and command-line utilities. It covers process and mechanical
+calculators, signal and data processing, robotics model generation, motion
+analysis, and project file management. Every graphical tool is reachable from a
+single PyQt6 launcher; the underlying libraries are importable on their own and
+are shared with other D-sorganization repositories.
 
-## 📂 Repository Structure
+- **Audience**: engineers and researchers who want working desktop tools, and
+  developers who want the libraries behind them.
+- **Platform**: Windows, macOS, and Linux. Python 3.11 or 3.12.
+- **Status**: actively developed. Interfaces outside `src/shared/` may change
+  between releases.
 
-Canonical topology policy: `docs/architecture/CANONICAL_TOPOLOGY.md`.
+## Contents
 
-The repository is organized into several key areas:
+| Section                                                 | Purpose                                        |
+| ------------------------------------------------------- | ---------------------------------------------- |
+| [Tool catalog](#tool-catalog)                           | Every application in the repository, by domain |
+| [Command-line entry points](#command-line-entry-points) | Installed console scripts                      |
+| [Installation](#installation)                           | Set up a working environment                   |
+| [Running the tools](#running-the-tools)                 | Launch the GUI and individual applications     |
+| [Repository layout](#repository-layout)                 | Where code lives and why                       |
+| [Documentation](#documentation)                         | Guides, architecture, and reference material   |
+| [Contributing](#contributing)                           | Branching, testing, and review requirements    |
+| [Security](#security)                                   | Vulnerability reporting                        |
+| [License](#license)                                     | MIT terms                                      |
 
-### 🔬 Scientific Computing
+## Tool catalog
 
-- **`matlab/`**: Core scientific code for golf swing modeling and simulations.
-- **`src/scientific_modeling/`**: Additional modeling resources and documentation.
+All graphical applications below launch from `python UnifiedToolsLauncher.py`.
+The launcher groups them by the same categories used here.
 
-### 🛠️ Python Tools
+### Process and mechanical engineering
 
-**Directory Structure:**
+| Tool                       | What it does                                                             |
+| -------------------------- | ------------------------------------------------------------------------ |
+| `pressure_drop_calculator` | Single- and two-phase pipe pressure drop analysis with fitting losses    |
+| `flow_rate_converter`      | Conversion between mass, volumetric, and standard-condition flow units   |
+| `steam_engine_calculator`  | Steam cycle and reciprocating engine performance calculations            |
+| `inertia_calculator`       | Inertia tensors and mass properties for composite rigid bodies           |
+| `vessel_drafter`           | Pressure vessel geometry and drafting output                             |
+| `pid_generator`            | P&ID diagram generation from YAML specifications, via `programmatic_pid` |
+| `financial_calculator`     | Project economics: cash flow, payback, and rate-of-return analysis       |
+| `p1am_control_system`      | P1AM programmable controller configuration and SCADA support tooling     |
 
-- **`src/python/`**: Core infrastructure and shared utilities
+### Signal, data, and documents
 
-  - **`src/python/src/core/`**: Plugin system and core launcher functionality
-  - **`src/python/src/utils/`**: Shared utilities (compatibility shims, logger utils)
-  - **`src/python/src/tile_launcher/`**: Tile launcher components
-  - **`src/shared/python/upstream_drift_tools/`**: **NEW** Centralized shared library for fleet-wide logic (Thermo, Conversion, Robotics)
-  - **`tests/`**: Canonical root test suite for the shared monorepo surface
+| Tool                       | What it does                                                              |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `signal_processing_studio` | Filtering, spectral analysis, and transform workbench                     |
+| `function_generator`       | Waveform and test-signal generation on the shared `signal_toolkit` engine |
+| `data_processing`          | Time-series import, cleaning, and analysis pipeline                       |
+| `data_explorer`            | Interactive workbench for browsing simulation datasets                    |
+| `document_processing`      | PDF metadata extraction and rule-based renaming                           |
+| `media_processing`         | Audio and video processing utilities                                      |
+| `video_analyzer`           | Frame-accurate video review with golf swing analysis overlays             |
 
-- **`src/tools/`**: Tool implementations and utilities
+### Robotics and biomechanics
 
-  - **`src/tools/folder_tools/`**: Folder management tools (folder_tool, folder_packer_pro, project_packer)
-  - **`src/tools/matlab_utilities/`**: MATLAB quality checking and testing utilities
-  - **`src/tools/matlab_code_analyzer_gui/`**: MATLAB code analyzer GUI
-  - **`src/tools/scientific_auditor.py`**: Scientific code auditing tool
+| Tool                   | What it does                                                          |
+| ---------------------- | --------------------------------------------------------------------- |
+| `urdf_builder_gui`     | Parametric URDF authoring for arbitrary robot chains                  |
+| `humanoid_builder_gui` | Anthropometric humanoid generation with URDF export                   |
+| `movement_optimizer`   | Sagittal-plane trajectory optimization by Lagrangian inverse dynamics |
+| `lower_body_model`     | Lower-limb multibody model and analysis API                           |
+| `c3d_viewer`           | C3D motion-capture file inspection and playback                       |
+| `rate_of_closure`      | Six-degree-of-freedom clubhead impact delivery analysis               |
+| `rrt_path_planner`     | Rapidly-exploring random tree motion planning                         |
 
-- **`src/`**: Major tool categories organized under standardized structure
-  - **`src/data_processing/`**: Data processing tools and pipelines
-  - **`src/document_processing/`**: Document processing utilities
-  - **`src/media_processing/`**: Audio and video processing tools
-  - **`src/scientific_modeling/`**: Scientific modeling and simulation tools
-  - **`src/web_applications/`**: Web-based dashboards and interfaces
-  - **`src/verification/`**: Verification and testing utilities
+### Simulation and numerical work
 
-**Note:** The distinction between `src/python/` and `src/tools/` is:
+| Tool                   | What it does                                                        |
+| ---------------------- | ------------------------------------------------------------------- |
+| `ode_solver`           | Symbolic and numeric solution of ODE systems                        |
+| `pendulum_simulator`   | Multi-link pendulum dynamics with parameter sweeps                  |
+| `optimizer_gui`        | General-purpose numerical optimization front end                    |
+| `multi_param_analysis` | Multi-parameter sweeps and sensitivity studies                      |
+| `solar_system_model`   | N-body orbital mechanics simulation and visualization               |
+| `rotation_converter`   | Conversion between Euler angles, quaternions, and rotation matrices |
 
-- `src/python/` = Core infrastructure, plugin system, shared utilities
-- `src/tools/` = Individual tool implementations and standalone utilities
-- `src/` = Major tool categories following standardized `src/` layout pattern
+### Project and file management
 
-Future consolidation may merge these, but current structure supports the plugin system architecture.
+| Tool                | What it does                                                           |
+| ------------------- | ---------------------------------------------------------------------- |
+| `folder_tool`       | Bulk file combining, organization, deduplication, and archiving        |
+| `folder_packer_pro` | Project packing with AES-256 encryption and syntax-highlighted preview |
+| `project_packer`    | Directory packing and unpacking for transfer and archival              |
 
-### 🚀 Launcher
+### Browser-based utilities
 
-The repository provides a unified launcher system for accessing all tools. The canonical entry point is:
+Served from `src/web_applications/`: a scientific `calculator`, a
+`unit_converter`, and a three-dimensional `urdf_viewer`. Each runs from a static
+file server with no Python runtime required.
 
-- **`UnifiedToolsLauncher.py`**: **PRIMARY AND RECOMMENDED** - Modern PyQt6-based GUI launcher
+## Command-line entry points
 
-  ```bash
-  python UnifiedToolsLauncher.py
-  ```
+Installing the package with `pip install -e .` provides these console scripts:
 
-  **Features:**
+| Command               | Purpose                                                      |
+| --------------------- | ------------------------------------------------------------ |
+| `urdf-gen`            | Generate URDF models from parameter files                    |
+| `generate-pid`        | Render P&ID diagrams to DXF or SVG from a YAML specification |
+| `video-analyzer`      | Launch the video analysis application                        |
+| `rate-of-closure-web` | Serve the rate-of-closure web companion                      |
+| `codemap`             | Build a structural map of a source tree                      |
+| `codemap-watch`       | Rebuild that map on file change                              |
+| `codemap-mcp`         | Expose the map over the Model Context Protocol               |
+| `sidekick`            | Shared calculation and assistant backend                     |
+| `mypy-autofix`        | Apply mechanical type-annotation repairs                     |
 
-  - Full plugin system support via `core/plugin_manager.py`
-  - Comprehensive error handling and user feedback
-  - Tool path validation and sanitization
-  - Output/error capture for launched tools
-  - Debug mode for troubleshooting
-  - Activity log for monitoring tool launches
-
-See [Launcher Hierarchy & Guide](docs/LAUNCHERS.md) for detailed documentation.
-
-#### Launcher Hierarchy
-
-1. **`UnifiedToolsLauncher.py`** (Primary) - Use this for all new development and general usage
-
-   - Location: Repository root
-   - Type: PyQt6 GUI application
-   - Status: ✅ Active and maintained
-   - Entry point: `python UnifiedToolsLauncher.py`
-
-> **Important:** `tools_launcher.py` does not exist and any references to it are outdated. Use `UnifiedToolsLauncher.py` as the canonical entry point.
-
-> **Note:** Historical launcher names are not supported entry points. Use `UnifiedToolsLauncher.py`.
-
-## 🚀 Quick Start
+## Installation
 
 ### Prerequisites
 
-- **Git**: Version control (ensure LFS is installed).
-- **Python**: Version **3.11+** required (3.12 recommended for best performance).
-  - Compatibility shims are retained only for older embedded helper modules; the package metadata requires Python 3.11 or newer.
-  - Python 3.13+ not yet tested
-  - **CI Testing**: The repository is tested against Python 3.11 and 3.12 (see CI/CD section)
-- **MATLAB**: Required for running the core simulations (R2020a or later).
-- **Node.js**: Required for web applications and some dev tools.
+- Python 3.11 or 3.12. Python 3.13 is not yet validated.
+- Git with Git LFS installed.
+- MATLAB R2020a or later, only for the tools under `matlab/`.
+- Node.js, only for the browser-based utilities.
 
-### Installation
+### Steps
 
-1. **Clone the Repository**
+```bash
+git clone https://github.com/D-sorganization/Tools.git
+cd Tools
+git lfs install && git lfs pull
 
-   ```bash
-   git clone https://github.com/D-sorganization/Tools.git
-   cd Tools
-   git lfs install
-   git lfs pull
-   ```
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
 
-2. **Set Up Python Environment**
+python -m pip install -e ".[dev]"
+```
 
-   ```bash
-   # Create a virtual environment
-   python -m venv venv
-   source venv/bin/activate  # On Windows: venv\Scripts\activate
+Optional dependency groups install the extras a given tool needs, for example
+`pip install -e ".[gui,process,robotics]"`. The full list is in `pyproject.toml`
+under `[project.optional-dependencies]`.
 
-   # Install dependencies and the editable package with dev tools
-   python -m pip install -r requirements.txt
-   python -m pip install -e ".[dev]"
-   ```
+Contributors should also install the pre-commit hooks:
 
-3. **Install Pre-commit Hooks** (For developers)
+```bash
+bash scripts/setup_precommit.sh
+```
 
-   ```bash
-   bash scripts/setup_precommit.sh
-   ```
+## Running the tools
 
-4. **Use the Makefile** (Optional but recommended)
-
-   ```bash
-   make help      # Show available targets
-   make install   # Install all dependencies
-   make check     # Run linters and tests
-   make format    # Format code with ruff
-   ```
-
-### Running the Tools
-
-The easiest way to explore the available tools is via the unified launcher:
+The launcher is the canonical entry point for every graphical application:
 
 ```bash
 python UnifiedToolsLauncher.py
 ```
 
-## Optional Rust Acceleration
+It presents the tools grouped by domain, validates each tool path before
+launching, and captures output and errors from the child process. Pass
+`--verbose` for diagnostic logging when a tool fails to start.
 
-Several modules in this repository ship optional Rust extensions (built via
-[maturin](https://www.maturin.rs/)) that replace hot Python loops with compiled
-native code. The extensions are **not distributed as pre-built wheels today** — there
-is currently no maturin CI build job. When the wheel is absent the code falls back to
-pure-Python automatically and logs a `WARNING` so you know you are on the slow path.
+Common development tasks run through the Makefile:
 
-To build the extensions locally:
+```bash
+make help      # List available targets
+make check     # Run linters and the test suite
+make format    # Apply Ruff formatting
+```
+
+### Optional Rust acceleration
+
+Several modules ship optional Rust extensions built with
+[maturin](https://www.maturin.rs/). Pre-built wheels are not published today, so
+the extensions must be built locally; without them the pure-Python
+implementation is used automatically and logs a warning that the slower path is
+active.
 
 ```bash
 pip install maturin
@@ -160,171 +181,78 @@ cd rust_core/tools-core && maturin develop --features python
 cd rust_core/ai_backend  && maturin develop --features python
 ```
 
-For full details — what each crate contains, the missing CI workflow spec, and
-per-module performance numbers — see
-[docs/development/rust_distribution.md](docs/development/rust_distribution.md).
+See [Rust distribution](docs/development/rust_distribution.md) for crate
+contents and measured performance differences, and
+[AI backend setup](docs/ai_backend_setup.md) for the optional ONNX-based local
+embedding feature.
 
-### Local Embeddings (`ai_backend`)
+## Repository layout
 
-`ai_backend` supports an optional `local-embeddings` feature for offline
-ONNX-based embeddings without a remote API. This requires the ONNX Runtime
-shared library and the `ORT_DYLIB_PATH` environment variable — especially on
-Windows where the library must be downloaded manually.
-
-```bash
-# Build with local embeddings (ORT_DYLIB_PATH must be set first)
-cd rust_core/ai_backend && maturin develop --features python,local-embeddings
-
-# Preflight check — verifies ORT_DYLIB_PATH before starting your app
-python -m src.shared.python.ai._onnx_preflight
+```text
+Tools/
+├── UnifiedToolsLauncher.py   Canonical GUI entry point
+├── src/
+│   ├── <tool_name>/          One directory per application (see catalog above)
+│   ├── shared/python/        Libraries shared across the repository fleet
+│   ├── web_applications/     Browser-based utilities
+│   └── python/src/core/      Plugin system and launcher infrastructure
+├── matlab/                   MATLAB scientific code and utilities
+├── rust_core/                Optional Rust extension crates
+├── docs/                     Documentation (see below)
+└── tests/                    Test suite for the shared monorepo surface
 ```
 
-See [docs/ai_backend_setup.md](docs/ai_backend_setup.md) for the full setup
-guide, per-OS instructions, download links, and troubleshooting.
+`src/shared/python/` holds code with more than one consumer and is the only part
+of the tree treated as a stable interface. Everything under an individual tool
+directory belongs to that tool.
 
-## 📖 Documentation
+## Documentation
 
-Detailed documentation is available in the `docs/` directory:
+**Getting started**
 
-- **[Architecture](docs/architecture/JULES_ARCHITECTURE.md)**: Overview of the CI/CD system and "Control Tower" architecture.
-- **[Fleet Architecture](docs/architecture/FLEET_ARCHITECTURE.md)**: Shared tools architecture across the repository fleet.
-- **[Development Guidelines](docs/development/GUARDRAILS_GUIDELINES.md)**: Coding standards, guardrails, and safety protocols.
-- **[Branching Strategy](docs/development/BRANCHING_WORKFLOW_RULE.md)**: Mandatory workflow for feature branches and PRs.
-- **[Enhanced Tools](docs/tools/ENHANCED_TOOLS.md)**: Documentation for the "Pro" versions of the folder and project tools.
-- **[Visualization Guide](docs/VISUALIZATION_GUIDE.md)**: Colorblind-safe plotting and accessibility guidelines.
-- **[Plugin System](docs/PLUGIN_SYSTEM.md)**: Automatic tool discovery via manifest files.
-- **[Quick Start Guide](QUICKSTART.md)**: Getting started with the Tools repository.
-- **[Release Notes](docs/release/CHANGELOG.md)**: History of changes and updates.
-- **[Security Policy](SECURITY.md)**: How to report vulnerabilities responsibly.
-- **[AI Backend Setup](docs/ai_backend_setup.md)**: ONNX Runtime setup for `local-embeddings`.
+- [Quick start](docs/quickstart.md) — first run and basic usage.
+- [User manual](docs/USER_MANUAL.md) — per-tool operating instructions.
+- [Launcher guide](docs/architecture/LAUNCHERS.md) — entry points and selection logic.
 
-## 🤝 Contribution
+**Architecture and development**
 
-We follow a strict **"Safety First"** contribution policy.
+- [Architecture overview](docs/ARCHITECTURE_OVERVIEW.md) — system structure and boundaries.
+- [Canonical topology](docs/architecture/CANONICAL_TOPOLOGY.md) — directory policy.
+- [Fleet architecture](docs/architecture/FLEET_ARCHITECTURE.md) — shared code across repositories.
+- [Plugin system](docs/architecture/PLUGIN_SYSTEM.md) — automatic tool discovery.
+- [Build a tool](docs/BUILD_A_TOOL.md) — adding a new application.
+- [Development guidelines](docs/development/GUARDRAILS_GUIDELINES.md) — coding standards and guardrails.
+- [Branching workflow](docs/development/BRANCHING_WORKFLOW_RULE.md) — required branch and PR process.
 
-1. **Branching**: Always use feature branches (`feature/your-feature`). Direct commits to `main` are blocked.
-2. **Testing**: All new features must be accompanied by tests. Tests run on Python 3.11 and 3.12.
-3. **Linting**: Ensure your code passes all `pre-commit` checks (Ruff, MyPy, etc.).
-4. **Review**: All changes require a Pull Request review.
-5. **Security**: Report vulnerabilities through the process documented in [SECURITY.md](SECURITY.md), not through public issues.
+**Reference**
 
-### CI/CD Testing
+- [Tools inventory](docs/tools/TOOLS_INVENTORY.md) — per-tool platform coverage.
+- [Enhanced tools](docs/tools/ENHANCED_TOOLS.md) — the extended folder and project tools.
+- [Visualization guide](docs/architecture/VISUALIZATION_GUIDE.md) — colorblind-safe plotting standards.
+- [Changelog](docs/release/CHANGELOG.md) — release history.
 
-The repository uses GitHub Actions for continuous integration:
+## Contributing
 
-- **Quality Gate**: Linting (Ruff), formatting (Black), type checking (Mypy), security scanning (pip-audit)
-- **Multi-Version Testing**: Tests run on Python 3.11 and 3.12 to ensure compatibility
-- **Code Analysis**: Automated code quality checks and security scanning
+Contributions are welcome. The repository enforces the following:
 
-For more details, please read the [Development Guidelines](docs/development/GUARDRAILS_GUIDELINES.md).
+1. **Branching** — work on a feature branch. Direct commits to `main` are blocked.
+2. **Testing** — new behaviour requires tests. The suite runs on Python 3.11 and 3.12.
+3. **Linting** — code must pass the pre-commit checks: Ruff, Black, and Mypy.
+4. **Review** — all changes merge through a reviewed pull request.
 
-## 🔧 Troubleshooting
+Continuous integration runs a quality gate (Ruff, Black, Mypy, `pip-audit`) and
+the test suite across both supported Python versions. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
 
-### Python Version Issues
+If a tool fails to start or a test will not collect, see the
+[troubleshooting guide](docs/help/troubleshooting.md) before opening an issue.
 
-**Problem:** `ImportError: cannot import name 'StrEnum' from 'enum'` or `ImportError: cannot import name 'UTC' from 'datetime'`
+## Security
 
-**Cause:** You're running Python earlier than 3.11, which lacks features required by this package.
+Report vulnerabilities through the process in [SECURITY.md](SECURITY.md), not
+through public issues.
 
-**Solutions:**
+## License
 
-1. **Recommended:** Use Python 3.11 or newer (3.12 recommended)
-
-   ```bash
-   # Ubuntu/Debian
-   sudo apt update
-   sudo apt install python3.12
-
-   # macOS (Homebrew)
-   brew install python@3.12
-   ```
-
-2. **Note:** Some legacy helper modules still include compatibility shims, but the installable package requires Python 3.11 or newer.
-
-### Launcher Won't Start
-
-**Problem:** `UnifiedToolsLauncher.py` fails to launch or crashes immediately.
-
-**Solutions:**
-
-1. Ensure all dependencies are installed: `pip install -r requirements.txt`
-2. Check Python version: `python --version` (must be 3.11+)
-3. Try running with verbose output: `python UnifiedToolsLauncher.py --verbose`
-4. Check for missing PyQt6: `pip install PyQt6>=6.6.0`
-
-### MATLAB Tools Not Working
-
-**Problem:** MATLAB-based tools (Audio Processor, RRT Path Planner, Scientific Modeling tools) fail silently or cannot be launched.
-
-**Cause:** These tools require MATLAB to be installed and accessible in your system PATH.
-
-**MATLAB Requirements:**
-
-- **Minimum Version:** MATLAB R2020a or later
-- **Required Toolboxes:**
-  - Signal Processing Toolbox (for audio processing tools)
-  - Statistics and Machine Learning Toolbox (for some modeling tools)
-  - Image Processing Toolbox (for visualization tools)
-
-**Solutions:**
-
-1. **Install MATLAB**
-
-   - Download from [MathWorks](https://www.mathworks.com/products/matlab.html)
-   - Ensure R2020a or later is installed
-   - Install required toolboxes during setup
-
-2. **Add MATLAB to System PATH**
-
-   ```bash
-   # Linux/macOS
-   export PATH="/usr/local/MATLAB/R2023a/bin:$PATH"
-   # Or for your specific installation:
-   export PATH="/path/to/matlab/bin:$PATH"
-
-   # Windows (PowerShell)
-   $env:PATH += ";C:\Program Files\MATLAB\R2023a\bin"
-
-   # Windows (Command Prompt) - Add to System Environment Variables permanently
-   ```
-
-3. **Verify MATLAB Installation**
-
-   ```bash
-   # Check MATLAB version
-   matlab -batch "version"
-
-   # Test MATLAB execution
-   matlab -batch "disp('MATLAB is working')"
-   ```
-
-4. **Tool Availability**
-
-   - **Audio Processor**: Requires MATLAB + Signal Processing Toolbox
-   - **RRT Path Planner**: Requires MATLAB + Statistics Toolbox
-   - **Solar System Model**: Requires MATLAB (basic installation sufficient)
-   - **Golf Modeling Suite**: Requires MATLAB + Optimization Toolbox
-
-5. **If MATLAB is Not Available**
-   - Python-only tools will still work
-   - Web applications are independent of MATLAB
-   - Some tools have Python alternatives (check individual tool documentation)
-
-**Note:** The launcher will attempt to open MATLAB files in your default editor if MATLAB is not found in PATH, but full functionality requires MATLAB to be properly installed and configured.
-
-### Tests Not Running
-
-**Problem:** `pytest` fails with collection errors or import errors.
-
-**Solutions:**
-
-1. Ensure you're in the repository root: `cd /path/to/Tools`
-2. Install test dependencies: `pip install pytest>=8.2.0`
-3. Run from virtual environment: `source venv/bin/activate`
-4. Check Python version compatibility (3.11+ required, 3.12 recommended)
-
-For more help, see [GitHub Issues](https://github.com/D-sorganization/Tools/issues) or create a new issue.
-
-## 🛡️ License
-
-This project is licensed under the MIT License. See individual tool directories for specific licensing terms where applicable.
+Released under the MIT License. See [LICENSE](LICENSE). Individual tool
+directories may carry additional notices where third-party code is vendored.

--- a/docs/architecture/LAUNCHERS.md
+++ b/docs/architecture/LAUNCHERS.md
@@ -1,35 +1,53 @@
-# Launcher Hierarchy
+# Launcher Guide
 
-This repository utilizes a specific hierarchy for launching tools to ensure compatibility and ease of use.
+This repository has one supported entry point for its graphical tools. This
+document records that entry point, how individual tools are reached, and what to
+do when the launcher fails.
 
-## Primary Launcher
+## Canonical entry point
 
-**`UnifiedToolsLauncher.py`**
+**`UnifiedToolsLauncher.py`** — PyQt6 desktop launcher, at the repository root.
 
-- **Type:** PyQt6 (Modern GUI)
-- **Role:** The **canonical entry point** for the repository. It provides a modern, tabbed interface to access all tools, including Python, MATLAB, and Web Applications.
-- **Requirement:** Python 3.11+
-- **Usage:**
-  ```bash
-  python UnifiedToolsLauncher.py
-  ```
+```bash
+python UnifiedToolsLauncher.py
+```
 
-## Legacy Launcher (Fallback)
+- **Requirement**: Python 3.11 or newer, with PyQt6 installed
+  (`pip install -e ".[gui]"` or `".[dev]"`).
+- **Role**: presents every graphical application grouped by domain, validates
+  each tool path before launching, and captures the child process's output and
+  errors into an activity log.
+- **Diagnostics**: pass `--verbose` for detailed logging. A session log is
+  written to `unified_launcher.log` in the working directory.
 
-**`launch_tools_main.py`**
+The launcher discovers tools through the plugin system described in
+[Plugin system](PLUGIN_SYSTEM.md), so a correctly registered tool appears
+without changes to the launcher itself.
 
-- **Type:** Tkinter (Legacy GUI)
-- **Role:** A robust fallback launcher used if PyQt6 is unavailable or if the unified launcher fails. It focuses on core data processing tools.
-- **Usage:**
-  ```bash
-  python launch_tools_main.py
-  ```
+## Individual tool launchers
 
-## Specialized Launchers
+Some tools also carry their own entry point for direct use, for example
+`src/web_applications/urdf_viewer/main.py`. These exist to support development
+and embedding; the launcher remains the supported path for normal use.
 
-Individual tools may have their own specific launchers (e.g., `src/web_applications/urdf_viewer/main.py`), but users are encouraged to use the `UnifiedToolsLauncher.py` for a unified experience.
+A subset of tools is installed as console scripts by
+`pip install -e .`. Those are listed in the
+[repository README](../../README.md#command-line-entry-points) and defined under
+`[project.scripts]` in `pyproject.toml`.
 
-## Launcher Selection Logic
+## Unsupported entry points
 
-1. Users should attempt to run `UnifiedToolsLauncher.py` first.
-2. If dependencies (PyQt6) are missing or the environment is restricted, `launch_tools_main.py` serves as a reliable alternative using the standard Tkinter library.
+Names that appear in older documentation, commit messages, or issue history do
+not resolve to files in this repository and are not supported:
+
+- `tools_launcher.py`
+- `launch_tools_main.py`
+
+Neither exists. There is no Tkinter fallback launcher. If PyQt6 cannot be
+installed in the target environment, use the command-line entry points or the
+browser-based utilities under `src/web_applications/` instead.
+
+## When the launcher fails
+
+See [Troubleshooting](../help/troubleshooting.md#the-launcher-will-not-start)
+for the ordered checks.

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -1,0 +1,155 @@
+# Troubleshooting
+
+Common failures when installing, launching, or testing the tools in this
+repository, with the checks that resolve them.
+
+## Contents
+
+- [Python version errors](#python-version-errors)
+- [The launcher will not start](#the-launcher-will-not-start)
+- [MATLAB tools do nothing](#matlab-tools-do-nothing)
+- [Tests fail to collect](#tests-fail-to-collect)
+- [Rust extensions are not used](#rust-extensions-are-not-used)
+
+## Python version errors
+
+**Symptom**
+
+```text
+ImportError: cannot import name 'StrEnum' from 'enum'
+ImportError: cannot import name 'UTC' from 'datetime'
+```
+
+**Cause**
+
+The interpreter is older than Python 3.11. Both symbols were added in 3.11 and
+the installable package requires it.
+
+**Resolution**
+
+Install Python 3.11 or 3.12 and recreate the virtual environment.
+
+```bash
+# Ubuntu and Debian
+sudo apt update && sudo apt install python3.12
+
+# macOS with Homebrew
+brew install python@3.12
+```
+
+```bash
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+python -m pip install -e ".[dev]"
+```
+
+Some legacy helper modules still carry compatibility shims for older
+interpreters. Those shims do not make the package itself importable below 3.11.
+
+## The launcher will not start
+
+**Symptom**
+
+`python UnifiedToolsLauncher.py` exits immediately or raises on import.
+
+**Checks, in order**
+
+1. Confirm the interpreter: `python --version` must report 3.11 or newer.
+2. Confirm the environment is active and the package is installed:
+   `python -m pip install -e ".[dev]"`.
+3. Confirm the GUI dependency is present: `python -c "import PyQt6"`. If it
+   fails, install it with `pip install "PyQt6>=6.6.0"`.
+4. Re-run with diagnostics: `python UnifiedToolsLauncher.py --verbose`, and
+   check `unified_launcher.log` in the working directory.
+
+On Windows, a `WinError 127` from a PyQt6 import usually means the installed
+Microsoft Visual C++ runtime is older than the wheel requires. Install the
+current Visual C++ Redistributable, or pin an earlier PyQt6 release.
+
+## MATLAB tools do nothing
+
+**Symptom**
+
+MATLAB-backed tools fail silently, or the launcher opens the `.m` file in a text
+editor instead of running it.
+
+**Cause**
+
+MATLAB is not on the system `PATH`. The launcher falls back to opening the file
+when it cannot find the executable.
+
+**Requirements**
+
+- MATLAB R2020a or later.
+- Signal Processing Toolbox for the audio tools.
+- Statistics and Machine Learning Toolbox for the planning and modeling tools.
+- Image Processing Toolbox for the visualization tools.
+
+**Resolution**
+
+Add MATLAB to `PATH` and verify it responds:
+
+```bash
+# Linux and macOS
+export PATH="/usr/local/MATLAB/R2023a/bin:$PATH"
+```
+
+```powershell
+# Windows PowerShell, current session
+$env:PATH += ";C:\Program Files\MATLAB\R2023a\bin"
+```
+
+```bash
+matlab -batch "disp('MATLAB is working')"
+```
+
+Set the variable permanently through the system environment settings rather than
+per session. Python-only tools and the browser-based utilities do not depend on
+MATLAB and remain available without it.
+
+## Tests fail to collect
+
+**Symptom**
+
+`pytest` reports collection or import errors before running any test.
+
+**Checks**
+
+1. Run from the repository root, not from a subdirectory.
+2. Activate the virtual environment used for the editable install.
+3. Confirm test dependencies are present: `python -m pip install -e ".[test]"`.
+4. Confirm the interpreter version is 3.11 or 3.12.
+
+A second Python installation on `PATH` is the most common cause: the tests then
+import a different interpreter's packages than the one the editable install
+targeted.
+
+## Rust extensions are not used
+
+**Symptom**
+
+A warning that the pure-Python fallback path is active, and slower than expected
+numerical performance.
+
+**Cause**
+
+The optional Rust extensions are not published as pre-built wheels, so they are
+absent until built locally.
+
+**Resolution**
+
+```bash
+pip install maturin
+cd rust_core/tools-core && maturin develop --features python
+cd rust_core/ai_backend  && maturin develop --features python
+```
+
+See [Rust distribution](../development/rust_distribution.md) for crate contents
+and measured performance differences.
+
+## Still stuck
+
+Search the [issue tracker](https://github.com/D-sorganization/Tools/issues)
+before opening a new issue. Include the output of `python --version`,
+`python -m pip show ud-tools`, and the relevant portion of
+`unified_launcher.log`.

--- a/docs/tools/TOOLS_INVENTORY.md
+++ b/docs/tools/TOOLS_INVENTORY.md
@@ -1,275 +1,130 @@
-# Tools Repository — Application Inventory & Platform Parity
+# Application Inventory and Platform Coverage
 
-> **Last Updated**: 2026-03-13
-> **Repository**: D-sorganization/Tools (AffineDrift)
+Every application in this repository, with the user interfaces each one
+provides. The catalog in the [repository README](../../README.md#tool-catalog)
+groups the same set by domain and describes what each tool does; this document
+records interface coverage and identifies gaps.
 
-## Overview
+## Interface surfaces
 
-This repository contains a suite of engineering, scientific, and utility
-applications. Each tool targets one or more UI surfaces:
+| Surface   | Stack                      | Role                         |
+| --------- | -------------------------- | ---------------------------- |
+| **PyQt6** | Python, PyQt6, Matplotlib  | Desktop GUI, primary surface |
+| **Web**   | HTML, CSS, JavaScript      | Browser interface            |
+| **Tauri** | Rust wrapper over a web UI | Packaged desktop application |
 
-| Surface   | Stack                       | Description                   |
-| --------- | --------------------------- | ----------------------------- |
-| **PyQt6** | Python + PyQt6 + Matplotlib | Desktop GUI (primary surface) |
-| **Web**   | HTML/JS/CSS (plain or Vite) | Browser-based UI              |
-| **Tauri** | Rust + Web + Tauri          | Desktop app from web frontend |
+"Yes" means an implementation is present in the tree. It does not assert feature
+parity between surfaces.
 
----
+## Process and mechanical engineering
 
-## Application Inventory
+| Tool                       | PyQt6 | Web | Tauri | Domain                   |
+| -------------------------- | :---: | :-: | :---: | ------------------------ |
+| `pressure_drop_calculator` |  Yes  | Yes |  No   | Fluid mechanics          |
+| `flow_rate_converter`      |  Yes  | Yes |  No   | Unit conversion          |
+| `steam_engine_calculator`  |  Yes  | Yes |  No   | Thermodynamics           |
+| `inertia_calculator`       |  Yes  | No  |  No   | Mechanical properties    |
+| `vessel_drafter`           |  Yes  | No  |  No   | Pressure vessel drafting |
+| `pid_generator`            |  Yes  | No  |  No   | P&ID generation          |
+| `financial_calculator`     |  Yes  | Yes |  No   | Project economics        |
+| `p1am_control_system`      |  Yes  | Yes |  No   | Industrial control       |
 
-### Engineering Calculators
+## Signal, data, and documents
 
-| #   | Tool                        | PyQt6 | Web | Tauri | Category                     |
-| --- | --------------------------- | :---: | :-: | :---: | ---------------------------- |
-| 1   | `acid_gas_dewpoint`         |  ✅   | ✅  |  ❌   | Chemical Engineering         |
-| 2   | `baghouse_calculator`       |  ✅   | ✅  |  ❌   | Environmental Engineering    |
-| 3   | `electrode_advisor`         |  ✅   | ✅  |  ❌   | Welding Engineering          |
-| 4   | `financial_calculator`      |  ✅   | ✅  |  ❌   | Financial Analysis           |
-| 5   | `flare_calculator`          |  ✅   | ✅  |  ❌   | Process Safety               |
-| 6   | `flow_rate_converter`       |  ✅   | ✅  |  ❌   | Unit Conversion              |
-| 7   | `pressure_drop_calculator`  |  ✅   | ✅  |  ❌   | Fluid Mechanics              |
-| 8   | `scrubber_calculator`       |  ✅   | ✅  |  ❌   | Environmental Engineering    |
-| 9   | `steam_engine_calculator`   |  ✅   | ✅  |  ❌   | Thermodynamics               |
-| 10  | `syngas_compression`        |  ✅   | ✅  |  ❌   | Chemical Engineering         |
-| 11  | `syngas_water_calculator`   |  ✅   | ✅  |  ❌   | Chemical Engineering         |
-| 12  | `thermal_profile_predictor` |  ✅   | ✅  |  ❌   | Heat Transfer                |
-| 13  | `trc_vessel_designer`       |  ✅   | ✅  |  ❌   | Pressure Vessel Design       |
-| 14  | `wgs_reactor`               |  ✅   | ✅  |  ❌   | Chemical Engineering         |
-| 15  | `inertia_calculator`        |  ✅   | ❌  |  ❌   | Mechanical Engineering       |
-| 16  | `glass_bath_fea`            |  ✅   | ❌  |  ❌   | Finite Element Analysis      |
-| 17  | `multi_param_analysis`      |  ✅   | ❌  |  ❌   | Multi-Parameter Optimization |
-| 18  | `psa_package`               |  ✅   | ❌  |  ❌   | Pressure Swing Adsorption    |
+| Tool                       | PyQt6 | Web | Tauri | Domain                    |
+| -------------------------- | :---: | :-: | :---: | ------------------------- |
+| `signal_processing_studio` |  Yes  | No  |  No   | Signal processing         |
+| `function_generator`       |  Yes  | Yes |  Yes  | Waveform generation       |
+| `data_processing`          |  Yes  | Yes |  Yes  | Time-series analysis      |
+| `data_explorer`            |  Yes  | No  |  No   | Dataset browsing          |
+| `document_processing`      |  Yes  | No  |  No   | PDF metadata and renaming |
+| `media_processing`         |  Yes  | Yes |  No   | Audio and video           |
+| `video_analyzer`           |  Yes  | No  |  No   | Video review and overlays |
 
-### Scientific & Simulation Tools
+## Robotics and biomechanics
 
-| #   | Tool                       | PyQt6 | Web | Tauri | Category                  |
-| --- | -------------------------- | :---: | :-: | :---: | ------------------------- |
-| 19  | `ode_solver`               |  ✅   | ✅  |  ❌   | Differential Equations    |
-| 20  | `pendulum_simulator`       |  ✅   | ✅  |  ✅   | Physics Simulation        |
-| 21  | `function_generator`       |  ✅   | ✅  |  ✅   | Signal Generation         |
-| 22  | `rotation_converter`       |  ✅   | ✅  |  ✅   | Robotics / Spatial Math   |
-| 23  | `signal_processing_studio` |  ✅   | ❌  |  ❌   | Signal Processing         |
-| 24  | `optimizer_gui`            |  ✅   | ❌  |  ❌   | Mathematical Optimization |
-| 25  | `gasification_equilibrium` |  ✅   | ❌  |  ❌   | Chemical Equilibrium      |
-| 26  | `pid_generator`            |  ✅   | ❌  |  ❌   | P&ID Diagram Generation   |
+| Tool                   | PyQt6 | Web | Tauri | Domain                    |
+| ---------------------- | :---: | :-: | :---: | ------------------------- |
+| `urdf_builder_gui`     |  Yes  | No  |  No   | URDF authoring            |
+| `humanoid_builder_gui` |  Yes  | No  |  No   | Anthropometric modeling   |
+| `movement_optimizer`   |  Yes  | No  |  No   | Trajectory optimization   |
+| `lower_body_model`     |  Yes  | No  |  No   | Multibody limb model      |
+| `c3d_viewer`           |  Yes  | No  |  No   | Motion capture inspection |
+| `rate_of_closure`      |  Yes  | Yes |  No   | Impact delivery analysis  |
+| `rrt_path_planner`     |  No   | No  |  No   | Motion planning, API only |
 
-### Biomechanics & Robotics
+## Simulation and numerical work
 
-| #   | Tool                   | PyQt6 | Web | Tauri | Category               |
-| --- | ---------------------- | :---: | :-: | :---: | ---------------------- |
-| 27  | `humanoid_builder_gui` |  ✅   | ❌  |  ❌   | URDF Humanoid Building |
-| 28  | `urdf_builder_gui`     |  ✅   | ❌  |  ❌   | URDF Robot Building    |
-| 29  | `c3d_viewer`           |  ✅   | ❌  |  ❌   | Motion Capture Viewer  |
-| 30  | `vessel_drafter`       |  ✅   | ❌  |  ❌   | Vessel CAD Drafting    |
+| Tool                   | PyQt6 | Web | Tauri | Domain                      |
+| ---------------------- | :---: | :-: | :---: | --------------------------- |
+| `ode_solver`           |  Yes  | Yes |  No   | Differential equations      |
+| `pendulum_simulator`   |  Yes  | Yes |  Yes  | Multibody dynamics          |
+| `optimizer_gui`        |  Yes  | No  |  No   | Numerical optimization      |
+| `multi_param_analysis` |  Yes  | No  |  No   | Parameter sweeps            |
+| `solar_system_model`   |  No   | No  |  No   | Orbital mechanics, API only |
+| `rotation_converter`   |  Yes  | Yes |  Yes  | Spatial rotation math       |
+| `asteroid_jumper`      |  Yes  | No  |  No   | Simulation demonstration    |
 
-### File & Data Processing
+## Project and file management
 
-| #   | Tool                | PyQt6 | Web | Tauri | Category                    |
-| --- | ------------------- | :---: | :-: | :---: | --------------------------- |
-| 31  | `folder_tool`       |  ✅   | ❌  |  ❌   | Directory Management        |
-| 32  | `folder_packer_pro` |  ✅   | ❌  |  ❌   | Project Archiving (AES-256) |
-| 33  | `project_packer`    |  ✅   | ❌  |  ❌   | Folder Packing/Unpacking    |
+| Tool                | PyQt6 | Web | Tauri | Domain                    |
+| ------------------- | :---: | :-: | :---: | ------------------------- |
+| `folder_tool`       |  Yes  | No  |  No   | Bulk file operations      |
+| `folder_packer_pro` |  Yes  | No  |  No   | Encrypted project packing |
+| `project_packer`    |  Yes  | No  |  No   | Directory packing         |
 
-### Web-Only Utilities
+## Browser-only utilities
 
-| #   | Tool                              | PyQt6 | Web | Tauri | Category              |
-| --- | --------------------------------- | :---: | :-: | :---: | --------------------- |
-| 34  | `web_applications/calculator`     |  ❌   | ✅  |  ❌   | Scientific Calculator |
-| 35  | `web_applications/unit_converter` |  ❌   | ✅  |  ❌   | Unit Conversion       |
-| 36  | `web_applications/urdf_viewer`    |  ❌   | ✅  |  ❌   | URDF 3D Viewer        |
+Served as static files from `src/web_applications/`.
 
-### Libraries & Processing Modules (not standalone apps)
+| Application      | Purpose                          |
+| ---------------- | -------------------------------- |
+| `calculator`     | Scientific calculator            |
+| `unit_converter` | General unit conversion          |
+| `urdf_viewer`    | Three-dimensional URDF rendering |
 
-| #   | Module                         | Description                                    |
-| --- | ------------------------------ | ---------------------------------------------- |
-| 37  | `shared/python/signal_toolkit` | Signal generation, filtering, series, calculus |
-| 38  | `shared/python/safe_eval`      | Safe expression evaluation                     |
-| 39  | `data_processing`              | Data import/export pipeline                    |
-| 40  | `document_processing`          | PDF renaming & metadata extraction             |
-| 41  | `media_processing`             | Media file processing                          |
-| 42  | `scientific_modeling`          | Scientific modeling utilities                  |
+## Libraries, not standalone applications
 
-### Infrastructure & Build
+| Module                           | Purpose                                            |
+| -------------------------------- | -------------------------------------------------- |
+| `shared/python/signal_toolkit`   | Signal generation, filtering, series, and calculus |
+| `shared/python/safe_eval`        | Constrained expression evaluation                  |
+| `shared/python/codemap`          | Source-tree structural mapping and MCP server      |
+| `shared/python/programmatic_pid` | P&ID rendering engine behind `pid_generator`       |
+| `shared/python/model_generation` | URDF generation engine behind the builder GUIs     |
+| `sidekick`                       | Shared calculation and assistant backend           |
+| `matlab/`                        | MATLAB scientific code and quality utilities       |
+| `verification/`                  | Verification and audit scripts                     |
 
-| #   | Module                        | Description                                          |
-| --- | ----------------------------- | ---------------------------------------------------- |
-| 43  | `tools/` (launcher utilities) | config_loader, launch_utils, quality_utils, ui_utils |
-| 44  | `matlab/`                     | MATLAB integration scripts                           |
-| 45  | `python/`                     | Shared Python utilities                              |
-| 46  | `hcl_reactor/`                | Notebook-only (no GUI)                               |
-| 47  | `dwsim_model/`                | DWSIM integration (external model)                   |
-| 48  | `verification/`               | Verification scripts                                 |
-| 49  | `folder_tool_pro/`            | Empty scaffold (v3.0 shell — no source)              |
+## Known gaps
 
----
+**Experimental and incomplete**
 
-## Platform Parity Summary
+- `plant_simulator` — neural-network plant simulator. Not wired into any
+  launcher or tool manifest.
+- `folder_tool_pro` — scaffold only, no implementation.
+- `rotation_converter` — the pure-Python module is deprecated in favour of the
+  `math-primitives` Rust crate. The GUI remains supported.
 
-### PyQt6 → Web Gaps (PyQt6 apps missing web surface)
+**No web surface**
 
-The following **12 applications** have a PyQt6 GUI but **no web implementation**:
+Fifteen desktop applications have no browser implementation:
+`inertia_calculator`, `vessel_drafter`, `pid_generator`,
+`signal_processing_studio`, `data_explorer`, `document_processing`,
+`video_analyzer`, `urdf_builder_gui`, `humanoid_builder_gui`,
+`movement_optimizer`, `lower_body_model`, `c3d_viewer`, `optimizer_gui`,
+`multi_param_analysis`, and `asteroid_jumper`, plus the three file-management
+tools, which are inherently local.
 
-1. `inertia_calculator` — Mechanical Engineering
-2. `glass_bath_fea` — Finite Element Analysis
-3. `multi_param_analysis` — Multi-Parameter Optimization
-4. `psa_package` — Pressure Swing Adsorption
-5. `signal_processing_studio` — Signal Processing
-6. `optimizer_gui` — Mathematical Optimization
-7. `gasification_equilibrium` — Chemical Equilibrium
-8. `pid_generator` — P&ID Diagram Generation
-9. `humanoid_builder_gui` — URDF Humanoid Building
-10. `urdf_builder_gui` — URDF Robot Building
-11. `c3d_viewer` — Motion Capture Viewer
-12. `vessel_drafter` — Vessel CAD Drafting
+**No graphical surface**
 
-### PyQt6 → Web Gaps (File Processing Tools)
+`rrt_path_planner` and `solar_system_model` are importable libraries with
+example scripts but no maintained GUI.
 
-The following **3 file processing tools** have PyQt6 but no web surface:
+## Maintaining this document
 
-13. `folder_tool` — Directory Management
-14. `folder_packer_pro` — Project Archiving
-15. `project_packer` — Folder Packing
-
-### Web → Tauri Gaps
-
-The following **14 applications** have a web frontend but **no Tauri desktop wrapper**:
-
-1. `acid_gas_dewpoint`
-2. `baghouse_calculator`
-3. `electrode_advisor`
-4. `financial_calculator`
-5. `flare_calculator`
-6. `flow_rate_converter`
-7. `ode_solver`
-8. `pressure_drop_calculator`
-9. `scrubber_calculator`
-10. `steam_engine_calculator`
-11. `syngas_compression`
-12. `syngas_water_calculator`
-13. `thermal_profile_predictor`
-14. `trc_vessel_designer`
-15. `wgs_reactor`
-
-### Web → PyQt6 Gaps
-
-The following **3 web-only utilities** have no PyQt6 desktop version:
-
-1. `web_applications/calculator`
-2. `web_applications/unit_converter`
-3. `web_applications/urdf_viewer`
-
----
-
-## File Organization
-
-```
-src/
-├── acid_gas_dewpoint/        # Chemical Eng calculator
-├── asteroid_jumper/          # Game (standalone)
-├── baghouse_calculator/      # Environmental Eng calculator
-├── c3d_viewer/               # Motion capture viewer
-├── data_processing/          # Data processing library
-├── document_processing/      # PDF processing library
-├── dwsim_model/              # DWSIM integration
-├── electrode_advisor/        # Welding advisor
-├── financial_calculator/     # Financial calculator
-├── flare_calculator/         # Flare system calculator
-├── flow_rate_converter/      # Flow rate converter
-├── folder_packer_pro/        # Project archiving (AES-256)  ← RELOCATED
-├── folder_tool/              # Directory management utility  ← RELOCATED
-├── folder_tool_pro/          # Empty v3.0 scaffold           ← RELOCATED
-├── function_generator/       # Signal/function generator
-├── gasification_equilibrium/ # Chemical equilibrium
-├── glass_bath_fea/           # FEA analysis
-├── hcl_reactor/              # HCl reactor (notebook)
-├── humanoid_builder_gui/     # URDF humanoid builder
-├── inertia_calculator/       # Inertia calculator
-├── matlab/                   # MATLAB scripts
-├── media_processing/         # Media processing
-├── multi_param_analysis/     # Multi-parameter optimization
-├── ode_solver/               # ODE solver
-├── optimizer_gui/            # Mathematical optimizer
-├── pendulum_simulator/       # Pendulum simulator
-├── pid_generator/            # P&ID generator
-├── pressure_drop_calculator/ # Pressure drop calculator
-├── project_packer/           # Folder packing/unpacking      ← RELOCATED
-├── psa_package/              # PSA calculator
-├── python/                   # Shared Python utilities
-├── rotation_converter/       # Rotation converter
-├── scientific_modeling/      # Scientific modeling
-├── scrubber_calculator/      # Scrubber calculator
-├── shared/                   # Shared libraries
-├── signal_processing_studio/ # Signal processing
-├── steam_engine_calculator/  # Steam engine calculator
-├── syngas_compression/       # Syngas compression
-├── syngas_water_calculator/  # Syngas water calculator
-├── thermal_profile_predictor/# Thermal profile predictor
-├── tools/                    # Launcher & quality utilities
-├── trc_vessel_designer/      # TRC vessel designer
-├── urdf_builder_gui/         # URDF robot builder
-├── verification/             # Verification scripts
-├── vessel_drafter/           # Vessel drafting
-├── web_applications/         # Web-only utilities
-└── wgs_reactor/              # WGS reactor
-```
-
----
-
-## Rust Shared Kernel (tools-core)
-
-The `rust_core/` workspace provides the single source of truth for computation,
-compiled to both **PyO3 (Python)** and **WASM (web)** via feature gates.
-
-### Rust Crates
-
-| Crate             | Location                                | Modules                                                    | Tests |
-| ----------------- | --------------------------------------- | ---------------------------------------------------------- | ----- |
-| `math-primitives` | `rust_core/math-primitives/`            | quaternion, rotation, matrix3, geometry, transform, types  | 88    |
-| `tools-core`      | `rust_core/tools-core/`                 | math, atmosphere, ball_flight, **signal**, **engineering** | 58    |
-| `pendulum-core`   | `src/pendulum_simulator/pendulum-core/` | physics, RK4 solver                                        | 12+   |
-
-### Signal Processing Kernel (`tools-core::signal`)
-
-| Function      | Formula                      | Status         |
-| ------------- | ---------------------------- | -------------- |
-| `sinusoid`    | y = A·sin(2πft + φ) + offset | ✅ Implemented |
-| `cosine`      | y = A·cos(2πft + φ) + offset | ✅ Implemented |
-| `exponential` | y = A·exp(-λt) + offset      | ✅ Implemented |
-| `linear`      | y = slope·t + intercept      | ✅ Implemented |
-| `step`        | Heaviside step               | ✅ Implemented |
-| `square`      | Square wave with duty cycle  | ✅ Implemented |
-| `triangle`    | Triangle wave                | ✅ Implemented |
-| `chirp`       | Linear frequency sweep       | ✅ Implemented |
-| `polynomial`  | y = Σ cₙ·tⁿ                  | ✅ Implemented |
-| `pulse`       | Rectangular pulse            | ✅ Implemented |
-
-### Engineering Calculation Kernel (`tools-core::engineering`)
-
-| Function                             | Domain          | Status         |
-| ------------------------------------ | --------------- | -------------- |
-| `reynolds_number`                    | Fluid mechanics | ✅ Implemented |
-| `churchill_friction_factor`          | Fluid mechanics | ✅ Implemented |
-| `darcy_weisbach_pressure_drop`       | Fluid mechanics | ✅ Implemented |
-| `flow_rate_from_velocity`            | Fluid mechanics | ✅ Implemented |
-| `ideal_gas_density`                  | Thermodynamics  | ✅ Implemented |
-| `compressibility_factor_vdw`         | Thermodynamics  | ✅ Implemented |
-| `isentropic_work`                    | Thermodynamics  | ✅ Implemented |
-| `convective_heat_transfer`           | Heat transfer   | ✅ Implemented |
-| `radiative_heat_transfer`            | Heat transfer   | ✅ Implemented |
-| `lmtd`                               | Heat transfer   | ✅ Implemented |
-| Unit conversions (C/K/F, bar/psi/Pa) | Units           | ✅ Implemented |
-
-### Tool → Rust Integration Status
-
-| Tool                        | Uses Rust? | Via                                 | Issue |
-| --------------------------- | :--------: | ----------------------------------- | ----- |
-| `rotation_converter`        |     ✅     | `tools_core.math_primitives` (PyO3) | —     |
-| `pendulum_simulator`        |     ✅     | `pendulum_core` (PyO3)              | —     |
-| `function_generator`        |     ❌     | Planned: `tools_core.signal`        | #1354 |
-| `signal_processing_studio`  |     ❌     | Planned: `tools_core.signal`        | #1354 |
-| `pressure_drop_calculator`  |     ❌     | Planned: `tools_core.engineering`   | #1355 |
-| `flow_rate_converter`       |     ❌     | Planned: `tools_core.engineering`   | #1355 |
-| `thermal_profile_predictor` |     ❌     | Planned: `tools_core.engineering`   | #1355 |
-| `syngas_compression`        |     ❌     | Planned: `tools_core.engineering`   | #1355 |
-| Web frontends (WASM)        |     ❌     | Planned: `wasm-pack` build          | #1356 |
+This inventory is derived from the directories present under `src/`. When adding
+or removing a tool, update this table and the catalog in the repository README
+in the same change. Process calculators that were previously listed here and are
+no longer present were relocated to the private companion repository and are not
+part of the public distribution.


### PR DESCRIPTION
## Problem

A visitor to this repository could not find out what is in it.

The README opened with "Welcome to the Tools Monorepo", then described a directory taxonomy — including its own unresolved indecision about that taxonomy ("Future consolidation may merge these") — across roughly eighty lines, without naming a single one of the ~40 applications the repository ships. It then spent 100 lines on how to add MATLAB to `PATH`.

It also carried:

- **Four dead navigation links.** `docs/LAUNCHERS.md`, `docs/VISUALIZATION_GUIDE.md`, and `docs/PLUGIN_SYSTEM.md` had moved to `docs/architecture/`; `QUICKSTART.md` to `docs/`.
- **Eleven emoji headings** plus status checkmarks.
- Two consecutive blockquotes both explaining that `tools_launcher.py` does not exist — an internal correction on the public front page.
- A "Launcher Hierarchy" numbered list with one item.

**The repository was also effectively unlicensed.** `LICENSE` was a truncated MIT that dropped the attribution clause entirely and cut the warranty disclaimer mid-sentence, leaving no liability limitation at all. GitHub could not identify it: the API reports `"license": "NOASSERTION"`, and no license appeared in the sidebar.

## Changes

**Tool catalog** — the main addition. Every application, grouped by domain, one line each on what it does:

| Group | Count |
| --- | --- |
| Process and mechanical engineering | 8 |
| Signal, data, and documents | 7 |
| Robotics and biomechanics | 7 |
| Simulation and numerical work | 6 |
| Project and file management | 3 |
| Browser-based utilities | 3 |

Plus a table of the nine console scripts `pip install -e .` actually installs, taken from `[project.scripts]`.

**License** — restored the full MIT text with the attribution clause and complete warranty and liability disclaimer, and named the copyright holder. GitHub should detect MIT and show it in the sidebar once merged.

**Broken links** — all four repointed at their current locations.

**Emoji** — removed from all eleven headings and the status markers.

**Troubleshooting** — moved to `docs/help/troubleshooting.md` rather than dropped, and extended: Python version errors, launcher failures (including the Windows `WinError 127` MSVC-runtime case), MATLAB `PATH` setup, test collection failures, and the Rust fallback path.

**`docs/architecture/LAUNCHERS.md`** — rewritten. It documented `launch_tools_main.py` as a Tkinter fallback launcher with selection logic for choosing between the two. That file does not exist in this repository. The page now records the one real entry point and names both phantom launchers as unsupported so they stop resurfacing.

**`docs/tools/TOOLS_INVENTORY.md`** — rebuilt against the actual tree. It listed 18 process calculators (`acid_gas_dewpoint`, `baghouse_calculator`, `flare_calculator`, `wgs_reactor`, and others) that have since moved to the private companion repository, so the public inventory advertised tools that are not here. Now derived from `src/`, with a Known Gaps section recording what is scaffold-only, deprecated, or has no GUI.

**Issue templates** — `.github/ISSUE_TEMPLATES/` (plural) folded into `ISSUE_TEMPLATE/`. GitHub only reads the singular name, so `geometry_sync_analysis.md` was never offered to anyone. Added a `config.yml` routing readers to the catalog, troubleshooting, user manual, and SECURITY.md.

## Verification

- All 20 relative links resolve.
- No emoji in the README or any file it links to.
- Catalog entries and console scripts cross-checked against `src/` and `pyproject.toml`.
- Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)