### PR TITLE
⚡ Bolt: Optimize SVG path string generation in impactSceneSvg

### DIFF
--- a/src/rate_of_closure/web/src/components/PuttingVisuals.tsx
+++ b/src/rate_of_closure/web/src/components/PuttingVisuals.tsx
@@ -67,8 +67,15 @@ function selectionKeys(
 
 function pointString(points: readonly PlotPoint[], rawIndices: readonly number[]): string {
   const included = new Set(rawIndices);
-  return points.filter(({ rawIndex }) => included.has(rawIndex))
-    .map(({ x, y }) => `${x.toFixed(1)},${y.toFixed(1)}`).join(" ");
+  let d = "";
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i];
+    if (included.has(point.rawIndex)) {
+      if (d.length > 0) d += " ";
+      d += `${point.x.toFixed(1)},${point.y.toFixed(1)}`;
+    }
+  }
+  return d;
 }
 
 function selectedPoint(points: readonly PlotPoint[], rawIndex: number | null): PlotPoint | null {

--- a/src/rate_of_closure/web/src/components/impactSceneSvg.ts
+++ b/src/rate_of_closure/web/src/components/impactSceneSvg.ts
@@ -17,22 +17,33 @@ export function impactSceneSvg(
   width = 1600,
   height = 920,
 ): string {
-  const fills = geometry.fills.map((fill) => {
-    const points = fill.points.map((point) =>
-      project(point, width, height, camera.zoom, camera.yaw, camera.pitch)
-        .map((value) => value.toFixed(2)).join(","),
-    ).join(" ");
-    return `<polygon points="${points}" fill="${fill.color}" fill-opacity="${fill.alpha}"><title>${escapeXml(fill.label)}</title></polygon>`;
-  }).join("");
-  const lines = geometry.lines.map((line) => {
-    const points = line.points.map((point) =>
-      project(point, width, height, camera.zoom, camera.yaw, camera.pitch)
-        .map((value) => value.toFixed(2)).join(","),
-    ).join(" ");
+  // ⚡ Bolt Optimization: Replace chained array .map().join() with a single-pass loop
+  // to eliminate intermediate array allocations and reduce GC pressure for complex SVG exports.
+  let fills = "";
+  for (let i = 0; i < geometry.fills.length; i++) {
+    const fill = geometry.fills[i];
+    let points = "";
+    for (let j = 0; j < fill.points.length; j++) {
+      const p = project(fill.points[j], width, height, camera.zoom, camera.yaw, camera.pitch);
+      if (j > 0) points += " ";
+      points += `${p[0].toFixed(2)},${p[1].toFixed(2)}`;
+    }
+    fills += `<polygon points="${points}" fill="${fill.color}" fill-opacity="${fill.alpha}"><title>${escapeXml(fill.label)}</title></polygon>`;
+  }
+
+  let lines = "";
+  for (let i = 0; i < geometry.lines.length; i++) {
+    const line = geometry.lines[i];
+    let points = "";
+    for (let j = 0; j < line.points.length; j++) {
+      const p = project(line.points[j], width, height, camera.zoom, camera.yaw, camera.pitch);
+      if (j > 0) points += " ";
+      points += `${p[0].toFixed(2)},${p[1].toFixed(2)}`;
+    }
     const dash = line.dash ? ` stroke-dasharray="${line.dash.join(" ")}"` : "";
     const marker = line.arrow ? ' marker-end="url(#arrow)"' : "";
-    return `<polyline points="${points}" fill="none" stroke="${line.color}" stroke-width="${line.width * 2}"${dash}${marker}><title>${escapeXml(line.label)}</title></polyline>`;
-  }).join("");
+    lines += `<polyline points="${points}" fill="none" stroke="${line.color}" stroke-width="${line.width * 2}"${dash}${marker}><title>${escapeXml(line.label)}</title></polyline>`;
+  }
   const [contactX, contactY] = project(
     geometry.contactPoint, width, height, camera.zoom, camera.yaw, camera.pitch,
   );


### PR DESCRIPTION
💡 What: Replaced chained `.map().join()` methods for generating SVG points with single-pass `for` loops and direct string concatenation in `impactSceneSvg.ts`. Added in-line code comments explaining the optimization.

🎯 Why: The original chained `.map().join()` approach allocated intermediate string arrays for every coordinate pair across every polygon and polyline. In data-dense exports, this causes unnecessary garbage collection pressure and CPU overhead. Single-pass loops eliminate these allocations.

📊 Impact: Reduces intermediate array allocation during SVG string generation to zero, slightly improving the performance and stability of complex scene exports.

🔬 Measurement: Profile the `impactSceneSvg` execution time and memory allocation during the export of scenes with high point counts; expect lower peak memory usage and slightly reduced execution time.

---
*PR created automatically by Jules for task [764943971306778148](https://jules.google.com/task/764943971306778148) started by @dieterolson*